### PR TITLE
FROM feat/439-flag-duplicate-issue-prs-in TO development

### DIFF
--- a/.claude/skills/pr-audit/SKILL.md
+++ b/.claude/skills/pr-audit/SKILL.md
@@ -3,7 +3,7 @@ name: pr-audit
 description: |
   Audit all open PRs in one bulk query and triage them into actionable
   buckets: ready-to-merge, needs-review, CI-failing, conflicting/behind, plus
-  stale/convention flags. Draft PRs are split out as a separate work-in-progress
+  stale/convention/duplicate issue-reference flags. Draft PRs are split out as a separate work-in-progress
   class (promotable / WIP / limbo), checked first and never mixed into the
   actionable buckets. Read-only by default; --deep escalates flagged PRs to
   parallel diff reviewers, --proof writes each PR's verdict + evidence back as a
@@ -91,7 +91,7 @@ Build filter flags from the parsed args: `--label "$L"`, `--author "$A"`,
 ```bash
 gh pr list --state open --repo "$REPO" --limit 200 \
   $LABEL_FILTER $AUTHOR_FILTER $BASE_FILTER \
-  --json number,title,headRefName,baseRefName,isDraft,mergeable,mergeStateStatus,reviewDecision,statusCheckRollup,createdAt,updatedAt,author,additions,deletions,changedFiles,labels,url \
+  --json number,title,headRefName,baseRefName,isDraft,mergeable,mergeStateStatus,reviewDecision,statusCheckRollup,createdAt,updatedAt,author,additions,deletions,changedFiles,labels,url,body,closingIssuesReferences \
   > /tmp/pr-audit.json
 
 echo "open PRs fetched: $(jq 'length' /tmp/pr-audit.json)"
@@ -132,6 +132,26 @@ jq -r --argjson stale "$STALE_DAYS" --arg base "$BASE_DEFAULT" '
       (.reviewDecision // "NONE"), .title_ok, .base_ok, .baseRefName,
       .changedFiles, (.author.login), .title ]
   | @tsv
+' /tmp/pr-audit.json
+```
+
+Before assigning primary states, derive issue references and duplicate groups from the same cached payload — still no per-PR API loop. Treat linked metadata as best-effort and fall back to the PR branch/title/body because development-targeted PRs can carry `Closes #N` while GitHub leaves `closingIssuesReferences` empty until default-branch semantics apply:
+
+```bash
+jq -r '
+  def issue_refs:
+    ([.closingIssuesReferences[]?.number]
+     + [(.headRefName // ""), (.title // ""), (.body // "")]
+       | map(tostring)
+       | join("\n")
+       | [scan("(?i)(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?|issue)?[[:space:]]*#([0-9]+)")[]]
+       | map(tonumber))
+    | unique;
+  [ .[] | {number, issue_refs: issue_refs} ] as $refs_by_pr
+  | ($refs_by_pr | map(.issue_refs[]) | group_by(.) | map(select(length > 1) | .[0])) as $dupes
+  | $refs_by_pr[]
+  | select((.issue_refs | map(IN($dupes[])) | any))
+  | "#\(.number) duplicate issue refs: \(.issue_refs | map(select(IN($dupes[]))) | join(","))"
 ' /tmp/pr-audit.json
 ```
 
@@ -177,6 +197,7 @@ A stale draft (💤, below) is *draft-limbo* — route to `/watchdog` to complet
 |------|------|
 | 💤 **Stale** | `age > STALE_DAYS` (days since `updatedAt`); on a 📝 Draft this is *draft-limbo* |
 | 📐 **Convention** | `title_ok==false` (not `FROM … TO …`), or `base_ok==false` (base ≠ `development`), or oversized (`changedFiles > 50`) — see `.claude/skills/git/SKILL.md` |
+| 🔁 **Duplicate issue refs** | Two or more open PRs reference the same issue via `closingIssuesReferences`, branch/title issue number, or body closing keywords (`Closes #N`, `Fixes #N`, `Resolves #N`) |
 
 ### 4. Emit the triage report
 
@@ -207,10 +228,10 @@ lists the recommended read-only command (report-and-recommend, like
 | #41 | … | 🚧 still-WIP  | 21d | 💤 limbo | `/watchdog`: complete branch, then `gh pr ready` |
 
 ### Flag rollup
-💤 stale: #41   📐 convention: #73 (title), #55 (base≠development)
+💤 stale: #41   📐 convention: #73 (title), #55 (base≠development)   🔁 duplicate issue refs: #433/#434/#435 → #432
 
 ### Summary
-ci-fail F · conflict C · changes-req X · needs-review R · ready M · pending P · draft D (✅ promotable Dp · 🚧 wip Dw)  ·  flagged: stale S, conv V
+ci-fail F · conflict C · changes-req X · needs-review R · ready M · pending P · draft D (✅ promotable Dp · 🚧 wip Dw)  ·  flagged: stale S, conv V, duplicate issue refs U
 ```
 
 A flag never moves a PR out of its state section — `#68` stale + ready shows
@@ -334,6 +355,7 @@ Then run the qualify/improve pass per `context/rules/memory.md`.
 | ⏳ Pending / other | CI running / mergeable unknown | re-check shortly |
 | 💤 Stale (flag) | no update > `--stale-days` | ping or `--close-stale` |
 | 📐 Convention (flag) | title/base/size off-spec | fix title/base per `git.md` |
+| 🔁 Duplicate issue refs (flag) | multiple open PRs reference the same issue | choose the canonical PR; close/rebase duplicates only after human review |
 
 ### `gh pr list --json` field glossary
 
@@ -345,6 +367,7 @@ Then run the qualify/improve pass per `context/rules/memory.md`.
 | `createdAt`, `updatedAt` | age / staleness |
 | `title`, `baseRefName`, `changedFiles` | convention checks |
 | `labels`, `author`, `url`, `number` | filtering, proof comment, reporting |
+| `body`, `closingIssuesReferences`, `headRefName`, `title` | duplicate issue-reference flags without per-PR API loops |
 
 ### Severity / thresholds
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,11 @@ Update policy and release automation live in [`/git`](.claude/skills/git/SKILL.m
 ## [Unreleased]
 
 ### Added
+- `pr-audit-duplicate-issue-refs` eval probe guards that `/pr-audit` keeps duplicate open-PR issue references visible as a read-only triage flag ([#439](https://github.com/mifunedev/openharness/issues/439)).
 - `autopilot-open-pr-reference-dedupe` eval probe guards that issue selection checks open PR metadata, branch names, titles, and bodies before launching duplicate autopilot work ([#437](https://github.com/mifunedev/openharness/issues/437)).
 - `harness-audit-shared-memory` eval probe guards that `/harness-audit` reads durable long-term memory from `AUDIT_LOG_ROOT` in cron worktrees while preserving source inspection via `AUDIT_ROOT` ([#432](https://github.com/mifunedev/openharness/issues/432)).
 ### Changed
+- `/pr-audit` now documents a duplicate issue-reference flag so multiple open PRs that close/reference the same issue are grouped for human canonical-PR selection instead of appearing as unrelated conflicts ([#439](https://github.com/mifunedev/openharness/issues/439)).
 ### Fixed
 - Autopilot issue selection now dedupes against open PR references in linked metadata, branch names, titles, and bodies before starting work, preventing repeated PRs for the same issue when GitHub linked-PR metadata is empty ([#437](https://github.com/mifunedev/openharness/issues/437)).
 ### Removed

--- a/evals/RESULTS.md
+++ b/evals/RESULTS.md
@@ -6,53 +6,54 @@ probe id; git history is the time series.** Schema and exit-code semantics are i
 
 | probe | tier | last-run (UTC) | status | source |
 |-------|------|----------------|--------|--------|
-| agent-browser-cli | A | 2026-06-18 20:00 | PASS | memory/MEMORY.md 2026-06-07 (agent-browser 0.8.5 CLI) |
-| autopilot-executor-toggle | A | 2026-06-18 20:00 | PASS | conversation 2026-06-13 (autopilot delegate-advisor executor) |
-| autopilot-no-pr-session-close | A | 2026-06-18 20:00 | PASS | issue #209 (autopilot no-PR tmux session closure) 2026-06-16 |
-| autopilot-open-pr-reference-dedupe | A | 2026-06-18 20:00 | PASS | issue #437 — autopilot must not start duplicate work when open PRs reference the same issue without linked-PR metadata |
-| autopilot-pi-agent | A | 2026-06-18 20:00 | PASS | issue #116 (autopilot Pi tmux alignment) 2026-06-14; issue #118 (attachable Pi TUI tmux) 2026-06-14; issue #126 (kept Pi overlap lock release) 2026-06-14; issue #142 (worktree-by-default, skip→worktree) 2026-06-14 |
-| autopilot-preflight-gate | A | 2026-06-18 20:00 | PASS | issue #194 (deterministic autopilot caps preflight gate) 2026-06-15 |
-| autopilot-upstream-default | A | 2026-06-18 20:00 | PASS | issue #420 — future autopilots must target canonical repo, not personal fork |
-| autopilot-worktree-log-root | A | 2026-06-18 20:00 | PASS | issue #152 (persist autopilot worktree logs) 2026-06-15 |
-| boot-lint-glob | A | 2026-06-18 20:00 | PASS | issue #90, issue #120 |
-| capability-benchmark-schema | A | 2026-06-18 20:00 | PASS | issue #167 — capability benchmark instrument |
-| clean-restore | A | 2026-06-18 20:00 | PASS | issue #63 (autopilot-stray-wip-guard) 2026-06-12; issue #81 (owned-paths-zsh-split) 2026-06-13 |
-| cleanup-tasks-scoped-guard | A | 2026-06-18 20:00 | PASS | issue #85 |
-| cleanup-tasks-worktree-grooming | A | 2026-06-18 20:00 | PASS | issue #168 |
-| cron-claude-codex-fallback | A | 2026-06-18 20:00 | PASS | conversation 2026-06-12 (default Codex fallback for crons) |
-| cron-watchdog | A | 2026-06-18 20:00 | PASS | issue #130 (cron runtime watchdog) 2026-06-14 |
-| curl-bash-safe-alternatives | A | 2026-06-18 20:00 | PASS | vet-run/vet integration — public curl|bash examples need review-first alternatives |
-| datasets-schema | A | 2026-06-18 20:00 | PASS | issue #196 — evals/datasets verifiable trajectory corpus (Repo2RLEnv-inspired) |
-| devtcp-hook | A | 2026-06-18 20:00 | PASS | memory/MEMORY.md 2026-06-10 (zsh /dev/tcp) |
-| drift-check-cron-staleness-glob | A | 2026-06-18 20:00 | PASS | issue #98; issue #225 (restart-required cron frontmatter/config drift) |
-| eval-ci-gate | A | 2026-06-18 20:00 | PASS | #103 — eval probe suite gated in CI |
-| eval-gate | A | 2026-06-18 20:00 | PASS | memory/MEMORY.md 2026-06-11 (eval-gate) |
-| eval-results-atomic | A | 2026-06-18 20:00 | PASS | issue #83 (eval-results-atomic-write) |
-| eval-runner-exit | A | 2026-06-18 20:00 | PASS | memory/MEMORY.md 2026-06-11 (eval-runner-exit) #29 |
-| git-skill | A | 2026-06-18 20:00 | PASS | conversation 2026-06-15 — rules are not always supported; git workflow must be the /git skill |
-| harness-audit-empty-output-gate | A | 2026-06-18 20:00 | PASS | issue #246 — /harness-audit must fail closed on empty auditor outputs |
-| harness-audit-memory-path | A | 2026-06-18 20:00 | PASS | issue #183 — /harness-audit must inspect the active worktree, not a hardcoded root |
-| harness-audit-shared-memory | A | 2026-06-18 20:00 | PASS | issue #432 — /harness-audit must load durable memory from shared log root in cron worktrees |
-| harness-ci-core-paths | A | 2026-06-18 20:00 | PASS | #165 — core sandbox config files must trigger harness CI |
-| harness-ci-hooks-paths | A | 2026-06-18 20:00 | PASS | issue #202 — credential/security hook changes must trigger harness CI |
-| health-check-docker-stats | A | 2026-06-18 20:00 | PASS | memory/MEMORY.md 2026-06-10 (docker stats vs ps Size) |
-| locked-append-critical-path | A | 2026-06-18 20:00 | PASS | issue #204 (lock shared runtime log appends) 2026-06-15 |
-| loop-benchmark-gate | A | 2026-06-18 20:00 | PASS | issue #179 — wire the executable-loop `benchmark` node (close the cycle) |
-| loop-handoff-consistency | A | 2026-06-18 20:00 | PASS | context/rules/loop.md § 4 (executable-loop Handoff convention) |
-| loop-repeat-gate | A | 2026-06-18 20:00 | PASS | issue #173 — wire the executable-loop `repeat` node (cycle-closing edge) |
-| memory-gitignore-claim | A | 2026-06-18 20:00 | PASS | issue #101 |
-| next-dev-prod | A | 2026-06-18 20:00 | PASS | memory/MEMORY.md 2026-06-04 |
-| orchestrate-contract | A | 2026-06-18 20:00 | PASS | issue #160 — /orchestrate contract; issue #175 — reserved /loop command rename |
-| owned-surface-guard | A | 2026-06-18 20:00 | PASS | issue #63 (autopilot-stray-wip-guard) 2026-06-12; issue #81 (owned-paths-zsh-split) 2026-06-13 |
-| pnpm-audit-ci-gate | A | 2026-06-18 20:00 | PASS | issue #171 — pnpm security audits must run in CI |
-| ralph-fallback-order | A | 2026-06-18 20:00 | PASS | conversation 2026-06-12 (Ralph default fallback order) |
-| rl-delegation-write-worker | A | 2026-06-18 20:00 | PASS | memory/MEMORY.md 2026-06-10 (rl-delegation) #57 |
-| ship-spec-ready-finalization | A | 2026-06-18 20:00 | PASS | issue #134 — /ship-spec must finalize ready PRs after gates, not stop at draft scaffold |
-| skill-paths | A | 2026-06-18 20:00 | PASS | issue #43 — stale path references; extended by issue #69 — apps/->packages/ rename guard |
-| submitted-by-trailers | A | 2026-06-18 20:00 | PASS | conversation 2026-06-12 (commit attribution trailers) |
-| watchdog-completed-session-reap | A | 2026-06-18 20:00 | PASS | issue #235 (completed autopilot PR session reaping) |
-| watchdog-draft-prs | A | 2026-06-18 20:00 | PASS | conversation 2026-06-15 (generic watchdog + stale draft PR recovery) |
-| watchdog-stuck-sessions | A | 2026-06-18 20:00 | PASS | issue #240 (Codex zero-credit stuck autopilot sessions) 2026-06-17 |
-| wiki-readme-index | A | 2026-06-18 20:00 | PASS | issue #132 — wiki README index drift guard |
+| agent-browser-cli | A | 2026-06-18 20:11 | PASS | memory/MEMORY.md 2026-06-07 (agent-browser 0.8.5 CLI) |
+| autopilot-executor-toggle | A | 2026-06-18 20:11 | PASS | conversation 2026-06-13 (autopilot delegate-advisor executor) |
+| autopilot-no-pr-session-close | A | 2026-06-18 20:11 | PASS | issue #209 (autopilot no-PR tmux session closure) 2026-06-16 |
+| autopilot-open-pr-reference-dedupe | A | 2026-06-18 20:11 | PASS | issue #437 — autopilot must not start duplicate work when open PRs reference the same issue without linked-PR metadata |
+| autopilot-pi-agent | A | 2026-06-18 20:11 | PASS | issue #116 (autopilot Pi tmux alignment) 2026-06-14; issue #118 (attachable Pi TUI tmux) 2026-06-14; issue #126 (kept Pi overlap lock release) 2026-06-14; issue #142 (worktree-by-default, skip→worktree) 2026-06-14 |
+| autopilot-preflight-gate | A | 2026-06-18 20:11 | PASS | issue #194 (deterministic autopilot caps preflight gate) 2026-06-15 |
+| autopilot-upstream-default | A | 2026-06-18 20:11 | PASS | issue #420 — future autopilots must target canonical repo, not personal fork |
+| autopilot-worktree-log-root | A | 2026-06-18 20:11 | PASS | issue #152 (persist autopilot worktree logs) 2026-06-15 |
+| boot-lint-glob | A | 2026-06-18 20:11 | PASS | issue #90, issue #120 |
+| capability-benchmark-schema | A | 2026-06-18 20:11 | PASS | issue #167 — capability benchmark instrument |
+| clean-restore | A | 2026-06-18 20:11 | PASS | issue #63 (autopilot-stray-wip-guard) 2026-06-12; issue #81 (owned-paths-zsh-split) 2026-06-13 |
+| cleanup-tasks-scoped-guard | A | 2026-06-18 20:11 | PASS | issue #85 |
+| cleanup-tasks-worktree-grooming | A | 2026-06-18 20:11 | PASS | issue #168 |
+| cron-claude-codex-fallback | A | 2026-06-18 20:11 | PASS | conversation 2026-06-12 (default Codex fallback for crons) |
+| cron-watchdog | A | 2026-06-18 20:11 | PASS | issue #130 (cron runtime watchdog) 2026-06-14 |
+| curl-bash-safe-alternatives | A | 2026-06-18 20:11 | PASS | vet-run/vet integration — public curl|bash examples need review-first alternatives |
+| datasets-schema | A | 2026-06-18 20:11 | PASS | issue #196 — evals/datasets verifiable trajectory corpus (Repo2RLEnv-inspired) |
+| devtcp-hook | A | 2026-06-18 20:11 | PASS | memory/MEMORY.md 2026-06-10 (zsh /dev/tcp) |
+| drift-check-cron-staleness-glob | A | 2026-06-18 20:11 | PASS | issue #98; issue #225 (restart-required cron frontmatter/config drift) |
+| eval-ci-gate | A | 2026-06-18 20:11 | PASS | #103 — eval probe suite gated in CI |
+| eval-gate | A | 2026-06-18 20:11 | PASS | memory/MEMORY.md 2026-06-11 (eval-gate) |
+| eval-results-atomic | A | 2026-06-18 20:11 | PASS | issue #83 (eval-results-atomic-write) |
+| eval-runner-exit | A | 2026-06-18 20:11 | PASS | memory/MEMORY.md 2026-06-11 (eval-runner-exit) #29 |
+| git-skill | A | 2026-06-18 20:11 | PASS | conversation 2026-06-15 — rules are not always supported; git workflow must be the /git skill |
+| harness-audit-empty-output-gate | A | 2026-06-18 20:11 | PASS | issue #246 — /harness-audit must fail closed on empty auditor outputs |
+| harness-audit-memory-path | A | 2026-06-18 20:11 | PASS | issue #183 — /harness-audit must inspect the active worktree, not a hardcoded root |
+| harness-audit-shared-memory | A | 2026-06-18 20:11 | PASS | issue #432 — /harness-audit must load durable memory from shared log root in cron worktrees |
+| harness-ci-core-paths | A | 2026-06-18 20:11 | PASS | #165 — core sandbox config files must trigger harness CI |
+| harness-ci-hooks-paths | A | 2026-06-18 20:11 | PASS | issue #202 — credential/security hook changes must trigger harness CI |
+| health-check-docker-stats | A | 2026-06-18 20:11 | PASS | memory/MEMORY.md 2026-06-10 (docker stats vs ps Size) |
+| locked-append-critical-path | A | 2026-06-18 20:11 | PASS | issue #204 (lock shared runtime log appends) 2026-06-15 |
+| loop-benchmark-gate | A | 2026-06-18 20:11 | PASS | issue #179 — wire the executable-loop `benchmark` node (close the cycle) |
+| loop-handoff-consistency | A | 2026-06-18 20:11 | PASS | context/rules/loop.md § 4 (executable-loop Handoff convention) |
+| loop-repeat-gate | A | 2026-06-18 20:11 | PASS | issue #173 — wire the executable-loop `repeat` node (cycle-closing edge) |
+| memory-gitignore-claim | A | 2026-06-18 20:11 | PASS | issue #101 |
+| next-dev-prod | A | 2026-06-18 20:11 | PASS | memory/MEMORY.md 2026-06-04 |
+| orchestrate-contract | A | 2026-06-18 20:11 | PASS | issue #160 — /orchestrate contract; issue #175 — reserved /loop command rename |
+| owned-surface-guard | A | 2026-06-18 20:11 | PASS | issue #63 (autopilot-stray-wip-guard) 2026-06-12; issue #81 (owned-paths-zsh-split) 2026-06-13 |
+| pnpm-audit-ci-gate | A | 2026-06-18 20:11 | PASS | issue #171 — pnpm security audits must run in CI |
+| pr-audit-duplicate-issue-refs | A | 2026-06-18 20:11 | PASS | issue #439 — /pr-audit must flag duplicate open PRs that reference the same issue |
+| ralph-fallback-order | A | 2026-06-18 20:11 | PASS | conversation 2026-06-12 (Ralph default fallback order) |
+| rl-delegation-write-worker | A | 2026-06-18 20:11 | PASS | memory/MEMORY.md 2026-06-10 (rl-delegation) #57 |
+| ship-spec-ready-finalization | A | 2026-06-18 20:11 | PASS | issue #134 — /ship-spec must finalize ready PRs after gates, not stop at draft scaffold |
+| skill-paths | A | 2026-06-18 20:11 | PASS | issue #43 — stale path references; extended by issue #69 — apps/->packages/ rename guard |
+| submitted-by-trailers | A | 2026-06-18 20:11 | PASS | conversation 2026-06-12 (commit attribution trailers) |
+| watchdog-completed-session-reap | A | 2026-06-18 20:11 | PASS | issue #235 (completed autopilot PR session reaping) |
+| watchdog-draft-prs | A | 2026-06-18 20:11 | PASS | conversation 2026-06-15 (generic watchdog + stale draft PR recovery) |
+| watchdog-stuck-sessions | A | 2026-06-18 20:11 | PASS | issue #240 (Codex zero-credit stuck autopilot sessions) 2026-06-17 |
+| wiki-readme-index | A | 2026-06-18 20:11 | PASS | issue #132 — wiki README index drift guard |
 
 <!-- benchmark: pass-rate = PASS / (PASS + REGRESSION + TIMEOUT); SKIPPED excluded -->

--- a/evals/probes/pr-audit-duplicate-issue-refs.sh
+++ b/evals/probes/pr-audit-duplicate-issue-refs.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# tier: A
+# source: issue #439 — /pr-audit must flag duplicate open PRs that reference the same issue
+# desc: /pr-audit surfaces duplicate issue-reference groups as a read-only orthogonal triage flag.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SKILL="$ROOT/.claude/skills/pr-audit/SKILL.md"
+
+if [[ ! -f "$SKILL" ]]; then
+  echo "SKIPPED: pr-audit skill absent: $SKILL" >&2
+  exit 2
+fi
+
+missing=()
+for literal in \
+  'stale/convention/duplicate issue-reference flags' \
+  'body,closingIssuesReferences' \
+  'def issue_refs:' \
+  'closingIssuesReferences' \
+  'Closes #N' \
+  'Fixes #N' \
+  'Resolves #N' \
+  '🔁 **Duplicate issue refs**' \
+  'duplicate issue refs U' \
+  'choose the canonical PR; close/rebase duplicates only after human review' \
+  'duplicate issue-reference flags without per-PR API loops'
+do
+  if ! grep -Fq "$literal" "$SKILL"; then
+    missing+=("$literal")
+  fi
+done
+
+if (( ${#missing[@]} > 0 )); then
+  echo "REGRESSION: pr-audit duplicate issue-reference flag contract is incomplete; missing literals:" >&2
+  printf '  - %s\n' "${missing[@]}" >&2
+  exit 1
+fi
+
+echo "PASS: pr-audit documents duplicate issue-reference detection and read-only triage flags" >&2
+exit 0


### PR DESCRIPTION
## Selection rationale

Research selection: the actionable `autopilot` issue queue was empty; a first-principles audit of the live PR queue ranked duplicate issue-reference triage as the top harness-infra candidate because open PRs #433/#434/#435 all reference issue #432 and now appear as separate dirty PRs instead of one duplicate group. Filed as #439 and built in this run.

---

Closes #439.

## Summary
- Add a read-only duplicate issue-reference flag to `/pr-audit` guidance.
- Teach `/pr-audit` to derive duplicate groups from one bulk PR payload using linked metadata plus branch/title/body fallbacks.
- Add the `pr-audit-duplicate-issue-refs` Tier-A eval probe and refresh `evals/RESULTS.md`.

## Verification
- `bash evals/probes/pr-audit-duplicate-issue-refs.sh`
- `bash .claude/skills/eval/run.sh --probe pr-audit-duplicate-issue-refs`
- `bash .claude/skills/eval/run.sh` → 49 probes PASS
- `bash -n evals/probes/pr-audit-duplicate-issue-refs.sh`
- `pnpm run test:scripts` → 275 tests PASS
