### PR TITLE
FROM task/415-public-sync TO development

### DIFF
--- a/.claude/skills/drift-check/SKILL.md
+++ b/.claude/skills/drift-check/SKILL.md
@@ -245,12 +245,105 @@ Then print a single `OK` token for class C:
 
 **Step C-2 — compare cron file mtimes:**
 
-When `RUNTIME_START` is set, check each `crons/*.md` for a mtime strictly
-after the runtime start time:
+When `RUNTIME_START` is set, check each **schedulable cron file** for a
+mtime strictly after the runtime start time. A `crons/*.md` file qualifies
+only if it passes the predicate below (a leading `---` frontmatter block
+declaring a non-empty, anchored, comment-excluding `schedule:` key that parses
+with the same Croner constructor used by `scripts/cron-runtime.ts`, and not
+`enabled: false`) — so non-cron docs like `crons/README.md` and malformed cron
+files the runtime logs as `SCHED_INVALID` are skipped by the predicate, never
+mtime-compared, and never counted. Qualification is property-based, not a
+hard-coded name list:
 
 ```bash
 INERT=()
+# Qualify each crons/*.md as a SCHEDULABLE cron BEFORE the mtime check, mirroring
+# scripts/cron-runtime.ts parseCronFile + loadCrons: a file the runtime never
+# loads cannot be "inert". A file qualifies IFF all of:
+#   1. first line is literally '---' (trailing \r stripped, CRLF-safe) — so a
+#      '---' inside a fenced code block (the crons/README.md trap) cannot match,
+#   2. a closing '---' delimiter exists on a later line (well-formed frontmatter),
+#   3. the leading frontmatter has a non-empty, anchored, comment-excluding
+#      schedule: key (^[[:space:]]*schedule: — skips '# schedule:' and substring
+#      'pre_schedule:'),
+#   4. it is not disabled (no enabled: set to false, bare or quoted),
+#   5. the schedule parses with Croner, matching the runtime's isValidSchedule()
+#      / SCHED_INVALID path so malformed schedules are skipped, not flagged inert.
+# Non-qualifying files (e.g. crons/README.md or invalid schedules) are skipped
+# silently — never mtime-compared, never counted toward the inert aggregate. The
+# predicate is property-based: no hard-coded cron name list or count.
+cron_fm_value() {
+  local key="$1"
+  awk -v wanted="$key" '
+    /^[[:space:]]*#/ || /^[[:space:]]*$/ { next }
+    {
+      i = index($0, ":")
+      if (i == 0) next
+      k = substr($0, 1, i - 1)
+      v = substr($0, i + 1)
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", k)
+      if (k != wanted) next
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", v)
+      sub(/^["\047]/, "", v)
+      sub(/["\047]$/, "", v)
+      print v
+      found = 1
+      exit
+    }
+    END { exit !found }
+  '
+}
+
+is_valid_cron_schedule() {
+  local schedule="$1" root
+  root="${DRIFT_CHECK_ROOT:-}"
+  if [ -z "$root" ]; then
+    root=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+  fi
+
+  DRIFT_CHECK_ROOT="$root" node --input-type=module -e '
+    import { createRequire } from "node:module";
+    const schedule = process.argv[1] ?? "";
+    const root = (process.env.DRIFT_CHECK_ROOT || process.cwd()).replace(/\/$/, "");
+    const requireFromRoot = createRequire(`${root}/package.json`);
+    const mod = await import(requireFromRoot.resolve("croner"));
+    const CronCtor = mod.Cron ?? mod.default?.Cron ?? mod.default;
+    let probe;
+    let ok = false;
+    try {
+      probe = new CronCtor(schedule);
+      ok = true;
+    } catch {
+      ok = false;
+    } finally {
+      probe?.stop?.();
+    }
+    process.exit(ok ? 0 : 1);
+  ' "$schedule" >/dev/null 2>&1
+}
+
+is_schedulable_cron() {
+  local f="$1" fm schedule enabled
+
+  [ "$(head -n1 "$f" | tr -d '\r')" = '---' ] || return 1
+  awk 'NR>1 { sub(/\r$/,""); if ($0 ~ /^---[[:space:]]*$/) { ok=1; exit } } END { exit !ok }' "$f" || return 1
+
+  fm=$(awk 'NR>1 { sub(/\r$/,""); if ($0 ~ /^---[[:space:]]*$/) exit; print }' "$f")
+
+  schedule=$(printf '%s\n' "$fm" | cron_fm_value schedule) || return 1
+  [ -n "$schedule" ] || return 1
+  is_valid_cron_schedule "$schedule" || return 1
+
+  if enabled=$(printf '%s\n' "$fm" | cron_fm_value enabled); then
+    [ "$enabled" = "false" ] && return 1
+  fi
+
+  return 0
+}
+
+INERT=()
 for f in crons/*.md; do
+  is_schedulable_cron "$f" || continue
   FILE_MTIME=$(stat -c '%Y' "$f" 2>/dev/null || stat -f '%m' "$f" 2>/dev/null)
   if [ -n "$FILE_MTIME" ] && [ "$FILE_MTIME" -gt "$RUNTIME_START" ]; then
     INERT+=("$f")

--- a/.claude/skills/eval/run.sh
+++ b/.claude/skills/eval/run.sh
@@ -23,6 +23,12 @@ while [ $# -gt 0 ]; do
   esac
 done
 
+# Temp-file handle for the atomic scoreboard write (assigned at the write block).
+# Initialized empty BEFORE the --ablate guard so the guarded EXIT trap is harmless
+# on the ablation exec path (the exec at run.sh:~49 replaces this shell entirely).
+tmp=""
+trap '[ -n "$tmp" ] && rm -f "$tmp"' EXIT
+
 # --- M-2: recover orphaned ablation backups from a crashed prior run ---
 # scripts/ablate.sh records in-flight "<target>\t<bak>" lines in this sentinel;
 # if a prior ablation was SIGKILLed before its trap fired, restore here.
@@ -51,10 +57,16 @@ fi
 
 hdr() { grep -E "^# $1:" "$2" 2>/dev/null | head -1 | sed "s/^# $1:[[:space:]]*//" || true; }
 prior_row() {
-  [ -f "$RESULTS" ] || return 0
-  grep -E "^\| ${1} \|" "$RESULTS" 2>/dev/null | head -1 || true
+  grep -E "^\| ${1} \|" <<<"$RESULTS_ORIG" 2>/dev/null | head -1 || true
 }
-prior_status() { prior_row "$1" | awk -F'|' '{gsub(/^[ \t]+|[ \t]+$/,"",$5); print $5}'; }
+prior_status() { prior_row "$1" | awk -F'|' '{gsub(/^[ \t]+|[ \t]+$/, "", $5); print $5}'; }
+
+# Capture the pre-write scoreboard ONCE. Carry-forward (prior_row) reads this
+# snapshot, never the live $RESULTS — so a filtered run can't erase untouched
+# rows, and a crash mid-write leaves the original file intact (atomic mv below).
+# set -e-safe: the [ -f ] short-circuits the cat so a missing file can't abort.
+RESULTS_ORIG=""
+[ -f "$RESULTS" ] && RESULTS_ORIG="$(cat "$RESULTS")"
 
 now="$(date -u +'%Y-%m-%d %H:%M')"
 declare -A NEWROW
@@ -100,8 +112,12 @@ for probe in "$PROBES_DIR"/*.sh; do
   ran=$((ran + 1))
 done
 
-# --- rewrite RESULTS.md: new rows for probes run; carry prior rows for the rest ---
-cat > "$RESULTS" <<'HDR'
+# --- rewrite RESULTS.md: build the full scoreboard into a temp sibling file, then
+#     replace the live file in ONE atomic mv -f. New rows for probes run this
+#     invocation; carry prior rows (from the RESULTS_ORIG snapshot) for the rest.
+#     The temp path is a SIBLING of $RESULTS (same filesystem) so mv -f is atomic. ---
+tmp="$RESULTS.tmp.$$"
+cat > "$tmp" <<'HDR'
 # Probe results — benchmark scoreboard
 
 Current status per probe id, written by `/eval`. Policy: **overwrite the row per
@@ -114,17 +130,19 @@ HDR
 for probe in "$PROBES_DIR"/*.sh; do
   id="$(basename "$probe" .sh)"
   if [ -n "${NEWROW[$id]+x}" ]; then
-    printf '%s\n' "${NEWROW[$id]}" >> "$RESULTS"
+    printf '%s\n' "${NEWROW[$id]}" >> "$tmp"
   else
     pr="$(prior_row "$id")"
     if [ -n "$pr" ]; then
-      printf '%s\n' "$pr" >> "$RESULTS"
+      printf '%s\n' "$pr" >> "$tmp"
     else
-      printf '| %s | %s | — | (not run) | %s |\n' "$id" "$(hdr tier "$probe")" "$(hdr source "$probe")" >> "$RESULTS"
+      printf '| %s | %s | — | (not run) | %s |\n' "$id" "$(hdr tier "$probe")" "$(hdr source "$probe")" >> "$tmp"
     fi
   fi
 done
-printf '\n<!-- benchmark: pass-rate = PASS / (PASS + REGRESSION + TIMEOUT); SKIPPED excluded -->\n' >> "$RESULTS"
+printf '\n<!-- benchmark: pass-rate = PASS / (PASS + REGRESSION + TIMEOUT); SKIPPED excluded -->\n' >> "$tmp"
+mv -f "$tmp" "$RESULTS"
+tmp=""
 
 # --- summary to stdout: regressions first ---
 if [ "${#regressions[@]}" -gt 0 ]; then

--- a/.claude/skills/pr-audit/LICENSE
+++ b/.claude/skills/pr-audit/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Open Harness contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/.claude/skills/pr-audit/SKILL.md
+++ b/.claude/skills/pr-audit/SKILL.md
@@ -1,0 +1,352 @@
+---
+name: pr-audit
+description: |
+  Audit all open PRs in one bulk query and triage them into actionable
+  buckets: ready-to-merge, needs-review, CI-failing, conflicting/behind, plus
+  stale/convention flags. Draft PRs are split out as a separate work-in-progress
+  class (promotable / WIP / limbo), checked first and never mixed into the
+  actionable buckets. Read-only by default; --deep escalates flagged PRs to
+  parallel diff reviewers, --proof writes each PR's verdict + evidence back as a
+  comment for human reviewers, and opt-in flags (--label-apply/--close-stale)
+  apply triage actions after confirmation.
+  TRIGGER when: asked to audit open PRs, "check the open PRs", "what PRs
+  are stuck", "triage the PR queue", PR backlog review, or before a merge sweep.
+argument-hint: "[--deep] [--proof] [--label <l>] [--author <a>] [--mine] [--base <b>] [--stale-days <n>] [--label-apply] [--close-stale <n>] [--dry-run]"
+---
+
+# PR Audit
+
+Triage the whole open-PR queue and surface what needs attention.
+
+**Core principle: one bulk query, then classify — never loop per-PR, and never
+mutate without explicit opt-in.** A single `gh pr list --json` call pulls every
+triage signal (CI, mergeability, reviews, age, draft) for every open PR; all
+classification is local `jq` over that one payload. The skill is read-only by
+default — depth (`--deep`) and writes (`--proof`, `--label-apply`,
+`--close-stale`) happen only when the flag is present, and every mutation
+confirms first.
+
+## Decision Flow
+
+```mermaid
+flowchart TD
+    A["Resolve args + repo: $ARGUMENTS"] --> B["Bulk fetch — ONE gh pr list --json"]
+    B --> C["Classify into buckets (jq) + convention checks"]
+    C --> D["Emit triage report (read-only)"]
+    D --> E{"--deep?"}
+    E -- yes --> F["Spawn parallel reviewers for flagged PRs"]
+    E -- no --> G
+    F --> G{"opt-in writes?"}
+    G -- "--proof" --> H["Post/update per-PR proof comment (confirm)"]
+    G -- "--label-apply / --close-stale" --> I["Apply labels / close stale (confirm)"]
+    G -- none --> J
+    H & I --> J["Memory Protocol"]
+    G -- none --> J
+```
+
+## Instructions
+
+### 1. Resolve arguments & repo
+
+Arguments received: `$ARGUMENTS`
+
+Parse flags (all optional):
+
+| Flag | Effect |
+|------|--------|
+| `--deep` | After triage, fan out parallel reviewers for flagged PRs (§5) |
+| `--proof` | Write each PR's verdict back as an idempotent comment (§6) — **mutating** |
+| `--label <l>` | Restrict the audit to PRs carrying label `<l>` |
+| `--author <a>` | Restrict to PRs by author `<a>` |
+| `--mine` | Restrict to the authenticated user's PRs |
+| `--base <b>` | Restrict to PRs targeting base branch `<b>` |
+| `--stale-days <n>` | Staleness threshold in days (default **14**) |
+| `--label-apply` | Apply triage labels (§7) — **mutating** |
+| `--close-stale <n>` | Close PRs idle > n days (§7) — **mutating** |
+| `--dry-run` | Print intended mutations/proof bodies; do not write |
+
+Resolve the target repo exactly as `/ci-status` does (reuse, don't reinvent):
+
+```bash
+if [ -n "$REPO_OVERRIDE" ]; then
+  case "$REPO_OVERRIDE" in
+    */*) REPO="$REPO_OVERRIDE" ;;
+    *) echo "ERROR: --repo must be owner/name format (got '$REPO_OVERRIDE')"; exit 1 ;;
+  esac
+else
+  REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
+fi
+[ -n "$REPO" ] || { echo "ERROR: could not derive repo — is gh authenticated? Try: gh auth login"; exit 1; }
+
+STALE_DAYS=14   # override with --stale-days
+BASE_DEFAULT=development   # the harness default target branch (context/rules/git.md)
+# --mine → resolve login:  ME=$(gh api user --jq .login)
+```
+
+Build filter flags from the parsed args: `--label "$L"`, `--author "$A"`,
+`--base "$B"` (pass `--author "$ME"` for `--mine`). Absent flags → no filter.
+
+### 2. Bulk fetch — ONE call (the efficient core)
+
+```bash
+gh pr list --state open --repo "$REPO" --limit 200 \
+  $LABEL_FILTER $AUTHOR_FILTER $BASE_FILTER \
+  --json number,title,headRefName,baseRefName,isDraft,mergeable,mergeStateStatus,reviewDecision,statusCheckRollup,createdAt,updatedAt,author,additions,deletions,changedFiles,labels,url \
+  > /tmp/pr-audit.json
+
+echo "open PRs fetched: $(jq 'length' /tmp/pr-audit.json)"
+```
+
+`statusCheckRollup` here is the **same field `/ci-status` reads** — CI state for
+every PR arrives in this one payload, so there is no per-PR `gh pr checks` loop.
+If the set is empty, report "no open PRs match" and skip to the Memory Protocol.
+
+### 3. Classify into buckets
+
+Annotate each PR with a derived CI state and age, then assign buckets. Run this
+`jq` over the cached payload (no further network calls):
+
+```bash
+jq -r --argjson stale "$STALE_DAYS" --arg base "$BASE_DEFAULT" '
+  def ci_state:
+    [ (.statusCheckRollup // [])[] | (.conclusion // .state // .status // "") ] as $t
+    | if ($t|length)==0 then "NONE"
+      elif ($t | any(. as $x | ["FAILURE","ERROR","TIMED_OUT","CANCELLED","ACTION_REQUIRED","STARTUP_FAILURE"] | index($x))) then "FAIL"
+      elif ($t | any(. as $x | ["IN_PROGRESS","QUEUED","PENDING","WAITING","EXPECTED"] | index($x))) then "PEND"
+      else "PASS" end;
+  .[]
+  | . + {
+      ci: ci_state,
+      age: (((now - (.updatedAt|fromdateiso8601))/86400) | floor),
+      title_ok: (.title | test("^FROM .+ TO .+")),
+      base_ok: (.baseRefName == $base),
+      reviewers: ((.reviewDecision // "") | length > 0)
+    }
+  | . + {
+      draft_sub: (if .isDraft then
+                    (if (.mergeable=="MERGEABLE" and .mergeStateStatus=="CLEAN" and .ci=="PASS")
+                     then "promotable" else "wip" end)
+                  else "" end)
+    }
+  | [ .number, .ci, .age, .isDraft, .draft_sub, .mergeable, .mergeStateStatus,
+      (.reviewDecision // "NONE"), .title_ok, .base_ok, .baseRefName,
+      .changedFiles, (.author.login), .title ]
+  | @tsv
+' /tmp/pr-audit.json
+```
+
+Assign each PR **one primary state** (first matching rule wins — the order below
+*is* the actionability priority), then layer **orthogonal flags** on top. A
+single primary state avoids contradictions like "ready" *and* "needs review" on
+the same green PR; flags annotate whatever state the PR is in.
+
+**Primary state — first match wins, top to bottom:**
+
+| State | Rule |
+|-------|------|
+| 📝 **Draft** | `isDraft==true` — checked **first**. A draft is intentional WIP, so its CI/conflict/review state is *expected*, not actionable; drafts never enter the buckets below. Classify their readiness with the **draft sub-status** table instead. |
+| ❌ **CI failing** | `ci=="FAIL"` |
+| ⚠ **Conflicting / behind** | `mergeable=="CONFLICTING"` \|\| `mergeStateStatus ∈ {DIRTY, BEHIND}` |
+| 🔴 **Changes requested** | `reviewDecision=="CHANGES_REQUESTED"` |
+| 👀 **Needs review** | `reviewDecision=="REVIEW_REQUIRED"` (review is *required* but not yet given) |
+| ✅ **Ready to merge** | `mergeable=="MERGEABLE"` && `mergeStateStatus=="CLEAN"` && `ci=="PASS"` && `reviewDecision ∈ {APPROVED, "", null}` — the same selector `crons/heartbeat.md` uses to nudge merges |
+| ⏳ **Pending / other** | none of the above (e.g. `ci=="PEND"`, or `mergeable=="UNKNOWN"` — re-check shortly) |
+
+Because Draft wins first, the actionable states below it (CI-failing … pending)
+describe **ready-for-review PRs only** — a draft's red CI or conflict is WIP, and
+surfaces as a draft sub-status, never as an actionable alarm.
+
+> Note on empty `reviewDecision`: a repo without required reviews returns `""`,
+> so a green PR is **Ready**, not Needs-review. Only `REVIEW_REQUIRED` (branch
+> protection awaiting a review) lands in Needs-review — this is why #70-style
+> solo-dev PRs read as Ready rather than nagging for a reviewer that isn't required.
+
+**Draft sub-status — classify each 📝 Draft (the `draft_sub` column) by
+*readiness*, not actionability:**
+
+| Sub-status | Rule | Meaning |
+|------------|------|---------|
+| ✅ **promotable** | `mergeable=="MERGEABLE" && mergeStateStatus=="CLEAN" && ci=="PASS"` | green WIP — could be marked ready (`gh pr ready <N>`) |
+| 🚧 **still-WIP** | otherwise (red/pending CI, or `CONFLICTING`/`DIRTY`/`BEHIND`) | expected work-in-progress; informational only, never a "fix me" alarm |
+
+A stale draft (💤, below) is *draft-limbo* — promote or close.
+
+**Orthogonal flags — tag any PR regardless of its primary state:**
+
+| Flag | Rule |
+|------|------|
+| 💤 **Stale** | `age > STALE_DAYS` (days since `updatedAt`); on a 📝 Draft this is *draft-limbo* |
+| 📐 **Convention** | `title_ok==false` (not `FROM … TO …`), or `base_ok==false` (base ≠ `development`), or oversized (`changedFiles > 50`) — see `context/rules/git.md` |
+
+### 4. Emit the triage report
+
+One section per **non-empty primary state**, most-actionable first. Drafts get
+their own block **after** the actionable (ready-for-review) sections — least
+urgent, never mixed in. Each PR is one line, carries its 💤/📐 flags inline, and
+lists the recommended read-only command (report-and-recommend, like
+`/drift-check` — never auto-run):
+
+```
+## Open PR Audit — YYYY-MM-DD  (N open · filters: <…>)
+
+### ❌ CI failing (ready-for-review)
+| PR | Title | CI | Age | Flags | Recommend |
+|----|-------|----|-----|-------|-----------|
+| #81 | … | ✗ build | 3d | — | fix branch (`--deep` for root cause) |
+
+### ⚠ Conflicting / behind · 🔴 Changes requested · 👀 Needs review · ✅ Ready to merge
+…one section per non-empty actionable state, same column shape (ready-for-review PRs only)…
+
+### 📝 Drafts — work-in-progress (not actionable)
+| PR | Title | Sub-status | Age | Flags | Recommend |
+|----|-------|-----------|-----|-------|-----------|
+| #68 | … | ✅ promotable | 2d | — | mark ready (`gh pr ready 68`) |
+| #72 | … | 🚧 still-WIP  | 1d | — | finish work; no action |
+| #41 | … | 🚧 still-WIP  | 21d | 💤 limbo | promote or close |
+
+### Flag rollup
+💤 stale: #41   📐 convention: #73 (title), #55 (base≠development)
+
+### Summary
+ci-fail F · conflict C · changes-req X · needs-review R · ready M · pending P · draft D (✅ promotable Dp · 🚧 wip Dw)  ·  flagged: stale S, conv V
+```
+
+A flag never moves a PR out of its state section — `#68` stale + ready shows
+under **Ready to merge** with a 💤 in its Flags column and again in the rollup.
+
+When `--label autopilot`, append a **cap-headroom** line citing
+`.claude/skills/autopilot/SKILL.md` (§ Guardrails): `total open <n>/10`,
+`created today <n>/6` (a same-day close/merge frees a slot):
+
+```bash
+echo "autopilot caps — total: $(gh pr list --state open --label autopilot --json number --jq 'length')/10 · today: $(gh pr list --state open --search "label:autopilot created:>=$(date -u +%Y-%m-%d)" --json number --jq 'length')/6"
+```
+
+### 5. `--deep` escalation (optional)
+
+Only when `--deep` is set. For PRs in the **CI-failing / conflicting /
+changes-requested** buckets (the ones whose *why* isn't visible from metadata),
+spawn parallel sub-agent reviewers **in one message**, capped at ~5 (state in
+the report if more were flagged than reviewed — no silent truncation). Brief
+each per `context/rules/advisor-model.md` (Goal / Constraints / Acceptance /
+Start here / Out of scope). Each reviewer:
+
+- reads `gh pr diff <N>` and `gh pr checks <N>` (and the failing job log for CI reds)
+- returns a **structured verdict**: first line `ROOT-CAUSE:` (CI red → failing
+  job + likely cause; conflict → conflicting files), then a one-line fix hint.
+
+Append each verdict to its PR's row. This **complements, not duplicates, a
+full diff review** — keep this skill focused on triage rather than per-PR code
+review.
+
+### 6. `--proof` — write each PR's verdict back (human-visibility path)
+
+Only when `--proof` is set. For every audited PR, post **or update** a per-PR
+proof comment so an async reviewer sees the auditor's evidence on the PR itself.
+**Mutating → confirm the batch first** (show the PR count and a sample body);
+`--dry-run` prints the bodies and writes nothing.
+
+Body template (the hidden marker on line 1 is load-bearing — see idempotency):
+
+```markdown
+<!-- pr-audit-proof -->
+🤖 **PR Audit — YYYY-MM-DD** · bucket: **<bucket>**
+- CI: <✓ green | ❌ `<job>` red ([run](<url>)) | ⏳ pending | — none>
+- Mergeable: <state> · Reviews: <decision/none> · Age: <Nd> (updated <Nd> ago)
+- Convention: title <ok/✗> · base=<branch> <ok/✗>
+- Root cause: <only when --deep produced one>
+
+_Read-only audit; verdict is advisory. Re-run updates this comment._
+```
+
+For a **draft**, `bucket:` carries the sub-status — `Draft (promotable)` or
+`Draft (WIP)` — so a green draft gets a "consider marking ready" nudge while a
+WIP draft's verdict stays purely informational.
+
+**Idempotency** — re-runs must update the same comment, not stack duplicates.
+Find a prior proof by the `<!-- pr-audit-proof -->` marker and edit it; create
+only if none exists:
+
+```bash
+PROOF_ID=$(gh api "repos/$REPO/issues/$N/comments" \
+  --jq '[.[] | select(.body | startswith("<!-- pr-audit-proof -->"))][-1].id // empty')
+if [ -n "$PROOF_ID" ]; then
+  gh api -X PATCH "repos/$REPO/issues/comments/$PROOF_ID" -f body="$BODY" >/dev/null
+else
+  gh pr comment "$N" --repo "$REPO" --body "$BODY"
+fi
+```
+
+### 7. Other opt-in actions (mutating — confirm first)
+
+Default does nothing here. Each requires an explicit flag and a confirmation.
+
+- `--label-apply` → add triage labels (`needs-review` / `stale` / `ci-failing`)
+  via `gh pr edit <N> --add-label <label>`. Skip labels that don't exist rather
+  than creating them silently; report which were skipped.
+- `--close-stale <n>` → `gh pr close <N>` for PRs idle > n days. **Always print
+  the full target list and require explicit confirmation** before closing — a
+  close is hard to reverse and outward-facing; look at each target's age/title
+  before acting. `--dry-run` prints the intended closes and exits.
+
+### 8. Memory Protocol
+
+Append to `memory/$(date -u +%Y-%m-%d)/log.md` (create the dir first):
+
+```markdown
+## PR Audit -- HH:MM UTC
+- **Result**: OP | DRY-RUN | PARTIAL | FAIL
+- **Scope**: [N open PRs; filters]
+- **Triage**: ready M | review R | ci-fail F | conflict C | stale S | draft D (promotable Dp)
+- **Actions**: [none | proof posted X | labeled Y | closed Z]
+- **Observation**: [one sentence — top finding]
+```
+
+Then run the qualify/improve pass per `context/rules/memory.md`.
+
+## Reference
+
+### Bucket definitions & recommended action
+
+| Bucket | Signal | Recommended (operator) action |
+|--------|--------|-------------------------------|
+| ✅ Ready to merge | green + clean + approved | `gh pr merge <N>` |
+| ❌ CI failing | rollup has a failure | fix the branch; `--deep` for root cause |
+| ⚠ Conflicting / behind | CONFLICTING / DIRTY / BEHIND | rebase on `development` |
+| 🔴 Changes requested | review demands changes | address review |
+| 👀 Needs review | `REVIEW_REQUIRED` pending | request a reviewer |
+| 📝 Draft (separate WIP class) | `isDraft` — checked first; sub-status ✅ promotable (green+clean) / 🚧 still-WIP / 💤 limbo (stale) | `gh pr ready <N>` to promote, or close |
+| ⏳ Pending / other | CI running / mergeable unknown | re-check shortly |
+| 💤 Stale (flag) | no update > `--stale-days` | ping or `--close-stale` |
+| 📐 Convention (flag) | title/base/size off-spec | fix title/base per `git.md` |
+
+### `gh pr list --json` field glossary
+
+| Field | Used for |
+|-------|----------|
+| `isDraft`, `mergeable`, `mergeStateStatus` | ready / conflict buckets (heartbeat selector) |
+| `statusCheckRollup` | CI state without a per-PR `gh pr checks` loop |
+| `reviewDecision` | review buckets (`APPROVED`/`CHANGES_REQUESTED`/`REVIEW_REQUIRED`/∅) |
+| `createdAt`, `updatedAt` | age / staleness |
+| `title`, `baseRefName`, `changedFiles` | convention checks |
+| `labels`, `author`, `url`, `number` | filtering, proof comment, reporting |
+
+### Severity / thresholds
+
+| Knob | Default | Meaning |
+|------|---------|---------|
+| `--stale-days` | 14 | days since `updatedAt` before a PR is stale |
+| oversized | > 50 changed files | flagged as a convention/size concern |
+| deep cap | ~5 PRs | max parallel reviewers per run (report overflow) |
+
+### Key paths
+
+| Resource | Path |
+|----------|------|
+| Repo-resolution / `REPO_OVERRIDE` pattern | `.claude/skills/ci-status/SKILL.md` |
+| Ready-PR selector | `crons/heartbeat.md` (autopilot ready-PR nudge) |
+| PR title / base / size conventions | `context/rules/git.md` |
+| Autopilot caps (10 total / 6 daily) | `.claude/skills/autopilot/SKILL.md` § Guardrails |
+| Parallel-agent briefing format | `context/rules/advisor-model.md` |
+| Per-PR diff correctness (escalate, don't duplicate) | dedicated manual review workflow |
+| Memory Improvement Protocol | `context/rules/memory.md` |

--- a/.github/workflows/ci-harness.yml
+++ b/.github/workflows/ci-harness.yml
@@ -20,6 +20,8 @@ on:
       - "context/**"
       - ".devcontainer/**"
       - "install/**"
+      - "workspace/**"
+      - "evals/**"
   pull_request:
     paths:
       - "packages/**"
@@ -35,6 +37,8 @@ on:
       - "context/**"
       - ".devcontainer/**"
       - "install/**"
+      - "workspace/**"
+      - "evals/**"
 
 concurrency:
   group: ci-harness-${{ github.ref }}
@@ -106,7 +110,7 @@ jobs:
         run: |
           command -v shellcheck >/dev/null 2>&1 || { sudo apt-get update && sudo apt-get install -y shellcheck; }
           shellcheck --version
-          shellcheck -S warning .devcontainer/*.sh install/*.sh
+          shellcheck -S warning .devcontainer/*.sh install/*.sh scripts/*.sh workspace/*.sh
 
       - name: Hadolint Dockerfile
         uses: hadolint/hadolint-action@54c9adbab1582c2ef04b2016b760714a4bfde3cf # v3.1.0
@@ -114,3 +118,33 @@ jobs:
           dockerfile: .devcontainer/Dockerfile
           config: .hadolint.yaml
           failure-threshold: warning
+
+  eval-probes:
+    name: "Eval Probe Regression Gate"
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node 22.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: ~/.local/share/pnpm/store/v3
+          key: pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run eval probe suite
+        run: bash .claude/skills/eval/run.sh

--- a/.pi/.gitignore
+++ b/.pi/.gitignore
@@ -1,3 +1,5 @@
 sessions/
 git/
 npm/
+tasks/
+tasks-config.json

--- a/.pi/extensions/__tests__/settings.test.ts
+++ b/.pi/extensions/__tests__/settings.test.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+interface PiSettings {
+  packages?: string[];
+}
+
+function readPiSettings(): PiSettings {
+  return JSON.parse(readFileSync(".pi/settings.json", "utf8")) as PiSettings;
+}
+
+describe("project Pi settings", () => {
+  it("pins the default Pi packages used by the harness", () => {
+    const settings = readPiSettings();
+
+    expect(settings.packages).toEqual([
+      "npm:@tintinweb/pi-subagents@0.7.1",
+      "npm:@tintinweb/pi-tasks@0.7.0",
+      "npm:@tintinweb/pi-goal",
+    ]);
+  });
+});

--- a/.pi/settings.json
+++ b/.pi/settings.json
@@ -15,5 +15,9 @@
   "prompts": ["./prompts"],
   "themes": ["./themes"],
   "enableSkillCommands": true,
-  "packages": ["npm:@tintinweb/pi-subagents@0.7.1"]
+  "packages": [
+    "npm:@tintinweb/pi-subagents@0.7.1",
+    "npm:@tintinweb/pi-tasks@0.7.0",
+    "npm:@tintinweb/pi-goal"
+  ]
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,6 +109,7 @@ Remove the sandbox.
 |-------|------|
 | `/release` | CalVer release — branch, tag, push, GHCR |
 | `/ci-status` | After `git push` — poll CI, report pass/fail |
+| `/pr-audit` | Bulk triage open PRs in one query; classify ready / CI-failing / conflicting / changes-requested / needs-review / draft; read-only by default with optional deep review, proof comments, label application, and stale close actions |
 | `/health-check` | Triage host memory/disk/Docker before starting a stack; rank reclaim levers by safety×yield, prune build cache, confirm destructive removal |
 | `/agent-browser` | Open a URL headless for screenshots / preview checks |
 | `/interview` | Adaptive pre-work clarifier — batches 2–4 task-specific questions via `AskUserQuestion`, then proceeds |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,17 @@ Update policy and release automation live in [`.claude/rules/git.md`](.claude/ru
 ## [Unreleased]
 
 ### Added
+- Add an `Eval Probe Regression Gate` CI job, new eval self-guard probes, and atomic `/eval` scoreboard writes so green→red probe regressions block public harness changes ([#415](https://github.com/mifunedev/openharness/issues/415)).
+- Load `@tintinweb/pi-goal` and `@tintinweb/pi-tasks` by default in Pi, document their usage, and ignore Pi task runtime state ([#415](https://github.com/mifunedev/openharness/issues/415)).
+- Add the public-safe `/pr-audit` skill for one-shot bulk PR triage; read-only by default with optional deep review, proof comments, label application, and stale close actions ([#415](https://github.com/mifunedev/openharness/issues/415)).
+
 ### Changed
+
 ### Fixed
+- Tighten `/drift-check` cron-staleness detection to compare only schedulable cron files and skip README, disabled, unscheduled, empty, and invalid cron docs ([#415](https://github.com/mifunedev/openharness/issues/415)).
+- Correct `context/rules/memory.md` so daily `memory/YYYY-MM-DD/log.md` files are documented as local/gitignored journals unless force-added ([#415](https://github.com/mifunedev/openharness/issues/415)).
+- Expand boot-path shellcheck coverage to `scripts/*.sh` and `workspace/*.sh` while preserving the intentional literal `~/.openharness` installer message ([#415](https://github.com/mifunedev/openharness/issues/415)).
+
 ### Removed
 ### Deprecated
 ### Security

--- a/context/rules/memory.md
+++ b/context/rules/memory.md
@@ -28,8 +28,16 @@ memory/
   MEMORY.md              # long-term lessons (tracked)
   <topic>.md             # per-topic reference notes (tracked or gitignored per need)
   YYYY-MM-DD/
-    log.md               # daily append log (gitignored directory; log.md tracked inside)
+    log.md               # daily append log (gitignored - local-only unless force-added)
 ```
+
+The `memory/YYYY-MM-DD/` directory is gitignored via `.gitignore`'s
+`memory/[0-9]*/` rule, so daily logs are a **local/gitignored journal** unless
+you force-add them. They do not survive a fresh clone. Only `MEMORY.md`,
+`README.md`, and topic notes persist in git. The two pre-ignore logs
+(`memory/2026-05-03`, `memory/2026-05-04`) predate that rule and remain
+tracked as a historical vestige; do not treat them as evidence that daily logs
+are committed.
 
 Date format: always `date -u +%Y-%m-%d` (UTC). Never local time.
 

--- a/docs/harnesses/pi.md
+++ b/docs/harnesses/pi.md
@@ -30,7 +30,25 @@ This is Pi-specific. The Codex CLI has its own headless path (`codex login --dev
 
 ## Upstream
 
-[`@earendil-works/pi-coding-agent` on npm](https://www.npmjs.com/package/@earendil-works/pi-coding-agent) — see the upstream repository at [earendil-works/pi-mono](https://github.com/earendil-works/pi-mono) for documentation, configuration, and roadmap. (The previous package, `@mariozechner/pi-coding-agent`, is deprecated as of late 2026 — install the `@earendil-works/...` successor instead.)
+[`@earendil-works/pi-coding-agent` on npm](https://www.npmjs.com/package/@earendil-works/pi-coding-agent) — see the upstream repository at [earendil-works/pi-mono](https://github.com/earendil-works/pi-mono) for documentation, configuration, and roadmap. (The previous package, `@mariozechner/pi-coding-agent`, is deprecated — install the `@earendil-works/...` successor instead.)
+
+## Default packages
+
+Open Harness loads these project-local Pi packages from `.pi/settings.json`:
+
+- [`@tintinweb/pi-subagents`](https://pi.dev/packages/@tintinweb/pi-subagents) — Claude Code-style sub-agent commands for Pi.
+- [`@tintinweb/pi-tasks`](https://github.com/tintinweb/pi-tasks) — task tracking for Pi with `TaskCreate`, `TaskList`, `TaskGet`, `TaskUpdate`, `TaskOutput`, `TaskStop`, and `TaskExecute` tools; a `/tasks` menu; and a persistent task widget. `TaskExecute` integrates with `@tintinweb/pi-subagents` so tracked tasks can run through configured subagents.
+- [`@tintinweb/pi-goal`](https://pi.dev/packages/@tintinweb/pi-goal?name=goal) — `/goal <task>` mode that keeps Pi working until it verifies completion and calls the `goal_complete` tool. Use `/goal pause`, `/goal resume`, or `/goal clear` to manage the active goal.
+
+Pi installs missing project packages automatically on startup after the project is trusted. To try the goal package manually, run:
+
+```bash
+pi -e npm:@tintinweb/pi-goal
+```
+
+## Task tracking
+
+The default task runtime state lives under `.pi/tasks/`, which is gitignored. Leave the default for per-checkout task state; set `PI_TASKS=off` to disable task tracking; set `PI_TASKS=<named-list>` to select a named task list; or pass an explicit task-list path when you intentionally want a shared list outside the gitignored default.
 
 ## Slack integration
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -135,6 +135,8 @@ Once installed, proceed to the [Quickstart](./quickstart) to authenticate inside
 
 The sandbox image ships a complete development environment. The only host dependency is Docker.
 
+Project-local Pi packages are loaded from `.pi/settings.json`; the defaults include `@tintinweb/pi-subagents`, `@tintinweb/pi-tasks`, and `@tintinweb/pi-goal`.
+
 ### Base image
 
 Debian Bookworm (slim). The `sandbox` user has passwordless sudo.

--- a/evals/README.md
+++ b/evals/README.md
@@ -1,4 +1,4 @@
-# evals/ — Context fitness-function probe corpus
+# `evals/` — Context fitness-function probe corpus
 
 This directory is the harness's **fitness function**: a corpus of deterministic
 **probes** that turn lessons into runnable, exit-code-scored checks against
@@ -37,7 +37,7 @@ exact contract `grep -E '^# (tier|source|desc):'`):
 ```sh
 #!/usr/bin/env bash
 # tier: A          # A | ablation
-# source: issue #410   # the lesson/rule this probe closes
+# source: issue #103   # the lesson/rule this probe closes
 # desc: /eval run.sh exits non-zero when a prior PASS regresses
 set -euo pipefail
 # ... inspect REAL state (running processes, actual files, live sandbox) — never mocks ...
@@ -89,9 +89,13 @@ surface** first:
 ## Runner
 
 `/eval` (`.claude/skills/eval/`) discovers `evals/probes/*.sh`, runs each, and
-writes `RESULTS.md`. Run it manually when validating a change, or wire it into a
-site-specific cron only after deciding that scheduled evals should be enabled for
-that installation.
+writes `RESULTS.md`. The scoreboard is **built into a temp sibling file
+(`RESULTS.md.tmp.$$`) and swapped in with a single atomic `mv -f`** — never
+truncated-then-appended in place — so a crash or concurrent run can never leave a
+partially-written scoreboard. Carry-forward rows for probes not run this
+invocation are read from a pre-write snapshot of the original file taken before
+the rewrite, never from the live file being replaced, so a filtered run cannot
+erase untouched rows.
 
 ### Runner aggregate exit code
 
@@ -104,5 +108,44 @@ above, which governs individual probe results).
 | `0` | No new green→red regressions this run. Pre-existing `REGRESSION` rows whose status is unchanged do **not** trigger a non-zero exit. |
 | `1` | One or more probes transitioned from a prior `PASS` to `REGRESSION` in this run. |
 
-This `0`/`1` contract is the gate callers should use when deciding whether a run
-is clean.
+This `0`/`1` contract is what the automation gate uses when checking whether a
+run is clean.
+
+## CI gate (`eval-probes`)
+
+The probe suite is wired into `.github/workflows/ci-harness.yml` as a third
+independent job, **`eval-probes`** (display name "Eval Probe Regression Gate"),
+running in parallel with `ci` and `boot-lint`. Its sole substantive step runs
+`bash .claude/skills/eval/run.sh` (the unfiltered runner), and the job — and so
+the pipeline — fails **iff** the runner exits non-zero (a new green→red
+regression this run). This makes the suite a live PR-time guardrail instead of a
+manual-`/eval`-only check.
+
+- **Triggers.** Runs on every pull request and on every push to
+  `development`/`main` whose changed paths match the workflow's path filters.
+  `evals/**` is one of those filters, so probe and `RESULTS.md` edits gate
+themselves.
+- **Git read-only.** The runner rewrites `evals/RESULTS.md` in the writable
+  checkout (expected), but the job gates **purely on the exit code** — it has no
+  `git add`/`commit`/`push` step, so the CI run never persists that churn back to
+  the branch.
+- **Self-guard.** The `eval-ci-gate` probe asserts the workflow still invokes
+  `bash .claude/skills/eval/run.sh`, so the gate itself cannot be silently
+  deleted.
+- **Escape hatch.** There is no merge-bypass label. To unblock a probe that is
+  false-failing CI, either (a) re-run the job — via the workflow's
+  `workflow_dispatch` trigger (Actions → "CI: Harness" → Run workflow) or by
+  re-running the failed check from the PR's Checks tab — if the failure was
+  transient, or (b) push a follow-up commit that fixes the offending probe, or
+  temporarily removes/SKIPs it (restoring it in a later commit).
+
+### Known limitation: `PASS→SKIPPED` is silent in CI
+
+A probe that is `PASS` in the committed `RESULTS.md` baseline but `SKIPPED`
+(exit 2) in a cold CI runner — no docker/tmux/live process — is **not** a
+regression: `run.sh` flags only a `PASS → REGRESSION|TIMEOUT|ERROR`
+transition. This is exactly what keeps the gate hermetic, but it also means a
+probe that should be exercising real state can silently degrade to a no-op in CI
+without failing the gate. Keeping the committed `RESULTS.md` fresh — so the
+baseline reflects each probe's true status — is the **operator's
+responsibility**; the `eval-probes` job does not commit or refresh it.

--- a/evals/RESULTS.md
+++ b/evals/RESULTS.md
@@ -6,10 +6,13 @@ probe id; git history is the time series.** Schema and exit-code semantics are i
 
 | probe | tier | last-run (UTC) | status | source |
 |-------|------|----------------|--------|--------|
-| clean-restore | A | 2026-06-12 02:34 | PASS | issue #412 — autopilot branch restore guard |
-| eval-gate | A | 2026-06-12 02:34 | PASS | issue #412 — autopilot eval gate |
-| eval-runner-exit | A | 2026-06-12 02:34 | PASS | issue #410 — eval runner aggregate exit contract |
-| health-check-docker-stats | A | 2026-06-12 02:34 | PASS | issue #408 — health-check in-container RAM reclaim |
-| skill-paths | A | 2026-06-12 02:34 | PASS | issue #408 — harness-audit & skill-lint stale path references |
+| clean-restore | A | 2026-06-14 00:44 | PASS | issue #412 — autopilot branch restore guard |
+| drift-check-cron-staleness-glob | A | 2026-06-14 00:44 | PASS | issue #415 |
+| eval-ci-gate | A | 2026-06-14 00:44 | PASS | issue #415 — eval probe suite gated in CI |
+| eval-gate | A | 2026-06-14 00:44 | PASS | issue #412 — autopilot eval gate |
+| eval-runner-exit | A | 2026-06-14 00:44 | PASS | issue #410 — eval runner aggregate exit contract |
+| health-check-docker-stats | A | 2026-06-14 00:44 | PASS | issue #408 — health-check in-container RAM reclaim |
+| memory-gitignore-claim | A | 2026-06-14 00:44 | PASS | issue #415 |
+| skill-paths | A | 2026-06-14 00:44 | PASS | issue #408 — harness-audit & skill-lint stale path references |
 
 <!-- benchmark: pass-rate = PASS / (PASS + REGRESSION + TIMEOUT); SKIPPED excluded -->

--- a/evals/probes/drift-check-cron-staleness-glob.sh
+++ b/evals/probes/drift-check-cron-staleness-glob.sh
@@ -1,0 +1,253 @@
+#!/usr/bin/env bash
+# tier: A
+# source: issue #415
+# desc: extract the LIVE Step C-2 bash block from drift-check SKILL.md and RUN it
+#       against fixtures (README-style, valid scheduled cron, disabled cron,
+#       missing schedule, empty schedules, invalid schedule) with RUNTIME_START
+#       before their mtimes; PASS only if the inert set includes the valid cron
+#       and excludes the README, disabled, missing, empty, and invalid fixtures.
+#       This is a behavioral extract-and-run probe (not a text-presence grep): a
+#       revert of Step C-2 to the raw `for f in crons/*.md` glob flags all
+#       fixtures and flips the probe to REGRESSION.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SKILL="${DRIFT_CHECK_SKILL:-$ROOT/.claude/skills/drift-check/SKILL.md}"
+
+# --- SKIPPED: hard prerequisites genuinely absent --------------------------
+if [[ ! -f "$SKILL" ]]; then
+  echo "SKIPPED: drift-check SKILL.md absent: $SKILL" >&2
+  exit 2
+fi
+if ! command -v stat >/dev/null 2>&1; then
+  echo "SKIPPED: stat unavailable — cannot exercise the mtime comparison" >&2
+  exit 2
+fi
+
+# --- Extract the live Step C-2 bash block ----------------------------------
+# Anchor on the heading line `**Step C-2 — compare cron file mtimes:**` (matched
+# without relying on the em-dash byte sequence), then capture the lines of the
+# first following ```bash fence up to its closing ```.
+BLOCK="$(awk '
+  /^\*\*Step C-2 /   { hit=1; next }
+  hit && /^```bash$/ { cap=1; next }
+  cap && /^```$/     { exit }
+  cap                { print }
+' "$SKILL")"
+
+{
+  echo "---- extracted Step C-2 block (from $SKILL) ----"
+  printf '%s\n' "$BLOCK"
+  echo "---- end extracted block ----"
+} >&2
+
+# --- REGRESSION: mis-extraction can never yield a false PASS ----------------
+if [[ -z "${BLOCK//[[:space:]]/}" ]]; then
+  echo "REGRESSION: Step C-2 bash block extraction was empty — heading/fence anchor broken in $SKILL" >&2
+  exit 1
+fi
+if ! printf '%s' "$BLOCK" | grep -qF 'crons/*.md'; then
+  echo "REGRESSION: extracted Step C-2 block does not iterate crons/*.md — wrong block captured" >&2
+  exit 1
+fi
+
+# --- SKIPPED: the behavioral predicate needs node + croner -------------------
+# The extracted Step C-2 block's is_valid_cron_schedule() shells out to `node`
+# and resolves the `croner` package from DRIFT_CHECK_ROOT/package.json (here
+# $ROOT). A cold CI runner (the eval-probes job: checkout + bash, no
+# `pnpm install`) has no node_modules/croner, so the predicate cannot run and the
+# valid-cron fixture would be mis-excluded — a false REGRESSION. SKIP when node or
+# croner is unavailable (the extraction-integrity checks above still gate in CI;
+# the full behavioral predicate is exercised by manual /eval and the weekly cron
+# where deps are installed). Mirrors the block's own croner resolution exactly.
+if ! command -v node >/dev/null 2>&1; then
+  echo "SKIPPED: node unavailable — Step C-2 schedule validation needs node + croner" >&2
+  exit 2
+fi
+if ! DRIFT_CHECK_ROOT="$ROOT" node --input-type=module -e '
+  import { createRequire } from "node:module";
+  const root = (process.env.DRIFT_CHECK_ROOT || process.cwd()).replace(/\/$/, "");
+  createRequire(`${root}/package.json`).resolve("croner");
+' >/dev/null 2>&1; then
+  echo "SKIPPED: croner not resolvable from $ROOT (no node_modules) — Step C-2 needs deps installed; skipping in this environment" >&2
+  exit 2
+fi
+
+# --- Fixtures: trap-based cleanup registered BEFORE any fixture exists ------
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+mkdir -p "$WORK/crons"
+
+# (a) README-style: first line is an H1, NO line-1 '---'. The '---' lines live
+#     inside a fenced code block — the crons/README.md trap. Must be EXCLUDED.
+cat > "$WORK/crons/aaa-readme.md" <<'EOF_A'
+# Crons Directory
+
+Not a cron — a directory README. The frontmatter below is an EXAMPLE inside a
+fenced code block and must not qualify this file as schedulable.
+
+```yaml
+---
+schedule: "0 * * * *"
+enabled: true
+---
+```
+EOF_A
+
+# (b) Valid scheduled cron: line-1 '---', anchored schedule:, enabled: true,
+#     closing '---'. Must be INCLUDED (flagged inert).
+cat > "$WORK/crons/bbb-valid.md" <<'EOF_B'
+---
+id: probe-valid
+schedule: "0 * * * *"
+timezone: UTC
+enabled: true
+---
+
+# Valid scheduled cron
+
+Body.
+EOF_B
+
+# (c) Disabled cron: schedule: present but enabled: false → loadCrons drops it.
+#     Must be EXCLUDED.
+cat > "$WORK/crons/ccc-disabled.md" <<'EOF_C'
+---
+id: probe-disabled
+schedule: "0 * * * *"
+enabled: false
+---
+
+# Disabled cron
+
+Body.
+EOF_C
+
+# (d) Missing schedule: parseCronFile returns null because fm.schedule is absent.
+#     Must be EXCLUDED.
+cat > "$WORK/crons/ddd-missing-schedule.md" <<'EOF_D'
+---
+id: probe-missing
+enabled: true
+---
+
+# Missing schedule cron
+
+Body.
+EOF_D
+
+# (e) Empty bare schedule: parseCronFile returns null because fm.schedule is empty.
+#     Must be EXCLUDED.
+cat > "$WORK/crons/eee-empty-schedule-bare.md" <<'EOF_E'
+---
+id: probe-empty-bare
+schedule:
+enabled: true
+---
+
+# Empty bare schedule cron
+
+Body.
+EOF_E
+
+# (f) Empty double-quoted schedule: parseCronFile strips quotes to empty.
+#     Must be EXCLUDED.
+cat > "$WORK/crons/fff-empty-schedule-double-quoted.md" <<'EOF_F'
+---
+id: probe-empty-double
+schedule: ""
+enabled: true
+---
+
+# Empty double-quoted schedule cron
+
+Body.
+EOF_F
+
+# (g) Empty single-quoted schedule: parseCronFile strips quotes to empty.
+#     Must be EXCLUDED.
+cat > "$WORK/crons/ggg-empty-schedule-single-quoted.md" <<'EOF_G'
+---
+id: probe-empty-single
+schedule: ''
+enabled: true
+---
+
+# Empty single-quoted schedule cron
+
+Body.
+EOF_G
+
+# (h) Invalid cron: frontmatter and schedule key exist, but Croner rejects it.
+#     loadCrons logs SCHED_INVALID and drops it, so it must be EXCLUDED.
+cat > "$WORK/crons/hhh-invalid-schedule-not-a-cron.md" <<'EOF_H'
+---
+id: probe-invalid
+schedule: "not-a-cron"
+enabled: true
+---
+
+# Invalid cron
+
+Body.
+EOF_H
+
+printf '%s' "$BLOCK" > "$WORK/block.sh"
+
+# --- Run the extracted predicate against the fixtures ----------------------
+# RUNTIME_START=1 (epoch 1s) sits before every freshly-written fixture mtime, so
+# under the OLD raw-glob logic ALL fixtures would be flagged inert; only the
+# corrected predicate excludes the non-cron (a), disabled cron (c), missing
+# schedule (d), empty schedules (e-g), and invalid schedule (h).
+# The block prints one `DRIFT-CHECK (C): crons/<file> ...` line per inert file —
+# we read that observable contract rather than the internal INERT array name.
+output="$(cd "$WORK" && DRIFT_CHECK_ROOT="$ROOT" RUNTIME_START=1 bash block.sh 2>/dev/null)" || true
+
+inert_contains() { printf '%s\n' "$output" | grep -q "$1"; }
+
+fail=0
+if inert_contains "aaa-readme.md"; then
+  echo "REGRESSION: README-style fixture (no line-1 ---) was flagged inert — predicate over-includes a non-cron" >&2
+  fail=1
+fi
+if ! inert_contains "bbb-valid.md"; then
+  echo "REGRESSION: valid scheduled cron was NOT flagged inert — predicate over-excludes a real cron" >&2
+  fail=1
+fi
+if inert_contains "ccc-disabled.md"; then
+  echo "REGRESSION: disabled cron (enabled: false) was flagged inert — predicate ignores the enabled toggle" >&2
+  fail=1
+fi
+if inert_contains "ddd-missing-schedule.md"; then
+  echo "REGRESSION: missing schedule was flagged inert — predicate diverges from parseCronFile/loadCrons skip" >&2
+  fail=1
+fi
+if inert_contains "eee-empty-schedule-bare.md"; then
+  echo "REGRESSION: empty bare schedule was flagged inert — predicate diverges from parseCronFile/loadCrons skip" >&2
+  fail=1
+fi
+if inert_contains "fff-empty-schedule-double-quoted.md"; then
+  echo "REGRESSION: empty double-quoted schedule was flagged inert — predicate diverges from parseCronFile/loadCrons skip" >&2
+  fail=1
+fi
+if inert_contains "ggg-empty-schedule-single-quoted.md"; then
+  echo "REGRESSION: empty single-quoted schedule was flagged inert — predicate diverges from parseCronFile/loadCrons skip" >&2
+  fail=1
+fi
+if inert_contains "hhh-invalid-schedule-not-a-cron.md"; then
+  echo "REGRESSION: invalid schedule was flagged inert — predicate diverges from runtime SCHED_INVALID skip" >&2
+  fail=1
+fi
+
+if (( fail )); then
+  {
+    echo "  --- inert output from extracted block was: ---"
+    printf '%s\n' "$output"
+    echo "  --- end inert output ---"
+  } >&2
+  echo "REGRESSION: drift-check Step C-2 predicate does not match the schedulable-cron contract" >&2
+  exit 1
+fi
+
+echo "PASS: drift-check Step C-2 includes the valid scheduled cron and excludes README-style, disabled, missing, empty, and invalid fixtures" >&2
+exit 0

--- a/evals/probes/eval-ci-gate.sh
+++ b/evals/probes/eval-ci-gate.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# tier: A
+# source: issue #415 — eval probe suite gated in CI
+# desc: string-presence (not semantic) check — the eval-probes CI job's runner invocation `bash .claude/skills/eval/run.sh` must stay in ci-harness.yml so the regression gate can't be silently deleted
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WORKFLOW="$ROOT/.github/workflows/ci-harness.yml"
+
+if [[ ! -f "$WORKFLOW" ]]; then
+  echo "SKIPPED: workflow file absent: $WORKFLOW" >&2
+  exit 2
+fi
+
+# Unanchored match: the invocation is indented under the eval-probes job's
+# `run:` step, so a `^bash` anchor would match nothing. Mirror boot-lint-glob.sh.
+if grep -q 'bash .claude/skills/eval/run.sh' "$WORKFLOW"; then
+  echo "PASS: eval-probes CI gate invokes 'bash .claude/skills/eval/run.sh' in $WORKFLOW" >&2
+  exit 0
+fi
+
+echo "REGRESSION: eval-probes CI gate removed — no 'bash .claude/skills/eval/run.sh' invocation in $WORKFLOW" >&2
+exit 1

--- a/evals/probes/memory-gitignore-claim.sh
+++ b/evals/probes/memory-gitignore-claim.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# tier: A
+# source: issue #415
+# desc: context/rules/memory.md must not claim daily logs are git-tracked, and .gitignore must keep ignoring memory/[0-9]*/ so the false "tracked inside" persistence claim cannot return
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+GITIGNORE="$ROOT/.gitignore"
+RULE="$ROOT/context/rules/memory.md"
+
+# SKIPPED guard: a grep against a missing file would silently false-PASS
+# Assertion B (grep -q on absent file exits non-zero → "not present"), so
+# bail out as SKIPPED if EITHER input file is absent.
+if [[ ! -f "$GITIGNORE" ]]; then
+  echo "SKIPPED: gitignore file absent: $GITIGNORE" >&2
+  exit 2
+fi
+if [[ ! -f "$RULE" ]]; then
+  echo "SKIPPED: rule file absent: $RULE" >&2
+  exit 2
+fi
+
+# Assertion A: an UNCOMMENTED `memory/[0-9]*/` line must exist in .gitignore.
+# Strip comment lines first so a commented-out `# memory/[0-9]*/` cannot
+# false-PASS. The pattern is a literal string in the ignore file, so match
+# fixed (-F), not as a regex.
+if ! grep -v '^[[:space:]]*#' "$GITIGNORE" | grep -qF 'memory/[0-9]*/'; then
+  echo "REGRESSION: uncommented 'memory/[0-9]*/' ignore rule missing from $GITIGNORE" >&2
+  exit 1
+fi
+
+# Assertion B: the corrected rule must NOT reassert the false claim. The
+# literal 'tracked inside' string was the false daily-log persistence claim.
+if grep -qF 'tracked inside' "$RULE"; then
+  echo "REGRESSION: false 'tracked inside' daily-log claim returned to $RULE" >&2
+  exit 1
+fi
+
+echo "PASS: .gitignore keeps ignoring memory/[0-9]*/ and context/rules/memory.md drops the false 'tracked inside' claim" >&2
+exit 0

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -222,6 +222,7 @@ else
   __HAS_OLD=0; __HAS_NEW=0
   [ -d "$OLD_REPO/.git" ] && __HAS_OLD=1
   if [ -d "$REPO_DIR" ] && [ ! -d "$REPO_DIR/.git" ]; then
+    # shellcheck disable=SC2088  # ~ is intentional display text in this user-facing message; do not substitute $HOME
     die "~/.openharness exists but is not a git clone. Inspect and remove it, then re-run."
   fi
   [ -d "$REPO_DIR/.git" ] && __HAS_NEW=1


### PR DESCRIPTION
Closes #415

## Summary

- Adds an eval probe CI gate, atomic `/eval` scoreboard writes, and new public probes for eval CI coverage, drift-check cron qualification, and memory daily-log persistence wording.
- Ports public-safe Pi defaults for `pi-goal` and `pi-tasks`, with docs and a settings regression test.
- Adds the public-safe `/pr-audit` skill surface.
- Preserves public cleanup: no private task/wiki/memory/doc-agent artifacts, no timezone reversion, and no private marker additions.

## Validation

- `bash .claude/skills/eval/run.sh`
- `shellcheck -S warning .devcontainer/*.sh install/*.sh scripts/*.sh workspace/*.sh`
- `pnpm run typecheck`
- `pnpm run test`
- `pnpm run build`
- public-marker scan on added lines: clean
- delegated reviews: public-safety `PUBLIC_SAFE: yes`; diff re-review `BLOCKERS: none`
