### PR TITLE
fix: load harness-audit memory from shared root

### DIFF
--- a/.claude/skills/harness-audit/SKILL.md
+++ b/.claude/skills/harness-audit/SKILL.md
@@ -62,8 +62,9 @@ else
   AUDIT_ROOT="$(git rev-parse --show-toplevel)"
 fi
 
-# Runtime observability logs may intentionally live in the shared checkout when
-# a cron worktree is ephemeral. Source inspection still uses $AUDIT_ROOT.
+# Runtime observability logs and durable memory may intentionally live in the
+# shared checkout when a cron worktree is ephemeral. Source inspection still
+# uses $AUDIT_ROOT; only runtime/durable context reads use $AUDIT_LOG_ROOT.
 AUDIT_LOG_ROOT="${AUTOPILOT_LOG_ROOT:-$AUDIT_ROOT}"
 if [ -n "${CRON_WORKTREE:-}" ] && [ "$AUDIT_LOG_ROOT" = "$AUDIT_ROOT" ]; then
   root="$(git -C "$AUDIT_ROOT" worktree list --porcelain 2>/dev/null | awk 'NR==1 && $1 == "worktree" { sub(/^worktree /, ""); print; exit }' || true)"
@@ -87,8 +88,8 @@ ls "$AUDIT_ROOT/.github/workflows/" 2>/dev/null
 # Worktrees
 git -C "$AUDIT_ROOT" worktree list 2>/dev/null
 
-# Recent long-term memory (tracked source artifact)
-tail -40 "$AUDIT_ROOT/memory/MEMORY.md" 2>/dev/null
+# Recent long-term memory (durable runtime artifact; shared root in cron worktrees)
+tail -40 "$AUDIT_LOG_ROOT/memory/MEMORY.md" 2>/dev/null
 ```
 
 Assemble a **Context Snapshot** (compact markdown, ~300 words):
@@ -349,7 +350,7 @@ See `context/rules/memory.md` for the canonical Memory Improvement Protocol.
 | Workspace skills | `workspace/.claude/skills/` when created by a pack/runtime (not part of the minimal workspace template) |
 | Crons | `crons/` |
 | Memory logs | `memory/YYYY-MM-DD/log.md` |
-| Long-term memory | `memory/MEMORY.md` |
+| Long-term memory | `memory/MEMORY.md` via `AUDIT_LOG_ROOT` in cron worktrees; source checkout fallback otherwise |
 | Wiki | `wiki/` |
 | Compose | `.devcontainer/docker-compose.yml` |
 | Entrypoint | `.devcontainer/entrypoint.sh` |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Update policy and release automation live in [`/git`](.claude/skills/git/SKILL.m
 ### Added
 ### Changed
 ### Fixed
+- `/harness-audit` now tails durable long-term memory from `AUDIT_LOG_ROOT` in cron worktrees while keeping source inspection on `AUDIT_ROOT`, guarded by the `harness-audit-memory-path` eval probe ([#432](https://github.com/mifunedev/openharness/issues/432)).
 ### Removed
 ### Deprecated
 ### Security

--- a/evals/RESULTS.md
+++ b/evals/RESULTS.md
@@ -6,51 +6,51 @@ probe id; git history is the time series.** Schema and exit-code semantics are i
 
 | probe | tier | last-run (UTC) | status | source |
 |-------|------|----------------|--------|--------|
-| agent-browser-cli | A | 2026-06-18 05:43 | PASS | memory/MEMORY.md 2026-06-07 (agent-browser 0.8.5 CLI) |
-| autopilot-executor-toggle | A | 2026-06-18 05:43 | PASS | conversation 2026-06-13 (autopilot delegate-advisor executor) |
-| autopilot-no-pr-session-close | A | 2026-06-18 05:43 | PASS | issue #209 (autopilot no-PR tmux session closure) 2026-06-16 |
-| autopilot-pi-agent | A | 2026-06-18 05:43 | PASS | issue #116 (autopilot Pi tmux alignment) 2026-06-14; issue #118 (attachable Pi TUI tmux) 2026-06-14; issue #126 (kept Pi overlap lock release) 2026-06-14; issue #142 (worktree-by-default, skip→worktree) 2026-06-14 |
-| autopilot-preflight-gate | A | 2026-06-18 05:43 | PASS | issue #194 (deterministic autopilot caps preflight gate) 2026-06-15 |
-| autopilot-upstream-default | A | 2026-06-18 05:43 | PASS | issue #420 — future autopilots must target canonical repo, not personal fork |
-| autopilot-worktree-log-root | A | 2026-06-18 05:43 | PASS | issue #152 (persist autopilot worktree logs) 2026-06-15 |
-| boot-lint-glob | A | 2026-06-18 05:43 | PASS | issue #90, issue #120 |
-| capability-benchmark-schema | A | 2026-06-18 05:43 | PASS | issue #167 — capability benchmark instrument |
-| clean-restore | A | 2026-06-18 05:43 | PASS | issue #63 (autopilot-stray-wip-guard) 2026-06-12; issue #81 (owned-paths-zsh-split) 2026-06-13 |
-| cleanup-tasks-scoped-guard | A | 2026-06-18 05:43 | PASS | issue #85 |
-| cleanup-tasks-worktree-grooming | A | 2026-06-18 05:43 | PASS | issue #168 |
-| cron-claude-codex-fallback | A | 2026-06-18 05:43 | PASS | conversation 2026-06-12 (default Codex fallback for crons) |
-| cron-watchdog | A | 2026-06-18 05:43 | PASS | issue #130 (cron runtime watchdog) 2026-06-14 |
-| curl-bash-safe-alternatives | A | 2026-06-18 05:43 | PASS | vet-run/vet integration — public curl|bash examples need review-first alternatives |
-| datasets-schema | A | 2026-06-18 05:43 | PASS | issue #196 — evals/datasets verifiable trajectory corpus (Repo2RLEnv-inspired) |
-| devtcp-hook | A | 2026-06-18 05:43 | PASS | memory/MEMORY.md 2026-06-10 (zsh /dev/tcp) |
-| drift-check-cron-staleness-glob | A | 2026-06-18 05:43 | PASS | issue #98; issue #225 (restart-required cron frontmatter/config drift) |
-| eval-ci-gate | A | 2026-06-18 05:43 | PASS | #103 — eval probe suite gated in CI |
-| eval-gate | A | 2026-06-18 05:43 | PASS | memory/MEMORY.md 2026-06-11 (eval-gate) |
-| eval-results-atomic | A | 2026-06-18 05:43 | PASS | issue #83 (eval-results-atomic-write) |
-| eval-runner-exit | A | 2026-06-18 05:43 | PASS | memory/MEMORY.md 2026-06-11 (eval-runner-exit) #29 |
-| git-skill | A | 2026-06-18 05:43 | PASS | conversation 2026-06-15 — rules are not always supported; git workflow must be the /git skill |
-| harness-audit-empty-output-gate | A | 2026-06-18 05:43 | PASS | issue #246 — /harness-audit must fail closed on empty auditor outputs |
-| harness-audit-memory-path | A | 2026-06-18 05:43 | PASS | issue #183 — /harness-audit must inspect the active worktree, not a hardcoded root |
-| harness-ci-core-paths | A | 2026-06-18 05:43 | PASS | #165 — core sandbox config files must trigger harness CI |
-| harness-ci-hooks-paths | A | 2026-06-18 05:43 | PASS | issue #202 — credential/security hook changes must trigger harness CI |
-| health-check-docker-stats | A | 2026-06-18 05:43 | PASS | memory/MEMORY.md 2026-06-10 (docker stats vs ps Size) |
-| locked-append-critical-path | A | 2026-06-18 05:43 | PASS | issue #204 (lock shared runtime log appends) 2026-06-15 |
-| loop-benchmark-gate | A | 2026-06-18 05:43 | PASS | issue #179 — wire the executable-loop `benchmark` node (close the cycle) |
-| loop-handoff-consistency | A | 2026-06-18 05:43 | PASS | context/rules/loop.md § 4 (executable-loop Handoff convention) |
-| loop-repeat-gate | A | 2026-06-18 05:43 | PASS | issue #173 — wire the executable-loop `repeat` node (cycle-closing edge) |
-| memory-gitignore-claim | A | 2026-06-18 05:43 | PASS | issue #101 |
-| next-dev-prod | A | 2026-06-18 05:43 | PASS | memory/MEMORY.md 2026-06-04 |
-| orchestrate-contract | A | 2026-06-18 05:43 | PASS | issue #160 — /orchestrate contract; issue #175 — reserved /loop command rename |
-| owned-surface-guard | A | 2026-06-18 05:43 | PASS | issue #63 (autopilot-stray-wip-guard) 2026-06-12; issue #81 (owned-paths-zsh-split) 2026-06-13 |
-| pnpm-audit-ci-gate | A | 2026-06-18 05:43 | PASS | issue #171 — pnpm security audits must run in CI |
-| ralph-fallback-order | A | 2026-06-18 05:43 | PASS | conversation 2026-06-12 (Ralph default fallback order) |
-| rl-delegation-write-worker | A | 2026-06-18 05:43 | PASS | memory/MEMORY.md 2026-06-10 (rl-delegation) #57 |
-| ship-spec-ready-finalization | A | 2026-06-18 05:43 | PASS | issue #134 — /ship-spec must finalize ready PRs after gates, not stop at draft scaffold |
-| skill-paths | A | 2026-06-18 05:43 | PASS | issue #43 — stale path references; extended by issue #69 — apps/->packages/ rename guard |
-| submitted-by-trailers | A | 2026-06-18 05:43 | PASS | conversation 2026-06-12 (commit attribution trailers) |
-| watchdog-completed-session-reap | A | 2026-06-18 05:43 | PASS | issue #235 (completed autopilot PR session reaping) |
-| watchdog-draft-prs | A | 2026-06-18 05:43 | PASS | conversation 2026-06-15 (generic watchdog + stale draft PR recovery) |
-| watchdog-stuck-sessions | A | 2026-06-18 05:43 | PASS | issue #240 (Codex zero-credit stuck autopilot sessions) 2026-06-17 |
-| wiki-readme-index | A | 2026-06-18 05:43 | PASS | issue #132 — wiki README index drift guard |
+| agent-browser-cli | A | 2026-06-18 08:11 | PASS | memory/MEMORY.md 2026-06-07 (agent-browser 0.8.5 CLI) |
+| autopilot-executor-toggle | A | 2026-06-18 08:11 | PASS | conversation 2026-06-13 (autopilot delegate-advisor executor) |
+| autopilot-no-pr-session-close | A | 2026-06-18 08:11 | PASS | issue #209 (autopilot no-PR tmux session closure) 2026-06-16 |
+| autopilot-pi-agent | A | 2026-06-18 08:11 | PASS | issue #116 (autopilot Pi tmux alignment) 2026-06-14; issue #118 (attachable Pi TUI tmux) 2026-06-14; issue #126 (kept Pi overlap lock release) 2026-06-14; issue #142 (worktree-by-default, skip→worktree) 2026-06-14 |
+| autopilot-preflight-gate | A | 2026-06-18 08:11 | PASS | issue #194 (deterministic autopilot caps preflight gate) 2026-06-15 |
+| autopilot-upstream-default | A | 2026-06-18 08:11 | PASS | issue #420 — future autopilots must target canonical repo, not personal fork |
+| autopilot-worktree-log-root | A | 2026-06-18 08:11 | PASS | issue #152 (persist autopilot worktree logs) 2026-06-15 |
+| boot-lint-glob | A | 2026-06-18 08:11 | PASS | issue #90, issue #120 |
+| capability-benchmark-schema | A | 2026-06-18 08:11 | PASS | issue #167 — capability benchmark instrument |
+| clean-restore | A | 2026-06-18 08:11 | PASS | issue #63 (autopilot-stray-wip-guard) 2026-06-12; issue #81 (owned-paths-zsh-split) 2026-06-13 |
+| cleanup-tasks-scoped-guard | A | 2026-06-18 08:11 | PASS | issue #85 |
+| cleanup-tasks-worktree-grooming | A | 2026-06-18 08:11 | PASS | issue #168 |
+| cron-claude-codex-fallback | A | 2026-06-18 08:11 | PASS | conversation 2026-06-12 (default Codex fallback for crons) |
+| cron-watchdog | A | 2026-06-18 08:11 | PASS | issue #130 (cron runtime watchdog) 2026-06-14 |
+| curl-bash-safe-alternatives | A | 2026-06-18 08:11 | PASS | vet-run/vet integration — public curl|bash examples need review-first alternatives |
+| datasets-schema | A | 2026-06-18 08:11 | PASS | issue #196 — evals/datasets verifiable trajectory corpus (Repo2RLEnv-inspired) |
+| devtcp-hook | A | 2026-06-18 08:11 | PASS | memory/MEMORY.md 2026-06-10 (zsh /dev/tcp) |
+| drift-check-cron-staleness-glob | A | 2026-06-18 08:11 | PASS | issue #98; issue #225 (restart-required cron frontmatter/config drift) |
+| eval-ci-gate | A | 2026-06-18 08:11 | PASS | #103 — eval probe suite gated in CI |
+| eval-gate | A | 2026-06-18 08:11 | PASS | memory/MEMORY.md 2026-06-11 (eval-gate) |
+| eval-results-atomic | A | 2026-06-18 08:11 | PASS | issue #83 (eval-results-atomic-write) |
+| eval-runner-exit | A | 2026-06-18 08:11 | PASS | memory/MEMORY.md 2026-06-11 (eval-runner-exit) #29 |
+| git-skill | A | 2026-06-18 08:11 | PASS | conversation 2026-06-15 — rules are not always supported; git workflow must be the /git skill |
+| harness-audit-empty-output-gate | A | 2026-06-18 08:11 | PASS | issue #246 — /harness-audit must fail closed on empty auditor outputs |
+| harness-audit-memory-path | A | 2026-06-18 08:11 | PASS | issue #183 and #432 — /harness-audit must inspect active worktree source but load shared durable memory |
+| harness-ci-core-paths | A | 2026-06-18 08:11 | PASS | #165 — core sandbox config files must trigger harness CI |
+| harness-ci-hooks-paths | A | 2026-06-18 08:11 | PASS | issue #202 — credential/security hook changes must trigger harness CI |
+| health-check-docker-stats | A | 2026-06-18 08:11 | PASS | memory/MEMORY.md 2026-06-10 (docker stats vs ps Size) |
+| locked-append-critical-path | A | 2026-06-18 08:11 | PASS | issue #204 (lock shared runtime log appends) 2026-06-15 |
+| loop-benchmark-gate | A | 2026-06-18 08:11 | PASS | issue #179 — wire the executable-loop `benchmark` node (close the cycle) |
+| loop-handoff-consistency | A | 2026-06-18 08:11 | PASS | context/rules/loop.md § 4 (executable-loop Handoff convention) |
+| loop-repeat-gate | A | 2026-06-18 08:11 | PASS | issue #173 — wire the executable-loop `repeat` node (cycle-closing edge) |
+| memory-gitignore-claim | A | 2026-06-18 08:11 | PASS | issue #101 |
+| next-dev-prod | A | 2026-06-18 08:11 | PASS | memory/MEMORY.md 2026-06-04 |
+| orchestrate-contract | A | 2026-06-18 08:11 | PASS | issue #160 — /orchestrate contract; issue #175 — reserved /loop command rename |
+| owned-surface-guard | A | 2026-06-18 08:11 | PASS | issue #63 (autopilot-stray-wip-guard) 2026-06-12; issue #81 (owned-paths-zsh-split) 2026-06-13 |
+| pnpm-audit-ci-gate | A | 2026-06-18 08:11 | PASS | issue #171 — pnpm security audits must run in CI |
+| ralph-fallback-order | A | 2026-06-18 08:11 | PASS | conversation 2026-06-12 (Ralph default fallback order) |
+| rl-delegation-write-worker | A | 2026-06-18 08:11 | PASS | memory/MEMORY.md 2026-06-10 (rl-delegation) #57 |
+| ship-spec-ready-finalization | A | 2026-06-18 08:11 | PASS | issue #134 — /ship-spec must finalize ready PRs after gates, not stop at draft scaffold |
+| skill-paths | A | 2026-06-18 08:11 | PASS | issue #43 — stale path references; extended by issue #69 — apps/->packages/ rename guard |
+| submitted-by-trailers | A | 2026-06-18 08:11 | PASS | conversation 2026-06-12 (commit attribution trailers) |
+| watchdog-completed-session-reap | A | 2026-06-18 08:11 | PASS | issue #235 (completed autopilot PR session reaping) |
+| watchdog-draft-prs | A | 2026-06-18 08:11 | PASS | conversation 2026-06-15 (generic watchdog + stale draft PR recovery) |
+| watchdog-stuck-sessions | A | 2026-06-18 08:11 | PASS | issue #240 (Codex zero-credit stuck autopilot sessions) 2026-06-17 |
+| wiki-readme-index | A | 2026-06-18 08:11 | PASS | issue #132 — wiki README index drift guard |
 
 <!-- benchmark: pass-rate = PASS / (PASS + REGRESSION + TIMEOUT); SKIPPED excluded -->

--- a/evals/probes/harness-audit-memory-path.sh
+++ b/evals/probes/harness-audit-memory-path.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # tier: A
-# source: issue #183 — /harness-audit must inspect the active worktree, not a hardcoded root
-# desc: /harness-audit context snapshot must resolve AUDIT_ROOT and avoid hardcoded source paths
+# source: issue #183 and #432 — /harness-audit must inspect active worktree source but load shared durable memory
+# desc: /harness-audit context snapshot must resolve AUDIT_ROOT for source and AUDIT_LOG_ROOT for long-term memory
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
@@ -19,8 +19,18 @@ if ! grep -q 'AUDIT_ROOT' "$SKILL" || ! grep -q 'CRON_WORKTREE' "$SKILL"; then
   exit 1
 fi
 
-if ! grep -q '\$AUDIT_ROOT/memory/MEMORY\.md' "$SKILL"; then
-  echo "REGRESSION: harness-audit context snapshot does not tail tracked memory/MEMORY.md via AUDIT_ROOT" >&2
+if ! grep -q 'AUDIT_LOG_ROOT="${AUTOPILOT_LOG_ROOT:-\$AUDIT_ROOT}"' "$SKILL"; then
+  echo "REGRESSION: harness-audit does not derive AUDIT_LOG_ROOT from AUTOPILOT_LOG_ROOT with AUDIT_ROOT fallback" >&2
+  exit 1
+fi
+
+if ! grep -Eq 'tail -40 "\$AUDIT_LOG_ROOT/memory/MEMORY\.md"' "$SKILL"; then
+  echo "REGRESSION: harness-audit context snapshot does not tail durable memory/MEMORY.md via AUDIT_LOG_ROOT" >&2
+  exit 1
+fi
+
+if grep -Eq '^tail -40 "\$AUDIT_ROOT/memory/MEMORY\.md"' "$SKILL"; then
+  echo "REGRESSION: harness-audit executable context snapshot tails long-term memory via AUDIT_ROOT" >&2
   exit 1
 fi
 
@@ -30,5 +40,5 @@ if grep -n '/home/sandbox/harness' "$SKILL" >"$TMP"; then
   exit 1
 fi
 
-echo "PASS: harness-audit resolves source inspection through AUDIT_ROOT" >&2
+echo "PASS: harness-audit resolves source through AUDIT_ROOT and durable memory through AUDIT_LOG_ROOT" >&2
 exit 0

--- a/tasks/make-harness-audit-load-shared-memory/critique.md
+++ b/tasks/make-harness-audit-load-shared-memory/critique.md
@@ -1,0 +1,24 @@
+# Critique — make-harness-audit-load-shared-memory
+
+Generated 2026-06-18; reviews `prd.md` post-/prd, pre-/ralph.
+
+## Critic A — Implementer lens
+
+CRITIC_A — IMPLEMENTER LENS
+[SEVERITY: H] [STORY: US-001] `AUDIT_LOG_ROOT` contract is underspecified; PRD does not say whether `/harness-audit` must compute it, consume `AUTOPILOT_LOG_ROOT`, or require an exported env var, risking manual/root-mode breakage or empty tails. | [EVIDENCE: US-001 AC: “tails "$AUDIT_LOG_ROOT/memory/MEMORY.md"”; existing pattern uses `AUTOPILOT_LOG_ROOT` fallback] | Define required resolution order and fallback behavior, e.g. `AUDIT_LOG_ROOT="${AUTOPILOT_LOG_ROOT:-$AUDIT_ROOT}"`, plus worktree root derivation when `CRON_WORKTREE` is set.
+[SEVERITY: M] [STORY: US-002] Eval AC is too broad about failing on `AUDIT_ROOT/memory/MEMORY.md`; `/harness-audit` may still mention that path in docs, prompts, or path tables, so a grep-only probe could create false failures. | [EVIDENCE: US-002 AC: “fails if the context snapshot tails `AUDIT_ROOT/memory/MEMORY.md` for long-term memory”] | Specify the probe checks the executable context-snapshot tail command only, not every textual mention of memory paths.
+[SEVERITY: M] [STORY: US-003] Task-artifact AC asks `critique.md` to “reflect the completed task,” which conflicts with critique’s role as pre-implementation review evidence and may cause implementers to overwrite critic findings after the fact. | [EVIDENCE: US-003 AC: “prd.json, prompt.md, progress.txt, and critique.md reflect the completed task”] | Change to “critique.md records pre-implementation findings and synthesis; progress.txt records completion.”
+
+## Critic B — User lens
+
+CRITIC_B — USER LENS
+[SEVERITY: M] [STORY: US-001] [AUDIT_LOG_ROOT fallback/missing-file behavior is undefined, so implementers may break manual `/harness-audit` runs outside cron or fail noisily when shared memory is absent.] | [EVIDENCE: PRD US-001 acceptance criteria] | [RECOMMENDATION: Specify expected behavior when `AUDIT_LOG_ROOT` is unset, missing, or lacks `memory/MEMORY.md`.]
+[SEVERITY: L] [STORY: US-003] [`critique.md` “reflect the completed task” is circular before implementation and ambiguous for critics producing this review.] | [EVIDENCE: PRD US-003 acceptance criteria] | [RECOMMENDATION: Reword to require `critique.md` to preserve pre-implementation critic findings and task state artifacts to reflect completion after implementation.]
+[SEVERITY: L] [STORY: *] [Wiki impact marked NOT-APPLICABLE despite introducing a reusable root-semantics distinction (`AUDIT_ROOT` source vs `AUDIT_LOG_ROOT` runtime memory) that future agents could misapply.] | [EVIDENCE: PRD Wiki Alignment; US-001] | [RECOMMENDATION: Either add/update a concise wiki note for audit root semantics, or explicitly justify why skill text plus eval is sufficient.]
+
+## Synthesis
+
+- **High-severity findings**: 1, mitigated in `prd.md` US-001 by specifying the required `AUDIT_LOG_ROOT` resolution order and missing-file fallback behavior.
+- **Medium-severity findings**: 3, mitigated in `prd.md` by scoping the eval guard to the executable tail command, preserving critique as pre-implementation evidence, and defining fallback behavior.
+- **Low-severity findings**: 2, mitigated by clarifying task-artifact roles and documenting why the root-semantics distinction lives in the skill text rather than a new wiki entry for this narrow internal fix.
+- **Recommendation**: PROCEED — no unmitigated high-severity findings remain.

--- a/tasks/make-harness-audit-load-shared-memory/prd.json
+++ b/tasks/make-harness-audit-load-shared-memory/prd.json
@@ -1,0 +1,45 @@
+{
+  "slug": "make-harness-audit-load-shared-memory",
+  "issue": 432,
+  "branchName": "feat/432-make-harness-audit-load-shared-memory",
+  "title": "Make /harness-audit load shared memory",
+  "stories": [
+    {
+      "id": "US-001",
+      "title": "Read durable memory from AUDIT_LOG_ROOT",
+      "priority": 1,
+      "passes": true,
+      "acceptanceCriteria": [
+        "The skill keeps AUDIT_LOG_ROOT resolution via AUTOPILOT_LOG_ROOT fallback and shared worktree-list root derivation in cron worktree mode.",
+        "Manual/root-mode runs remain non-fatal when shared memory is absent.",
+        "The executable context-snapshot command tails $AUDIT_LOG_ROOT/memory/MEMORY.md for recent long-term memory.",
+        "Source inspection paths continue to use AUDIT_ROOT."
+      ],
+      "notes": "Completed 2026-06-18; harness-audit tails durable memory via AUDIT_LOG_ROOT while source inspection stays on AUDIT_ROOT."
+    },
+    {
+      "id": "US-002",
+      "title": "Guard the memory-root contract with eval",
+      "priority": 2,
+      "passes": true,
+      "acceptanceCriteria": [
+        "evals/probes/harness-audit-memory-path.sh fails if the executable context-snapshot tail command uses AUDIT_ROOT/memory/MEMORY.md.",
+        "The probe passes only when AUDIT_ROOT is still resolved from CRON_WORKTREE and AUDIT_LOG_ROOT/memory/MEMORY.md is used for the memory tail.",
+        "The probe remains free of hardcoded checkout paths."
+      ],
+      "notes": "Completed 2026-06-18; harness-audit-memory-path probe guards AUDIT_LOG_ROOT memory tail and AUDIT_ROOT source resolution."
+    },
+    {
+      "id": "US-003",
+      "title": "Update release notes and task state",
+      "priority": 3,
+      "passes": true,
+      "acceptanceCriteria": [
+        "CHANGELOG.md records the fix under Unreleased.",
+        "Task artifacts preserve critique findings and record completion.",
+        "/eval is run and evals/RESULTS.md is refreshed."
+      ],
+      "notes": "Completed 2026-06-18; changelog, task artifacts, and eval scoreboard refreshed."
+    }
+  ]
+}

--- a/tasks/make-harness-audit-load-shared-memory/prd.md
+++ b/tasks/make-harness-audit-load-shared-memory/prd.md
@@ -1,0 +1,61 @@
+# PRD — Make /harness-audit load shared memory
+
+## Summary
+
+Make `/harness-audit` read durable long-term memory from the shared runtime log root (`AUDIT_LOG_ROOT`) when running inside an isolated cron worktree, while preserving source inspection against the isolated checkout (`AUDIT_ROOT`).
+
+## Goals
+
+- Prevent autopilot research audits from using template-empty `memory/MEMORY.md` files in ephemeral cron worktrees.
+- Keep harness source inspection worktree-local so audits still evaluate the branch under test.
+- Add a deterministic eval guard that fails if the long-term memory tail reverts to `AUDIT_ROOT`.
+
+## Non-Goals
+
+- Do not change auditor prompts beyond the context snapshot path semantics.
+- Do not alter autopilot selection, cap enforcement, or cron worktree creation.
+- Do not move or rewrite memory files.
+
+## User Stories
+
+### US-001 — Read durable memory from `AUDIT_LOG_ROOT`
+
+As the autopilot loop, I want `/harness-audit` to tail shared long-term memory in cron worktree mode so research uses durable lessons rather than template-empty worktree memory.
+
+Acceptance criteria:
+- The skill keeps the existing resolution order: `AUDIT_LOG_ROOT="${AUTOPILOT_LOG_ROOT:-$AUDIT_ROOT}"`, then derives the shared worktree-list root when `CRON_WORKTREE` is set and no explicit log root was provided.
+- Manual/root-mode runs remain safe: when `AUDIT_LOG_ROOT` is unset, missing, or lacks `memory/MEMORY.md`, the `tail ... 2>/dev/null` behavior stays non-fatal.
+- The executable context-snapshot command tails `"$AUDIT_LOG_ROOT/memory/MEMORY.md"`, not `"$AUDIT_ROOT/memory/MEMORY.md"`, for recent long-term memory.
+- Source inspection paths continue to use `AUDIT_ROOT` for skills, agents, crons, wiki, package files, CI definitions, and worktree listing.
+- The skill text explains that long-term memory is a durable/runtime artifact while source inspection remains worktree-local.
+
+### US-002 — Guard the memory-root contract with eval
+
+As a maintainer, I want a deterministic eval probe to catch regressions in the `/harness-audit` memory path contract.
+
+Acceptance criteria:
+- `evals/probes/harness-audit-memory-path.sh` fails if the executable context-snapshot tail command uses `AUDIT_ROOT/memory/MEMORY.md` for long-term memory.
+- The probe may allow explanatory prose or tables to mention `memory/MEMORY.md`; it must guard the live tail command, not every textual mention.
+- The probe passes only when the skill still resolves `AUDIT_ROOT` from `CRON_WORKTREE` and uses `AUDIT_LOG_ROOT/memory/MEMORY.md` for the memory tail.
+- The probe remains free of hardcoded checkout paths.
+
+### US-003 — Update release notes and task state
+
+As a reviewer, I want the task artifacts and changelog to document the behavioral fix.
+
+Acceptance criteria:
+- `CHANGELOG.md` records the fix under `## [Unreleased]`.
+- `critique.md` preserves the pre-implementation critic findings and mitigation synthesis; `prd.json`, `prompt.md`, and `progress.txt` reflect implementation completion.
+- `/eval` is run and `evals/RESULTS.md` is refreshed.
+
+## Wiki Alignment
+
+- **Impact**: NOT-APPLICABLE
+- **Local entries**: none
+- **Spec alignment**: This is a narrow internal path-root bug fix guarded by an eval probe and explicit skill prose; it does not introduce a new public operator workflow. The reusable root-semantics distinction (`AUDIT_ROOT` = source checkout, `AUDIT_LOG_ROOT` = runtime/durable logs and memory) is documented in the skill itself where future auditors read it before execution.
+- **DeepWiki comparison**: no relevant DeepWiki page required for this narrow source-path correction.
+- **Acceptance criteria**: changelog + eval guard are sufficient documentation for reviewers and future agents.
+
+## Critique Synthesis
+
+Critics flagged one high-severity ambiguity: `AUDIT_LOG_ROOT` fallback behavior was underspecified. Mitigation is encoded directly in US-001: keep the existing resolution order (`AUTOPILOT_LOG_ROOT` override, then shared worktree-list root in cron worktree mode, otherwise `AUDIT_ROOT`) and preserve non-fatal missing-file behavior. Medium/low findings were also mitigated: US-002 now scopes the grep to the executable tail command, US-003 preserves critique as pre-implementation evidence, and the Wiki Alignment section explains why skill-local prose plus the eval guard is sufficient for this narrow internal fix.

--- a/tasks/make-harness-audit-load-shared-memory/progress.txt
+++ b/tasks/make-harness-audit-load-shared-memory/progress.txt
@@ -1,0 +1,52 @@
+# progress
+
+## Codebase Patterns
+
+- `/harness-audit` distinguishes `AUDIT_ROOT` (source checkout under audit) from `AUDIT_LOG_ROOT` (shared runtime log/memory checkout for ephemeral cron worktrees). Keep source inspection on `AUDIT_ROOT`; use `AUDIT_LOG_ROOT` only for runtime observability and durable memory reads.
+
+## US-001 — 2026-06-18 08:11 UTC
+
+**Title**: Read durable memory from `AUDIT_LOG_ROOT`
+**Files changed**: `.claude/skills/harness-audit/SKILL.md`
+**Commit**: pending
+**Result**: PASS
+
+### What I did
+Changed the context snapshot's long-term memory tail to use `AUDIT_LOG_ROOT` while preserving `AUDIT_ROOT` for source inspection. Clarified the skill comments and key-path table so future auditors keep the root split intact.
+
+### Learnings for future iterations
+In cron worktree mode, durable memory is runtime context rather than branch source; read it from the shared log root but keep code/wiki/package inspection on the isolated worktree.
+
+---
+
+## US-002 — 2026-06-18 08:11 UTC
+
+**Title**: Guard the memory-root contract with eval
+**Files changed**: `evals/probes/harness-audit-memory-path.sh`
+**Commit**: pending
+**Result**: PASS
+
+### What I did
+Updated the probe to require `AUDIT_LOG_ROOT` fallback derivation and the executable `tail -40 "$AUDIT_LOG_ROOT/memory/MEMORY.md"` command. The probe still checks `AUDIT_ROOT`/`CRON_WORKTREE` resolution and rejects hardcoded checkout paths.
+
+### Learnings for future iterations
+Probe the executable command shape rather than all prose references to avoid false positives when docs mention historical or conceptual paths.
+
+---
+
+## US-003 — 2026-06-18 08:11 UTC
+
+**Title**: Update release notes and task state
+**Files changed**: `CHANGELOG.md`, `evals/RESULTS.md`, `tasks/make-harness-audit-load-shared-memory/*`
+**Commit**: pending
+**Result**: PASS
+
+### What I did
+Recorded the fix in the changelog, preserved critic findings and mitigations, marked all stories complete in `prd.json`, and ran the full eval suite. `/eval` exited 0 with all 46 probes PASS.
+
+### Learnings for future iterations
+An existing eval probe can be updated to guard a refined contract when the old assertion conflicts with the new bug fix.
+
+---
+
+STATUS: COMPLETE

--- a/tasks/make-harness-audit-load-shared-memory/prompt.md
+++ b/tasks/make-harness-audit-load-shared-memory/prompt.md
@@ -1,0 +1,17 @@
+# Ralph iteration — make-harness-audit-load-shared-memory
+
+You are one iteration of a Ralph loop implementing `make-harness-audit-load-shared-memory`.
+
+## Context
+
+- PRD: `tasks/make-harness-audit-load-shared-memory/prd.md`
+- Structured stories: `tasks/make-harness-audit-load-shared-memory/prd.json`
+- Critique: `tasks/make-harness-audit-load-shared-memory/critique.md`
+- Branch: `feat/432-make-harness-audit-load-shared-memory`
+- Issue: #432
+
+## Critical rules
+
+- Harness-infra only.
+- Preserve source inspection against `AUDIT_ROOT`; move only the long-term memory tail to `AUDIT_LOG_ROOT`.
+- Run the relevant eval probe and the full `/eval` runner before finalizing.


### PR DESCRIPTION
## Selection rationale

Queue selection: the in-session queue check selected open autopilot issue #432 ("feat: make harness-audit load shared memory") as the oldest ticket it considered actionable. Reconciliation after PR creation found existing open PRs #433 and #434 also close #432, so this PR is ready for review but may be duplicate; autopilot is leaving all PRs open for human review rather than auto-closing.

---

## Summary

- Make `/harness-audit` tail durable long-term memory from `AUDIT_LOG_ROOT` in cron worktrees.
- Keep source inspection on `AUDIT_ROOT` and document the root split in the skill.
- Update the `harness-audit-memory-path` eval probe and refresh `evals/RESULTS.md`.

## Verification

- `bash evals/probes/harness-audit-memory-path.sh`
- `bash .claude/skills/eval/run.sh` → 46 probes PASS
- `pnpm run test:scripts` → 275 tests PASS

Closes #432

