### PR TITLE
FROM docs/441-harness-audit-memory-docs TO development

### DIFF
--- a/.claude/skills/harness-audit/SKILL.md
+++ b/.claude/skills/harness-audit/SKILL.md
@@ -90,7 +90,12 @@ git -C "$AUDIT_ROOT" worktree list 2>/dev/null
 # Recent long-term memory (durable shared artifact). In cron worktree mode,
 # source inspection stays on AUDIT_ROOT, but long-term lessons live in the
 # shared checkout resolved as AUDIT_LOG_ROOT.
-tail -40 "$AUDIT_LOG_ROOT/memory/MEMORY.md" 2>/dev/null
+if [ -r "$AUDIT_LOG_ROOT/memory/MEMORY.md" ]; then
+  printf 'long_term_memory: loaded %s\n' "$AUDIT_LOG_ROOT/memory/MEMORY.md"
+  tail -40 "$AUDIT_LOG_ROOT/memory/MEMORY.md"
+else
+  printf 'long_term_memory: missing-or-unreadable %s\n' "$AUDIT_LOG_ROOT/memory/MEMORY.md"
+fi
 ```
 
 Assemble a **Context Snapshot** (compact markdown, ~300 words):
@@ -223,7 +228,7 @@ Launch 4 Agent tool calls **in a single message**. Each receives the Context Sna
 >
 > **Audit areas:**
 >
-> 1. **Memory system quality** — Read the 5 most recent daily logs in `memory/`. Are entries following the Memory Improvement Protocol (Result/Action/Observation/Duration)? Is quality declining over time (shorter entries, missing fields)? Are entries actually present?
+> 1. **Memory system quality** — Use the Context Snapshot's `AUDIT_LOG_ROOT` memory/log context (not `AUDIT_ROOT` when they differ) to inspect the 5 most recent daily logs. Are entries following the Memory Improvement Protocol (Result/Action/Observation/Duration)? Is quality declining over time (shorter entries, missing fields)? Are entries actually present? Report if `long_term_memory` is `missing-or-unreadable`.
 >
 > 2. **Wiki utilization** — List all files under `wiki/`. For each, check if it has substantive content (>10 lines) or is a placeholder stub. What percentage is populated?
 >
@@ -231,7 +236,7 @@ Launch 4 Agent tool calls **in a single message**. Each receives the Context Sna
 >
 > 4. **Agent worktree status** — In the source checkout listed as `AUDIT_ROOT`, run `git worktree list` and `git branch -a | grep agent/`. Classify each: ACTIVE (commits in last 7 days), IDLE (commits 7-30 days ago), ORPHANED (no commits in 30+ days or branch deleted).
 >
-> 5. **Skill usage patterns** — Read `memory/MEMORY.md` and recent daily logs. Which skills appear in memory entries (evidence of use)? Which skills exist in `.claude/skills/` but never appear in logs (potentially stale or unknown)?
+> 5. **Skill usage patterns** — Use the Context Snapshot's long-term memory and recent daily-log excerpts from `AUDIT_LOG_ROOT`; keep `.claude/skills/` existence checks on `AUDIT_ROOT`. Which skills appear in memory entries (evidence of use)? Which skills exist in `.claude/skills/` but never appear in logs (potentially stale or unknown)?
 >
 > **Return format (Ultra compression):**
 > ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Update policy and release automation live in [`/git`](.claude/skills/git/SKILL.m
 ## [Unreleased]
 
 ### Added
+- `harness-audit` wiki entry and Context Snapshot memory load-status diagnostics preserve the shared-memory model salvaged from duplicate #432 PRs ([#441](https://github.com/mifunedev/openharness/issues/441)).
 - `autopilot-open-pr-reference-dedupe` eval probe guards that issue selection checks open PR metadata, branch names, titles, and bodies before launching duplicate autopilot work ([#437](https://github.com/mifunedev/openharness/issues/437)).
 - `harness-audit-shared-memory` eval probe guards that `/harness-audit` reads durable long-term memory from `AUDIT_LOG_ROOT` in cron worktrees while preserving source inspection via `AUDIT_ROOT` ([#432](https://github.com/mifunedev/openharness/issues/432)).
 ### Changed

--- a/evals/RESULTS.md
+++ b/evals/RESULTS.md
@@ -6,53 +6,53 @@ probe id; git history is the time series.** Schema and exit-code semantics are i
 
 | probe | tier | last-run (UTC) | status | source |
 |-------|------|----------------|--------|--------|
-| agent-browser-cli | A | 2026-06-18 20:00 | PASS | memory/MEMORY.md 2026-06-07 (agent-browser 0.8.5 CLI) |
-| autopilot-executor-toggle | A | 2026-06-18 20:00 | PASS | conversation 2026-06-13 (autopilot delegate-advisor executor) |
-| autopilot-no-pr-session-close | A | 2026-06-18 20:00 | PASS | issue #209 (autopilot no-PR tmux session closure) 2026-06-16 |
-| autopilot-open-pr-reference-dedupe | A | 2026-06-18 20:00 | PASS | issue #437 — autopilot must not start duplicate work when open PRs reference the same issue without linked-PR metadata |
-| autopilot-pi-agent | A | 2026-06-18 20:00 | PASS | issue #116 (autopilot Pi tmux alignment) 2026-06-14; issue #118 (attachable Pi TUI tmux) 2026-06-14; issue #126 (kept Pi overlap lock release) 2026-06-14; issue #142 (worktree-by-default, skip→worktree) 2026-06-14 |
-| autopilot-preflight-gate | A | 2026-06-18 20:00 | PASS | issue #194 (deterministic autopilot caps preflight gate) 2026-06-15 |
-| autopilot-upstream-default | A | 2026-06-18 20:00 | PASS | issue #420 — future autopilots must target canonical repo, not personal fork |
-| autopilot-worktree-log-root | A | 2026-06-18 20:00 | PASS | issue #152 (persist autopilot worktree logs) 2026-06-15 |
-| boot-lint-glob | A | 2026-06-18 20:00 | PASS | issue #90, issue #120 |
-| capability-benchmark-schema | A | 2026-06-18 20:00 | PASS | issue #167 — capability benchmark instrument |
-| clean-restore | A | 2026-06-18 20:00 | PASS | issue #63 (autopilot-stray-wip-guard) 2026-06-12; issue #81 (owned-paths-zsh-split) 2026-06-13 |
-| cleanup-tasks-scoped-guard | A | 2026-06-18 20:00 | PASS | issue #85 |
-| cleanup-tasks-worktree-grooming | A | 2026-06-18 20:00 | PASS | issue #168 |
-| cron-claude-codex-fallback | A | 2026-06-18 20:00 | PASS | conversation 2026-06-12 (default Codex fallback for crons) |
-| cron-watchdog | A | 2026-06-18 20:00 | PASS | issue #130 (cron runtime watchdog) 2026-06-14 |
-| curl-bash-safe-alternatives | A | 2026-06-18 20:00 | PASS | vet-run/vet integration — public curl|bash examples need review-first alternatives |
-| datasets-schema | A | 2026-06-18 20:00 | PASS | issue #196 — evals/datasets verifiable trajectory corpus (Repo2RLEnv-inspired) |
-| devtcp-hook | A | 2026-06-18 20:00 | PASS | memory/MEMORY.md 2026-06-10 (zsh /dev/tcp) |
-| drift-check-cron-staleness-glob | A | 2026-06-18 20:00 | PASS | issue #98; issue #225 (restart-required cron frontmatter/config drift) |
-| eval-ci-gate | A | 2026-06-18 20:00 | PASS | #103 — eval probe suite gated in CI |
-| eval-gate | A | 2026-06-18 20:00 | PASS | memory/MEMORY.md 2026-06-11 (eval-gate) |
-| eval-results-atomic | A | 2026-06-18 20:00 | PASS | issue #83 (eval-results-atomic-write) |
-| eval-runner-exit | A | 2026-06-18 20:00 | PASS | memory/MEMORY.md 2026-06-11 (eval-runner-exit) #29 |
-| git-skill | A | 2026-06-18 20:00 | PASS | conversation 2026-06-15 — rules are not always supported; git workflow must be the /git skill |
-| harness-audit-empty-output-gate | A | 2026-06-18 20:00 | PASS | issue #246 — /harness-audit must fail closed on empty auditor outputs |
-| harness-audit-memory-path | A | 2026-06-18 20:00 | PASS | issue #183 — /harness-audit must inspect the active worktree, not a hardcoded root |
-| harness-audit-shared-memory | A | 2026-06-18 20:00 | PASS | issue #432 — /harness-audit must load durable memory from shared log root in cron worktrees |
-| harness-ci-core-paths | A | 2026-06-18 20:00 | PASS | #165 — core sandbox config files must trigger harness CI |
-| harness-ci-hooks-paths | A | 2026-06-18 20:00 | PASS | issue #202 — credential/security hook changes must trigger harness CI |
-| health-check-docker-stats | A | 2026-06-18 20:00 | PASS | memory/MEMORY.md 2026-06-10 (docker stats vs ps Size) |
-| locked-append-critical-path | A | 2026-06-18 20:00 | PASS | issue #204 (lock shared runtime log appends) 2026-06-15 |
-| loop-benchmark-gate | A | 2026-06-18 20:00 | PASS | issue #179 — wire the executable-loop `benchmark` node (close the cycle) |
-| loop-handoff-consistency | A | 2026-06-18 20:00 | PASS | context/rules/loop.md § 4 (executable-loop Handoff convention) |
-| loop-repeat-gate | A | 2026-06-18 20:00 | PASS | issue #173 — wire the executable-loop `repeat` node (cycle-closing edge) |
-| memory-gitignore-claim | A | 2026-06-18 20:00 | PASS | issue #101 |
-| next-dev-prod | A | 2026-06-18 20:00 | PASS | memory/MEMORY.md 2026-06-04 |
-| orchestrate-contract | A | 2026-06-18 20:00 | PASS | issue #160 — /orchestrate contract; issue #175 — reserved /loop command rename |
-| owned-surface-guard | A | 2026-06-18 20:00 | PASS | issue #63 (autopilot-stray-wip-guard) 2026-06-12; issue #81 (owned-paths-zsh-split) 2026-06-13 |
-| pnpm-audit-ci-gate | A | 2026-06-18 20:00 | PASS | issue #171 — pnpm security audits must run in CI |
-| ralph-fallback-order | A | 2026-06-18 20:00 | PASS | conversation 2026-06-12 (Ralph default fallback order) |
-| rl-delegation-write-worker | A | 2026-06-18 20:00 | PASS | memory/MEMORY.md 2026-06-10 (rl-delegation) #57 |
-| ship-spec-ready-finalization | A | 2026-06-18 20:00 | PASS | issue #134 — /ship-spec must finalize ready PRs after gates, not stop at draft scaffold |
-| skill-paths | A | 2026-06-18 20:00 | PASS | issue #43 — stale path references; extended by issue #69 — apps/->packages/ rename guard |
-| submitted-by-trailers | A | 2026-06-18 20:00 | PASS | conversation 2026-06-12 (commit attribution trailers) |
-| watchdog-completed-session-reap | A | 2026-06-18 20:00 | PASS | issue #235 (completed autopilot PR session reaping) |
-| watchdog-draft-prs | A | 2026-06-18 20:00 | PASS | conversation 2026-06-15 (generic watchdog + stale draft PR recovery) |
-| watchdog-stuck-sessions | A | 2026-06-18 20:00 | PASS | issue #240 (Codex zero-credit stuck autopilot sessions) 2026-06-17 |
-| wiki-readme-index | A | 2026-06-18 20:00 | PASS | issue #132 — wiki README index drift guard |
+| agent-browser-cli | A | 2026-06-18 20:15 | PASS | memory/MEMORY.md 2026-06-07 (agent-browser 0.8.5 CLI) |
+| autopilot-executor-toggle | A | 2026-06-18 20:15 | PASS | conversation 2026-06-13 (autopilot delegate-advisor executor) |
+| autopilot-no-pr-session-close | A | 2026-06-18 20:15 | PASS | issue #209 (autopilot no-PR tmux session closure) 2026-06-16 |
+| autopilot-open-pr-reference-dedupe | A | 2026-06-18 20:15 | PASS | issue #437 — autopilot must not start duplicate work when open PRs reference the same issue without linked-PR metadata |
+| autopilot-pi-agent | A | 2026-06-18 20:15 | PASS | issue #116 (autopilot Pi tmux alignment) 2026-06-14; issue #118 (attachable Pi TUI tmux) 2026-06-14; issue #126 (kept Pi overlap lock release) 2026-06-14; issue #142 (worktree-by-default, skip→worktree) 2026-06-14 |
+| autopilot-preflight-gate | A | 2026-06-18 20:15 | PASS | issue #194 (deterministic autopilot caps preflight gate) 2026-06-15 |
+| autopilot-upstream-default | A | 2026-06-18 20:15 | PASS | issue #420 — future autopilots must target canonical repo, not personal fork |
+| autopilot-worktree-log-root | A | 2026-06-18 20:15 | PASS | issue #152 (persist autopilot worktree logs) 2026-06-15 |
+| boot-lint-glob | A | 2026-06-18 20:15 | PASS | issue #90, issue #120 |
+| capability-benchmark-schema | A | 2026-06-18 20:15 | PASS | issue #167 — capability benchmark instrument |
+| clean-restore | A | 2026-06-18 20:15 | PASS | issue #63 (autopilot-stray-wip-guard) 2026-06-12; issue #81 (owned-paths-zsh-split) 2026-06-13 |
+| cleanup-tasks-scoped-guard | A | 2026-06-18 20:15 | PASS | issue #85 |
+| cleanup-tasks-worktree-grooming | A | 2026-06-18 20:15 | PASS | issue #168 |
+| cron-claude-codex-fallback | A | 2026-06-18 20:15 | PASS | conversation 2026-06-12 (default Codex fallback for crons) |
+| cron-watchdog | A | 2026-06-18 20:15 | PASS | issue #130 (cron runtime watchdog) 2026-06-14 |
+| curl-bash-safe-alternatives | A | 2026-06-18 20:15 | PASS | vet-run/vet integration — public curl|bash examples need review-first alternatives |
+| datasets-schema | A | 2026-06-18 20:15 | PASS | issue #196 — evals/datasets verifiable trajectory corpus (Repo2RLEnv-inspired) |
+| devtcp-hook | A | 2026-06-18 20:15 | PASS | memory/MEMORY.md 2026-06-10 (zsh /dev/tcp) |
+| drift-check-cron-staleness-glob | A | 2026-06-18 20:15 | PASS | issue #98; issue #225 (restart-required cron frontmatter/config drift) |
+| eval-ci-gate | A | 2026-06-18 20:15 | PASS | #103 — eval probe suite gated in CI |
+| eval-gate | A | 2026-06-18 20:15 | PASS | memory/MEMORY.md 2026-06-11 (eval-gate) |
+| eval-results-atomic | A | 2026-06-18 20:15 | PASS | issue #83 (eval-results-atomic-write) |
+| eval-runner-exit | A | 2026-06-18 20:15 | PASS | memory/MEMORY.md 2026-06-11 (eval-runner-exit) #29 |
+| git-skill | A | 2026-06-18 20:15 | PASS | conversation 2026-06-15 — rules are not always supported; git workflow must be the /git skill |
+| harness-audit-empty-output-gate | A | 2026-06-18 20:15 | PASS | issue #246 — /harness-audit must fail closed on empty auditor outputs |
+| harness-audit-memory-path | A | 2026-06-18 20:15 | PASS | issue #183 — /harness-audit must inspect the active worktree, not a hardcoded root |
+| harness-audit-shared-memory | A | 2026-06-18 20:15 | PASS | issue #432 — /harness-audit must load durable memory from shared log root in cron worktrees |
+| harness-ci-core-paths | A | 2026-06-18 20:15 | PASS | #165 — core sandbox config files must trigger harness CI |
+| harness-ci-hooks-paths | A | 2026-06-18 20:15 | PASS | issue #202 — credential/security hook changes must trigger harness CI |
+| health-check-docker-stats | A | 2026-06-18 20:15 | PASS | memory/MEMORY.md 2026-06-10 (docker stats vs ps Size) |
+| locked-append-critical-path | A | 2026-06-18 20:15 | PASS | issue #204 (lock shared runtime log appends) 2026-06-15 |
+| loop-benchmark-gate | A | 2026-06-18 20:15 | PASS | issue #179 — wire the executable-loop `benchmark` node (close the cycle) |
+| loop-handoff-consistency | A | 2026-06-18 20:15 | PASS | context/rules/loop.md § 4 (executable-loop Handoff convention) |
+| loop-repeat-gate | A | 2026-06-18 20:15 | PASS | issue #173 — wire the executable-loop `repeat` node (cycle-closing edge) |
+| memory-gitignore-claim | A | 2026-06-18 20:15 | PASS | issue #101 |
+| next-dev-prod | A | 2026-06-18 20:15 | PASS | memory/MEMORY.md 2026-06-04 |
+| orchestrate-contract | A | 2026-06-18 20:15 | PASS | issue #160 — /orchestrate contract; issue #175 — reserved /loop command rename |
+| owned-surface-guard | A | 2026-06-18 20:15 | PASS | issue #63 (autopilot-stray-wip-guard) 2026-06-12; issue #81 (owned-paths-zsh-split) 2026-06-13 |
+| pnpm-audit-ci-gate | A | 2026-06-18 20:15 | PASS | issue #171 — pnpm security audits must run in CI |
+| ralph-fallback-order | A | 2026-06-18 20:15 | PASS | conversation 2026-06-12 (Ralph default fallback order) |
+| rl-delegation-write-worker | A | 2026-06-18 20:15 | PASS | memory/MEMORY.md 2026-06-10 (rl-delegation) #57 |
+| ship-spec-ready-finalization | A | 2026-06-18 20:15 | PASS | issue #134 — /ship-spec must finalize ready PRs after gates, not stop at draft scaffold |
+| skill-paths | A | 2026-06-18 20:15 | PASS | issue #43 — stale path references; extended by issue #69 — apps/->packages/ rename guard |
+| submitted-by-trailers | A | 2026-06-18 20:15 | PASS | conversation 2026-06-12 (commit attribution trailers) |
+| watchdog-completed-session-reap | A | 2026-06-18 20:15 | PASS | issue #235 (completed autopilot PR session reaping) |
+| watchdog-draft-prs | A | 2026-06-18 20:15 | PASS | conversation 2026-06-15 (generic watchdog + stale draft PR recovery) |
+| watchdog-stuck-sessions | A | 2026-06-18 20:15 | PASS | issue #240 (Codex zero-credit stuck autopilot sessions) 2026-06-17 |
+| wiki-readme-index | A | 2026-06-18 20:15 | PASS | issue #132 — wiki README index drift guard |
 
 <!-- benchmark: pass-rate = PASS / (PASS + REGRESSION + TIMEOUT); SKIPPED excluded -->

--- a/evals/probes/harness-audit-shared-memory.sh
+++ b/evals/probes/harness-audit-shared-memory.sh
@@ -32,5 +32,15 @@ if ! grep -Fq 'ls "$AUDIT_LOG_ROOT/memory/"' "$SKILL"; then
   exit 1
 fi
 
-echo "PASS: harness-audit tails durable memory from AUDIT_LOG_ROOT while inspecting source via AUDIT_ROOT" >&2
+if ! grep -Fq 'long_term_memory: loaded' "$SKILL" || ! grep -Fq 'long_term_memory: missing-or-unreadable' "$SKILL"; then
+  echo "REGRESSION: harness-audit does not surface long-term memory load status" >&2
+  exit 1
+fi
+
+if ! grep -Fq "Context Snapshot's \`AUDIT_LOG_ROOT\` memory/log context" "$SKILL"; then
+  echo "REGRESSION: harness-audit Explorer prompt no longer routes memory/log checks through AUDIT_LOG_ROOT" >&2
+  exit 1
+fi
+
+echo "PASS: harness-audit tails durable memory from AUDIT_LOG_ROOT while inspecting source via AUDIT_ROOT and surfacing load status" >&2
 exit 0

--- a/wiki/README.md
+++ b/wiki/README.md
@@ -26,5 +26,6 @@ Schema rule, frontmatter spec, and all authoring conventions: `context/rules/wik
 
 | Slug | Title | Tags | Updated |
 | --- | --- | --- | --- |
+| harness-audit | Harness Audit | [audit, skills, autopilot, memory, worktrees] | 2026-06-18 |
 | sandbox-auth-volumes | Sandbox Auth Volume Ownership | [sandbox, devcontainer, auth, docker, ownership] | 2026-06-16 |
 | cron-runtime | Cron Runtime | [cron, runtime, scheduler, drift-check, automation, open-harness] | 2026-06-16 |

--- a/wiki/harness-audit.md
+++ b/wiki/harness-audit.md
@@ -1,0 +1,46 @@
+---
+title: "Harness Audit"
+slug: harness-audit
+tags: [audit, skills, autopilot, memory, worktrees]
+created: 2026-06-18
+updated: 2026-06-18
+sources:
+  - raw/2026-06-18-harness-audit.md
+related: [cron-runtime]
+confidence: provisional
+---
+
+# Harness Audit
+
+## Relevant Source Files
+- `.claude/skills/harness-audit/SKILL.md` — resolves `AUDIT_ROOT` for source inspection and `AUDIT_LOG_ROOT` for runtime memory/log context.
+- `evals/probes/harness-audit-shared-memory.sh` — guards that durable long-term memory is loaded from `AUDIT_LOG_ROOT`, not the isolated worktree root.
+- `evals/probes/harness-audit-memory-path.sh` — guards worktree-aware source inspection through `AUDIT_ROOT`.
+- `crons/autopilot.md` — runs hourly autopilot in worktree mode, the scenario where source checkout and durable logs can diverge.
+
+## Summary
+`/harness-audit` is the first-principles research pass that feeds the autopilot queue when no actionable `autopilot` issue is available. In worktree-mode cron runs, it must split source inspection from durable memory: audit the isolated checkout via `AUDIT_ROOT`, but read runtime logs and long-term lessons from `AUDIT_LOG_ROOT`.
+
+## Detail
+The audit root exists to make source inspection truthful for the checkout that invoked the skill. When `CRON_WORKTREE` points at a valid checkout, `/harness-audit` sets `AUDIT_ROOT` to that worktree; otherwise it falls back to the current repository root. Skills, agents, crons, package metadata, CI workflows, wiki files, and worktree state are all read through that source root.
+
+Runtime observability has a different lifecycle. Cron worktrees are ephemeral and can be based on a public/template branch whose `memory/MEMORY.md` is intentionally sparse, while the live operator's durable lessons and daily logs live in the shared checkout. `/harness-audit` therefore resolves `AUDIT_LOG_ROOT` separately and uses it for recent memory directories and long-term memory.
+
+The context snapshot reports `long_term_memory: loaded` or `long_term_memory: missing-or-unreadable` so a quiet memory miss is visible. Troubleshooting starts by comparing the snapshot's `AUDIT_ROOT` and `AUDIT_LOG_ROOT`: source findings may still be valid, but memory-derived judgments are incomplete until the shared root has a readable `memory/MEMORY.md` or `AUTOPILOT_LOG_ROOT` points at the checkout that owns durable logs.
+
+## System Relationships
+
+```mermaid
+flowchart LR
+  Cron["autopilot cron<br/>worktree: true"] --> WT["isolated CRON_WORKTREE"]
+  WT --> AuditRoot["AUDIT_ROOT<br/>source under audit"]
+  Root["shared checkout"] --> LogRoot["AUDIT_LOG_ROOT<br/>runtime logs + durable memory"]
+  AuditRoot --> Source["skills / agents / crons / CI / wiki source"]
+  LogRoot --> Memory["memory/YYYY-MM-DD logs<br/>memory/MEMORY.md lessons"]
+  Source --> Auditors["4 harness-audit perspectives"]
+  Memory --> Auditors
+  Auditors --> Queue["ranked autopilot findings"]
+```
+
+## See Also
+- [[cron-runtime]]

--- a/wiki/raw/2026-06-18-harness-audit.md
+++ b/wiki/raw/2026-06-18-harness-audit.md
@@ -1,0 +1,19 @@
+# Harness Audit Shared Memory Root Finding — 2026-06-18
+
+Source: hourly autopilot `/harness-audit` run in isolated cron worktree `/home/sandbox/harness/.worktrees/cron/cron-autopilot-0618-0005`.
+
+Explorer Auditor finding:
+
+> [MEMORY] [SEVERITY: H] [EFFORT: M] `/harness-audit` reads long-term memory from isolated `AUDIT_ROOT`, but this cron worktree has template-empty `memory/MEMORY.md`; real lessons live in shared root, so auditors lose durable context. Evidence: `.claude/skills/harness-audit/SKILL.md:91`; worktree `memory/MEMORY.md`; shared-root `memory/MEMORY.md`.
+
+Resolution in issue #432:
+
+- Keep source inspection rooted at `AUDIT_ROOT`.
+- Read durable long-term memory from `AUDIT_LOG_ROOT/memory/MEMORY.md`.
+- Guard the split with `evals/probes/harness-audit-shared-memory.sh`.
+
+Salvage pass in issue #441:
+
+- Surface `long_term_memory: loaded` or `long_term_memory: missing-or-unreadable` in the Context Snapshot command block.
+- Instruct Explorer to use `AUDIT_LOG_ROOT` memory/log context when roots differ while keeping source inspection on `AUDIT_ROOT`.
+- Preserve this wiki model from superseded duplicate PRs #433/#434 before closing them.


### PR DESCRIPTION
Closes #441.

## Summary
- Salvage the `harness-audit` wiki model from superseded duplicate PRs #433/#434.
- Surface `long_term_memory: loaded` / `missing-or-unreadable` in the `/harness-audit` Context Snapshot so durable-memory misses are visible.
- Strengthen the Explorer auditor prompt and eval guard to keep memory/log checks on `AUDIT_LOG_ROOT` while source inspection stays on `AUDIT_ROOT`.

## Verification
- `bash evals/probes/harness-audit-shared-memory.sh`
- `bash evals/probes/wiki-readme-index.sh`
- `bash .claude/skills/eval/run.sh` — 48 probes PASS
- `pnpm run test:scripts` — 275 tests PASS

## Duplicate cleanup
After this lands, #433/#434/#435 can be closed as superseded by #436 + this PR.
