### PR TITLE
FROM feat/git-skill-rename TO development

### DIFF
--- a/.claude/skills/git/SKILL.md
+++ b/.claude/skills/git/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: git-workflow
+name: git
 description: |
   Use when creating issues, branches, worktrees, commits, PRs, changelog entries,
   stacked PRs, or releases in Open Harness. Provider-portable source of truth for
@@ -21,7 +21,7 @@ The legacy rules file remains only as a pointer to this skill.
 
 ## When to Use
 
-Load or invoke `/git-workflow` whenever you need to:
+Load or invoke `/git` whenever you need to:
 
 - create or title a GitHub issue
 - name a branch or worktree

--- a/.claude/skills/worktrees/SKILL.md
+++ b/.claude/skills/worktrees/SKILL.md
@@ -10,7 +10,7 @@ allowed-tools: Bash
 
 # Worktrees
 
-Manage `.worktrees/`. Full policy: `/git-workflow` § Worktrees; `context/rules/git.md` is only a compatibility pointer.
+Manage `.worktrees/`. Full policy: `/git` § Worktrees; `context/rules/git.md` is only a compatibility pointer.
 
 ## DETECT BASE
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,7 +96,7 @@ Remove the sandbox.
 
 ## Git Workflow
 
-Full provider-portable policy lives in `/git-workflow` (`.claude/skills/git-workflow/SKILL.md`). The table below is only the quick-reference subset.
+Full provider-portable policy lives in `/git` (`.claude/skills/git/SKILL.md`). The table below is only the quick-reference subset.
 
 | Item | Convention |
 |------|-----------|
@@ -141,7 +141,7 @@ flowchart LR
 |-------|------|
 | `/release` | CalVer release — branch, tag, push, GHCR |
 | `/ci-status` | After `git push` — poll CI, report pass/fail |
-| `/git-workflow` | Provider-portable source of truth for issue titles, branch/worktree conventions, PR titles/bodies, commits, changelog, stacked PRs, releases, and after-push checks. Use this instead of relying on `context/rules/git.md`, which is now only a pointer for providers that load rules. |
+| `/git` | Provider-portable source of truth for issue titles, branch/worktree conventions, PR titles/bodies, commits, changelog, stacked PRs, releases, and after-push checks. Use this instead of relying on `context/rules/git.md`, which is now only a pointer for providers that load rules. |
 | `/pr-audit` | Triage all open PRs in one bulk `gh pr list --json` query — actionable buckets (ready/CI-failing/conflicting/changes-requested/needs-review) for ready-for-review PRs, with draft PRs split out first as a separate WIP class (promotable/WIP/limbo) + stale/convention flags; read-only by default, `--deep` fans out diff reviewers for flagged PRs, `--proof` writes an idempotent per-PR verdict comment, `--label-apply`/`--close-stale` mutate after confirmation |
 | `/watchdog` | Generic stuck/stale automation watchdog. Current primary action: inspect autopilot draft PRs, complete stale/stuck branches, and remove draft only after the PR is green/mergeable/clean; also kills tmux sessions frozen at usage-limit/resume prompts. Never merges. |
 | `/health-check` | Triage host memory/disk/Docker before starting a stack; rank reclaim levers by safety×yield, prune build cache, confirm destructive removal |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,12 @@ All notable changes to this project are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions use CalVer (`YYYY.M.D` with `-N` suffix for same-day releases) and match git tags.
 
-Update policy and release automation live in [`/git-workflow`](.claude/skills/git-workflow/SKILL.md) § Changelog.
+Update policy and release automation live in [`/git`](.claude/skills/git/SKILL.md) § Changelog.
 
 ## [Unreleased]
 
 ### Added
-- `/git-workflow` skill promotes the former `context/rules/git.md` conventions into a provider-portable command skill, leaving the rules file as a pointer for providers that still load rules ([#422](https://github.com/mifunedev/openharness/issues/422)).
+- `/git` skill promotes the former `context/rules/git.md` conventions into a provider-portable command skill, leaving the rules file as a pointer for providers that still load rules ([#422](https://github.com/mifunedev/openharness/issues/422), [#424](https://github.com/mifunedev/openharness/issues/424)).
 - `/watchdog` skill replaces the autopilot-specific watchdog intent with a generic stuck/stale automation watchdog; its first guarded action completes stale autopilot draft PRs and removes draft only after verification, rather than merely nudging for a merge.
 - `autopilot-upstream-default` eval probe — guards that future `/autopilot` and `/ship-spec` runs default GitHub/git operations to upstream `mifunedev/openharness` via `upstream/development`, not the personal fork checkout.
 

--- a/context/rules/directory-readme.md
+++ b/context/rules/directory-readme.md
@@ -22,7 +22,7 @@ doc + folder anchor) without the empty-file smell.
 3. **Conventions** — naming, lifecycle, gitignore behaviour, anything
    non-obvious to someone landing fresh in the directory.
 4. **Pointer to canonical docs** — link to the skill, rule, or doc that owns
-   the deeper detail (`/git-workflow` § Worktrees, `scripts/cron-runtime.ts`,
+   the deeper detail (`/git` § Worktrees, `scripts/cron-runtime.ts`,
    etc.).
 
 ## What the README MUST NOT contain

--- a/context/rules/git.md
+++ b/context/rules/git.md
@@ -1,9 +1,9 @@
 # Git Workflow
 
-Provider-portable source of truth: `/git-workflow` (`.claude/skills/git-workflow/SKILL.md`).
+Provider-portable source of truth: `/git` (`.claude/skills/git/SKILL.md`).
 
 This file intentionally stays as a short compatibility pointer. Not every
 harness provider loads `context/rules/*`, while skills are available across the
 provider surfaces Open Harness supports. Keep active git/branch/PR/changelog/
-release/worktree instructions in `/git-workflow`; update this pointer only if the
+release/worktree instructions in `/git`; update this pointer only if the
 skill moves.

--- a/crons/cleanup-tasks.md
+++ b/crons/cleanup-tasks.md
@@ -38,7 +38,7 @@ subfolder.
    `OK (archived N, skipped M)` success token and the `HEARTBEAT_OK`
    nothing-to-do reply. Do not contaminate the archive branch with
    unrelated changes.
-3. Resolve `$BASE` = default target branch per `/git-workflow`
+3. Resolve `$BASE` = default target branch per `/git`
    (`development` → `main` → `master`, whichever exists). Fetch it
    (`git fetch origin "$BASE"`), then provision a dedicated, crash-safe
    worktree for the archive work — never branch or commit against the
@@ -87,7 +87,7 @@ subfolder.
    - Commit: `git -C .worktrees/archive/$TODAY commit -m "archive: weekly cleanup $TODAY (N tasks)"`.
    - Push: `git -C .worktrees/archive/$TODAY push -u origin "archive/$TODAY"`.
    - Open a PR (or update an existing one for the same branch) per
-     `/git-workflow` conventions:
+     `/git` conventions:
      `gh pr create --base "$BASE" --head "archive/$TODAY" \
         --title "FROM archive/$TODAY TO $BASE" \
         --body "Weekly task sweep — archived N completed tasks, skipped M still-active.\n\nArchived: <list>\nSkipped: <list>"`.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -157,10 +157,10 @@ Run the skill from inside the orchestrator sandbox:
 /release
 ```
 
-For details on the full workflow and manual procedure, see `/git-workflow`
-(`.claude/skills/git-workflow/SKILL.md`) in the repo.
+For details on the full workflow and manual procedure, see `/git`
+(`.claude/skills/git/SKILL.md`) in the repo.
 
 ---
 
-Need to dive deeper? See `/git-workflow` (`.claude/skills/git-workflow/SKILL.md`)
+Need to dive deeper? See `/git` (`.claude/skills/git/SKILL.md`)
 in the repo for the canonical workflow.

--- a/evals/RESULTS.md
+++ b/evals/RESULTS.md
@@ -20,7 +20,7 @@ probe id; git history is the time series.** Schema and exit-code semantics are i
 | eval-gate | A | 2026-06-14 21:27 | PASS | memory/MEMORY.md 2026-06-11 (eval-gate) |
 | eval-results-atomic | A | 2026-06-14 21:27 | PASS | issue #83 (eval-results-atomic-write) |
 | eval-runner-exit | A | 2026-06-14 21:27 | PASS | memory/MEMORY.md 2026-06-11 (eval-runner-exit) #29 |
-| git-workflow-skill | A | 2026-06-15 17:03 | PASS | conversation 2026-06-15 — rules are not always supported; git workflow must be a skill |
+| git-skill | A | 2026-06-15 17:20 | PASS | conversation 2026-06-15 — rules are not always supported; git workflow must be the /git skill |
 | health-check-docker-stats | A | 2026-06-14 21:27 | PASS | memory/MEMORY.md 2026-06-10 (docker stats vs ps Size) |
 | memory-gitignore-claim | A | 2026-06-14 21:27 | PASS | issue #101 |
 | next-dev-prod | A | 2026-06-14 21:27 | PASS | memory/MEMORY.md 2026-06-04 |

--- a/evals/probes/git-skill.sh
+++ b/evals/probes/git-skill.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 # tier: A
-# source: conversation 2026-06-15 — rules are not always supported; git workflow must be a skill
-# desc: context/rules/git.md is only a pointer and the executable git conventions live in /git-workflow.
+# source: conversation 2026-06-15 — rules are not always supported; git workflow must be the /git skill
+# desc: context/rules/git.md is only a pointer and the executable git conventions live in /git.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-SKILL="$ROOT/.claude/skills/git-workflow/SKILL.md"
+SKILL="$ROOT/.claude/skills/git/SKILL.md"
 RULE="$ROOT/context/rules/git.md"
 AGENTS="$ROOT/AGENTS.md"
 WORKTREES="$ROOT/.claude/skills/worktrees/SKILL.md"
@@ -14,11 +14,11 @@ CHANGELOG="$ROOT/CHANGELOG.md"
 
 missing=()
 
-[[ -f "$SKILL" ]] || missing+=("/git-workflow skill exists")
+[[ -f "$SKILL" ]] || missing+=("/git skill exists")
 [[ -f "$RULE" ]] || missing+=("context/rules/git.md pointer exists")
 
 if [[ -f "$SKILL" ]]; then
-  grep -Fq 'name: git-workflow' "$SKILL" || missing+=("skill frontmatter name")
+  grep -Fq 'name: git' "$SKILL" || missing+=("skill frontmatter name")
   grep -Fq 'Provider Portability' "$SKILL" || missing+=("skill explains provider portability")
   grep -Fq 'Issue Titles' "$SKILL" || missing+=("issue title convention moved to skill")
   grep -Fq 'Branch Names' "$SKILL" || missing+=("branch convention moved to skill")
@@ -32,23 +32,23 @@ if [[ -f "$SKILL" ]]; then
 fi
 
 if [[ -f "$RULE" ]]; then
-  grep -Fq 'Provider-portable source of truth: `/git-workflow`' "$RULE" || missing+=("rules file points to /git-workflow")
+  grep -Fq 'Provider-portable source of truth: `/git`' "$RULE" || missing+=("rules file points to /git")
   grep -Fq 'This file intentionally stays as a short compatibility pointer' "$RULE" || missing+=("rules file declares pointer-only role")
   if grep -Fq '## Branch Names' "$RULE" || grep -Fq '## Releases' "$RULE" || grep -Fq '## Worktrees' "$RULE"; then
     missing+=("rules file still contains active git workflow sections")
   fi
 fi
 
-grep -Fq '| `/git-workflow` | Provider-portable source of truth' "$AGENTS" || missing+=("AGENTS lists /git-workflow")
-grep -Fq 'Full provider-portable policy lives in `/git-workflow`' "$AGENTS" || missing+=("AGENTS git section points to /git-workflow")
-grep -Fq 'Full policy: `/git-workflow` § Worktrees' "$WORKTREES" || missing+=("/worktrees points to /git-workflow")
-grep -Fq 'per `/git-workflow`' "$CLEANUP" || missing+=("cleanup cron points to /git-workflow")
-grep -Fq '.claude/skills/git-workflow/SKILL.md' "$CHANGELOG" || missing+=("CHANGELOG top pointer references skill")
+grep -Fq '| `/git` | Provider-portable source of truth' "$AGENTS" || missing+=("AGENTS lists /git")
+grep -Fq 'Full provider-portable policy lives in `/git`' "$AGENTS" || missing+=("AGENTS git section points to /git")
+grep -Fq 'Full policy: `/git` § Worktrees' "$WORKTREES" || missing+=("/worktrees points to /git")
+grep -Fq 'per `/git`' "$CLEANUP" || missing+=("cleanup cron points to /git")
+grep -Fq '.claude/skills/git/SKILL.md' "$CHANGELOG" || missing+=("CHANGELOG top pointer references skill")
 
 if (( ${#missing[@]} )); then
   printf 'REGRESSION: git workflow skill migration incomplete: %s\n' "${missing[*]}" >&2
   exit 1
 fi
 
-echo "PASS: git workflow lives in /git-workflow and context/rules/git.md is a provider-compat pointer" >&2
+echo "PASS: git workflow lives in /git and context/rules/git.md is a provider-compat pointer" >&2
 exit 0


### PR DESCRIPTION
Closes #424

## Summary
- rename the provider-portable git workflow skill from /git-workflow to /git
- update context/rules/git.md and all docs/skill/cron pointers to reference /git
- rename the regression probe to git-skill and guard the shorter command name

## Verification
- bash evals/probes/git-skill.sh
- bash .claude/skills/eval/run.sh --probe git-skill
- git diff --check