### PR TITLE
feat: default autopilot to upstream repo

### DIFF
--- a/.claude/skills/autopilot/SKILL.md
+++ b/.claude/skills/autopilot/SKILL.md
@@ -15,7 +15,7 @@ description: |
   autopilot PRs created per UTC day AND 10 total open; never auto-merges.
   TRIGGER when: the hourly crons/autopilot.md fires, or invoked manually on
   demand (e.g. /autopilot --dry-run to preview the next selection).
-argument-hint: "[--dry-run] [--executor=delegate-advisor|ralph]"
+argument-hint: "[--dry-run] [--executor=delegate-advisor|ralph] [--repo <owner/name>] [--remote <name>] [--base <branch>]"
 ---
 
 # Autopilot
@@ -28,6 +28,8 @@ When fired by the hourly cron, the run lives in its own detached Pi tmux session
 
 `--dry-run` prints the selection decision (queue ticket or research finding), executor mode, dedupe state, and open-PR counts, then exits without calling `/ship-spec`, `/delegate`, or the Ralph runner and without touching git or GitHub.
 
+**Default target repo:** future autopilot runs act on canonical upstream by default: `AUTOPILOT_REPO=mifunedev/openharness`, `AUTOPILOT_REMOTE=upstream`, and `AUTOPILOT_BASE=development`. The checkout may still have `origin` pointed at a personal fork; do not let implicit `gh` repo resolution or `git push origin` send autopilot issues/PRs there. Operators can override with `--repo`, `--remote`, `--base`, or the matching `AUTOPILOT_*` env vars.
+
 ## Instructions
 
 ### 1. Guardrails
@@ -37,14 +39,21 @@ Order matters — cheapest exits first.
 **Ensure the GitHub labels exist** (idempotent — safe every pulse):
 
 ```bash
-gh label create autopilot --color 6E40C9 --description "Opened by the autopilot loop" 2>/dev/null || true
-gh label create autopilot-blocked --color B60205 --description "Autopilot ticket blocked by a critic gate; remove to retry" 2>/dev/null || true
+AUTOPILOT_REPO="${AUTOPILOT_REPO:-mifunedev/openharness}"
+AUTOPILOT_REMOTE="${AUTOPILOT_REMOTE:-upstream}"
+AUTOPILOT_BASE="${AUTOPILOT_BASE:-development}"
+case "${ARGUMENTS:-}" in *--repo*) AUTOPILOT_REPO=$(printf '%s\n' "$ARGUMENTS" | sed -n 's/.*--repo[ =]\([^ ]*\).*/\1/p') ;; esac
+case "${ARGUMENTS:-}" in *--remote*) AUTOPILOT_REMOTE=$(printf '%s\n' "$ARGUMENTS" | sed -n 's/.*--remote[ =]\([^ ]*\).*/\1/p') ;; esac
+case "${ARGUMENTS:-}" in *--base*) AUTOPILOT_BASE=$(printf '%s\n' "$ARGUMENTS" | sed -n 's/.*--base[ =]\([^ ]*\).*/\1/p') ;; esac
+echo "autopilot target: repo=$AUTOPILOT_REPO remote=$AUTOPILOT_REMOTE base=$AUTOPILOT_BASE"
+gh label create autopilot --repo "$AUTOPILOT_REPO" --color 6E40C9 --description "Opened by the autopilot loop" 2>/dev/null || true
+gh label create autopilot-blocked --repo "$AUTOPILOT_REPO" --color B60205 --description "Autopilot ticket blocked by a critic gate; remove to retry" 2>/dev/null || true
 ```
 
 **Total-open ceiling** — at most 10 open autopilot PRs at any time (any age):
 
 ```bash
-TOTAL_OPEN=$(gh pr list --state open --label autopilot --json number --jq 'length')
+TOTAL_OPEN=$(gh pr list --repo "$AUTOPILOT_REPO" --state open --label autopilot --json number --jq 'length')
 echo "total open autopilot PRs: $TOTAL_OPEN (ceiling 10)"
 ```
 
@@ -54,7 +63,7 @@ If `$TOTAL_OPEN` ≥ 10 → memory log `Result: SKIPPED-CAP-TOTAL`, liveness `SK
 
 ```bash
 TODAY=$(date -u +%Y-%m-%d)
-OPEN_TODAY=$(gh pr list --state open --search "label:autopilot created:>=$TODAY" --json number --jq 'length')
+OPEN_TODAY=$(gh pr list --repo "$AUTOPILOT_REPO" --state open --search "label:autopilot created:>=$TODAY" --json number --jq 'length')
 echo "open autopilot PRs created today: $OPEN_TODAY (cap 6)"
 ```
 
@@ -108,14 +117,14 @@ fi
 
 If the OWNED surface is dirty, log `Result: BLOCKED-OWNED-WIP` + `Observation: dirty owned surface; run skipped until it is clean (foreign WIP untouched)` and exit 1 without touching GitHub — the distinct token (not bare `FAIL`) keeps a genuine owned-WIP stall visible to the heartbeat rather than looking idle. If instead HEAD is not on `development`, log `Result: FAIL` + `Observation: wrong branch` and exit 1.
 
-**Sync with origin** (mandatory — a stale `development` base means dedupe misses fresh merges and the run branches off old code):
+**Sync with target remote** (mandatory — a stale base means dedupe misses fresh merges and the run branches off old code):
 
 ```bash
-git fetch origin development
-git merge --ff-only origin/development || { echo "ERROR: development diverged from origin"; exit 1; }
+git fetch "$AUTOPILOT_REMOTE" "$AUTOPILOT_BASE"
+git merge --ff-only "$AUTOPILOT_REMOTE/$AUTOPILOT_BASE" || { echo "ERROR: $AUTOPILOT_BASE diverged from $AUTOPILOT_REMOTE"; exit 1; }
 ```
 
-If the fast-forward fails, log `Result: FAIL` + `Observation: development diverged from origin/development; manual reconcile needed` and exit 1 without touching GitHub.
+If the fast-forward fails, log `Result: FAIL` + `Observation: $AUTOPILOT_BASE diverged from $AUTOPILOT_REMOTE/$AUTOPILOT_BASE; manual reconcile needed` and exit 1 without touching GitHub.
 
 **Capture the tmux session context** (set by the cron runtime when `tmux: true`; EMPTY when invoked manually — every tmux step below must no-op when empty):
 
@@ -147,7 +156,7 @@ GitHub issues labeled `autopilot` ARE the work queue. There are no time throttle
 **Queue check** — actionable = open, labeled `autopilot`, NOT labeled `autopilot-blocked`, and with no linked PR (GitHub's `linked:pr` qualifier matches PRs with closing keywords — our `Closes #N` convention):
 
 ```bash
-gh issue list --state open --label autopilot \
+gh issue list --repo "$AUTOPILOT_REPO" --state open --label autopilot \
   --search "-linked:pr -label:autopilot-blocked" \
   --json number,title,createdAt --jq 'sort_by(.createdAt)'
 ```
@@ -162,8 +171,8 @@ gh issue list --state open --label autopilot \
   BRANCH="feat/$ISSUE_NUM-$SLUG"
   SAFE_SESSION=$(safe_branch_session "$BRANCH")   # autopilot-feat-123-slug
   ACTIVE_MARKER="/tmp/$SAFE_SESSION.active"
-  LINKED_PR=$(gh pr list --state open --head "$BRANCH" --json number --jq '.[0].number // empty')
-  LINKED_ISSUE_PR=$(gh issue list --state open --label autopilot --search "$ISSUE_NUM linked:pr" --json number --jq '.[0].number // empty')
+  LINKED_PR=$(gh pr list --repo "$AUTOPILOT_REPO" --state open --head "$BRANCH" --json number --jq '.[0].number // empty')
+  LINKED_ISSUE_PR=$(gh issue list --repo "$AUTOPILOT_REPO" --state open --label autopilot --search "$ISSUE_NUM linked:pr" --json number --jq '.[0].number // empty')
   if tmux has-session -t "$SAFE_SESSION" 2>/dev/null || [ -n "$LINKED_PR" ] || [ -n "$LINKED_ISSUE_PR" ] || [ -e "$ACTIVE_MARKER" ]; then
     echo "DEDUPE: issue #$ISSUE_NUM / $SLUG already active (session=$SAFE_SESSION pr=$LINKED_PR linked_issue_pr=$LINKED_ISSUE_PR marker=$ACTIVE_MARKER); skipping"
     # memory log Result: NOTHING-NEW, liveness NOTHING-NEW, exit 0; do not touch keep-marker.
@@ -180,14 +189,14 @@ gh issue list --state open --label autopilot \
 1. Run `/harness-audit`. Rank its harness-infra findings by impact.
 2. Dedupe each finding (in rank order) against open issues, open PRs, **and merged PRs** — advance past any hit (a blocked candidate must never end the run while others remain):
    ```bash
-   DUPE_OPEN_ISSUE=$(gh issue list --state open --json title --jq '.[].title' | grep -i "$SLUG" || true)
-   DUPE_OPEN_PR=$(gh pr list --state open --json title,headRefName --jq '.[] | "\(.title) \(.headRefName)"' | grep -i "$SLUG" || true)
-   DUPE_MERGED_PR=$(gh pr list --state merged --limit 50 --json number,title,headRefName --jq '.[] | "\(.number) \(.title) \(.headRefName)"' | grep -i "$SLUG" || true)
+   DUPE_OPEN_ISSUE=$(gh issue list --repo "$AUTOPILOT_REPO" --state open --json title --jq '.[].title' | grep -i "$SLUG" || true)
+   DUPE_OPEN_PR=$(gh pr list --repo "$AUTOPILOT_REPO" --state open --json title,headRefName --jq '.[] | "\(.title) \(.headRefName)"' | grep -i "$SLUG" || true)
+   DUPE_MERGED_PR=$(gh pr list --repo "$AUTOPILOT_REPO" --state merged --limit 50 --json number,title,headRefName --jq '.[] | "\(.number) \(.title) \(.headRefName)"' | grep -i "$SLUG" || true)
    ```
 3. **No survivor** → memory log `Result: NOTHING-NEW`, liveness `NOTHING-NEW`, exit 0 (no keep-marker). Research fires whenever no actionable ticket exists — both when the queue is fully drained AND when open tickets are all awaiting review. Dedupe (against open issues, open PRs, and merged PRs) plus the §1 caps bound the output: an already-filed finding dedupes to `NOTHING-NEW`; worst case an hourly audit yields `NOTHING-NEW` repeatedly — accepted cost.
 4. **Top survivor** → write a body to `/tmp/autopilot-research-$$.md` containing (a) the finding, (b) the first-principles rationale, (c) a 3–7-bullet plan sketch. If `--dry-run` is set, print the would-file finding in the dry-run block below and exit before any `gh issue create` mutation. Otherwise file the ticket from the plan:
    ```bash
-   gh issue create --label autopilot --title "feat: <finding>" --body-file /tmp/autopilot-research-$$.md
+   gh issue create --repo "$AUTOPILOT_REPO" --label autopilot --title "feat: <finding>" --body-file /tmp/autopilot-research-$$.md
    ```
    Capture `ISSUE_NUM`; derive `SLUG` from the title. Set:
    ```
@@ -213,7 +222,7 @@ In `--dry-run`, the research path ranks findings but MUST NOT `gh issue create` 
 Invoke the `pm` agent via the `Agent` tool with `subagent_type: pm`. The input is the **ticket body** — identical for queue tickets (user- or prior-run-filed) and just-created research tickets:
 
 ```bash
-gh issue view "$ISSUE_NUM" --json title,body --jq '"\(.title)\n\n\(.body)"'
+gh issue view "$ISSUE_NUM" --repo "$AUTOPILOT_REPO" --json title,body --jq '"\(.title)\n\n\(.body)"'
 ```
 
 Pass a 5-field advisor-model briefing:
@@ -232,7 +241,7 @@ Pass a 5-field advisor-model briefing:
 - A one-sentence feature description suitable for /ship-spec (≤ ~120 chars).
 - A bullet-list implementation plan (3–7 items).
 
-**Start here**: the ticket body (`gh issue view $ISSUE_NUM`), memory/MEMORY.md (recent context).
+**Start here**: the ticket body (`gh issue view $ISSUE_NUM --repo $AUTOPILOT_REPO`), memory/MEMORY.md (recent context).
 
 **Out of scope**: PRD JSON generation, branch creation, git operations.
 ```
@@ -245,14 +254,14 @@ In `delegate-advisor` mode, set the active goal with this exact phrase (preserve
 /goal Audit plan /w @"pm (agent)" using ultrathink, then run /ship-spec --issue to build it end-to-end (worktree Advisor, /delegate + ralph, /eval, /pr-audit undraft) into a ready-for-review PR
 ```
 
-Include `ISSUE_NUM`, `SLUG`, `BRANCH`, `SELECTION_RATIONALE`, `PM_DESC`, and `PM_PLAN` immediately under the goal prompt so the Advisor can audit the plan and run `/ship-spec`, which now owns the rest of the build (compacts, the worktree Advisor + `/delegate` + ralph, `/eval`, and the `/pr-audit` undraft) — autopilot does not re-run those steps itself.
+Include `ISSUE_NUM`, `SLUG`, `BRANCH`, `AUTOPILOT_REPO`, `AUTOPILOT_REMOTE`, `AUTOPILOT_BASE`, `SELECTION_RATIONALE`, `PM_DESC`, and `PM_PLAN` immediately under the goal prompt so the Advisor can audit the plan and run `/ship-spec`, which now owns the rest of the build (compacts, the worktree Advisor + `/delegate` + ralph, `/eval`, and the `/pr-audit` undraft) — autopilot does not re-run those steps itself.
 
 ### 4. /ship-spec --issue (owns the full build)
 
 In `delegate-advisor` mode the active `/goal` drives this step from the PM plan. Run `/ship-spec` against the existing ticket (the `--issue` flag links it instead of opening a duplicate):
 
 ```
-/ship-spec "$PM_DESC" --plan <PM_PLAN content> --prefix feat --issue $ISSUE_NUM
+/ship-spec "$PM_DESC" --plan <PM_PLAN content> --prefix feat --issue $ISSUE_NUM --repo "$AUTOPILOT_REPO" --remote "$AUTOPILOT_REMOTE" --base "$AUTOPILOT_BASE"
 ```
 
 `/ship-spec` now runs the **entire pipeline**: `/prd` → 2 critics → (skips issue creation, reuses #$ISSUE_NUM) → `/ralph` (JSON) → branch `feat/$ISSUE_NUM-$SLUG` → draft PR → `/compact` (before implement) → an expert `/worktrees` Advisor in its own `agent-ship-<slug>` tmux session that drives `/delegate` workers each running `scripts/ralph.sh` → `/eval` → `/compact` (after implement) → `/pr-audit` promotable → `gh pr ready` (or left draft with a comment). **Capture `PR_NUM`, the actual `BRANCH`, and ship-spec's terminal status (`READY` or `DRAFT-BLOCKED`).** After the branch exists, ensure the cron tmux session is named `$(safe_branch_session "$BRANCH")` (for example `autopilot-feat-123-slug`) and keep `ACTIVE_MARKER=/tmp/$(safe_branch_session "$BRANCH").active` until the run is finalized or left for manual continuation.
@@ -262,24 +271,24 @@ Because `/ship-spec` owns implement → eval → audit → undraft, **§5–§7 
 **Critic HALT handling** — if `/ship-spec` emits `HALT` (critic gate rejected the spec):
 - Comment the verdict on the ticket and block it so it can't retry-loop hourly:
   ```bash
-  gh issue comment "$ISSUE_NUM" --body "autopilot: /ship-spec critic gate rejected the spec. Verdict: <summary>. Labeled autopilot-blocked; remove the label to retry."
-  gh issue edit "$ISSUE_NUM" --add-label autopilot-blocked
+  gh issue comment "$ISSUE_NUM" --repo "$AUTOPILOT_REPO" --body "autopilot: /ship-spec critic gate rejected the spec. Verdict: <summary>. Labeled autopilot-blocked; remove the label to retry."
+  gh issue edit "$ISSUE_NUM" --repo "$AUTOPILOT_REPO" --add-label autopilot-blocked
   cleanup_active_marker
   ```
 - Memory log `Result: HALT-CRITIC-GATE`, liveness `HALT-CRITIC-GATE`, exit 0 (no PR → no keep-marker and no active-marker).
 
 **Add the `autopilot` label** to the PR:
 ```bash
-gh pr edit "$PR_NUM" --add-label autopilot
+gh pr edit "$PR_NUM" --repo "$AUTOPILOT_REPO" --add-label autopilot
 ```
 
 **State the selection rationale in the PR description** (mandatory — every autopilot PR explains why this item was chosen this session). Idempotent; prepends a `## Selection rationale` section so it is the first thing a reviewer reads:
 
 ```bash
-if ! gh pr view "$PR_NUM" --json body --jq .body | grep -q "## Selection rationale"; then
-  BODY=$(gh pr view "$PR_NUM" --json body --jq .body)
+if ! gh pr view "$PR_NUM" --repo "$AUTOPILOT_REPO" --json body --jq .body | grep -q "## Selection rationale"; then
+  BODY=$(gh pr view "$PR_NUM" --repo "$AUTOPILOT_REPO" --json body --jq .body)
   printf '## Selection rationale\n\n%s\n\n---\n\n%s\n' "$SELECTION_RATIONALE" "$BODY" > "/tmp/autopilot-pr-$PR_NUM.md"
-  gh pr edit "$PR_NUM" --body-file "/tmp/autopilot-pr-$PR_NUM.md"
+  gh pr edit "$PR_NUM" --repo "$AUTOPILOT_REPO" --body-file "/tmp/autopilot-pr-$PR_NUM.md"
   rm -f "/tmp/autopilot-pr-$PR_NUM.md"
 fi
 ```
@@ -294,7 +303,7 @@ Dispatch by executor. In `delegate-advisor` mode `/ship-spec` (§4) has already 
 
 **Delegate-advisor failure compensation** — if `/ship-spec` returns `DRAFT-BLOCKED` because its implement/`/delegate` phase failed, stalled, or left acceptance criteria incomplete (eval/CI reds are reconciled in §6/§7):
 ```bash
-gh pr comment "$PR_NUM" --body "autopilot: /ship-spec did not complete tasks/$SLUG/prd.json (implement/delegate phase). PR left draft; attach to tmux session $SESSION (or agent-ship-$SLUG) and resume. Status: DELEGATE-FAIL."
+gh pr comment "$PR_NUM" --repo "$AUTOPILOT_REPO" --body "autopilot: /ship-spec did not complete tasks/$SLUG/prd.json (implement/delegate phase). PR left draft; attach to tmux session $SESSION (or agent-ship-$SLUG) and resume. Status: DELEGATE-FAIL."
 ```
 - Memory log `Result: DELEGATE-FAIL`, liveness `DELEGATE-FAIL`, **persist the session** (`[ -n "$KEEP" ] && touch "$KEEP"`), leave `ACTIVE_MARKER` in place for duplicate suppression, the canonical scoped restore (`git checkout development -- "${OWNED_PATHS[@]}"` then `git checkout development`, then assert `git diff --quiet -- "${OWNED_PATHS[@]}" && git diff --cached --quiet -- "${OWNED_PATHS[@]}" || { echo "ERROR: autopilot restore left a dirty owned tree"; exit 1; }` and `[ "$(git rev-parse --abbrev-ref HEAD)" = "development" ] || exit 1`), exit 1 (non-destructive — never auto-close the issue or PR).
 
@@ -324,7 +333,7 @@ done
 **Ralph-incomplete compensation** — the partial implementation is committed on the branch and the four-file task state is resumable:
 ```bash
 tmux kill-session -t "$SLUG" 2>/dev/null || true
-gh pr comment "$PR_NUM" --body "autopilot: Ralph loop did not reach STATUS: COMPLETE (timeout / exhausted / error). PR left draft; tasks/$SLUG/ state is resumable — re-run \`scripts/ralph.sh $SLUG\` to continue. Status: RALPH-INCOMPLETE."
+gh pr comment "$PR_NUM" --repo "$AUTOPILOT_REPO" --body "autopilot: Ralph loop did not reach STATUS: COMPLETE (timeout / exhausted / error). PR left draft; tasks/$SLUG/ state is resumable — re-run \`scripts/ralph.sh $SLUG\` to continue. Status: RALPH-INCOMPLETE."
 ```
 - Memory log `Result: RALPH-INCOMPLETE`, liveness `RALPH-INCOMPLETE`, **persist the session** (`[ -n "$KEEP" ] && touch "$KEEP"`), leave `ACTIVE_MARKER` in place for duplicate suppression, the canonical scoped restore (`git checkout development -- "${OWNED_PATHS[@]}"` then `git checkout development`, then assert `git diff --quiet -- "${OWNED_PATHS[@]}" && git diff --cached --quiet -- "${OWNED_PATHS[@]}" || { echo "ERROR: autopilot restore left a dirty owned tree"; exit 1; }` and `[ "$(git rev-parse --abbrev-ref HEAD)" = "development" ] || exit 1`), exit 1 (non-destructive — never auto-close the issue or PR).
 
@@ -343,14 +352,14 @@ gh pr comment "$PR_NUM" --body "autopilot: Ralph loop did not reach STATUS: COMP
   git add evals/RESULTS.md && git commit -m "$(printf 'task: refresh evals benchmark\n\nSubmitted-by: %s\n' "${RALPH_HARNESS:-Claude}")" || true
   ```
 
-**Decision rule** (ralph fallback) — key on the runner's exit code and the green→red **delta**, NOT on the bare presence of a `REGRESSION` row in `evals/RESULTS.md`. A probe that was already red on the base (`origin/development`) is **pre-existing** — this PR did not cause it, so it must not block. **PROCEED** to §7 when BOTH of these hold:
+**Decision rule** (ralph fallback) — key on the runner's exit code and the green→red **delta**, NOT on the bare presence of a `REGRESSION` row in `evals/RESULTS.md`. A probe that was already red on the base (`$AUTOPILOT_REMOTE/$AUTOPILOT_BASE`) is **pre-existing** — this PR did not cause it, so it must not block. **PROCEED** to §7 when BOTH of these hold:
 
 1. the `/eval` runner exited `0`, AND
 2. every regressed probe's delta is `unchanged` vs the base (already-red — NOT a NEW green→red transition).
 
 **Keep the PR draft** (status `PR-DRAFT-EVAL-RED`) only on a **NEW (green→red) regression OR a non-zero runner exit**:
   ```bash
-  gh pr comment "$PR_NUM" --body "autopilot: /eval reported a NEW (green→red) probe regression (<probe ids>) or a non-zero runner exit. PR left draft; resolve before marking ready."
+  gh pr comment "$PR_NUM" --repo "$AUTOPILOT_REPO" --body "autopilot: /eval reported a NEW (green→red) probe regression (<probe ids>) or a non-zero runner exit. PR left draft; resolve before marking ready."
   ```
   Memory log `Result: PR-DRAFT-EVAL-RED`, liveness `PR-DRAFT-EVAL-RED`, then `[ -n "$KEEP" ] && touch "$KEEP"`, `cleanup_active_marker`, the canonical scoped restore (`git checkout development -- "${OWNED_PATHS[@]}"` then `git checkout development`, then assert `git diff --quiet -- "${OWNED_PATHS[@]}" && git diff --cached --quiet -- "${OWNED_PATHS[@]}" || { echo "ERROR: autopilot restore left a dirty owned tree"; exit 1; }` and `[ "$(git rev-parse --abbrev-ref HEAD)" = "development" ] || exit 1`), exit.
 
@@ -369,19 +378,19 @@ gh pr comment "$PR_NUM" --body "autopilot: Ralph loop did not reach STATUS: COMP
 
 **Push the branch**:
 ```bash
-git push origin HEAD
+git push "$AUTOPILOT_REMOTE" HEAD
 ```
 
 **Undraft gate** — run `/pr-audit` focused on this PR and key on its draft sub-status:
 
 - **Promotable** (`/pr-audit` reports CI green + mergeable + clean):
   ```bash
-  gh pr ready "$PR_NUM"
+  gh pr ready "$PR_NUM" --repo "$AUTOPILOT_REPO"
   ```
   Memory log `Result: PR-READY`, liveness `PR-READY`.
 - **Not promotable** (red/pending CI, conflicts, or `/pr-audit` could not classify):
   - Leave the PR **draft** (do NOT call `gh pr ready`).
-  - `gh pr comment "$PR_NUM" --body "autopilot: /pr-audit did not classify this PR promotable (CI red/pending or conflicts). PR left draft. Resolve and mark ready manually."`
+  - `gh pr comment "$PR_NUM" --repo "$AUTOPILOT_REPO" --body "autopilot: /pr-audit did not classify this PR promotable (CI red/pending or conflicts). PR left draft. Resolve and mark ready manually."`
   - Memory log `Result: PR-DRAFT-CI-RED`, liveness `PR-DRAFT-CI-RED`.
 
 **Never call `gh pr merge`** — autopilot does not auto-merge under any condition.

--- a/.claude/skills/pr-audit/SKILL.md
+++ b/.claude/skills/pr-audit/SKILL.md
@@ -169,7 +169,7 @@ surfaces as a draft sub-status, never as an actionable alarm.
 | ✅ **promotable** | `mergeable=="MERGEABLE" && mergeStateStatus=="CLEAN" && ci=="PASS"` | green WIP — could be marked ready (`gh pr ready <N>`) |
 | 🚧 **still-WIP** | otherwise (red/pending CI, or `CONFLICTING`/`DIRTY`/`BEHIND`) | expected work-in-progress; informational only, never a "fix me" alarm |
 
-A stale draft (💤, below) is *draft-limbo* — promote or close.
+A stale draft (💤, below) is *draft-limbo* — route to `/watchdog` to complete the branch and mark ready when green, or close only if explicitly abandoned.
 
 **Orthogonal flags — tag any PR regardless of its primary state:**
 
@@ -202,7 +202,7 @@ lists the recommended read-only command (report-and-recommend, like
 |----|-------|-----------|-----|-------|-----------|
 | #68 | … | ✅ promotable | 2d | — | mark ready (`gh pr ready 68`) |
 | #72 | … | 🚧 still-WIP  | 1d | — | finish work; no action |
-| #41 | … | 🚧 still-WIP  | 21d | 💤 limbo | promote or close |
+| #41 | … | 🚧 still-WIP  | 21d | 💤 limbo | `/watchdog`: complete branch, then `gh pr ready` |
 
 ### Flag rollup
 💤 stale: #41   📐 convention: #73 (title), #55 (base≠development)

--- a/.claude/skills/ship-spec/SKILL.md
+++ b/.claude/skills/ship-spec/SKILL.md
@@ -8,7 +8,7 @@ description: |
   implementation, eval, and CI gates pass.
   TRIGGER when: asked to scaffold a spec end-to-end, "ship a spec",
   "set up a task PR", or after planning a feature and ready to formalize.
-argument-hint: "<feature-description> [--plan <path>] [--prefix feat|bug|task|audit|skill|agent] [--issue <N>]"
+argument-hint: "<feature-description> [--plan <path>] [--prefix feat|bug|task|audit|skill|agent] [--issue <N>] [--repo <owner/name>] [--remote <name>] [--base <branch>]"
 ---
 
 # Ship Spec
@@ -50,6 +50,19 @@ Extract:
 - **`--plan <path>`** (optional) — if provided, use the file content as comprehensive input to `/prd` and skip clarifying questions
 - **`--prefix <type>`** (optional, default `feat`) — branch + issue prefix per `.claude/rules/git.md` (`feat | bug | task | audit | skill | agent`)
 - **`--issue <N>`** (optional) — link an EXISTING GitHub issue instead of creating one. When present, set `ISSUE_NUM=<N>` and skip Stage 5's `gh issue create`; `<N>` flows into the branch (`<prefix>/<N>-<slug>`), `/ralph --issue <N>`, `prompt.md`, and the PR `Closes #<N>` link, exactly as a freshly-created issue number would
+- **`--repo <owner/name>`** (optional, default `mifunedev/openharness`) — GitHub repository for issue/PR operations.
+- **`--remote <name>`** (optional, default `upstream`) — git remote to fetch/push work branches.
+- **`--base <branch>`** (optional, default `development`) — PR base and branch start point.
+
+```bash
+SHIP_SPEC_REPO="${SHIP_SPEC_REPO:-mifunedev/openharness}"
+SHIP_SPEC_REMOTE="${SHIP_SPEC_REMOTE:-upstream}"
+SHIP_SPEC_BASE="${SHIP_SPEC_BASE:-development}"
+case "${ARGUMENTS:-}" in *--repo*) SHIP_SPEC_REPO=$(printf '%s\n' "$ARGUMENTS" | sed -n 's/.*--repo[ =]\([^ ]*\).*/\1/p') ;; esac
+case "${ARGUMENTS:-}" in *--remote*) SHIP_SPEC_REMOTE=$(printf '%s\n' "$ARGUMENTS" | sed -n 's/.*--remote[ =]\([^ ]*\).*/\1/p') ;; esac
+case "${ARGUMENTS:-}" in *--base*) SHIP_SPEC_BASE=$(printf '%s\n' "$ARGUMENTS" | sed -n 's/.*--base[ =]\([^ ]*\).*/\1/p') ;; esac
+echo "ship-spec target: repo=$SHIP_SPEC_REPO remote=$SHIP_SPEC_REMOTE base=$SHIP_SPEC_BASE"
+```
 
 Derive `<slug>` per `/prd` rules: lowercase, kebab-case, `[a-z0-9-]+`, **≤5 words**, not `archive`. Reject and ask for a shorter name if invalid.
 
@@ -147,12 +160,13 @@ The HALT path is the whole point. Critics are the short feedback loop; honoring 
 
 Only reached after stage 4 PROCEED.
 
-**If `--issue <N>` was provided**: skip issue creation entirely — set `N=<N>`, print `Using existing issue #<N> (--issue); skipping creation.`, optionally confirm it exists with `gh issue view <N>`, and continue to Stage 6. Everything below in this stage applies ONLY when creating a fresh issue (no `--issue` flag).
+**If `--issue <N>` was provided**: skip issue creation entirely — set `N=<N>`, print `Using existing issue #<N> (--issue); skipping creation.`, optionally confirm it exists with `gh issue view <N> --repo "$SHIP_SPEC_REPO"`, and continue to Stage 6. Everything below in this stage applies ONLY when creating a fresh issue (no `--issue` flag).
 
 Compose issue body from the prd.md introduction + goals sections. Title format per `.claude/rules/git.md`:
 
 ```bash
 gh issue create \
+  --repo "$SHIP_SPEC_REPO" \
   --title "<prefix>: <slug-as-prose>" \
   --label "<prefix>" \
   --body-file <(printf '%s\n' \
@@ -175,7 +189,7 @@ gh issue create \
 
 Capture the returned issue URL; extract `<N>` (issue number) for downstream use.
 
-If `gh label create <prefix>` is needed (label doesn't exist), create it first with a sensible color. Heredoc bodies are safe — the `deny-env-dump.sh` hook strips heredoc bodies before pattern-scanning, so `--body "$(cat <<'EOF' ... EOF)"` is fine.
+If `gh label create <prefix> --repo "$SHIP_SPEC_REPO"` is needed (label doesn't exist), create it first with a sensible color. Heredoc bodies are safe — the `deny-env-dump.sh` hook strips heredoc bodies before pattern-scanning, so `--body "$(cat <<'EOF' ... EOF)"` is fine.
 
 ### Stage 6 — `/ralph` → `tasks/<slug>/prd.json`
 
@@ -227,8 +241,8 @@ Stages 8–9 re-read the files from disk, so a post-compact context is sufficien
 
 ```bash
 # Resume-safe: checkout existing branch or create new
-git fetch origin
-git checkout -b "<prefix>/<N>-<slug>" origin/development 2>/dev/null \
+git fetch "$SHIP_SPEC_REMOTE" "$SHIP_SPEC_BASE"
+git checkout -b "<prefix>/<N>-<slug>" "$SHIP_SPEC_REMOTE/$SHIP_SPEC_BASE" 2>/dev/null \
   || git checkout "<prefix>/<N>-<slug>"
 
 git add "tasks/<slug>/"
@@ -249,7 +263,7 @@ Submitted-by: <active submitter>
 EOF
 )"
 
-git push -u origin "<prefix>/<N>-<slug>"
+git push -u "$SHIP_SPEC_REMOTE" "<prefix>/<N>-<slug>"
 ```
 
 `Submitted-by:` is mandatory and must name the model/agent that actually
@@ -263,10 +277,11 @@ Pre-commit hook runs lint + tests; do not bypass.
 
 ```bash
 gh pr create \
+  --repo "$SHIP_SPEC_REPO" \
   --draft \
-  --base development \
+  --base "$SHIP_SPEC_BASE" \
   --head "<prefix>/<N>-<slug>" \
-  --title "FROM <prefix>/<N>-<slug> TO development" \
+  --title "FROM <prefix>/<N>-<slug> TO $SHIP_SPEC_BASE" \
   --body "$(cat <<'EOF'
 Closes #<N>.
 
@@ -308,7 +323,7 @@ tmux new-session -d -s "$SESSION" \
 
 **Advisor `/goal` prompt** (one line; fill the placeholders):
 
-> `/goal` As an **expert Advisor on `/worktrees`**, implement `tasks/<slug>/prd.json` for PR `#<PR>` on branch `<prefix>/<N>-<slug>`. (1) Create an isolated worktree at `.worktrees/<prefix>/<N>-<slug>` via `/worktrees`. (2) Orchestrate with `/delegate --plan tasks/<slug>/prd.json`: spawn `general-purpose` worker(s) that each `cd` into the worktree and run `scripts/ralph.sh <slug>` (the ralph loop), and **monitor** them by polling `tasks/<slug>/progress.txt` for `STATUS: COMPLETE` and the workers' tmux liveness. (3) Run the `/eval` gate (Stage 11). (4) Run `/compact` (Stage 11.5) to clear the implementation context before the audit. (5) In a **separate executor**, run `/pr-audit` for PR `#<PR>` and run `gh pr ready <PR>` **only if it is classified promotable** (CI green + mergeable + clean); otherwise `gh pr comment` the blocking gate and leave it draft. Never `gh pr merge`. Leave this tmux session alive for attach.
+> `/goal` As an **expert Advisor on `/worktrees`**, implement `tasks/<slug>/prd.json` for PR `#<PR>` on repo `<repo>` branch `<prefix>/<N>-<slug>`. (1) Create an isolated worktree at `.worktrees/<prefix>/<N>-<slug>` via `/worktrees`. (2) Orchestrate with `/delegate --plan tasks/<slug>/prd.json`: spawn `general-purpose` worker(s) that each `cd` into the worktree and run `scripts/ralph.sh <slug>` (the ralph loop), and **monitor** them by polling `tasks/<slug>/progress.txt` for `STATUS: COMPLETE` and the workers' tmux liveness. (3) Run the `/eval` gate (Stage 11). (4) Run `/compact` (Stage 11.5) to clear the implementation context before the audit. (5) In a **separate executor**, run `/pr-audit` for PR `#<PR>` and run `gh pr ready <PR> --repo "$SHIP_SPEC_REPO"` **only if it is classified promotable** (CI green + mergeable + clean); otherwise `gh pr comment` the blocking gate and leave it draft. Never `gh pr merge`. Leave this tmux session alive for attach.
 
 The Advisor owns Stages 11–13 inside its session. The orchestrator's turn ends after launching it and reporting the session name; the ready-for-review PR is produced asynchronously by the Advisor. Each worker commits the implementation on `<prefix>/<N>-<slug>` with a `Submitted-by:` trailer (per `templates/prompt.md`); worktree isolation keeps concurrent work off the shared checkout (avoiding the autopilot shared-checkout contamination class). If `tmux` is unavailable, fall back to running the executor inline (`scripts/ralph.sh <slug>`) and continue to Stage 11 in the foreground.
 
@@ -328,20 +343,20 @@ Non-blocking — if `/compact` is unavailable or errors, log a warning and conti
 
 ### Stage 12 — `/pr-audit` promotable gate (separate executor)
 
-Push the branch so CI runs (`git push origin HEAD`). The Advisor then hands off to a **separate executor** (a `/delegate` worker or `Agent` call — "another executor") whose sole job is to run `/pr-audit` focused on PR `#<PR>` and report its draft sub-status. `/pr-audit` is read-only: it classifies the draft as **promotable** only when CI is green AND the PR is mergeable AND clean (it reads the `statusCheckRollup`, so it subsumes a bare `/ci-status` check). The executor returns `promotable` / `still-WIP` / `limbo`. Do not infer green from silence — a no-run CI status is not promotable.
+Push the branch so CI runs (`git push "$SHIP_SPEC_REMOTE" HEAD`). The Advisor then hands off to a **separate executor** (a `/delegate` worker or `Agent` call — "another executor") whose sole job is to run `/pr-audit` focused on PR `#<PR>` in `$SHIP_SPEC_REPO` and report its draft sub-status. `/pr-audit` is read-only: it classifies the draft as **promotable** only when CI is green AND the PR is mergeable AND clean (it reads the `statusCheckRollup`, so it subsumes a bare `/ci-status` check). The executor returns `promotable` / `still-WIP` / `limbo`. Do not infer green from silence — a no-run CI status is not promotable.
 
 ### Stage 13 — `gh pr ready` (undraft only if promotable)
 
 When implementation is complete, `/eval` has no new green→red regression, and Stage 12's `/pr-audit` classified the PR **promotable**, the executor undrafts it:
 
 ```bash
-gh pr ready <PR>
+gh pr ready <PR> --repo "$SHIP_SPEC_REPO"
 ```
 
 Otherwise (not promotable: red/pending CI, conflicts, or a new eval regression) keep the PR draft and add a comment naming the blocking gate plus resume/fix instructions:
 
 ```bash
-gh pr comment <PR> --body "ship-spec: PR left draft — <blocking gate>. Resume: <command>."
+gh pr comment <PR> --repo "$SHIP_SPEC_REPO" --body "ship-spec: PR left draft — <blocking gate>. Resume: <command>."
 ```
 
 Never auto-merge. The `agent-ship-<slug>` tmux session is left alive for attach/continue (per `context/rules/sandbox-processes.md`). Print the PR URL and terminal status (`READY` or `DRAFT-BLOCKED`) as the final pipeline output.
@@ -359,7 +374,7 @@ Never auto-merge. The `agent-ship-<slug>` tmux session is left alive for attach/
 | 7 | Four-file contract incomplete | Print missing files; abort; user investigates |
 | 7.5 | `/compact` unavailable or errors | Non-blocking; log a warning and continue (stages 8–9 re-read from disk) |
 | 8 | Pre-commit hook fails (lint, tests) | Fix issue; re-run from stage 8 |
-| 9 | `gh pr create` fails (no remote, branch missing on origin) | Verify push from stage 8; re-run from stage 9 |
+| 9 | `gh pr create` fails (no remote, branch missing on target remote) | Verify push from stage 8; re-run from stage 9 |
 | 10 | `tmux` unavailable, or the Advisor/worker stalls, times out, or leaves acceptance criteria incomplete | If `tmux` is missing, run the executor inline; otherwise leave PR draft and comment the resume command (`scripts/ralph.sh <slug>` / attach `agent-ship-<slug>`) |
 | 11 | `/eval` reports a NEW green→red regression or exits non-zero | Leave PR draft; fix or document the regression, then re-run `/eval` |
 | 11.5 | `/compact` unavailable or errors | Non-blocking; log a warning and continue to the audit |
@@ -379,7 +394,7 @@ Every stage checks for prior state and resumes rather than duplicating:
 | 6 | `tasks/<slug>/prd.json` exists | `/ralph` archives prior + regenerates (existing skill behavior) |
 | 7 | `prompt.md` / `progress.txt` exist | Skip if present |
 | 7.5 | (no resume — context optimization) | Always safe to run; skip silently if `/compact` is unavailable |
-| 8 | Branch exists on origin | Checkout + commit on top |
+| 8 | Branch exists on target remote | Checkout + commit on top |
 | 9 | Draft PR exists for this branch | Update body + comment-update; don't create duplicate |
 | 10 | `progress.txt` already says `STATUS: COMPLETE`; or the `agent-ship-<slug>`/ralph tmux session is already running | Skip relaunch — attach/monitor the existing session (`scripts/ralph.sh` reattaches idempotently); worktree present → reuse |
 | 11 | `evals/RESULTS.md` already reflects the current probe set and no new regression exists | Continue to the audit step; otherwise re-run `/eval` |

--- a/.claude/skills/ship-spec/templates/prompt.md
+++ b/.claude/skills/ship-spec/templates/prompt.md
@@ -18,8 +18,8 @@ Pick **one** user story, implement it, commit, mark it `passes: true`, and appen
 
 2. **Verify branch** — your branch is `<prefix>/<N>-<slug>` (per `prd.json` `branchName`). If `/ship-spec`'s Advisor launched you in an isolated worktree at `.worktrees/<prefix>/<N>-<slug>`, that directory already has the branch checked out — `cd` into it and skip the checkout below. Otherwise, if you are not on the branch:
    ```bash
-   git fetch origin
-   git checkout -b <prefix>/<N>-<slug> origin/development 2>/dev/null \
+   git fetch "${SHIP_SPEC_REMOTE:-upstream}" "${SHIP_SPEC_BASE:-development}"
+   git checkout -b <prefix>/<N>-<slug> "${SHIP_SPEC_REMOTE:-upstream}/${SHIP_SPEC_BASE:-development}" 2>/dev/null \
      || git checkout <prefix>/<N>-<slug>
    ```
    Never push to `development` or `main` directly.

--- a/.claude/skills/watchdog/SKILL.md
+++ b/.claude/skills/watchdog/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: watchdog
+description: |
+  Generic watchdog for stuck or stale automation. Inspects one or more action
+  classes, determines whether they are merely slow vs actually stuck/stale, and
+  takes the smallest safe completion action. Includes the autopilot draft-PR
+  watchdog: stale draft PRs should be completed and marked ready for review,
+  not merely surfaced as merge nudges.
+argument-hint: "[--repo <owner/name>] [--stale-hours <n>] [--action <autopilot-drafts|sessions|all>] [--dry-run]"
+---
+
+# Watchdog
+
+Generic watchdog for automation that can get stuck between observable states.
+It is intentionally broader than the old autopilot-specific health nudge: each
+watchdog action must define (1) objective stuck/stale signals, (2) safe allowed
+mutations, and (3) a terminal verification state.
+
+## When to Use
+
+Use `/watchdog` when an automation loop or long-running action may be wedged:
+
+- heartbeat/cron pulses checking for stuck work
+- draft PRs that should have been completed by an autonomous loop
+- tmux sessions frozen at usage-limit/resume prompts
+- future watchdog classes with similarly objective signals
+
+Default target repo for Open Harness automation: `mifunedev/openharness`.
+Override with `--repo owner/name` for tests or forks.
+
+## Arguments
+
+Parse `$ARGUMENTS`:
+
+| Flag | Default | Meaning |
+|------|---------|---------|
+| `--repo <owner/name>` | `mifunedev/openharness` | GitHub repo to inspect/mutate |
+| `--stale-hours <n>` | `2` | Age threshold for draft PR limbo |
+| `--action <...>` | `all` | `autopilot-drafts`, `sessions`, or `all` |
+| `--dry-run` | false | Report intended actions only |
+
+```bash
+WATCHDOG_REPO="${WATCHDOG_REPO:-mifunedev/openharness}"
+WATCHDOG_STALE_HOURS="${WATCHDOG_STALE_HOURS:-2}"
+WATCHDOG_ACTION="${WATCHDOG_ACTION:-all}"
+```
+
+## Action: autopilot draft PRs
+
+Goal: determine whether draft PRs are stuck or stale, complete them when
+possible, and remove the draft state only after verification. A draft PR is not
+a final nudge; it is unfinished work that the watchdog should drive to a
+ready-for-review PR when safe.
+
+### 1. Fetch draft candidates in one query
+
+```bash
+gh pr list --repo "$WATCHDOG_REPO" --state open --label autopilot \
+  --json number,title,url,headRefName,baseRefName,isDraft,mergeable,mergeStateStatus,statusCheckRollup,updatedAt,labels \
+  --jq '.[] | select(.isDraft == true)' > /tmp/watchdog-draft-prs.json
+```
+
+If the file is empty, report `WATCHDOG_OK: no autopilot draft PRs`.
+
+### 2. Classify each draft
+
+For each draft PR, derive:
+
+- `age_hours`: hours since `updatedAt`
+- `ci`: `PASS`, `FAIL`, `PEND`, or `NONE` from `statusCheckRollup`
+- `promotable`: `mergeable == "MERGEABLE" && mergeStateStatus == "CLEAN" && ci == "PASS"`
+- `stale`: `age_hours >= WATCHDOG_STALE_HOURS`
+- `stuck`: stale plus one of: no active tmux session for the head branch, CI failed,
+  merge state dirty/conflicting/behind, or no status/check progress
+
+### 3. Safe actions
+
+Allowed mutations:
+
+1. **Promotable draft → mark ready.** If `promotable`, run:
+   ```bash
+   gh pr ready <PR> --repo "$WATCHDOG_REPO"
+   ```
+   Then verify `gh pr view <PR> --repo "$WATCHDOG_REPO" --json isDraft,mergeable,mergeStateStatus`
+   reports `isDraft == false`.
+
+2. **Stale/stuck draft → complete work first.** If stale or stuck but not
+   promotable, check out the PR branch in an isolated worktree, finish the
+   remaining implementation, run the relevant targeted checks/probes, push the
+   branch, then mark ready only when the PR is green, mergeable, and clean.
+   Use the PR's `headRefName`; do not start a duplicate feature branch.
+
+3. **Slow-but-active draft → watch.** If under the stale threshold or there is
+   clear active session/log progress, report `WATCHING: draft PR #<n> still active`.
+   Do not mark ready.
+
+Never merge from the watchdog. The terminal state is ready-for-review, not
+merged.
+
+### 4. Verification before `gh pr ready`
+
+Before removing draft, verify all of:
+
+```bash
+gh pr view <PR> --repo "$WATCHDOG_REPO" \
+  --json isDraft,mergeable,mergeStateStatus,statusCheckRollup
+```
+
+Required:
+
+- `isDraft == true` before the action
+- `mergeable == "MERGEABLE"`
+- `mergeStateStatus == "CLEAN"`
+- no failing or pending checks in `statusCheckRollup` unless the repo has no checks
+  and local targeted checks passed
+
+After `gh pr ready`, re-read the PR and require `isDraft == false`.
+
+## Action: stuck sessions
+
+For `cron-autopilot-*` or legacy `autopilot-*` tmux sessions, kill only when the
+pane tail shows a terminal prompt the detached run cannot clear itself: usage or
+session limit, `/upgrade`, `Resume from summary`, `Resume full session`, or a
+fatal error banner. Age alone is not enough.
+
+```bash
+for s in $(tmux ls 2>/dev/null | grep -oE '^(cron-)?autopilot-[^:]*'); do
+  if tmux capture-pane -p -t "$s" 2>/dev/null | tail -25 \
+       | grep -qiE 'hit your (usage|session) limit|session limit|/usage-credits|/upgrade|Resume from summary|Resume full session'; then
+    tmux kill-session -t "$s"; rm -f "/tmp/$s.keep"
+    echo "NUDGE: killed stuck session $s"
+  fi
+done
+```
+
+## Reporting
+
+- No candidates: `WATCHDOG_OK: <action>`
+- Draft marked ready: `NUDGE: completed draft PR #<n> and marked ready`
+- Draft needs work: `NUDGE: completing stale draft PR #<n> (<reason>)`
+- Active but not stale: `WATCHING: draft PR #<n> still active`
+- Stuck session killed: `NUDGE: killed stuck session <s>`
+
+## Common Pitfalls
+
+- Do not treat a draft PR as a merge nudge. First decide if it is promotable;
+  otherwise finish the work.
+- Do not run `gh pr ready` on red, pending, dirty, behind, or conflicting PRs.
+- Do not merge. Watchdog completion stops at ready-for-review.
+- Do not derive the repo from the local checkout for Open Harness automation;
+  default to `mifunedev/openharness` and accept explicit `--repo` overrides.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,6 +140,7 @@ flowchart LR
 | `/release` | CalVer release — branch, tag, push, GHCR |
 | `/ci-status` | After `git push` — poll CI, report pass/fail |
 | `/pr-audit` | Triage all open PRs in one bulk `gh pr list --json` query — actionable buckets (ready/CI-failing/conflicting/changes-requested/needs-review) for ready-for-review PRs, with draft PRs split out first as a separate WIP class (promotable/WIP/limbo) + stale/convention flags; read-only by default, `--deep` fans out diff reviewers for flagged PRs, `--proof` writes an idempotent per-PR verdict comment, `--label-apply`/`--close-stale` mutate after confirmation |
+| `/watchdog` | Generic stuck/stale automation watchdog. Current primary action: inspect autopilot draft PRs, complete stale/stuck branches, and remove draft only after the PR is green/mergeable/clean; also kills tmux sessions frozen at usage-limit/resume prompts. Never merges. |
 | `/health-check` | Triage host memory/disk/Docker before starting a stack; rank reclaim levers by safety×yield, prune build cache, confirm destructive removal |
 | `/agent-browser` | Open a URL headless for screenshots / preview checks |
 | `/interview` | Adaptive pre-work clarifier — batches 2–4 task-specific questions via `AskUserQuestion`, then proceeds |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Update policy and release automation live in [`.claude/rules/git.md`](.claude/ru
 ## [Unreleased]
 
 ### Added
+- `/watchdog` skill replaces the autopilot-specific watchdog intent with a generic stuck/stale automation watchdog; its first guarded action completes stale autopilot draft PRs and removes draft only after verification, rather than merely nudging for a merge.
+- `autopilot-upstream-default` eval probe — guards that future `/autopilot` and `/ship-spec` runs default GitHub/git operations to upstream `mifunedev/openharness` via `upstream/development`, not the personal fork checkout.
+
 ### Changed
 ### Fixed
 ### Removed

--- a/crons/heartbeat.md
+++ b/crons/heartbeat.md
@@ -34,44 +34,14 @@ that catches anything time-sensitive without doing real work.
     `DRIFT: <summary>`. When `/drift-check` reports all classes clean,
     append nothing extra — the existing `HEARTBEAT_OK` reply stays
     unchanged; do NOT add a per-pulse "no drift" block on clean runs.
-2.8. **Autopilot health (nudge).** Check the hourly `/autopilot` loop for
-    stuck per-run sessions and a jammed queue, and nudge where the signal
-    is unambiguous. Three checks, only the first acts autonomously:
-
-    - **Stuck sessions (KILL — autonomous nudge).** For each new `cron-autopilot-*`
-      or legacy `autopilot-*` tmux session, read the pane tail for a terminal
-      interactive prompt the run can never clear on its own — a Claude
-      usage/session limit, a `Resume from summary` menu, `/upgrade`, or a fatal
-      error banner. A detached cron run frozen there will never finish and,
-      under `overlap: false`, blocks every later `:05` fire:
-      ```bash
-      for s in $(tmux ls 2>/dev/null | grep -oE '^(cron-)?autopilot-[^:]*'); do
-        if tmux capture-pane -p -t "$s" 2>/dev/null | tail -25 \
-             | grep -qiE 'hit your (usage|session) limit|session limit|/usage-credits|/upgrade|Resume from summary|Resume full session'; then
-          tmux kill-session -t "$s"; rm -f "/tmp/$s.keep"
-          echo "NUDGE: killed stuck autopilot session $s (frozen at a usage-limit/resume prompt)"
-        fi
-      done
-      # sweep orphaned keep-markers (session already gone)
-      for m in /tmp/cron-autopilot-*.keep /tmp/autopilot-*.keep; do [ -e "$m" ] || continue; \
-        s=$(basename "$m" .keep); tmux has-session -t "$s" 2>/dev/null || rm -f "$m"; done
-      ```
-    - **Long-lived sessions (SURFACE — never kill on age).** A new
-      `cron-autopilot-*` or legacy `autopilot-*` session alive > 90 min with no
-      stuck marker may be a persisted ready-PR session the operator is driving,
-      or a slow build. Surface
-      `WATCHING: autopilot session <s> alive <age> — verify it is not hung`
-      and leave it. Age alone never justifies a kill.
-    - **Ready / jammed-loop PR (SURFACE — never merge).** A green, mergeable,
-      non-draft open `autopilot` PR sitting unreviewed wants an operator
-      merge (the loop self-merges nothing):
-      ```bash
-      gh pr list --state open --label autopilot \
-        --json number,isDraft,mergeable,mergeStateStatus \
-        --jq '.[] | select(.isDraft==false and .mergeable=="MERGEABLE" and .mergeStateStatus=="CLEAN") | .number'
-      ```
-      Surface each as `NUDGE: autopilot PR #<n> is green + mergeable — merge
-      to free the queue`. Do NOT run `gh pr merge`.
+2.8. **Watchdog nudge.** Run `/watchdog --action all --repo mifunedev/openharness`.
+    The watchdog is generic, but its current required action is autopilot draft
+    PR recovery: determine whether draft PRs are active, stuck, or stale; if a
+    draft is already green/mergeable/clean, remove draft with `gh pr ready`; if
+    it is stale but not promotable, complete the remaining work on that PR branch,
+    run targeted checks, push, and only then remove draft. It may also kill tmux
+    sessions frozen at usage-limit/resume prompts. It never merges PRs and never
+    kills sessions on age alone.
 3. Decide whether anything needs action right now.
 4. If yes, act. If no, append a brief "nothing pressing" note to
    `memory/<today>/log.md` and exit.
@@ -87,17 +57,16 @@ that catches anything time-sensitive without doing real work.
 - Drift detected by `/drift-check` → include in reply as
   `DRIFT: <summary>` and note in `memory/<today>/log.md`. Clean run →
   no extra output.
-- Autopilot nudge (step 2.8) → killed stuck session or a surfaced
-  ready/long-lived signal → include in reply as `NUDGE: <action>` (and
-  `WATCHING: autopilot ...` for surfaced-only items) and note in
-  `memory/<today>/log.md`. No stuck session and no ready PR → no extra
-  output.
+- Watchdog nudge (step 2.8) → completed/undrafted stale PRs, killed stuck
+  sessions, or active-watch signals → include in reply as `NUDGE: <action>`
+  (and `WATCHING: ...` for active-but-not-stale items) and note in
+  `memory/<today>/log.md`. Clean watchdog run → no extra output.
 - Append the result to `memory/<today>/log.md` either way.
 - **Mandatory closing step (do this even after long action chains):**
   append one liveness line to `crons/.cron.log`:
   `printf '[%s] heartbeat: %s\n' "$(date -Iseconds)" "<status>" >> crons/.cron.log`
   where `<status>` is one of `OK`, `OK (N watching)`, `OK (stale ralph: <name>)`,
-  `OK (resolved: <item-snippet>)`, `OK (nudged autopilot: <session>)`. This is the cron's only liveness
+  `OK (resolved: <item-snippet>)`, `OK (watchdog: <summary>)`. This is the cron's only liveness
   signal — it MUST execute every pulse regardless of what else happened.
 
 ## Active items

--- a/evals/RESULTS.md
+++ b/evals/RESULTS.md
@@ -8,6 +8,7 @@ probe id; git history is the time series.** Schema and exit-code semantics are i
 |-------|------|----------------|--------|--------|
 | autopilot-executor-toggle | A | 2026-06-14 21:27 | PASS | conversation 2026-06-13 (autopilot delegate-advisor executor) |
 | autopilot-pi-agent | A | 2026-06-14 21:27 | PASS | issue #116 (autopilot Pi tmux alignment) 2026-06-14; issue #118 (attachable Pi TUI tmux) 2026-06-14; issue #126 (kept Pi overlap lock release) 2026-06-14 |
+| autopilot-upstream-default | A | 2026-06-15 16:36 | PASS | issue #420 — future autopilots must target upstream, not personal fork |
 | boot-lint-glob | A | 2026-06-14 21:27 | PASS | issue #90, issue #120 |
 | clean-restore | A | 2026-06-14 21:27 | PASS | issue #63 (autopilot-stray-wip-guard) 2026-06-12; issue #81 (owned-paths-zsh-split) 2026-06-13 |
 | cleanup-tasks-scoped-guard | A | 2026-06-14 21:27 | PASS | issue #85 |
@@ -28,6 +29,7 @@ probe id; git history is the time series.** Schema and exit-code semantics are i
 | ship-spec-ready-finalization | A | 2026-06-14 21:27 | PASS | issue #134 — /ship-spec must finalize ready PRs after gates, not stop at draft scaffold |
 | skill-paths | A | 2026-06-14 21:27 | PASS | issue #43 — stale path references; extended by issue #69 — apps/->packages/ rename guard |
 | submitted-by-trailers | A | 2026-06-14 21:27 | PASS | conversation 2026-06-12 (commit attribution trailers) |
+| watchdog-draft-prs | A | 2026-06-15 16:36 | PASS | conversation 2026-06-15 (generic watchdog + stale draft PR recovery) |
 | wiki-readme-index | A | 2026-06-14 21:27 | PASS | issue #132 — wiki README index drift guard |
 
 <!-- benchmark: pass-rate = PASS / (PASS + REGRESSION + TIMEOUT); SKIPPED excluded -->

--- a/evals/probes/autopilot-upstream-default.sh
+++ b/evals/probes/autopilot-upstream-default.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# tier: A
+# source: issue #420 — future autopilots must target upstream, not personal fork
+# desc: /autopilot and /ship-spec default GitHub/git operations to mifunedev/openharness + upstream/development and avoid implicit origin/current-checkout routing.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+AUTO="$ROOT/.claude/skills/autopilot/SKILL.md"
+SHIP="$ROOT/.claude/skills/ship-spec/SKILL.md"
+PROMPT="$ROOT/.claude/skills/ship-spec/templates/prompt.md"
+missing=()
+
+for f in "$AUTO" "$SHIP" "$PROMPT"; do
+  [[ -f "$f" ]] || missing+=("missing $f")
+done
+
+if [[ -f "$AUTO" ]]; then
+  grep -Fq 'AUTOPILOT_REPO="${AUTOPILOT_REPO:-mifunedev/openharness}"' "$AUTO" || missing+=("autopilot repo defaults to mifunedev/openharness")
+  grep -Fq 'AUTOPILOT_REMOTE="${AUTOPILOT_REMOTE:-upstream}"' "$AUTO" || missing+=("autopilot remote defaults to upstream")
+  grep -Fq 'AUTOPILOT_BASE="${AUTOPILOT_BASE:-development}"' "$AUTO" || missing+=("autopilot base defaults to development")
+  grep -Fq 'gh issue list --repo "$AUTOPILOT_REPO"' "$AUTO" || missing+=("autopilot queue reads target repo")
+  grep -Fq 'gh issue create --repo "$AUTOPILOT_REPO"' "$AUTO" || missing+=("autopilot research issues create in target repo")
+  grep -Fq 'gh pr list --repo "$AUTOPILOT_REPO"' "$AUTO" || missing+=("autopilot PR reads target repo")
+  grep -Fq 'git push "$AUTOPILOT_REMOTE" HEAD' "$AUTO" || missing+=("autopilot fallback pushes target remote")
+  grep -Fq -- '--repo "$AUTOPILOT_REPO" --remote "$AUTOPILOT_REMOTE" --base "$AUTOPILOT_BASE"' "$AUTO" || missing+=("autopilot passes target repo/remote/base to ship-spec")
+fi
+
+if [[ -f "$SHIP" ]]; then
+  grep -Fq 'SHIP_SPEC_REPO="${SHIP_SPEC_REPO:-mifunedev/openharness}"' "$SHIP" || missing+=("ship-spec repo defaults to mifunedev/openharness")
+  grep -Fq 'SHIP_SPEC_REMOTE="${SHIP_SPEC_REMOTE:-upstream}"' "$SHIP" || missing+=("ship-spec remote defaults to upstream")
+  grep -Fq 'SHIP_SPEC_BASE="${SHIP_SPEC_BASE:-development}"' "$SHIP" || missing+=("ship-spec base defaults to development")
+  grep -Fq 'gh pr create \' "$SHIP" && grep -Fq -- '--repo "$SHIP_SPEC_REPO"' "$SHIP" || missing+=("ship-spec PR creation uses target repo")
+  grep -Fq 'git push -u "$SHIP_SPEC_REMOTE"' "$SHIP" || missing+=("ship-spec scaffold push uses target remote")
+  grep -Fq 'gh pr ready <PR> --repo "$SHIP_SPEC_REPO"' "$SHIP" || missing+=("ship-spec undraft uses target repo")
+fi
+
+if [[ -f "$PROMPT" ]]; then
+  grep -Fq 'git fetch "${SHIP_SPEC_REMOTE:-upstream}" "${SHIP_SPEC_BASE:-development}"' "$PROMPT" || missing+=("ralph prompt fetches target remote/base")
+fi
+
+# No autonomous path should depend on the personal fork literal.
+if grep -R "ryaneggz/openharness" "$AUTO" "$SHIP" "$PROMPT" >/dev/null 2>&1; then
+  missing+=("autonomous autopilot docs contain personal fork literal")
+fi
+
+if (( ${#missing[@]} )); then
+  printf 'REGRESSION: autopilot upstream-default contract missing: %s\n' "${missing[*]}" >&2
+  exit 1
+fi
+
+echo "PASS: future autopilot/ship-spec runs default to mifunedev/openharness via upstream/development" >&2
+exit 0

--- a/evals/probes/watchdog-draft-prs.sh
+++ b/evals/probes/watchdog-draft-prs.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# tier: A
+# source: conversation 2026-06-15 (generic watchdog + stale draft PR recovery)
+# desc: /watchdog exists as generic watchdog and heartbeat uses it to complete stale draft PRs, verifying before removing draft.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WATCHDOG="$ROOT/.claude/skills/watchdog/SKILL.md"
+HEARTBEAT="$ROOT/crons/heartbeat.md"
+PRAUDIT="$ROOT/.claude/skills/pr-audit/SKILL.md"
+AGENTS="$ROOT/AGENTS.md"
+
+missing=()
+
+[[ -f "$WATCHDOG" ]] || missing+=("/watchdog skill exists")
+if [[ -f "$WATCHDOG" ]]; then
+  grep -Fq 'name: watchdog' "$WATCHDOG" || missing+=("watchdog skill frontmatter name")
+  grep -Fq 'WATCHDOG_REPO="${WATCHDOG_REPO:-mifunedev/openharness}"' "$WATCHDOG" || missing+=("watchdog defaults to upstream repo")
+  grep -Fq 'WATCHDOG_STALE_HOURS="${WATCHDOG_STALE_HOURS:-2}"' "$WATCHDOG" || missing+=("watchdog stale-hours default")
+  grep -Fq 'gh pr list --repo "$WATCHDOG_REPO" --state open --label autopilot' "$WATCHDOG" || missing+=("watchdog fetches autopilot draft PRs from target repo")
+  grep -Fq 'select(.isDraft == true)' "$WATCHDOG" || missing+=("watchdog filters draft PRs")
+  grep -Fq 'gh pr ready <PR> --repo "$WATCHDOG_REPO"' "$WATCHDOG" || missing+=("watchdog removes draft via target repo")
+  grep -Fq 'Stale/stuck draft → complete work first' "$WATCHDOG" || missing+=("watchdog completes stale drafts before ready")
+  grep -Fq 'isDraft == false' "$WATCHDOG" || missing+=("watchdog verifies draft removed")
+  grep -Fq 'Never merge from the watchdog' "$WATCHDOG" || missing+=("watchdog never merges")
+fi
+
+grep -Fq '/watchdog --action all --repo mifunedev/openharness' "$HEARTBEAT" || missing+=("heartbeat invokes generic /watchdog")
+grep -Fq 'complete the remaining work on that PR branch' "$HEARTBEAT" || missing+=("heartbeat says complete stale drafts")
+grep -Fq 'only then remove draft' "$HEARTBEAT" || missing+=("heartbeat requires verification before undraft")
+grep -Fq 'Watchdog nudge' "$HEARTBEAT" || missing+=("heartbeat reporting renamed to watchdog")
+
+grep -Fq 'route to `/watchdog` to complete the branch' "$PRAUDIT" || missing+=("pr-audit stale draft routes to watchdog")
+grep -Fq '| `/watchdog` | Generic stuck/stale automation watchdog' "$AGENTS" || missing+=("AGENTS lists /watchdog")
+
+if grep -R "autopilot-watchdog" "$WATCHDOG" "$HEARTBEAT" "$PRAUDIT" "$AGENTS" >/dev/null 2>&1; then
+  missing+=("new watchdog docs must not use old /autopilot-watchdog name")
+fi
+
+if (( ${#missing[@]} )); then
+  printf 'REGRESSION: watchdog stale-draft contract missing: %s\n' "${missing[*]}" >&2
+  exit 1
+fi
+
+echo "PASS: /watchdog is generic and recovers stale autopilot draft PRs through verified undraft" >&2
+exit 0


### PR DESCRIPTION
## Summary
- default /autopilot, /ship-spec, and /autopilot-watchdog GitHub operations to mifunedev/openharness
- route default git fetch/push through upstream/development while preserving --repo/--remote/--base overrides
- add an autopilot-upstream-default probe and update the stale-draft watchdog guard

Closes #420

## Verification
- bash evals/probes/autopilot-upstream-default.sh
- bash evals/probes/autopilot-stale-draft-watchdog.sh
- bash -n evals/probes/autopilot-upstream-default.sh evals/probes/autopilot-stale-draft-watchdog.sh
- bash .claude/skills/eval/run.sh --probe autopilot-upstream-default
- git diff --check