### PR TITLE
feat: add GitHub star conversion to docs landing page

### DIFF
--- a/packages/docs/src/pages/index.module.css
+++ b/packages/docs/src/pages/index.module.css
@@ -100,6 +100,102 @@
   opacity: 0.85;
 }
 
+/* GitHub star conversion band */
+.starSection {
+  padding: 1.75rem 0 0;
+  background: var(--ifm-background-color);
+}
+
+.starBand {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(260px, 360px);
+  gap: 1.5rem;
+  align-items: center;
+  padding-top: 1.35rem;
+  padding-bottom: 1.35rem;
+  border: 1px solid var(--ifm-toc-border-color);
+  border-radius: 14px;
+  background:
+    linear-gradient(135deg, rgba(68, 255, 176, 0.08), transparent 42%),
+    var(--ifm-background-surface-color);
+  box-shadow: 0 12px 36px rgba(0, 0, 0, 0.18);
+}
+
+.starCopy {
+  min-width: 0;
+}
+
+.starEyebrow {
+  margin: 0 0 0.6rem;
+  color: var(--oh-accent-green);
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.starTitle {
+  margin: 0 0 0.65rem;
+  color: var(--ifm-heading-color);
+  font-size: clamp(1.35rem, 2.4vw, 1.8rem);
+  letter-spacing: -0.02em;
+  line-height: 1.15;
+}
+
+.starBody {
+  margin: 0;
+  max-width: 68ch;
+  color: var(--ifm-font-color-secondary);
+  line-height: 1.6;
+}
+
+.starPanel {
+  display: grid;
+  gap: 0.35rem;
+  padding: 1.1rem 1.2rem;
+  border: 1px solid var(--ifm-toc-border-color);
+  border-radius: 12px;
+  background: var(--ifm-background-color);
+  font-family: var(--ifm-font-family-monospace);
+}
+
+.starPanelLabel,
+.starPanelRepo {
+  color: var(--ifm-font-color-secondary);
+  font-size: 0.78rem;
+}
+
+.starPanelLabel {
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.starPanelValue {
+  color: var(--ifm-heading-color);
+  font-family: var(--ifm-font-family-base);
+  font-size: clamp(2rem, 4vw, 2.8rem);
+  font-weight: 800;
+  line-height: 1;
+  letter-spacing: -0.03em;
+}
+
+.starPanelCta {
+  justify-self: start;
+  margin-top: 0.55rem;
+  color: var(--ifm-font-color-base);
+  font-family: var(--ifm-font-family-base);
+  font-weight: 700;
+  text-decoration: none;
+  border-bottom: 1px solid currentColor;
+}
+
+.starPanelCta:hover {
+  color: var(--ifm-font-color-base);
+  opacity: 0.7;
+  text-decoration: none;
+}
+
 /* Hero terminal preview */
 .heroTerminal {
   border: 1px solid var(--ifm-toc-border-color);
@@ -399,6 +495,17 @@
   }
   .heroMeta {
     justify-content: center;
+  }
+  .starBand {
+    grid-template-columns: 1fr;
+    text-align: center;
+  }
+  .starBody {
+    margin-left: auto;
+    margin-right: auto;
+  }
+  .starPanel {
+    justify-items: center;
   }
 }
 

--- a/packages/docs/src/pages/index.tsx
+++ b/packages/docs/src/pages/index.tsx
@@ -1,8 +1,12 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import Layout from "@theme/Layout";
 import Link from "@docusaurus/Link";
 import CodeBlock from "@theme/CodeBlock";
 import styles from "./index.module.css";
+
+const GITHUB_REPO = "mifunedev/openharness";
+const GITHUB_URL = `https://github.com/${GITHUB_REPO}`;
+const FALLBACK_STARS = 18;
 
 const QUICKSTART = `# install (only host dep: Docker)
 curl -fsSL https://oh.mifune.dev/install.sh | bash
@@ -99,6 +103,9 @@ const WHY: Array<{ title: string; body: string }> = [
 ];
 
 export default function Home(): React.ReactElement {
+  const stars = useGitHubStars(FALLBACK_STARS);
+  const starLabel = formatStars(stars);
+
   return (
     <Layout description="We provide the sandbox; you choose the agent. Open Harness is a long-lived Docker sandbox dedicated to your project. Pick Claude Code, Codex, OpenCode, Pi, DeepAgents, Hermes, or Grok Build inside.">
       <main>
@@ -125,12 +132,15 @@ export default function Home(): React.ReactElement {
                 </Link>
                 <Link
                   className="button button--secondary button--lg"
-                  href="https://github.com/mifunedev/openharness"
+                  href={GITHUB_URL}
+                  aria-label={`Star Open Harness on GitHub, ${starLabel} stars`}
                 >
-                  View on GitHub
+                  ★ Star on GitHub
                 </Link>
               </div>
               <div className={styles.heroMeta}>
+                <span>{starLabel} GitHub stars</span>
+                <span aria-hidden="true">·</span>
                 <span>MIT licensed</span>
                 <span aria-hidden="true">·</span>
                 <span>Self-hosted</span>
@@ -147,6 +157,33 @@ export default function Home(): React.ReactElement {
               </div>
               <CodeBlock language="bash" children={QUICKSTART} />
             </aside>
+          </div>
+        </section>
+
+        <section className={styles.starSection} aria-labelledby="github-stars-title">
+          <div className={`${styles.container} ${styles.starBand}`}>
+            <div className={styles.starCopy}>
+              <p className={styles.starEyebrow}>Open source signal</p>
+              <h2 id="github-stars-title" className={styles.starTitle}>
+                Help more agent builders find Open Harness.
+              </h2>
+              <p className={styles.starBody}>
+                If the sandbox model saves you from one broken local agent setup,
+                star the repo so the next Claude Code, Codex, OpenCode, or Hermes user can find it faster.
+              </p>
+            </div>
+            <div className={styles.starPanel} aria-label={`${starLabel} GitHub stars for ${GITHUB_REPO}`}>
+              <span className={styles.starPanelLabel}>GitHub stars</span>
+              <span className={styles.starPanelValue}>★ {starLabel}</span>
+              <span className={styles.starPanelRepo}>{GITHUB_REPO}</span>
+              <Link
+                className={styles.starPanelCta}
+                href={GITHUB_URL}
+                aria-label={`Star Open Harness on GitHub, ${starLabel} stars`}
+              >
+                Star on GitHub →
+              </Link>
+            </div>
           </div>
         </section>
 
@@ -215,11 +252,11 @@ export default function Home(): React.ReactElement {
             <div className={styles.linkGrid}>
               <Link
                 className={styles.linkCard}
-                href="https://github.com/mifunedev/openharness"
+                href={GITHUB_URL}
               >
-                <span className={styles.linkCardLabel}>GitHub</span>
+                <span className={styles.linkCardLabel}>Star Open Harness</span>
                 <span className={styles.linkCardSub}>
-                  Source, issues, and discussions
+                  Help others discover the project on GitHub
                 </span>
               </Link>
               <Link
@@ -241,6 +278,40 @@ export default function Home(): React.ReactElement {
       </main>
     </Layout>
   );
+}
+
+function formatStars(stars: number): string {
+  if (stars >= 1000) {
+    return `${(stars / 1000).toFixed(stars >= 10000 ? 0 : 1)}k`;
+  }
+
+  return new Intl.NumberFormat("en-US").format(stars);
+}
+
+function useGitHubStars(fallback: number): number {
+  const [stars, setStars] = useState(fallback);
+
+  useEffect(() => {
+    const controller = new AbortController();
+
+    fetch(`https://api.github.com/repos/${GITHUB_REPO}`, {
+      signal: controller.signal,
+      headers: { Accept: "application/vnd.github+json" },
+    })
+      .then((response) => (response.ok ? response.json() : Promise.reject(response)))
+      .then((repo: { stargazers_count?: number }) => {
+        if (typeof repo.stargazers_count === "number") {
+          setStars(repo.stargazers_count);
+        }
+      })
+      .catch(() => {
+        // Keep the committed fallback if GitHub is rate-limited or unavailable.
+      });
+
+    return () => controller.abort();
+  }, []);
+
+  return stars;
 }
 
 /* ---------- Inline agent icons ----------


### PR DESCRIPTION
## Summary
- Adds a live/fallback GitHub star count to the OpenHarness docs landing page
- Makes the GitHub action explicit with a secondary "Star on GitHub" CTA while keeping Get started primary
- Adds a near-hero open source signal band to convert social proof into stars

## Verification
- pnpm --dir packages/docs typecheck
- pnpm --dir packages/docs build attempted locally; process was OOM-killed after server compile on the shared host, so GitHub Actions docs build is the authoritative build verification for this public PR.

Supersedes private/fork PR: https://github.com/ryaneggz/openharness/pull/193