### PR TITLE
FROM feat/432-make-harness-audit-shared-memory TO development

### DIFF
--- a/.claude/skills/harness-audit/SKILL.md
+++ b/.claude/skills/harness-audit/SKILL.md
@@ -87,8 +87,15 @@ ls "$AUDIT_ROOT/.github/workflows/" 2>/dev/null
 # Worktrees
 git -C "$AUDIT_ROOT" worktree list 2>/dev/null
 
-# Recent long-term memory (tracked source artifact)
-tail -40 "$AUDIT_ROOT/memory/MEMORY.md" 2>/dev/null
+# Recent long-term memory (runtime observability artifact)
+# Source inspection stays on AUDIT_ROOT, but durable lessons/logs may live in
+# AUDIT_LOG_ROOT when an isolated cron worktree audits a public/template checkout.
+if [ -r "$AUDIT_LOG_ROOT/memory/MEMORY.md" ]; then
+  printf 'long_term_memory: loaded %s\n' "$AUDIT_LOG_ROOT/memory/MEMORY.md"
+  tail -40 "$AUDIT_LOG_ROOT/memory/MEMORY.md"
+else
+  printf 'long_term_memory: missing-or-unreadable %s\n' "$AUDIT_LOG_ROOT/memory/MEMORY.md"
+fi
 ```
 
 Assemble a **Context Snapshot** (compact markdown, ~300 words):
@@ -221,7 +228,7 @@ Launch 4 Agent tool calls **in a single message**. Each receives the Context Sna
 >
 > **Audit areas:**
 >
-> 1. **Memory system quality** — Read the 5 most recent daily logs in `memory/`. Are entries following the Memory Improvement Protocol (Result/Action/Observation/Duration)? Is quality declining over time (shorter entries, missing fields)? Are entries actually present?
+> 1. **Memory system quality** — Use the Context Snapshot's `AUDIT_LOG_ROOT` memory/log context (not `AUDIT_ROOT` when they differ) to inspect the 5 most recent daily logs. Are entries following the Memory Improvement Protocol (Result/Action/Observation/Duration)? Is quality declining over time (shorter entries, missing fields)? Are entries actually present? Report if `long_term_memory` is `missing-or-unreadable`.
 >
 > 2. **Wiki utilization** — List all files under `wiki/`. For each, check if it has substantive content (>10 lines) or is a placeholder stub. What percentage is populated?
 >
@@ -229,7 +236,7 @@ Launch 4 Agent tool calls **in a single message**. Each receives the Context Sna
 >
 > 4. **Agent worktree status** — In the source checkout listed as `AUDIT_ROOT`, run `git worktree list` and `git branch -a | grep agent/`. Classify each: ACTIVE (commits in last 7 days), IDLE (commits 7-30 days ago), ORPHANED (no commits in 30+ days or branch deleted).
 >
-> 5. **Skill usage patterns** — Read `memory/MEMORY.md` and recent daily logs. Which skills appear in memory entries (evidence of use)? Which skills exist in `.claude/skills/` but never appear in logs (potentially stale or unknown)?
+> 5. **Skill usage patterns** — Use the Context Snapshot's long-term memory and recent daily-log excerpts from `AUDIT_LOG_ROOT`; keep `.claude/skills/` existence checks on `AUDIT_ROOT`. Which skills appear in memory entries (evidence of use)? Which skills exist in `.claude/skills/` but never appear in logs (potentially stale or unknown)?
 >
 > **Return format (Ultra compression):**
 > ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,10 @@ Update policy and release automation live in [`/git`](.claude/skills/git/SKILL.m
 ## [Unreleased]
 
 ### Added
+- `harness-audit-memory-path` eval coverage now guards the `AUDIT_ROOT` source-inspection / `AUDIT_LOG_ROOT` durable-memory split for `/harness-audit` ([#432](https://github.com/mifunedev/openharness/issues/432)).
 ### Changed
 ### Fixed
+- `/harness-audit` now reads durable long-term memory from `AUDIT_LOG_ROOT` during isolated cron worktree runs, so audits keep shared runtime lessons while source inspection stays on `AUDIT_ROOT` ([#432](https://github.com/mifunedev/openharness/issues/432)).
 ### Removed
 ### Deprecated
 ### Security

--- a/evals/RESULTS.md
+++ b/evals/RESULTS.md
@@ -6,51 +6,51 @@ probe id; git history is the time series.** Schema and exit-code semantics are i
 
 | probe | tier | last-run (UTC) | status | source |
 |-------|------|----------------|--------|--------|
-| agent-browser-cli | A | 2026-06-18 05:43 | PASS | memory/MEMORY.md 2026-06-07 (agent-browser 0.8.5 CLI) |
-| autopilot-executor-toggle | A | 2026-06-18 05:43 | PASS | conversation 2026-06-13 (autopilot delegate-advisor executor) |
-| autopilot-no-pr-session-close | A | 2026-06-18 05:43 | PASS | issue #209 (autopilot no-PR tmux session closure) 2026-06-16 |
-| autopilot-pi-agent | A | 2026-06-18 05:43 | PASS | issue #116 (autopilot Pi tmux alignment) 2026-06-14; issue #118 (attachable Pi TUI tmux) 2026-06-14; issue #126 (kept Pi overlap lock release) 2026-06-14; issue #142 (worktree-by-default, skip→worktree) 2026-06-14 |
-| autopilot-preflight-gate | A | 2026-06-18 05:43 | PASS | issue #194 (deterministic autopilot caps preflight gate) 2026-06-15 |
-| autopilot-upstream-default | A | 2026-06-18 05:43 | PASS | issue #420 — future autopilots must target canonical repo, not personal fork |
-| autopilot-worktree-log-root | A | 2026-06-18 05:43 | PASS | issue #152 (persist autopilot worktree logs) 2026-06-15 |
-| boot-lint-glob | A | 2026-06-18 05:43 | PASS | issue #90, issue #120 |
-| capability-benchmark-schema | A | 2026-06-18 05:43 | PASS | issue #167 — capability benchmark instrument |
-| clean-restore | A | 2026-06-18 05:43 | PASS | issue #63 (autopilot-stray-wip-guard) 2026-06-12; issue #81 (owned-paths-zsh-split) 2026-06-13 |
-| cleanup-tasks-scoped-guard | A | 2026-06-18 05:43 | PASS | issue #85 |
-| cleanup-tasks-worktree-grooming | A | 2026-06-18 05:43 | PASS | issue #168 |
-| cron-claude-codex-fallback | A | 2026-06-18 05:43 | PASS | conversation 2026-06-12 (default Codex fallback for crons) |
-| cron-watchdog | A | 2026-06-18 05:43 | PASS | issue #130 (cron runtime watchdog) 2026-06-14 |
-| curl-bash-safe-alternatives | A | 2026-06-18 05:43 | PASS | vet-run/vet integration — public curl|bash examples need review-first alternatives |
-| datasets-schema | A | 2026-06-18 05:43 | PASS | issue #196 — evals/datasets verifiable trajectory corpus (Repo2RLEnv-inspired) |
-| devtcp-hook | A | 2026-06-18 05:43 | PASS | memory/MEMORY.md 2026-06-10 (zsh /dev/tcp) |
-| drift-check-cron-staleness-glob | A | 2026-06-18 05:43 | PASS | issue #98; issue #225 (restart-required cron frontmatter/config drift) |
-| eval-ci-gate | A | 2026-06-18 05:43 | PASS | #103 — eval probe suite gated in CI |
-| eval-gate | A | 2026-06-18 05:43 | PASS | memory/MEMORY.md 2026-06-11 (eval-gate) |
-| eval-results-atomic | A | 2026-06-18 05:43 | PASS | issue #83 (eval-results-atomic-write) |
-| eval-runner-exit | A | 2026-06-18 05:43 | PASS | memory/MEMORY.md 2026-06-11 (eval-runner-exit) #29 |
-| git-skill | A | 2026-06-18 05:43 | PASS | conversation 2026-06-15 — rules are not always supported; git workflow must be the /git skill |
-| harness-audit-empty-output-gate | A | 2026-06-18 05:43 | PASS | issue #246 — /harness-audit must fail closed on empty auditor outputs |
-| harness-audit-memory-path | A | 2026-06-18 05:43 | PASS | issue #183 — /harness-audit must inspect the active worktree, not a hardcoded root |
-| harness-ci-core-paths | A | 2026-06-18 05:43 | PASS | #165 — core sandbox config files must trigger harness CI |
-| harness-ci-hooks-paths | A | 2026-06-18 05:43 | PASS | issue #202 — credential/security hook changes must trigger harness CI |
-| health-check-docker-stats | A | 2026-06-18 05:43 | PASS | memory/MEMORY.md 2026-06-10 (docker stats vs ps Size) |
-| locked-append-critical-path | A | 2026-06-18 05:43 | PASS | issue #204 (lock shared runtime log appends) 2026-06-15 |
-| loop-benchmark-gate | A | 2026-06-18 05:43 | PASS | issue #179 — wire the executable-loop `benchmark` node (close the cycle) |
-| loop-handoff-consistency | A | 2026-06-18 05:43 | PASS | context/rules/loop.md § 4 (executable-loop Handoff convention) |
-| loop-repeat-gate | A | 2026-06-18 05:43 | PASS | issue #173 — wire the executable-loop `repeat` node (cycle-closing edge) |
-| memory-gitignore-claim | A | 2026-06-18 05:43 | PASS | issue #101 |
-| next-dev-prod | A | 2026-06-18 05:43 | PASS | memory/MEMORY.md 2026-06-04 |
-| orchestrate-contract | A | 2026-06-18 05:43 | PASS | issue #160 — /orchestrate contract; issue #175 — reserved /loop command rename |
-| owned-surface-guard | A | 2026-06-18 05:43 | PASS | issue #63 (autopilot-stray-wip-guard) 2026-06-12; issue #81 (owned-paths-zsh-split) 2026-06-13 |
-| pnpm-audit-ci-gate | A | 2026-06-18 05:43 | PASS | issue #171 — pnpm security audits must run in CI |
-| ralph-fallback-order | A | 2026-06-18 05:43 | PASS | conversation 2026-06-12 (Ralph default fallback order) |
-| rl-delegation-write-worker | A | 2026-06-18 05:43 | PASS | memory/MEMORY.md 2026-06-10 (rl-delegation) #57 |
-| ship-spec-ready-finalization | A | 2026-06-18 05:43 | PASS | issue #134 — /ship-spec must finalize ready PRs after gates, not stop at draft scaffold |
-| skill-paths | A | 2026-06-18 05:43 | PASS | issue #43 — stale path references; extended by issue #69 — apps/->packages/ rename guard |
-| submitted-by-trailers | A | 2026-06-18 05:43 | PASS | conversation 2026-06-12 (commit attribution trailers) |
-| watchdog-completed-session-reap | A | 2026-06-18 05:43 | PASS | issue #235 (completed autopilot PR session reaping) |
-| watchdog-draft-prs | A | 2026-06-18 05:43 | PASS | conversation 2026-06-15 (generic watchdog + stale draft PR recovery) |
-| watchdog-stuck-sessions | A | 2026-06-18 05:43 | PASS | issue #240 (Codex zero-credit stuck autopilot sessions) 2026-06-17 |
-| wiki-readme-index | A | 2026-06-18 05:43 | PASS | issue #132 — wiki README index drift guard |
+| agent-browser-cli | A | 2026-06-18 06:20 | PASS | memory/MEMORY.md 2026-06-07 (agent-browser 0.8.5 CLI) |
+| autopilot-executor-toggle | A | 2026-06-18 06:20 | PASS | conversation 2026-06-13 (autopilot delegate-advisor executor) |
+| autopilot-no-pr-session-close | A | 2026-06-18 06:20 | PASS | issue #209 (autopilot no-PR tmux session closure) 2026-06-16 |
+| autopilot-pi-agent | A | 2026-06-18 06:20 | PASS | issue #116 (autopilot Pi tmux alignment) 2026-06-14; issue #118 (attachable Pi TUI tmux) 2026-06-14; issue #126 (kept Pi overlap lock release) 2026-06-14; issue #142 (worktree-by-default, skip→worktree) 2026-06-14 |
+| autopilot-preflight-gate | A | 2026-06-18 06:20 | PASS | issue #194 (deterministic autopilot caps preflight gate) 2026-06-15 |
+| autopilot-upstream-default | A | 2026-06-18 06:20 | PASS | issue #420 — future autopilots must target canonical repo, not personal fork |
+| autopilot-worktree-log-root | A | 2026-06-18 06:20 | PASS | issue #152 (persist autopilot worktree logs) 2026-06-15 |
+| boot-lint-glob | A | 2026-06-18 06:20 | PASS | issue #90, issue #120 |
+| capability-benchmark-schema | A | 2026-06-18 06:20 | PASS | issue #167 — capability benchmark instrument |
+| clean-restore | A | 2026-06-18 06:20 | PASS | issue #63 (autopilot-stray-wip-guard) 2026-06-12; issue #81 (owned-paths-zsh-split) 2026-06-13 |
+| cleanup-tasks-scoped-guard | A | 2026-06-18 06:20 | PASS | issue #85 |
+| cleanup-tasks-worktree-grooming | A | 2026-06-18 06:20 | PASS | issue #168 |
+| cron-claude-codex-fallback | A | 2026-06-18 06:20 | PASS | conversation 2026-06-12 (default Codex fallback for crons) |
+| cron-watchdog | A | 2026-06-18 06:20 | PASS | issue #130 (cron runtime watchdog) 2026-06-14 |
+| curl-bash-safe-alternatives | A | 2026-06-18 06:20 | PASS | vet-run/vet integration — public curl|bash examples need review-first alternatives |
+| datasets-schema | A | 2026-06-18 06:20 | PASS | issue #196 — evals/datasets verifiable trajectory corpus (Repo2RLEnv-inspired) |
+| devtcp-hook | A | 2026-06-18 06:20 | PASS | memory/MEMORY.md 2026-06-10 (zsh /dev/tcp) |
+| drift-check-cron-staleness-glob | A | 2026-06-18 06:20 | PASS | issue #98; issue #225 (restart-required cron frontmatter/config drift) |
+| eval-ci-gate | A | 2026-06-18 06:20 | PASS | #103 — eval probe suite gated in CI |
+| eval-gate | A | 2026-06-18 06:20 | PASS | memory/MEMORY.md 2026-06-11 (eval-gate) |
+| eval-results-atomic | A | 2026-06-18 06:20 | PASS | issue #83 (eval-results-atomic-write) |
+| eval-runner-exit | A | 2026-06-18 06:20 | PASS | memory/MEMORY.md 2026-06-11 (eval-runner-exit) #29 |
+| git-skill | A | 2026-06-18 06:20 | PASS | conversation 2026-06-15 — rules are not always supported; git workflow must be the /git skill |
+| harness-audit-empty-output-gate | A | 2026-06-18 06:20 | PASS | issue #246 — /harness-audit must fail closed on empty auditor outputs |
+| harness-audit-memory-path | A | 2026-06-18 06:20 | PASS | issue #183 and #432 — /harness-audit must inspect active source but read durable memory from log root |
+| harness-ci-core-paths | A | 2026-06-18 06:20 | PASS | #165 — core sandbox config files must trigger harness CI |
+| harness-ci-hooks-paths | A | 2026-06-18 06:20 | PASS | issue #202 — credential/security hook changes must trigger harness CI |
+| health-check-docker-stats | A | 2026-06-18 06:20 | PASS | memory/MEMORY.md 2026-06-10 (docker stats vs ps Size) |
+| locked-append-critical-path | A | 2026-06-18 06:20 | PASS | issue #204 (lock shared runtime log appends) 2026-06-15 |
+| loop-benchmark-gate | A | 2026-06-18 06:20 | PASS | issue #179 — wire the executable-loop `benchmark` node (close the cycle) |
+| loop-handoff-consistency | A | 2026-06-18 06:20 | PASS | context/rules/loop.md § 4 (executable-loop Handoff convention) |
+| loop-repeat-gate | A | 2026-06-18 06:20 | PASS | issue #173 — wire the executable-loop `repeat` node (cycle-closing edge) |
+| memory-gitignore-claim | A | 2026-06-18 06:20 | PASS | issue #101 |
+| next-dev-prod | A | 2026-06-18 06:20 | PASS | memory/MEMORY.md 2026-06-04 |
+| orchestrate-contract | A | 2026-06-18 06:20 | PASS | issue #160 — /orchestrate contract; issue #175 — reserved /loop command rename |
+| owned-surface-guard | A | 2026-06-18 06:20 | PASS | issue #63 (autopilot-stray-wip-guard) 2026-06-12; issue #81 (owned-paths-zsh-split) 2026-06-13 |
+| pnpm-audit-ci-gate | A | 2026-06-18 06:20 | PASS | issue #171 — pnpm security audits must run in CI |
+| ralph-fallback-order | A | 2026-06-18 06:20 | PASS | conversation 2026-06-12 (Ralph default fallback order) |
+| rl-delegation-write-worker | A | 2026-06-18 06:20 | PASS | memory/MEMORY.md 2026-06-10 (rl-delegation) #57 |
+| ship-spec-ready-finalization | A | 2026-06-18 06:20 | PASS | issue #134 — /ship-spec must finalize ready PRs after gates, not stop at draft scaffold |
+| skill-paths | A | 2026-06-18 06:20 | PASS | issue #43 — stale path references; extended by issue #69 — apps/->packages/ rename guard |
+| submitted-by-trailers | A | 2026-06-18 06:20 | PASS | conversation 2026-06-12 (commit attribution trailers) |
+| watchdog-completed-session-reap | A | 2026-06-18 06:20 | PASS | issue #235 (completed autopilot PR session reaping) |
+| watchdog-draft-prs | A | 2026-06-18 06:20 | PASS | conversation 2026-06-15 (generic watchdog + stale draft PR recovery) |
+| watchdog-stuck-sessions | A | 2026-06-18 06:20 | PASS | issue #240 (Codex zero-credit stuck autopilot sessions) 2026-06-17 |
+| wiki-readme-index | A | 2026-06-18 06:20 | PASS | issue #132 — wiki README index drift guard |
 
 <!-- benchmark: pass-rate = PASS / (PASS + REGRESSION + TIMEOUT); SKIPPED excluded -->

--- a/evals/probes/harness-audit-memory-path.sh
+++ b/evals/probes/harness-audit-memory-path.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # tier: A
-# source: issue #183 — /harness-audit must inspect the active worktree, not a hardcoded root
-# desc: /harness-audit context snapshot must resolve AUDIT_ROOT and avoid hardcoded source paths
+# source: issue #183 and #432 — /harness-audit must inspect active source but read durable memory from log root
+# desc: /harness-audit context snapshot must resolve AUDIT_ROOT for source and AUDIT_LOG_ROOT for memory/log context
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
@@ -19,8 +19,23 @@ if ! grep -q 'AUDIT_ROOT' "$SKILL" || ! grep -q 'CRON_WORKTREE' "$SKILL"; then
   exit 1
 fi
 
-if ! grep -q '\$AUDIT_ROOT/memory/MEMORY\.md' "$SKILL"; then
-  echo "REGRESSION: harness-audit context snapshot does not tail tracked memory/MEMORY.md via AUDIT_ROOT" >&2
+if ! grep -q '\$AUDIT_LOG_ROOT/memory/MEMORY\.md' "$SKILL"; then
+  echo "REGRESSION: harness-audit context snapshot does not tail durable memory/MEMORY.md via AUDIT_LOG_ROOT" >&2
+  exit 1
+fi
+
+if ! grep -q 'long_term_memory: loaded' "$SKILL" || ! grep -q 'long_term_memory: missing-or-unreadable' "$SKILL"; then
+  echo "REGRESSION: harness-audit does not disclose whether AUDIT_LOG_ROOT long-term memory loaded" >&2
+  exit 1
+fi
+
+if ! grep -q 'Use the Context Snapshot.*AUDIT_LOG_ROOT' "$SKILL"; then
+  echo "REGRESSION: harness-audit auditor prompts do not direct memory/log inspection through AUDIT_LOG_ROOT context" >&2
+  exit 1
+fi
+
+if grep -q '\$AUDIT_ROOT/memory/MEMORY\.md' "$SKILL"; then
+  echo "REGRESSION: harness-audit tails durable memory from AUDIT_ROOT instead of AUDIT_LOG_ROOT" >&2
   exit 1
 fi
 
@@ -30,5 +45,5 @@ if grep -n '/home/sandbox/harness' "$SKILL" >"$TMP"; then
   exit 1
 fi
 
-echo "PASS: harness-audit resolves source inspection through AUDIT_ROOT" >&2
+echo "PASS: harness-audit resolves source inspection through AUDIT_ROOT, durable memory through AUDIT_LOG_ROOT, and discloses memory load status" >&2
 exit 0

--- a/tasks/make-harness-audit-shared-memory/critique.md
+++ b/tasks/make-harness-audit-shared-memory/critique.md
@@ -1,0 +1,26 @@
+# Critique — make-harness-audit-shared-memory
+
+Generated 2026-06-18; reviews `prd.md` post-/prd, pre-/ralph.
+
+## Critic A — Implementer lens
+
+CRITIC_A — IMPLEMENTER LENS
+[SEVERITY: M] [STORY: US-001] [FINDING] PRD only requires the parent context snapshot to tail `$AUDIT_LOG_ROOT/memory/MEMORY.md`, but existing auditor mandates still direct sub-agents to inspect `AUDIT_ROOT` and read `memory/` / `memory/MEMORY.md`, so implementers can satisfy AC while auditors still re-read template-empty worktree memory. | [EVIDENCE: tasks/make-harness-audit-shared-memory/prd.md US-001 AC; .claude/skills/harness-audit/SKILL.md:221-235] | [RECOMMENDATION] Add explicit AC that memory/log-related auditor instructions use the context snapshot or `$AUDIT_LOG_ROOT`, while source inspections remain `$AUDIT_ROOT`; clarify that the “Do not alter unrelated auditor prompts” non-goal does not forbid memory-path prompt fixes.
+[SEVERITY: L] [STORY: US-002] [FINDING] Probe requirement is vulnerable to brittle string-grep implementations that fail on explanatory comments or docs mentioning the forbidden path, rather than actual long-term-memory reads. | [EVIDENCE: tasks/make-harness-audit-shared-memory/prd.md US-002 AC: “asserts `$AUDIT_ROOT/memory/MEMORY.md` is not used for long-term memory”] | [RECOMMENDATION] Specify the probe should check executable context-snapshot/read commands, not all prose occurrences, or define the allowed comment/documentation pattern.
+END
+
+## Critic B — User lens
+
+CRITIC_B — USER LENS
+[SEVERITY: M] [STORY: US-001] Missing user-visible failure state when `AUDIT_LOG_ROOT/memory/MEMORY.md` is absent or unreadable | [EVIDENCE: PRD § US-001 acceptance criteria] | Require the context snapshot to show resolved `AUDIT_LOG_ROOT` and an explicit `loaded/missing/unreadable` memory status instead of silently continuing.
+[SEVERITY: M] [STORY: US-002] Probe requirement can be satisfied by static path checks without proving the audit actually loads log-root memory content | [EVIDENCE: PRD § US-002 acceptance criteria] | Require a fixture/sentinel test with distinct `AUDIT_ROOT` and `AUDIT_LOG_ROOT` memory files, asserting only the log-root sentinel appears.
+[SEVERITY: L] [STORY: US-003] Wiki acceptance does not require documenting the failure/diagnostic behavior users should expect when roots differ or memory is missing | [EVIDENCE: PRD § US-003 acceptance criteria] | Add a short troubleshooting note to `wiki/harness-audit.md` covering root mismatch, missing memory, and how to verify which root was used.
+END
+
+## Synthesis
+- **High-severity findings**: 0
+- **Medium-severity findings**: 3
+- **Low-severity findings**: 2
+- **Recommendation**: PROCEED
+
+Medium findings were mitigated in the PRD and implementation: memory/log-related Explorer instructions now explicitly use the Context Snapshot / `AUDIT_LOG_ROOT`, the context snapshot emits `long_term_memory: loaded` or `missing-or-unreadable`, the eval probe guards both the load-status line and auditor-prompt direction, and `wiki/harness-audit.md` includes troubleshooting for missing/unreadable log-root memory. The fixture/sentinel recommendation was addressed with executable text guards rather than a shell fixture because the skill artifact is markdown instructions, not a standalone shell program.

--- a/tasks/make-harness-audit-shared-memory/prd.json
+++ b/tasks/make-harness-audit-shared-memory/prd.json
@@ -1,0 +1,46 @@
+{
+  "schemaVersion": 1,
+  "slug": "make-harness-audit-shared-memory",
+  "issue": 432,
+  "branchName": "feat/432-make-harness-audit-shared-memory",
+  "title": "Make harness-audit load shared memory",
+  "description": "Make /harness-audit read durable long-term memory from AUDIT_LOG_ROOT while preserving AUDIT_ROOT source inspection.",
+  "tasks": [
+    {
+      "id": "US-001",
+      "title": "Read durable memory from the log root",
+      "description": "Update .claude/skills/harness-audit/SKILL.md so the context snapshot tails AUDIT_LOG_ROOT/memory/MEMORY.md for long-term memory while keeping source inspection on AUDIT_ROOT.",
+      "acceptanceCriteria": [
+        "harness-audit tails $AUDIT_LOG_ROOT/memory/MEMORY.md for recent long-term memory",
+        "source listings and package/CI/worktree inspection still use $AUDIT_ROOT",
+        "comments explain why source and runtime memory roots differ",
+        "context snapshot prints whether long-term memory was loaded or missing-or-unreadable from AUDIT_LOG_ROOT",
+        "memory/log-related auditor instructions use the Context Snapshot / AUDIT_LOG_ROOT while source inspections remain on AUDIT_ROOT"
+      ],
+      "passes": true
+    },
+    {
+      "id": "US-002",
+      "title": "Guard against memory-root regression",
+      "description": "Update evals/probes/harness-audit-memory-path.sh to assert the AUDIT_ROOT/AUDIT_LOG_ROOT split.",
+      "acceptanceCriteria": [
+        "probe requires $AUDIT_LOG_ROOT/memory/MEMORY.md",
+        "probe fails on $AUDIT_ROOT/memory/MEMORY.md for long-term memory",
+        "probe guards the memory load-status disclosure and auditor prompt direction",
+        "probe passes locally"
+      ],
+      "passes": true
+    },
+    {
+      "id": "US-003",
+      "title": "Document the harness-audit root split",
+      "description": "Create a source-backed wiki entry for the harness-audit root split and refresh the wiki index.",
+      "acceptanceCriteria": [
+        "wiki/harness-audit.md documents AUDIT_ROOT vs AUDIT_LOG_ROOT and missing-memory diagnostics",
+        "wiki/README.md indexes the new entry",
+        "wiki-readme-index probe passes"
+      ],
+      "passes": true
+    }
+  ]
+}

--- a/tasks/make-harness-audit-shared-memory/prd.md
+++ b/tasks/make-harness-audit-shared-memory/prd.md
@@ -1,0 +1,61 @@
+# PRD — make-harness-audit-shared-memory
+
+## Summary
+Make `/harness-audit` load durable long-term memory from the runtime log root when it runs inside an isolated cron worktree, while preserving source inspection against the worktree under audit.
+
+## Problem
+`/harness-audit` already distinguishes `AUDIT_ROOT` (source checkout under audit) from `AUDIT_LOG_ROOT` (shared runtime observability checkout). Its context snapshot uses `AUDIT_LOG_ROOT` for daily memory logs, but still tails `AUDIT_ROOT/memory/MEMORY.md` for long-term memory. In cron worktree mode, `AUDIT_ROOT` can be a public/template checkout with an empty `memory/MEMORY.md`, so auditors lose durable lessons even though the real memory exists in the shared root.
+
+## Goals
+- Keep source inspection rooted at `AUDIT_ROOT`.
+- Read durable long-term memory from `AUDIT_LOG_ROOT/memory/MEMORY.md`.
+- Guard the contract with a deterministic eval probe.
+- Document the behavior in the harness wiki.
+
+## Non-goals
+- Do not move, rewrite, or merge memory files.
+- Do not change cron runtime worktree creation.
+- Do not alter unrelated harness-audit auditor prompts.
+
+## User stories
+
+### US-001 — Read durable memory from the log root
+As an autopilot audit, I want `/harness-audit` to tail `AUDIT_LOG_ROOT/memory/MEMORY.md`, so isolated cron worktrees still see the shared durable lessons.
+
+Acceptance criteria:
+- `.claude/skills/harness-audit/SKILL.md` tails `$AUDIT_LOG_ROOT/memory/MEMORY.md` for recent long-term memory.
+- Source checkout listings and package/CI/worktree inspection still use `$AUDIT_ROOT`.
+- The context snapshot comments explain why memory/log context can differ from source inspection.
+- The context snapshot prints whether long-term memory was `loaded` or `missing-or-unreadable` from `AUDIT_LOG_ROOT`.
+- Memory/log-related auditor instructions point to the Context Snapshot / `AUDIT_LOG_ROOT` while source inspections remain on `AUDIT_ROOT`.
+
+### US-002 — Guard against memory-root regression
+As a maintainer, I want a probe to fail if `/harness-audit` reverts to reading long-term memory from `AUDIT_ROOT`, so the worktree-mode bug cannot silently return.
+
+Acceptance criteria:
+- `evals/probes/harness-audit-memory-path.sh` asserts `$AUDIT_LOG_ROOT/memory/MEMORY.md` is used.
+- The probe asserts `$AUDIT_ROOT/memory/MEMORY.md` is not used for long-term memory.
+- The probe guards the memory load-status disclosure and auditor prompt direction.
+- The probe passes locally.
+
+### US-003 — Document the harness-audit root split
+As a future agent, I want a source-backed wiki entry explaining `AUDIT_ROOT` vs `AUDIT_LOG_ROOT`, so I do not reintroduce the wrong-memory read during future audit changes.
+
+Acceptance criteria:
+- `wiki/harness-audit.md` documents the source/root split, missing-memory diagnostic, with relevant source files and system relationships.
+- `wiki/README.md` indexes the new entry.
+- `bash evals/probes/wiki-readme-index.sh` passes.
+
+## Wiki Alignment
+
+- **Impact**: REQUIRED
+- **Local entries**: create `wiki/harness-audit.md`; refresh `wiki/README.md`.
+- **Spec alignment**: The entry must explain that source inspection uses `AUDIT_ROOT`, while durable memory and runtime observability use `AUDIT_LOG_ROOT` when cron worktrees are ephemeral.
+- **DeepWiki comparison**: No relevant DeepWiki page was available from the local corpus; use the repository source files and the existing `cron-runtime` entry's source-first style.
+- **Acceptance criteria**: US-003 covers the wiki entry and index probe.
+
+## Verification
+- `bash evals/probes/harness-audit-memory-path.sh`
+- `bash evals/probes/wiki-readme-index.sh`
+- `bash .claude/skills/eval/run.sh --probe harness-audit-memory-path`
+- `git diff --check`

--- a/tasks/make-harness-audit-shared-memory/progress.txt
+++ b/tasks/make-harness-audit-shared-memory/progress.txt
@@ -1,0 +1,6 @@
+# progress
+
+Implemented US-001: /harness-audit tails durable long-term memory from AUDIT_LOG_ROOT.
+Implemented US-002: harness-audit-memory-path probe guards AUDIT_ROOT/AUDIT_LOG_ROOT split.
+Implemented US-003: wiki/harness-audit.md documents the root split and wiki/README.md indexes it.
+STATUS: COMPLETE

--- a/tasks/make-harness-audit-shared-memory/prompt.md
+++ b/tasks/make-harness-audit-shared-memory/prompt.md
@@ -1,0 +1,21 @@
+# Ralph task — make-harness-audit-shared-memory
+
+Implement `tasks/make-harness-audit-shared-memory/prd.json` on branch `feat/432-make-harness-audit-shared-memory` for issue #432.
+
+## Read first
+- `tasks/make-harness-audit-shared-memory/prd.md`
+- `tasks/make-harness-audit-shared-memory/prd.json`
+- `tasks/make-harness-audit-shared-memory/critique.md`
+- `.claude/skills/harness-audit/SKILL.md`
+- `evals/probes/harness-audit-memory-path.sh`
+- `context/rules/wiki.md`
+
+## Done when
+- All `prd.json` tasks have `passes: true`.
+- `bash evals/probes/harness-audit-memory-path.sh` passes.
+- `bash evals/probes/wiki-readme-index.sh` passes.
+- `bash .claude/skills/eval/run.sh --probe harness-audit-memory-path` passes.
+- `git diff --check` passes.
+- Append `STATUS: COMPLETE` to `progress.txt`.
+
+Submitted-by: Pi

--- a/wiki/README.md
+++ b/wiki/README.md
@@ -26,5 +26,6 @@ Schema rule, frontmatter spec, and all authoring conventions: `context/rules/wik
 
 | Slug | Title | Tags | Updated |
 | --- | --- | --- | --- |
+| harness-audit | Harness Audit | [audit, skills, autopilot, memory, worktrees] | 2026-06-18 |
 | sandbox-auth-volumes | Sandbox Auth Volume Ownership | [sandbox, devcontainer, auth, docker, ownership] | 2026-06-16 |
 | cron-runtime | Cron Runtime | [cron, runtime, scheduler, drift-check, automation, open-harness] | 2026-06-16 |

--- a/wiki/harness-audit.md
+++ b/wiki/harness-audit.md
@@ -1,0 +1,50 @@
+---
+title: "Harness Audit"
+slug: harness-audit
+tags: [audit, skills, autopilot, memory, worktrees]
+created: 2026-06-18
+updated: 2026-06-18
+sources:
+  - raw/2026-06-18-harness-audit.md
+related: [cron-runtime]
+confidence: provisional
+---
+
+# Harness Audit
+
+## Relevant Source Files
+- `.claude/skills/harness-audit/SKILL.md:56-63` — resolves `AUDIT_ROOT` to the cron worktree when the audit is invoked from an isolated run.
+- `.claude/skills/harness-audit/SKILL.md:65-71` — resolves `AUDIT_LOG_ROOT` to the shared checkout when runtime observability differs from source inspection.
+- `.claude/skills/harness-audit/SKILL.md:73-98` — gathers source files from `AUDIT_ROOT`, recent daily logs from `AUDIT_LOG_ROOT`, and durable long-term memory from `AUDIT_LOG_ROOT` with an explicit load-status line.
+- `.claude/skills/harness-audit/SKILL.md:231-239` — directs memory/log-related Explorer checks through the Context Snapshot and `AUDIT_LOG_ROOT`, while keeping skill source checks on `AUDIT_ROOT`.
+- `evals/probes/harness-audit-memory-path.sh:17-48` — guards that source resolution remains worktree-aware, durable memory stays rooted at `AUDIT_LOG_ROOT`, and load status stays visible.
+- `crons/autopilot.md:1-11` — declares the hourly autopilot cron as a worktree-mode job.
+
+## Summary
+`/harness-audit` is the first-principles research pass that feeds the autopilot queue when no actionable `autopilot` issue is available. In worktree-mode cron runs, it must split source inspection from durable memory: audit the isolated checkout via `AUDIT_ROOT`, but read runtime logs and long-term lessons from `AUDIT_LOG_ROOT`. The context snapshot reports `long_term_memory: loaded` or `missing-or-unreadable` so a quiet memory miss is visible.
+
+## Detail
+The audit root exists to make source inspection truthful for the checkout that invoked the skill. When `CRON_WORKTREE` points at a valid checkout, `/harness-audit` sets `AUDIT_ROOT` to that worktree; otherwise it falls back to the current repository root (`.claude/skills/harness-audit/SKILL.md:56-63`). Skills, agents, crons, package metadata, CI workflows, wiki files, and worktree state are all read through that source root (`.claude/skills/harness-audit/SKILL.md:73-88`).
+
+Runtime observability has a different lifecycle. Cron worktrees are ephemeral and can be based on a public/template branch whose `memory/MEMORY.md` is intentionally sparse, while the live operator's durable lessons and daily logs live in the shared checkout. `/harness-audit` therefore resolves `AUDIT_LOG_ROOT` separately (`.claude/skills/harness-audit/SKILL.md:65-71`) and uses it for recent memory directories and long-term memory (`.claude/skills/harness-audit/SKILL.md:77,90-98`).
+
+The distinction matters because autopilot selection quality depends on the audit context. A successful-looking audit that reads template-empty memory can re-discover stale lessons or miss recent guardrails. The `harness-audit-memory-path` probe makes the split executable: it fails if the skill stops resolving `AUDIT_ROOT`/`CRON_WORKTREE`, fails if long-term memory is not read via `AUDIT_LOG_ROOT`, fails if the load-status line disappears, and fails if auditor prompts stop routing memory/log checks through the Context Snapshot (`evals/probes/harness-audit-memory-path.sh:17-48`).
+
+Troubleshooting: if an audit report shows `long_term_memory: missing-or-unreadable`, compare the snapshot's `AUDIT_ROOT` and `AUDIT_LOG_ROOT`. Source findings may still be valid, but memory-derived judgments are incomplete until the shared root has a readable `memory/MEMORY.md` or `AUTOPILOT_LOG_ROOT` is set to the checkout that owns durable logs.
+
+## System Relationships
+
+```mermaid
+flowchart LR
+  Cron["autopilot cron<br/>worktree: true"] --> WT["isolated CRON_WORKTREE"]
+  WT --> AuditRoot["AUDIT_ROOT<br/>source under audit"]
+  Root["shared checkout"] --> LogRoot["AUDIT_LOG_ROOT<br/>runtime logs + durable memory"]
+  AuditRoot --> Source["skills / agents / crons / CI / wiki source"]
+  LogRoot --> Memory["memory/YYYY-MM-DD logs<br/>memory/MEMORY.md lessons"]
+  Source --> Auditors["4 harness-audit perspectives"]
+  Memory --> Auditors
+  Auditors --> Queue["ranked autopilot findings"]
+```
+
+## See Also
+- [[cron-runtime]]

--- a/wiki/raw/2026-06-18-harness-audit.md
+++ b/wiki/raw/2026-06-18-harness-audit.md
@@ -1,0 +1,13 @@
+# Harness Audit Shared Memory Root Finding — 2026-06-18
+
+Source: hourly autopilot `/harness-audit` run in isolated cron worktree `/home/sandbox/harness/.worktrees/cron/cron-autopilot-0618-0005`.
+
+Explorer Auditor finding:
+
+> [MEMORY] [SEVERITY: H] [EFFORT: M] `/harness-audit` reads long-term memory from isolated `AUDIT_ROOT`, but this cron worktree has template-empty `memory/MEMORY.md`; real lessons live in shared root, so auditors lose durable context. Evidence: `.claude/skills/harness-audit/SKILL.md:91`; worktree `memory/MEMORY.md`; shared-root `memory/MEMORY.md`.
+
+Resolution in issue #432:
+
+- Keep source inspection rooted at `AUDIT_ROOT`.
+- Read durable long-term memory from `AUDIT_LOG_ROOT/memory/MEMORY.md`.
+- Guard the split with `evals/probes/harness-audit-memory-path.sh`.


### PR DESCRIPTION
## Selection rationale

Research selection: the actionable `autopilot` queue was empty after stale issue #420 was closed as already shipped; `/harness-audit` ranked the isolated-worktree memory-root bug as the highest-impact buildable harness-infra finding because it corrupts autopilot's research input while reports still appear successful. Filed as #432 from that finding and built in this run.

---

Closes #432.

**Status: DRAFT — final PR audit pending.**

## Summary
- Route `/harness-audit` long-term memory reads through `AUDIT_LOG_ROOT` while preserving source inspection on `AUDIT_ROOT`.
- Strengthen `harness-audit-memory-path` probe coverage for the root split and memory load-status disclosure.
- Add `wiki/harness-audit.md` and task artifacts documenting the behavior.

## Verification
- `bash evals/probes/harness-audit-memory-path.sh`
- `bash evals/probes/wiki-readme-index.sh`
- `bash -n evals/probes/harness-audit-memory-path.sh`
- `node -e "JSON.parse(require('fs').readFileSync('tasks/make-harness-audit-shared-memory/prd.json','utf8')); console.log('prd.json ok')"`
- `bash .claude/skills/eval/run.sh --probe harness-audit-memory-path`
- `bash .claude/skills/eval/run.sh`
- `git diff --check`
