### PR TITLE
FROM feat/437-autopilot-open-pr-dedupe TO development

### DIFF
--- a/.claude/skills/autopilot/SKILL.md
+++ b/.claude/skills/autopilot/SKILL.md
@@ -212,28 +212,62 @@ release_overlap_lock() { [ -n "${OVERLAP_PIDFILE:-}" ] && rm -f "$OVERLAP_PIDFIL
 
 GitHub issues labeled `autopilot` ARE the work queue. There are no time throttles and no in-repo backlog — the user steers by filing `autopilot`-labeled issues.
 
-**Queue check** — actionable = open, labeled `autopilot`, NOT labeled `autopilot-blocked`, and with no linked PR (GitHub's `linked:pr` qualifier matches PRs with closing keywords — our `Closes #N` convention):
+**Queue check** — actionable = open, labeled `autopilot`, NOT labeled `autopilot-blocked`, and with **no open PR reference**. Do **not** rely only on GitHub's `linked:pr` qualifier: PRs targeting `development` may carry `Closes #N` in their body while `closingIssuesReferences` / `linked:pr` stays empty until default-branch semantics apply. Enumerate open PRs once, then dedupe each candidate issue locally by linked metadata, head branch, title, and body text.
 
 ```bash
+OPEN_PRS_JSON="/tmp/autopilot-open-prs-$$.json"
+QUEUE_JSON="/tmp/autopilot-queue-$$.json"
+gh pr list --repo "$AUTOPILOT_REPO" --state open --limit 200 \
+  --json number,title,headRefName,body,closingIssuesReferences > "$OPEN_PRS_JSON"
 gh issue list --repo "$AUTOPILOT_REPO" --state open --label autopilot \
-  --search "-linked:pr -label:autopilot-blocked" \
-  --json number,title,createdAt --jq 'sort_by(.createdAt)'
+  --search "-label:autopilot-blocked" \
+  --json number,title,createdAt > "$QUEUE_JSON"
+
+issue_open_pr_refs() {
+  local issue="$1"
+  jq -r --arg issue "$issue" --argjson issue_num "$issue" '
+    def issue_re: "(^|[^0-9])" + $issue + "($|[^0-9])";
+    .[]
+    | select(
+        ([.closingIssuesReferences[]?.number] | index($issue_num))
+        or ((.headRefName // "") | test(issue_re))
+        or ((.title // "") | test("#" + $issue + "|issue[[:space:]]*" + $issue; "i"))
+        or ((.body // "") | test("#" + $issue + "|close[sd]?[[:space:]]+#" + $issue + "|fix(e[sd])?[[:space:]]+#" + $issue + "|resolve[sd]?[[:space:]]+#" + $issue; "i"))
+      )
+    | "#\(.number) \(.headRefName) \(.title)"
+  ' "$OPEN_PRS_JSON"
+}
+
+ISSUE_NUM=""; TITLE=""; CREATED=""; DEDUPE_STATE="none"
+while IFS= read -r row; do
+  n=$(jq -r .number <<<"$row")
+  refs=$(issue_open_pr_refs "$n" || true)
+  if [ -n "$refs" ]; then
+    DEDUPE_STATE="${DEDUPE_STATE}; issue #$n has open PR(s): $(printf '%s' "$refs" | paste -sd ', ' -)"
+    echo "DEDUPE: issue #$n already has open PR reference(s): $refs"
+    continue
+  fi
+  ISSUE_NUM="$n"
+  TITLE=$(jq -r .title <<<"$row")
+  CREATED=$(jq -r .createdAt <<<"$row")
+  break
+ done < <(jq -c 'sort_by(.createdAt)[]' "$QUEUE_JSON")
 ```
 
-- **Oldest actionable issue wins** → `ISSUE_NUM`, `TITLE`, `CREATED`. Derive `SLUG` from the title (kebab-case, ≤5 words). Set:
+- **Oldest actionable issue wins** → when `ISSUE_NUM` is non-empty, derive `SLUG` from the title (kebab-case, ≤5 words). Set:
   ```
   SELECTION_MODE=queue
-  SELECTION_RATIONALE="Queue selection: implementing open autopilot issue #$ISSUE_NUM (\"$TITLE\") — the oldest actionable ticket (filed $CREATED) with no open PR."
+  SELECTION_RATIONALE="Queue selection: implementing open autopilot issue #$ISSUE_NUM (\"$TITLE\") — the oldest actionable ticket (filed $CREATED) with no open PR reference after local PR dedupe."
   ```
-  Compute the expected work branch and dedupe before launching work:
+  Compute the expected work branch and run a final launch dedupe before starting work:
   ```bash
   BRANCH="feat/$ISSUE_NUM-$SLUG"
   SAFE_SESSION=$(safe_branch_session "$BRANCH")   # autopilot-feat-123-slug
   ACTIVE_MARKER="/tmp/$SAFE_SESSION.active"
   LINKED_PR=$(gh pr list --repo "$AUTOPILOT_REPO" --state open --head "$BRANCH" --json number --jq '.[0].number // empty')
-  LINKED_ISSUE_PR=$(gh issue list --repo "$AUTOPILOT_REPO" --state open --label autopilot --search "$ISSUE_NUM linked:pr" --json number --jq '.[0].number // empty')
+  LINKED_ISSUE_PR=$(issue_open_pr_refs "$ISSUE_NUM" || true)
   if tmux has-session -t "$SAFE_SESSION" 2>/dev/null || [ -n "$LINKED_PR" ] || [ -n "$LINKED_ISSUE_PR" ] || [ -e "$ACTIVE_MARKER" ]; then
-    echo "DEDUPE: issue #$ISSUE_NUM / $SLUG already active (session=$SAFE_SESSION pr=$LINKED_PR linked_issue_pr=$LINKED_ISSUE_PR marker=$ACTIVE_MARKER); skipping"
+    echo "DEDUPE: issue #$ISSUE_NUM / $SLUG already active (session=$SAFE_SESSION branch_pr=$LINKED_PR issue_pr_refs=$LINKED_ISSUE_PR marker=$ACTIVE_MARKER); skipping"
     # memory log Result: NOTHING-NEW, liveness NOTHING-NEW, close_no_pr_session, exit 0; do not touch keep-marker.
     close_no_pr_session
     exit 0
@@ -272,6 +306,7 @@ gh issue list --repo "$AUTOPILOT_REPO" --state open --label autopilot \
 [dry-run] selected: #$ISSUE_NUM ($SLUG)        # research path: "would file + build: <finding>"
 [dry-run] executor: $EXECUTOR
 [dry-run] open autopilot PRs created today: $OPEN_TODAY (cap 6); total open: $TOTAL_OPEN (ceiling 10)
+[dry-run] dedupe: $DEDUPE_STATE
 [dry-run] exiting without calling /ship-spec, /delegate, or scripts/ralph.sh
 ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,11 @@ Update policy and release automation live in [`/git`](.claude/skills/git/SKILL.m
 ## [Unreleased]
 
 ### Added
+- `autopilot-open-pr-reference-dedupe` eval probe guards that issue selection checks open PR metadata, branch names, titles, and bodies before launching duplicate autopilot work ([#437](https://github.com/mifunedev/openharness/issues/437)).
 - `harness-audit-shared-memory` eval probe guards that `/harness-audit` reads durable long-term memory from `AUDIT_LOG_ROOT` in cron worktrees while preserving source inspection via `AUDIT_ROOT` ([#432](https://github.com/mifunedev/openharness/issues/432)).
 ### Changed
 ### Fixed
+- Autopilot issue selection now dedupes against open PR references in linked metadata, branch names, titles, and bodies before starting work, preventing repeated PRs for the same issue when GitHub linked-PR metadata is empty ([#437](https://github.com/mifunedev/openharness/issues/437)).
 ### Removed
 ### Deprecated
 ### Security

--- a/crons/autopilot.md
+++ b/crons/autopilot.md
@@ -28,7 +28,8 @@ re-running implement/eval/finalize itself.
 Invoke the `/autopilot` skill. Reminders:
 
 - **Selection is issue-queue-first**: implement the oldest open issue labeled
-  `autopilot` that has no open PR. If the queue is empty, run first-principles
+  `autopilot` that has no open PR reference (linked metadata, branch, title, or body).
+  If the queue is empty, run first-principles
   research (`/harness-audit`), then **file an `autopilot` ticket from the
   top-ranked finding and build it** this same run. GitHub issues are the queue.
 - **Every PR states its selection rationale** in the description — why this item

--- a/evals/RESULTS.md
+++ b/evals/RESULTS.md
@@ -6,52 +6,53 @@ probe id; git history is the time series.** Schema and exit-code semantics are i
 
 | probe | tier | last-run (UTC) | status | source |
 |-------|------|----------------|--------|--------|
-| agent-browser-cli | A | 2026-06-18 11:08 | PASS | memory/MEMORY.md 2026-06-07 (agent-browser 0.8.5 CLI) |
-| autopilot-executor-toggle | A | 2026-06-18 11:08 | PASS | conversation 2026-06-13 (autopilot delegate-advisor executor) |
-| autopilot-no-pr-session-close | A | 2026-06-18 11:08 | PASS | issue #209 (autopilot no-PR tmux session closure) 2026-06-16 |
-| autopilot-pi-agent | A | 2026-06-18 11:08 | PASS | issue #116 (autopilot Pi tmux alignment) 2026-06-14; issue #118 (attachable Pi TUI tmux) 2026-06-14; issue #126 (kept Pi overlap lock release) 2026-06-14; issue #142 (worktree-by-default, skip→worktree) 2026-06-14 |
-| autopilot-preflight-gate | A | 2026-06-18 11:08 | PASS | issue #194 (deterministic autopilot caps preflight gate) 2026-06-15 |
-| autopilot-upstream-default | A | 2026-06-18 11:08 | PASS | issue #420 — future autopilots must target canonical repo, not personal fork |
-| autopilot-worktree-log-root | A | 2026-06-18 11:08 | PASS | issue #152 (persist autopilot worktree logs) 2026-06-15 |
-| boot-lint-glob | A | 2026-06-18 11:08 | PASS | issue #90, issue #120 |
-| capability-benchmark-schema | A | 2026-06-18 11:08 | PASS | issue #167 — capability benchmark instrument |
-| clean-restore | A | 2026-06-18 11:08 | PASS | issue #63 (autopilot-stray-wip-guard) 2026-06-12; issue #81 (owned-paths-zsh-split) 2026-06-13 |
-| cleanup-tasks-scoped-guard | A | 2026-06-18 11:08 | PASS | issue #85 |
-| cleanup-tasks-worktree-grooming | A | 2026-06-18 11:08 | PASS | issue #168 |
-| cron-claude-codex-fallback | A | 2026-06-18 11:08 | PASS | conversation 2026-06-12 (default Codex fallback for crons) |
-| cron-watchdog | A | 2026-06-18 11:08 | PASS | issue #130 (cron runtime watchdog) 2026-06-14 |
-| curl-bash-safe-alternatives | A | 2026-06-18 11:08 | PASS | vet-run/vet integration — public curl|bash examples need review-first alternatives |
-| datasets-schema | A | 2026-06-18 11:08 | PASS | issue #196 — evals/datasets verifiable trajectory corpus (Repo2RLEnv-inspired) |
-| devtcp-hook | A | 2026-06-18 11:08 | PASS | memory/MEMORY.md 2026-06-10 (zsh /dev/tcp) |
-| drift-check-cron-staleness-glob | A | 2026-06-18 11:08 | PASS | issue #98; issue #225 (restart-required cron frontmatter/config drift) |
-| eval-ci-gate | A | 2026-06-18 11:08 | PASS | #103 — eval probe suite gated in CI |
-| eval-gate | A | 2026-06-18 11:08 | PASS | memory/MEMORY.md 2026-06-11 (eval-gate) |
-| eval-results-atomic | A | 2026-06-18 11:08 | PASS | issue #83 (eval-results-atomic-write) |
-| eval-runner-exit | A | 2026-06-18 11:08 | PASS | memory/MEMORY.md 2026-06-11 (eval-runner-exit) #29 |
-| git-skill | A | 2026-06-18 11:08 | PASS | conversation 2026-06-15 — rules are not always supported; git workflow must be the /git skill |
-| harness-audit-empty-output-gate | A | 2026-06-18 11:08 | PASS | issue #246 — /harness-audit must fail closed on empty auditor outputs |
-| harness-audit-memory-path | A | 2026-06-18 11:08 | PASS | issue #183 — /harness-audit must inspect the active worktree, not a hardcoded root |
-| harness-audit-shared-memory | A | 2026-06-18 11:08 | PASS | issue #432 — /harness-audit must load durable memory from shared log root in cron worktrees |
-| harness-ci-core-paths | A | 2026-06-18 11:08 | PASS | #165 — core sandbox config files must trigger harness CI |
-| harness-ci-hooks-paths | A | 2026-06-18 11:08 | PASS | issue #202 — credential/security hook changes must trigger harness CI |
-| health-check-docker-stats | A | 2026-06-18 11:08 | PASS | memory/MEMORY.md 2026-06-10 (docker stats vs ps Size) |
-| locked-append-critical-path | A | 2026-06-18 11:08 | PASS | issue #204 (lock shared runtime log appends) 2026-06-15 |
-| loop-benchmark-gate | A | 2026-06-18 11:08 | PASS | issue #179 — wire the executable-loop `benchmark` node (close the cycle) |
-| loop-handoff-consistency | A | 2026-06-18 11:08 | PASS | context/rules/loop.md § 4 (executable-loop Handoff convention) |
-| loop-repeat-gate | A | 2026-06-18 11:08 | PASS | issue #173 — wire the executable-loop `repeat` node (cycle-closing edge) |
-| memory-gitignore-claim | A | 2026-06-18 11:08 | PASS | issue #101 |
-| next-dev-prod | A | 2026-06-18 11:08 | PASS | memory/MEMORY.md 2026-06-04 |
-| orchestrate-contract | A | 2026-06-18 11:08 | PASS | issue #160 — /orchestrate contract; issue #175 — reserved /loop command rename |
-| owned-surface-guard | A | 2026-06-18 11:08 | PASS | issue #63 (autopilot-stray-wip-guard) 2026-06-12; issue #81 (owned-paths-zsh-split) 2026-06-13 |
-| pnpm-audit-ci-gate | A | 2026-06-18 11:08 | PASS | issue #171 — pnpm security audits must run in CI |
-| ralph-fallback-order | A | 2026-06-18 11:08 | PASS | conversation 2026-06-12 (Ralph default fallback order) |
-| rl-delegation-write-worker | A | 2026-06-18 11:08 | PASS | memory/MEMORY.md 2026-06-10 (rl-delegation) #57 |
-| ship-spec-ready-finalization | A | 2026-06-18 11:08 | PASS | issue #134 — /ship-spec must finalize ready PRs after gates, not stop at draft scaffold |
-| skill-paths | A | 2026-06-18 11:08 | PASS | issue #43 — stale path references; extended by issue #69 — apps/->packages/ rename guard |
-| submitted-by-trailers | A | 2026-06-18 11:08 | PASS | conversation 2026-06-12 (commit attribution trailers) |
-| watchdog-completed-session-reap | A | 2026-06-18 11:08 | PASS | issue #235 (completed autopilot PR session reaping) |
-| watchdog-draft-prs | A | 2026-06-18 11:08 | PASS | conversation 2026-06-15 (generic watchdog + stale draft PR recovery) |
-| watchdog-stuck-sessions | A | 2026-06-18 11:08 | PASS | issue #240 (Codex zero-credit stuck autopilot sessions) 2026-06-17 |
-| wiki-readme-index | A | 2026-06-18 11:08 | PASS | issue #132 — wiki README index drift guard |
+| agent-browser-cli | A | 2026-06-18 20:00 | PASS | memory/MEMORY.md 2026-06-07 (agent-browser 0.8.5 CLI) |
+| autopilot-executor-toggle | A | 2026-06-18 20:00 | PASS | conversation 2026-06-13 (autopilot delegate-advisor executor) |
+| autopilot-no-pr-session-close | A | 2026-06-18 20:00 | PASS | issue #209 (autopilot no-PR tmux session closure) 2026-06-16 |
+| autopilot-open-pr-reference-dedupe | A | 2026-06-18 20:00 | PASS | issue #437 — autopilot must not start duplicate work when open PRs reference the same issue without linked-PR metadata |
+| autopilot-pi-agent | A | 2026-06-18 20:00 | PASS | issue #116 (autopilot Pi tmux alignment) 2026-06-14; issue #118 (attachable Pi TUI tmux) 2026-06-14; issue #126 (kept Pi overlap lock release) 2026-06-14; issue #142 (worktree-by-default, skip→worktree) 2026-06-14 |
+| autopilot-preflight-gate | A | 2026-06-18 20:00 | PASS | issue #194 (deterministic autopilot caps preflight gate) 2026-06-15 |
+| autopilot-upstream-default | A | 2026-06-18 20:00 | PASS | issue #420 — future autopilots must target canonical repo, not personal fork |
+| autopilot-worktree-log-root | A | 2026-06-18 20:00 | PASS | issue #152 (persist autopilot worktree logs) 2026-06-15 |
+| boot-lint-glob | A | 2026-06-18 20:00 | PASS | issue #90, issue #120 |
+| capability-benchmark-schema | A | 2026-06-18 20:00 | PASS | issue #167 — capability benchmark instrument |
+| clean-restore | A | 2026-06-18 20:00 | PASS | issue #63 (autopilot-stray-wip-guard) 2026-06-12; issue #81 (owned-paths-zsh-split) 2026-06-13 |
+| cleanup-tasks-scoped-guard | A | 2026-06-18 20:00 | PASS | issue #85 |
+| cleanup-tasks-worktree-grooming | A | 2026-06-18 20:00 | PASS | issue #168 |
+| cron-claude-codex-fallback | A | 2026-06-18 20:00 | PASS | conversation 2026-06-12 (default Codex fallback for crons) |
+| cron-watchdog | A | 2026-06-18 20:00 | PASS | issue #130 (cron runtime watchdog) 2026-06-14 |
+| curl-bash-safe-alternatives | A | 2026-06-18 20:00 | PASS | vet-run/vet integration — public curl|bash examples need review-first alternatives |
+| datasets-schema | A | 2026-06-18 20:00 | PASS | issue #196 — evals/datasets verifiable trajectory corpus (Repo2RLEnv-inspired) |
+| devtcp-hook | A | 2026-06-18 20:00 | PASS | memory/MEMORY.md 2026-06-10 (zsh /dev/tcp) |
+| drift-check-cron-staleness-glob | A | 2026-06-18 20:00 | PASS | issue #98; issue #225 (restart-required cron frontmatter/config drift) |
+| eval-ci-gate | A | 2026-06-18 20:00 | PASS | #103 — eval probe suite gated in CI |
+| eval-gate | A | 2026-06-18 20:00 | PASS | memory/MEMORY.md 2026-06-11 (eval-gate) |
+| eval-results-atomic | A | 2026-06-18 20:00 | PASS | issue #83 (eval-results-atomic-write) |
+| eval-runner-exit | A | 2026-06-18 20:00 | PASS | memory/MEMORY.md 2026-06-11 (eval-runner-exit) #29 |
+| git-skill | A | 2026-06-18 20:00 | PASS | conversation 2026-06-15 — rules are not always supported; git workflow must be the /git skill |
+| harness-audit-empty-output-gate | A | 2026-06-18 20:00 | PASS | issue #246 — /harness-audit must fail closed on empty auditor outputs |
+| harness-audit-memory-path | A | 2026-06-18 20:00 | PASS | issue #183 — /harness-audit must inspect the active worktree, not a hardcoded root |
+| harness-audit-shared-memory | A | 2026-06-18 20:00 | PASS | issue #432 — /harness-audit must load durable memory from shared log root in cron worktrees |
+| harness-ci-core-paths | A | 2026-06-18 20:00 | PASS | #165 — core sandbox config files must trigger harness CI |
+| harness-ci-hooks-paths | A | 2026-06-18 20:00 | PASS | issue #202 — credential/security hook changes must trigger harness CI |
+| health-check-docker-stats | A | 2026-06-18 20:00 | PASS | memory/MEMORY.md 2026-06-10 (docker stats vs ps Size) |
+| locked-append-critical-path | A | 2026-06-18 20:00 | PASS | issue #204 (lock shared runtime log appends) 2026-06-15 |
+| loop-benchmark-gate | A | 2026-06-18 20:00 | PASS | issue #179 — wire the executable-loop `benchmark` node (close the cycle) |
+| loop-handoff-consistency | A | 2026-06-18 20:00 | PASS | context/rules/loop.md § 4 (executable-loop Handoff convention) |
+| loop-repeat-gate | A | 2026-06-18 20:00 | PASS | issue #173 — wire the executable-loop `repeat` node (cycle-closing edge) |
+| memory-gitignore-claim | A | 2026-06-18 20:00 | PASS | issue #101 |
+| next-dev-prod | A | 2026-06-18 20:00 | PASS | memory/MEMORY.md 2026-06-04 |
+| orchestrate-contract | A | 2026-06-18 20:00 | PASS | issue #160 — /orchestrate contract; issue #175 — reserved /loop command rename |
+| owned-surface-guard | A | 2026-06-18 20:00 | PASS | issue #63 (autopilot-stray-wip-guard) 2026-06-12; issue #81 (owned-paths-zsh-split) 2026-06-13 |
+| pnpm-audit-ci-gate | A | 2026-06-18 20:00 | PASS | issue #171 — pnpm security audits must run in CI |
+| ralph-fallback-order | A | 2026-06-18 20:00 | PASS | conversation 2026-06-12 (Ralph default fallback order) |
+| rl-delegation-write-worker | A | 2026-06-18 20:00 | PASS | memory/MEMORY.md 2026-06-10 (rl-delegation) #57 |
+| ship-spec-ready-finalization | A | 2026-06-18 20:00 | PASS | issue #134 — /ship-spec must finalize ready PRs after gates, not stop at draft scaffold |
+| skill-paths | A | 2026-06-18 20:00 | PASS | issue #43 — stale path references; extended by issue #69 — apps/->packages/ rename guard |
+| submitted-by-trailers | A | 2026-06-18 20:00 | PASS | conversation 2026-06-12 (commit attribution trailers) |
+| watchdog-completed-session-reap | A | 2026-06-18 20:00 | PASS | issue #235 (completed autopilot PR session reaping) |
+| watchdog-draft-prs | A | 2026-06-18 20:00 | PASS | conversation 2026-06-15 (generic watchdog + stale draft PR recovery) |
+| watchdog-stuck-sessions | A | 2026-06-18 20:00 | PASS | issue #240 (Codex zero-credit stuck autopilot sessions) 2026-06-17 |
+| wiki-readme-index | A | 2026-06-18 20:00 | PASS | issue #132 — wiki README index drift guard |
 
 <!-- benchmark: pass-rate = PASS / (PASS + REGRESSION + TIMEOUT); SKIPPED excluded -->

--- a/evals/probes/autopilot-executor-toggle.sh
+++ b/evals/probes/autopilot-executor-toggle.sh
@@ -60,11 +60,17 @@ grep -Fq 'tmux rename-session -t "$SESSION" "$SAFE_SESSION"' "$SKILL" || missing
 grep -Fq 'do **not** spawn a second advisor session' "$SKILL" || missing+=("same Pi session is Advisor runtime")
 grep -Fq 'autopilot-<branch>' "$CRON" || missing+=("cron documents autopilot-<branch> session naming")
 
-# Duplicate guard: active tmux session, linked PR, or active marker suppresses duplicate work.
+# Duplicate guard: active tmux session, linked PR, local open-PR issue refs, or active marker suppresses duplicate work.
 grep -Fq 'ACTIVE_MARKER="/tmp/$SAFE_SESSION.active"' "$SKILL" || missing+=("active marker path")
 grep -Fq 'tmux has-session -t "$SAFE_SESSION"' "$SKILL" || missing+=("tmux duplicate guard")
 grep -F 'LINKED_PR=$(gh pr list' "$SKILL" | grep -Fq -- '--head "$BRANCH"' || missing+=("branch PR duplicate guard")
-grep -F 'LINKED_ISSUE_PR=$(gh issue list' "$SKILL" | grep -Fq -- '--search "$ISSUE_NUM linked:pr"' || missing+=("linked issue PR duplicate guard")
+grep -Fq 'OPEN_PRS_JSON="/tmp/autopilot-open-prs-$$.json"' "$SKILL" || missing+=("bulk open PR cache for issue dedupe")
+grep -Fq 'issue_open_pr_refs()' "$SKILL" || missing+=("local issue-to-open-PR reference helper")
+grep -Fq 'closingIssuesReferences' "$SKILL" || missing+=("linked metadata participates in issue PR dedupe")
+grep -Fq 'headRefName' "$SKILL" || missing+=("head branch participates in issue PR dedupe")
+grep -Fq 'body,closingIssuesReferences' "$SKILL" || missing+=("PR body fetched for issue PR dedupe")
+grep -F 'LINKED_ISSUE_PR=$(issue_open_pr_refs' "$SKILL" | grep -Fq '"$ISSUE_NUM"' || missing+=("issue PR reference duplicate guard")
+grep -Fq '[dry-run] dedupe: $DEDUPE_STATE' "$SKILL" || missing+=("dry-run surfaces dedupe state")
 grep -Fq '[ -e "$ACTIVE_MARKER" ]' "$SKILL" || missing+=("active marker duplicate guard")
 grep -Fq 'cleanup_active_marker() { [ -n "${ACTIVE_MARKER:-}" ] && rm -f "$ACTIVE_MARKER"; }' "$SKILL" || missing+=("active marker cleanup helper")
 grep -Fq 'Clean the active marker on finalized PR paths' "$SKILL" || missing+=("finalized PR paths clean active marker")

--- a/evals/probes/autopilot-open-pr-reference-dedupe.sh
+++ b/evals/probes/autopilot-open-pr-reference-dedupe.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# tier: A
+# source: issue #437 — autopilot must not start duplicate work when open PRs reference the same issue without linked-PR metadata
+# desc: /autopilot issue selection must dedupe open issues against open PR refs in linked metadata, branch, title, and body before launching work.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SKILL="$ROOT/.claude/skills/autopilot/SKILL.md"
+
+if [[ ! -f "$SKILL" ]]; then
+  echo "SKIPPED: autopilot skill absent: $SKILL" >&2
+  exit 2
+fi
+
+missing=()
+grep -Fq 'OPEN_PRS_JSON="/tmp/autopilot-open-prs-$$.json"' "$SKILL" || missing+=("bulk open PR JSON cache")
+grep -Fq 'issue_open_pr_refs()' "$SKILL" || missing+=("issue_open_pr_refs helper")
+grep -Fq 'closingIssuesReferences' "$SKILL" || missing+=("linked metadata check")
+grep -Fq 'headRefName' "$SKILL" || missing+=("head branch check")
+grep -Fq 'body,closingIssuesReferences' "$SKILL" || missing+=("PR body fetched")
+grep -Fq 'close[sd]?[[:space:]]+#' "$SKILL" || missing+=("closing keyword body regex")
+grep -Fq 'Queue selection: implementing open autopilot issue #$ISSUE_NUM' "$SKILL" || missing+=("queue rationale kept")
+grep -Fq 'no open PR reference after local PR dedupe' "$SKILL" || missing+=("rationale names local PR dedupe")
+grep -Fq '[dry-run] dedupe: $DEDUPE_STATE' "$SKILL" || missing+=("dry-run dedupe visibility")
+
+if grep -F -- '--search "-linked:pr -label:autopilot-blocked"' "$SKILL" >/dev/null; then
+  missing+=("queue still relies on -linked:pr")
+fi
+
+if (( ${#missing[@]} )); then
+  printf 'REGRESSION: autopilot open-PR reference dedupe missing: %s\n' "${missing[*]}" >&2
+  exit 1
+fi
+
+echo "PASS: autopilot dedupes issue selection against open PR metadata, branch, title, and body refs" >&2
+exit 0


### PR DESCRIPTION
Closes #437.

## Selection rationale

Manual goal-mode fix after the PR sweep found four overnight autopilot PRs for issue #432. The root cause was the queue dedupe relying on linked-PR metadata / exact branch checks even when open PRs referenced the issue by branch/body but GitHub did not expose `closingIssuesReferences`.

## Summary
- Enumerate open PRs before selecting an autopilot issue.
- Treat linked metadata, head branch names, titles, and PR bodies as open-PR references for issue dedupe.
- Surface dedupe state in `/autopilot --dry-run`.
- Add the `autopilot-open-pr-reference-dedupe` eval probe and extend the existing autopilot contract probe.

## Verification
- `bash evals/probes/autopilot-open-pr-reference-dedupe.sh`
- `bash evals/probes/autopilot-executor-toggle.sh`
- `bash .claude/skills/eval/run.sh --probe autopilot-open-pr-reference-dedupe`
- `bash .claude/skills/eval/run.sh` — 48 probes PASS
- `pnpm run test:scripts` — 275 tests PASS
