### PR TITLE
FROM feat/443-retro-deterministic TO development

### DIFF
--- a/.claude/skills/retro/SKILL.md
+++ b/.claude/skills/retro/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: retro
 argument-hint: "[--dry-run] [--focus <subsystem>]"
+allowed-tools: Read, Grep, Bash, Edit
 description: |
   Scientific session-closing retrospective: scan the current conversation,
   turn each signal into a falsifiable hypothesis, cite session evidence for
@@ -24,6 +25,8 @@ Scientific session-closing retrospective. Turn the current conversation's signal
 
 This is the deliberate "Improve" pass of the Memory Improvement Protocol defined in `context/rules/memory.md`, now evidence-driven. Running it as a named skill turns an optional afterthought into a first-class, propose-then-confirm operation — and the scientific layer guards against overfitting a single session into a durable lesson.
 
+Use the self-contained helpers in `${CLAUDE_SKILL_DIR}/scripts/` for deterministic checks and log rendering; use `${CLAUDE_SKILL_DIR}/references/report-schema.md` as the output contract. Shared repo primitives such as `scripts/locked-append.sh` are allowed only for cross-skill infrastructure.
+
 ## When to use
 
 - `/retro` invoked explicitly to close a session.
@@ -42,6 +45,28 @@ Key boundary: `/retro` is *session-scoped reflection*. The lint/audit skills abo
 ## Scope
 
 Current conversation only. `/retro` does not read prior daily logs, prior sessions, or the `~/.claude/projects/...` auto-memory store. It works from what is already in context.
+
+## Deterministic contract
+
+Before writing anything except the required log entry, produce a report that follows `${CLAUDE_SKILL_DIR}/references/report-schema.md`. At minimum it contains:
+
+```markdown
+## Session signals
+## Hypotheses
+| ID | Subsystem | Hypothesis | Evidence for | Evidence against | Verdict | Confidence | Promotion |
+|----|-----------|------------|--------------|------------------|---------|------------|-----------|
+## Promotion candidates
+## Log entry
+STATUS: RETRO-DONE
+```
+
+Run the helper when a report artifact exists:
+
+```bash
+bash "${CLAUDE_SKILL_DIR}/scripts/validate-retro-report.sh" /path/to/retro-report.md
+```
+
+If no artifact exists because the response is generated inline, still follow the schema exactly. The final non-empty line must be `STATUS: RETRO-DONE`.
 
 ## The scientific loop
 
@@ -106,7 +131,7 @@ For each signal, write one falsifiable statement and tag it with its subsystem. 
 
 ### 3. Test each hypothesis
 
-For every hypothesis, cite session evidence for it and actively search for evidence against it. Then assign a **verdict** (`supported` / `refuted` / `inconclusive`) and a **confidence** (`low` / `medium` / `high`) per the rubric above.
+For every hypothesis, cite session evidence for it and actively search for evidence against it. Then assign a **verdict** (`supported` / `refuted` / `inconclusive`) and a **confidence** (`low` / `medium` / `high`) per the rubric above. Record every hypothesis in the required `## Hypotheses` table, including `Evidence against`; write `none found in-session` only after actively checking.
 
 ### 4. Qualify filter
 
@@ -160,15 +185,21 @@ Before writing to `memory/MEMORY.md` or `context/IDENTITY.md`, present the propo
 
 ```
 Proposed MEMORY.md addition(s):
-- YYYY-MM-DD: <one-sentence lesson> [<subsystem> · <confidence>] — basis: <one clause>
+- YYYY-MM-DD: <one-sentence lesson> [<subsystem> · <confidence> · harden|proceduralize|eval] — probe: <id> | basis: <one clause>
 
 Proposed IDENTITY.md addition(s):
-- <prescriptive principle, "always X" or "never Y"> [<subsystem> · <confidence>] — basis: <one clause>
+- <prescriptive principle, "always X" or "never Y"> [<subsystem> · <confidence> · harden|proceduralize|eval] — probe: <id> | basis: <one clause>
 
 Type APPROVE to write, SKIP to discard any item, or EDIT <n> <new text> to revise.
 ```
 
-Do not write to either file until the user responds. Log-tier entries do not require approval. If `--dry-run` was passed, skip writing entirely and report what would have been written.
+Do not write to either file until the user responds. Log-tier entries do not require approval. If `--dry-run` was passed, write only the required `memory/<UTC-date>/log.md` entry with `Result: DRY-RUN`; never write MEMORY.md or IDENTITY.md in dry-run mode.
+
+Before proposing, pipe candidate lines through the self-contained duplicate helper and skip exact/substantive duplicates it reports:
+
+```bash
+printf "%s\n" "<candidate line>" | bash "${CLAUDE_SKILL_DIR}/scripts/check-memory-duplicates.sh"
+```
 
 ### 7. Write approved changes
 
@@ -196,16 +227,19 @@ TODAY=$(date -u +%Y-%m-%d)
 mkdir -p "memory/$TODAY"
 ```
 
-Then append to `memory/<UTC-date>/log.md`:
+Render the log entry with the skill-local helper, then append it with the shared locked append primitive:
 
-```markdown
-## Retro -- HH:MM UTC
-- **Result**: OP | DRY-RUN | SKIPPED-TRIVIAL
-- **Subsystems**: <which of the 6 produced signals, or "focus: <name>">
-- **Hypotheses**: <total formed> (supported <n> / refuted <n> / inconclusive <n>)
-- **Promoted**: <n> to MEMORY.md, <n> to IDENTITY.md
-- **Observation**: <one sentence — strongest supported finding, or "no durable patterns">
+```bash
+LOG_ENTRY=$(bash "${CLAUDE_SKILL_DIR}/scripts/render-log-entry.sh" \
+  --result OP \
+  --subsystems "<which of the 6 produced signals, or focus: name>" \
+  --hypotheses <total> --supported <n> --refuted <n> --inconclusive <n> \
+  --memory <n> --identity <n> \
+  --observation "<one sentence — strongest supported finding, or no durable patterns>")
+printf "%s\n" "$LOG_ENTRY" | scripts/locked-append.sh "memory/$TODAY/log.md"
 ```
+
+Use `--result DRY-RUN` for dry-runs and `--result SKIPPED-TRIVIAL` for trivial skips.
 
 ## MEMORY.md vs IDENTITY.md boundary
 
@@ -217,6 +251,31 @@ Then append to `memory/<UTC-date>/log.md`:
 | **Changed how** | Append-only; entries are never edited | Deliberate revision; graduation is rare |
 
 A lesson graduates from MEMORY.md to IDENTITY.md when it has recurred across multiple sessions or contexts, not from a single run. Do not graduate prematurely.
+
+## Example
+
+```markdown
+## Session signals
+- The session required manual release, PR land, and duplicate-PR cleanup command sequences.
+
+## Hypotheses
+| ID | Subsystem | Hypothesis | Evidence for | Evidence against | Verdict | Confidence | Promotion |
+|----|-----------|------------|--------------|------------------|---------|------------|-----------|
+| H1 | memory scaffolding | Release and PR cleanup have deterministic substeps worth scripting. | Repeated command sequences handled release verification and PR cleanup. | Canonical PR choice and /teach prose still required judgment. | supported | high | MEMORY |
+| H2 | docs | Every workflow gap found this session belongs in docs. | Several gaps were procedural. | Some were already encoded in skills and would be duplicate memory. | inconclusive | low | discarded |
+
+## Promotion candidates
+Proposed MEMORY.md addition(s):
+- 2026-06-18: Multi-step GitHub release and PR-cleanup workflows have deterministic substeps that should be scripted while leaving judgment gates explicit. [memory scaffolding · high · proceduralize] — probe: memory-scaffolding-20260618 | basis: release and PR cleanup repeated as command sequences
+
+Proposed IDENTITY.md addition(s):
+- none
+
+## Log entry
+- would append the rendered `Retro -- HH:MM UTC` block.
+
+STATUS: RETRO-DONE
+```
 
 ## Auto-trigger note
 
@@ -234,6 +293,7 @@ Claude Code skills cannot self-trigger. True automatic firing at session end wou
 - **Overfitting one session.** Single-session support is not a principle; that is the MEMORY.md → IDENTITY.md graduation bar.
 - **Confirmation bias.** Every hypothesis must be tested for disconfirming evidence, not just supporting evidence.
 - **Scope creep into the lint tools.** Point at `/context-audit`, `/wiki-lint`, `/skill-lint`, etc.; do not run them inline.
+- **Bypassing the schema/scripts.** The evidence table, duplicate check, and rendered log entry are part of the contract, not optional formatting.
 
 ## Handoff
 

--- a/.claude/skills/retro/references/report-schema.md
+++ b/.claude/skills/retro/references/report-schema.md
@@ -1,0 +1,44 @@
+# Retro Report Schema
+
+Every non-trivial `/retro` run must emit this structure before any MEMORY.md or
+IDENTITY.md approval gate. Keep the final line as `STATUS: RETRO-DONE`.
+
+## Required sections
+
+1. `## Session signals`
+2. `## Hypotheses`
+3. `## Promotion candidates`
+4. `## Log entry`
+5. final line: `STATUS: RETRO-DONE`
+
+## Hypotheses table
+
+Use exactly this header so `scripts/validate-retro-report.sh` can check it:
+
+```markdown
+| ID | Subsystem | Hypothesis | Evidence for | Evidence against | Verdict | Confidence | Promotion |
+|----|-----------|------------|--------------|------------------|---------|------------|-----------|
+```
+
+Rules:
+- `Evidence against` is required for every row; write `none found in-session` only after actively checking.
+- `Verdict` must be `supported`, `refuted`, or `inconclusive`.
+- `Confidence` must be `low`, `medium`, or `high`.
+- `Promotion` must be one of `log-only`, `MEMORY`, `IDENTITY`, or `discarded`.
+
+## Promotion candidate format
+
+MEMORY candidates must carry correction-surface metadata:
+
+```markdown
+- YYYY-MM-DD: <lesson> [<subsystem> · <confidence> · harden|proceduralize|eval] — probe: <id> | basis: <one clause>
+```
+
+IDENTITY candidates must remain prescriptive and are rare:
+
+```markdown
+- <principle> [<subsystem> · <confidence> · harden|proceduralize|eval] — probe: <id> | basis: <one clause>
+```
+
+If `eval` is used, the probe must be `deferred-tier-b` and the line must include
+`justification:` explaining why neither `harden` nor `proceduralize` fits.

--- a/.claude/skills/retro/scripts/check-memory-duplicates.sh
+++ b/.claude/skills/retro/scripts/check-memory-duplicates.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Reads proposed MEMORY/IDENTITY lines from stdin and reports lines whose lesson
+# text already appears in memory/MEMORY.md or context/IDENTITY.md. Exact enough to
+# catch double-writes without making subjective semantic judgments.
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+ROOT=$(cd "$SCRIPT_DIR/../../../.." && pwd)
+MEMORY_FILE="$ROOT/memory/MEMORY.md"
+IDENTITY_FILE="$ROOT/context/IDENTITY.md"
+
+status=0
+while IFS= read -r line; do
+  [[ -n "$line" ]] || continue
+  # Strip common bullet/date prefixes and metadata after the first bracket tag.
+  normalized=$(printf '%s' "$line" \
+    | sed -E 's/^- +//' \
+    | sed -E 's/^\*\*[0-9]{4}-[0-9]{2}-[0-9]{2}\*\*: //' \
+    | sed -E 's/^[0-9]{4}-[0-9]{2}-[0-9]{2}: //' \
+    | sed -E 's/ \[[^]]+\].*$//')
+  [[ -n "$normalized" ]] || continue
+  if { [[ -f "$MEMORY_FILE" ]] && grep -Fqi -- "$normalized" "$MEMORY_FILE"; } || \
+     { [[ -f "$IDENTITY_FILE" ]] && grep -Fqi -- "$normalized" "$IDENTITY_FILE"; }; then
+    echo "DUPLICATE: $line" >&2
+    status=1
+  fi
+done
+exit "$status"

--- a/.claude/skills/retro/scripts/render-log-entry.sh
+++ b/.claude/skills/retro/scripts/render-log-entry.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'USAGE'
+Usage: render-log-entry.sh --result OP|DRY-RUN|SKIPPED-TRIVIAL \
+  --subsystems TEXT --hypotheses N --supported N --refuted N --inconclusive N \
+  --memory N --identity N --observation TEXT [--time HH:MM]
+
+Renders the standard /retro log entry to stdout. It does not write files.
+USAGE
+}
+
+RESULT=""; SUBSYSTEMS=""; HYPOTHESES=""; SUPPORTED=""; REFUTED=""; INCONCLUSIVE=""; MEMORY=""; IDENTITY=""; OBSERVATION=""; TIME=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --result) RESULT=${2:-}; shift 2 ;;
+    --subsystems) SUBSYSTEMS=${2:-}; shift 2 ;;
+    --hypotheses) HYPOTHESES=${2:-}; shift 2 ;;
+    --supported) SUPPORTED=${2:-}; shift 2 ;;
+    --refuted) REFUTED=${2:-}; shift 2 ;;
+    --inconclusive) INCONCLUSIVE=${2:-}; shift 2 ;;
+    --memory) MEMORY=${2:-}; shift 2 ;;
+    --identity) IDENTITY=${2:-}; shift 2 ;;
+    --observation) OBSERVATION=${2:-}; shift 2 ;;
+    --time) TIME=${2:-}; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "unknown arg: $1" >&2; usage; exit 64 ;;
+  esac
+done
+
+case "$RESULT" in OP|DRY-RUN|SKIPPED-TRIVIAL) ;; *) echo "--result must be OP, DRY-RUN, or SKIPPED-TRIVIAL" >&2; exit 64 ;; esac
+for name in SUBSYSTEMS HYPOTHESES SUPPORTED REFUTED INCONCLUSIVE MEMORY IDENTITY OBSERVATION; do
+  if [[ -z "${!name}" ]]; then echo "missing --${name,,}" >&2; exit 64; fi
+done
+for value in "$HYPOTHESES" "$SUPPORTED" "$REFUTED" "$INCONCLUSIVE" "$MEMORY" "$IDENTITY"; do
+  [[ "$value" =~ ^[0-9]+$ ]] || { echo "counts must be non-negative integers" >&2; exit 64; }
+done
+if [[ -z "$TIME" ]]; then TIME=$(date -u +%H:%M); fi
+[[ "$TIME" =~ ^[0-2][0-9]:[0-5][0-9]$ ]] || { echo "--time must be HH:MM" >&2; exit 64; }
+
+cat <<ENTRY
+## Retro -- $TIME UTC
+- **Result**: $RESULT
+- **Subsystems**: $SUBSYSTEMS
+- **Hypotheses**: $HYPOTHESES (supported $SUPPORTED / refuted $REFUTED / inconclusive $INCONCLUSIVE)
+- **Promoted**: $MEMORY to MEMORY.md, $IDENTITY to IDENTITY.md
+- **Observation**: $OBSERVATION
+ENTRY

--- a/.claude/skills/retro/scripts/validate-retro-report.sh
+++ b/.claude/skills/retro/scripts/validate-retro-report.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPORT=${1:-}
+if [[ -z "$REPORT" || ! -f "$REPORT" ]]; then
+  echo "Usage: validate-retro-report.sh <report.md>" >&2
+  exit 64
+fi
+
+required_literals=(
+  '## Session signals'
+  '## Hypotheses'
+  '| ID | Subsystem | Hypothesis | Evidence for | Evidence against | Verdict | Confidence | Promotion |'
+  '## Promotion candidates'
+  '## Log entry'
+  'STATUS: RETRO-DONE'
+)
+for literal in "${required_literals[@]}"; do
+  if ! grep -Fq -- "$literal" "$REPORT"; then
+    echo "REGRESSION: retro report missing required literal: $literal" >&2
+    exit 1
+  fi
+done
+
+last_line=$(awk 'NF { line=$0 } END { print line }' "$REPORT")
+if [[ "$last_line" != 'STATUS: RETRO-DONE' ]]; then
+  echo "REGRESSION: final non-empty line must be STATUS: RETRO-DONE" >&2
+  exit 1
+fi
+
+# Validate table rows enough to catch skipped evidence/verdict/confidence fields.
+awk -F'|' '
+  /^\|[[:space:]]*[A-Z0-9-]+[[:space:]]*\|/ {
+    id=$2; gsub(/^[[:space:]]+|[[:space:]]+$/, "", id)
+    if (id == "ID" || id ~ /^-+$/) next
+    verdict=$7; confidence=$8; against=$6; promotion=$9
+    gsub(/^[[:space:]]+|[[:space:]]+$/, "", verdict)
+    gsub(/^[[:space:]]+|[[:space:]]+$/, "", confidence)
+    gsub(/^[[:space:]]+|[[:space:]]+$/, "", against)
+    gsub(/^[[:space:]]+|[[:space:]]+$/, "", promotion)
+    if (against == "") { print "REGRESSION: missing Evidence against" > "/dev/stderr"; exit 1 }
+    if (verdict !~ /^(supported|refuted|inconclusive)$/) { print "REGRESSION: bad verdict: " verdict > "/dev/stderr"; exit 1 }
+    if (confidence !~ /^(low|medium|high)$/) { print "REGRESSION: bad confidence: " confidence > "/dev/stderr"; exit 1 }
+    if (promotion !~ /^(log-only|MEMORY|IDENTITY|discarded)$/) { print "REGRESSION: bad promotion: " promotion > "/dev/stderr"; exit 1 }
+    rows++
+  }
+  END { if (rows < 1) { print "REGRESSION: no hypothesis rows" > "/dev/stderr"; exit 1 } }
+' "$REPORT"
+
+# If MEMORY candidates are present, enforce triage tag and probe id shape.
+if grep -Eq '^- [0-9]{4}-[0-9]{2}-[0-9]{2}: .*\[[^]]+ · (low|medium|high) · (harden|proceduralize|eval)\] — probe: ' "$REPORT"; then
+  true
+elif grep -Eq '^- [0-9]{4}-[0-9]{2}-[0-9]{2}: ' "$REPORT"; then
+  echo "REGRESSION: MEMORY candidate missing triage tag or probe id" >&2
+  exit 1
+fi
+
+echo "PASS: retro report satisfies deterministic schema" >&2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ Update policy and release automation live in [`/git`](.claude/skills/git/SKILL.m
 ## [Unreleased]
 
 ### Added
+- `retro-deterministic-contract` eval probe guards that `/retro` keeps schema-backed output, self-contained helper scripts, and synchronized `.pi`/`.claude` skill copies ([#443](https://github.com/mifunedev/openharness/issues/443)).
 ### Changed
+- `/retro` now uses a report schema plus skill-local helper scripts for deterministic hypothesis validation, duplicate-memory checks, and log rendering ([#443](https://github.com/mifunedev/openharness/issues/443)).
 ### Fixed
 ### Removed
 ### Deprecated
@@ -33,6 +35,7 @@ Update policy and release automation live in [`/git`](.claude/skills/git/SKILL.m
 ## [2026.6.17] - 2026-06-17
 
 ### Added
+- `retro-deterministic-contract` eval probe guards that `/retro` keeps schema-backed output, self-contained helper scripts, and synchronized `.pi`/`.claude` skill copies ([#443](https://github.com/mifunedev/openharness/issues/443)).
 ### Changed
 - Sync `ryaneggz/openharness:development` changes after `e863676` into canonical development, including Pi autoresearch package support, cron/watchdog hardening, issue-template generalization, Slack startup fixes, and fork branch-catch-up guidance ([#430](https://github.com/mifunedev/openharness/issues/430)).
 ### Fixed
@@ -69,6 +72,7 @@ Update policy and release automation live in [`/git`](.claude/skills/git/SKILL.m
 - Sandbox Docker healthcheck for tmux-managed runtime services: `scripts/sandbox-healthcheck.sh` verifies `cron-watchdog`/`cron-system`, flags legacy `system-cron`, conditionally checks configured Slack/Hermes dashboard sessions, and `.devcontainer/docker-compose.yml` reports failures through container health status ([#150](https://github.com/ryaneggz/openharness/issues/150)).
 
 ### Changed
+- `/retro` now uses a report schema plus skill-local helper scripts for deterministic hypothesis validation, duplicate-memory checks, and log rendering ([#443](https://github.com/mifunedev/openharness/issues/443)).
 ### Fixed
 ### Removed
 ### Deprecated
@@ -356,6 +360,7 @@ Update policy and release automation live in [`/git`](.claude/skills/git/SKILL.m
 ## [2026.5.15] - 2026-05-15
 
 ### Added
+- `retro-deterministic-contract` eval probe guards that `/retro` keeps schema-backed output, self-contained helper scripts, and synchronized `.pi`/`.claude` skill copies ([#443](https://github.com/mifunedev/openharness/issues/443)).
 ### Changed
 - `oh config slack` wizard UX overhaul. Token prompts now echo `●` per keystroke (was: silent — looked frozen) via a TTY-aware raw-mode `askSecret` that handles backspace, Ctrl-U, and Ctrl-C; piped/non-TTY stdin still uses the legacy readline fallback as `askSecretPiped` so `echo "" | oh config slack` keeps working. Flow is reframed into four numbered steps `[1/4] … [4/4]` with inline "Where:" hints and clickable URLs (OSC 8 hyperlinks; fall back to `label (url)` on legacy terminals). Each input shows `✓ valid prefix` / `✓ N user(s) accepted` after validation. A final summary screen lists the keys (tokens redacted, IDs visible) and gates the env-file write behind a `Proceed? [Y/n]` confirmation. New helpers exported from `apps/oh/src/lib/prompt.ts`: `step()`, `link()`, `bold()`. Zero new runtime dependencies. ([#290](https://github.com/mifunedev/openharness/issues/290))
 ### Fixed

--- a/evals/RESULTS.md
+++ b/evals/RESULTS.md
@@ -6,54 +6,55 @@ probe id; git history is the time series.** Schema and exit-code semantics are i
 
 | probe | tier | last-run (UTC) | status | source |
 |-------|------|----------------|--------|--------|
-| agent-browser-cli | A | 2026-06-18 20:22 | PASS | memory/MEMORY.md 2026-06-07 (agent-browser 0.8.5 CLI) |
-| autopilot-executor-toggle | A | 2026-06-18 20:22 | PASS | conversation 2026-06-13 (autopilot delegate-advisor executor) |
-| autopilot-no-pr-session-close | A | 2026-06-18 20:22 | PASS | issue #209 (autopilot no-PR tmux session closure) 2026-06-16 |
-| autopilot-open-pr-reference-dedupe | A | 2026-06-18 20:22 | PASS | issue #437 — autopilot must not start duplicate work when open PRs reference the same issue without linked-PR metadata |
-| autopilot-pi-agent | A | 2026-06-18 20:22 | PASS | issue #116 (autopilot Pi tmux alignment) 2026-06-14; issue #118 (attachable Pi TUI tmux) 2026-06-14; issue #126 (kept Pi overlap lock release) 2026-06-14; issue #142 (worktree-by-default, skip→worktree) 2026-06-14 |
-| autopilot-preflight-gate | A | 2026-06-18 20:22 | PASS | issue #194 (deterministic autopilot caps preflight gate) 2026-06-15 |
-| autopilot-upstream-default | A | 2026-06-18 20:22 | PASS | issue #420 — future autopilots must target canonical repo, not personal fork |
-| autopilot-worktree-log-root | A | 2026-06-18 20:22 | PASS | issue #152 (persist autopilot worktree logs) 2026-06-15 |
-| boot-lint-glob | A | 2026-06-18 20:22 | PASS | issue #90, issue #120 |
-| capability-benchmark-schema | A | 2026-06-18 20:22 | PASS | issue #167 — capability benchmark instrument |
-| clean-restore | A | 2026-06-18 20:22 | PASS | issue #63 (autopilot-stray-wip-guard) 2026-06-12; issue #81 (owned-paths-zsh-split) 2026-06-13 |
-| cleanup-tasks-scoped-guard | A | 2026-06-18 20:22 | PASS | issue #85 |
-| cleanup-tasks-worktree-grooming | A | 2026-06-18 20:22 | PASS | issue #168 |
-| cron-claude-codex-fallback | A | 2026-06-18 20:22 | PASS | conversation 2026-06-12 (default Codex fallback for crons) |
-| cron-watchdog | A | 2026-06-18 20:22 | PASS | issue #130 (cron runtime watchdog) 2026-06-14 |
-| curl-bash-safe-alternatives | A | 2026-06-18 20:22 | PASS | vet-run/vet integration — public curl|bash examples need review-first alternatives |
-| datasets-schema | A | 2026-06-18 20:22 | PASS | issue #196 — evals/datasets verifiable trajectory corpus (Repo2RLEnv-inspired) |
-| devtcp-hook | A | 2026-06-18 20:22 | PASS | memory/MEMORY.md 2026-06-10 (zsh /dev/tcp) |
-| drift-check-cron-staleness-glob | A | 2026-06-18 20:22 | PASS | issue #98; issue #225 (restart-required cron frontmatter/config drift) |
-| eval-ci-gate | A | 2026-06-18 20:22 | PASS | #103 — eval probe suite gated in CI |
-| eval-gate | A | 2026-06-18 20:22 | PASS | memory/MEMORY.md 2026-06-11 (eval-gate) |
-| eval-results-atomic | A | 2026-06-18 20:22 | PASS | issue #83 (eval-results-atomic-write) |
-| eval-runner-exit | A | 2026-06-18 20:22 | PASS | memory/MEMORY.md 2026-06-11 (eval-runner-exit) #29 |
-| git-skill | A | 2026-06-18 20:22 | PASS | conversation 2026-06-15 — rules are not always supported; git workflow must be the /git skill |
-| harness-audit-empty-output-gate | A | 2026-06-18 20:22 | PASS | issue #246 — /harness-audit must fail closed on empty auditor outputs |
-| harness-audit-memory-path | A | 2026-06-18 20:22 | PASS | issue #183 — /harness-audit must inspect the active worktree, not a hardcoded root |
-| harness-audit-shared-memory | A | 2026-06-18 20:22 | PASS | issue #432 — /harness-audit must load durable memory from shared log root in cron worktrees |
-| harness-ci-core-paths | A | 2026-06-18 20:22 | PASS | #165 — core sandbox config files must trigger harness CI |
-| harness-ci-hooks-paths | A | 2026-06-18 20:22 | PASS | issue #202 — credential/security hook changes must trigger harness CI |
-| health-check-docker-stats | A | 2026-06-18 20:22 | PASS | memory/MEMORY.md 2026-06-10 (docker stats vs ps Size) |
-| locked-append-critical-path | A | 2026-06-18 20:22 | PASS | issue #204 (lock shared runtime log appends) 2026-06-15 |
-| loop-benchmark-gate | A | 2026-06-18 20:22 | PASS | issue #179 — wire the executable-loop `benchmark` node (close the cycle) |
-| loop-handoff-consistency | A | 2026-06-18 20:22 | PASS | context/rules/loop.md § 4 (executable-loop Handoff convention) |
-| loop-repeat-gate | A | 2026-06-18 20:22 | PASS | issue #173 — wire the executable-loop `repeat` node (cycle-closing edge) |
-| memory-gitignore-claim | A | 2026-06-18 20:22 | PASS | issue #101 |
-| next-dev-prod | A | 2026-06-18 20:22 | PASS | memory/MEMORY.md 2026-06-04 |
-| orchestrate-contract | A | 2026-06-18 20:22 | PASS | issue #160 — /orchestrate contract; issue #175 — reserved /loop command rename |
-| owned-surface-guard | A | 2026-06-18 20:22 | PASS | issue #63 (autopilot-stray-wip-guard) 2026-06-12; issue #81 (owned-paths-zsh-split) 2026-06-13 |
-| pnpm-audit-ci-gate | A | 2026-06-18 20:22 | PASS | issue #171 — pnpm security audits must run in CI |
-| pr-audit-duplicate-issue-refs | A | 2026-06-18 20:22 | PASS | issue #439 — /pr-audit must flag duplicate open PRs that reference the same issue |
-| ralph-fallback-order | A | 2026-06-18 20:22 | PASS | conversation 2026-06-12 (Ralph default fallback order) |
-| rl-delegation-write-worker | A | 2026-06-18 20:22 | PASS | memory/MEMORY.md 2026-06-10 (rl-delegation) #57 |
-| ship-spec-ready-finalization | A | 2026-06-18 20:22 | PASS | issue #134 — /ship-spec must finalize ready PRs after gates, not stop at draft scaffold |
-| skill-paths | A | 2026-06-18 20:22 | PASS | issue #43 — stale path references; extended by issue #69 — apps/->packages/ rename guard |
-| submitted-by-trailers | A | 2026-06-18 20:22 | PASS | conversation 2026-06-12 (commit attribution trailers) |
-| watchdog-completed-session-reap | A | 2026-06-18 20:22 | PASS | issue #235 (completed autopilot PR session reaping) |
-| watchdog-draft-prs | A | 2026-06-18 20:22 | PASS | conversation 2026-06-15 (generic watchdog + stale draft PR recovery) |
-| watchdog-stuck-sessions | A | 2026-06-18 20:22 | PASS | issue #240 (Codex zero-credit stuck autopilot sessions) 2026-06-17 |
-| wiki-readme-index | A | 2026-06-18 20:22 | PASS | issue #132 — wiki README index drift guard |
+| agent-browser-cli | A | 2026-06-18 20:55 | PASS | memory/MEMORY.md 2026-06-07 (agent-browser 0.8.5 CLI) |
+| autopilot-executor-toggle | A | 2026-06-18 20:55 | PASS | conversation 2026-06-13 (autopilot delegate-advisor executor) |
+| autopilot-no-pr-session-close | A | 2026-06-18 20:55 | PASS | issue #209 (autopilot no-PR tmux session closure) 2026-06-16 |
+| autopilot-open-pr-reference-dedupe | A | 2026-06-18 20:55 | PASS | issue #437 — autopilot must not start duplicate work when open PRs reference the same issue without linked-PR metadata |
+| autopilot-pi-agent | A | 2026-06-18 20:55 | PASS | issue #116 (autopilot Pi tmux alignment) 2026-06-14; issue #118 (attachable Pi TUI tmux) 2026-06-14; issue #126 (kept Pi overlap lock release) 2026-06-14; issue #142 (worktree-by-default, skip→worktree) 2026-06-14 |
+| autopilot-preflight-gate | A | 2026-06-18 20:55 | PASS | issue #194 (deterministic autopilot caps preflight gate) 2026-06-15 |
+| autopilot-upstream-default | A | 2026-06-18 20:55 | PASS | issue #420 — future autopilots must target canonical repo, not personal fork |
+| autopilot-worktree-log-root | A | 2026-06-18 20:55 | PASS | issue #152 (persist autopilot worktree logs) 2026-06-15 |
+| boot-lint-glob | A | 2026-06-18 20:55 | PASS | issue #90, issue #120 |
+| capability-benchmark-schema | A | 2026-06-18 20:55 | PASS | issue #167 — capability benchmark instrument |
+| clean-restore | A | 2026-06-18 20:55 | PASS | issue #63 (autopilot-stray-wip-guard) 2026-06-12; issue #81 (owned-paths-zsh-split) 2026-06-13 |
+| cleanup-tasks-scoped-guard | A | 2026-06-18 20:55 | PASS | issue #85 |
+| cleanup-tasks-worktree-grooming | A | 2026-06-18 20:55 | PASS | issue #168 |
+| cron-claude-codex-fallback | A | 2026-06-18 20:55 | PASS | conversation 2026-06-12 (default Codex fallback for crons) |
+| cron-watchdog | A | 2026-06-18 20:55 | PASS | issue #130 (cron runtime watchdog) 2026-06-14 |
+| curl-bash-safe-alternatives | A | 2026-06-18 20:55 | PASS | vet-run/vet integration — public curl|bash examples need review-first alternatives |
+| datasets-schema | A | 2026-06-18 20:55 | PASS | issue #196 — evals/datasets verifiable trajectory corpus (Repo2RLEnv-inspired) |
+| devtcp-hook | A | 2026-06-18 20:55 | PASS | memory/MEMORY.md 2026-06-10 (zsh /dev/tcp) |
+| drift-check-cron-staleness-glob | A | 2026-06-18 20:55 | PASS | issue #98; issue #225 (restart-required cron frontmatter/config drift) |
+| eval-ci-gate | A | 2026-06-18 20:55 | PASS | #103 — eval probe suite gated in CI |
+| eval-gate | A | 2026-06-18 20:55 | PASS | memory/MEMORY.md 2026-06-11 (eval-gate) |
+| eval-results-atomic | A | 2026-06-18 20:55 | PASS | issue #83 (eval-results-atomic-write) |
+| eval-runner-exit | A | 2026-06-18 20:55 | PASS | memory/MEMORY.md 2026-06-11 (eval-runner-exit) #29 |
+| git-skill | A | 2026-06-18 20:55 | PASS | conversation 2026-06-15 — rules are not always supported; git workflow must be the /git skill |
+| harness-audit-empty-output-gate | A | 2026-06-18 20:55 | PASS | issue #246 — /harness-audit must fail closed on empty auditor outputs |
+| harness-audit-memory-path | A | 2026-06-18 20:55 | PASS | issue #183 — /harness-audit must inspect the active worktree, not a hardcoded root |
+| harness-audit-shared-memory | A | 2026-06-18 20:55 | PASS | issue #432 — /harness-audit must load durable memory from shared log root in cron worktrees |
+| harness-ci-core-paths | A | 2026-06-18 20:55 | PASS | #165 — core sandbox config files must trigger harness CI |
+| harness-ci-hooks-paths | A | 2026-06-18 20:55 | PASS | issue #202 — credential/security hook changes must trigger harness CI |
+| health-check-docker-stats | A | 2026-06-18 20:55 | PASS | memory/MEMORY.md 2026-06-10 (docker stats vs ps Size) |
+| locked-append-critical-path | A | 2026-06-18 20:55 | PASS | issue #204 (lock shared runtime log appends) 2026-06-15 |
+| loop-benchmark-gate | A | 2026-06-18 20:55 | PASS | issue #179 — wire the executable-loop `benchmark` node (close the cycle) |
+| loop-handoff-consistency | A | 2026-06-18 20:55 | PASS | context/rules/loop.md § 4 (executable-loop Handoff convention) |
+| loop-repeat-gate | A | 2026-06-18 20:55 | PASS | issue #173 — wire the executable-loop `repeat` node (cycle-closing edge) |
+| memory-gitignore-claim | A | 2026-06-18 20:55 | PASS | issue #101 |
+| next-dev-prod | A | 2026-06-18 20:55 | PASS | memory/MEMORY.md 2026-06-04 |
+| orchestrate-contract | A | 2026-06-18 20:55 | PASS | issue #160 — /orchestrate contract; issue #175 — reserved /loop command rename |
+| owned-surface-guard | A | 2026-06-18 20:55 | PASS | issue #63 (autopilot-stray-wip-guard) 2026-06-12; issue #81 (owned-paths-zsh-split) 2026-06-13 |
+| pnpm-audit-ci-gate | A | 2026-06-18 20:55 | PASS | issue #171 — pnpm security audits must run in CI |
+| pr-audit-duplicate-issue-refs | A | 2026-06-18 20:55 | PASS | issue #439 — /pr-audit must flag duplicate open PRs that reference the same issue |
+| ralph-fallback-order | A | 2026-06-18 20:55 | PASS | conversation 2026-06-12 (Ralph default fallback order) |
+| retro-deterministic-contract | A | 2026-06-18 20:55 | PASS | issue #443 — /retro deterministic output and self-contained helper contract |
+| rl-delegation-write-worker | A | 2026-06-18 20:55 | PASS | memory/MEMORY.md 2026-06-10 (rl-delegation) #57 |
+| ship-spec-ready-finalization | A | 2026-06-18 20:55 | PASS | issue #134 — /ship-spec must finalize ready PRs after gates, not stop at draft scaffold |
+| skill-paths | A | 2026-06-18 20:55 | PASS | issue #43 — stale path references; extended by issue #69 — apps/->packages/ rename guard |
+| submitted-by-trailers | A | 2026-06-18 20:55 | PASS | conversation 2026-06-12 (commit attribution trailers) |
+| watchdog-completed-session-reap | A | 2026-06-18 20:55 | PASS | issue #235 (completed autopilot PR session reaping) |
+| watchdog-draft-prs | A | 2026-06-18 20:55 | PASS | conversation 2026-06-15 (generic watchdog + stale draft PR recovery) |
+| watchdog-stuck-sessions | A | 2026-06-18 20:55 | PASS | issue #240 (Codex zero-credit stuck autopilot sessions) 2026-06-17 |
+| wiki-readme-index | A | 2026-06-18 20:55 | PASS | issue #132 — wiki README index drift guard |
 
 <!-- benchmark: pass-rate = PASS / (PASS + REGRESSION + TIMEOUT); SKIPPED excluded -->

--- a/evals/probes/retro-deterministic-contract.sh
+++ b/evals/probes/retro-deterministic-contract.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# tier: A
+# source: issue #443 — /retro deterministic output and self-contained helper contract
+# desc: /retro requires schema-backed hypothesis output, self-contained helper scripts, and synchronized skill copies.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PI_DIR="$ROOT/.pi/skills/retro"
+CLAUDE_DIR="$ROOT/.claude/skills/retro"
+
+for dir in "$PI_DIR" "$CLAUDE_DIR"; do
+  [[ -f "$dir/SKILL.md" ]] || { echo "REGRESSION: missing $dir/SKILL.md" >&2; exit 1; }
+  [[ -f "$dir/references/report-schema.md" ]] || { echo "REGRESSION: missing $dir/references/report-schema.md" >&2; exit 1; }
+  for script in render-log-entry.sh validate-retro-report.sh check-memory-duplicates.sh; do
+    [[ -x "$dir/scripts/$script" ]] || { echo "REGRESSION: missing executable $dir/scripts/$script" >&2; exit 1; }
+  done
+done
+
+if ! diff -qr "$PI_DIR" "$CLAUDE_DIR" >/tmp/retro-skill-diff.$$; then
+  echo "REGRESSION: .pi and .claude retro skill copies drifted:" >&2
+  cat /tmp/retro-skill-diff.$$ >&2
+  rm -f /tmp/retro-skill-diff.$$
+  exit 1
+fi
+rm -f /tmp/retro-skill-diff.$$
+
+missing=()
+for literal in \
+  'allowed-tools: Read, Grep, Bash, Edit' \
+  '${CLAUDE_SKILL_DIR}/references/report-schema.md' \
+  '${CLAUDE_SKILL_DIR}/scripts/validate-retro-report.sh' \
+  '${CLAUDE_SKILL_DIR}/scripts/render-log-entry.sh' \
+  '${CLAUDE_SKILL_DIR}/scripts/check-memory-duplicates.sh' \
+  '| ID | Subsystem | Hypothesis | Evidence for | Evidence against | Verdict | Confidence | Promotion |' \
+  'write only the required `memory/<UTC-date>/log.md` entry with `Result: DRY-RUN`' \
+  '[<subsystem> · <confidence> · harden|proceduralize|eval] — probe: <id> | basis:' \
+  'Bypassing the schema/scripts'
+do
+  if ! grep -Fq "$literal" "$PI_DIR/SKILL.md"; then
+    missing+=("$literal")
+  fi
+done
+if (( ${#missing[@]} > 0 )); then
+  echo "REGRESSION: retro deterministic contract missing literals:" >&2
+  printf '  - %s\n' "${missing[@]}" >&2
+  exit 1
+fi
+
+log_output=$("$PI_DIR/scripts/render-log-entry.sh" \
+  --result DRY-RUN \
+  --subsystems 'memory scaffolding' \
+  --hypotheses 1 --supported 1 --refuted 0 --inconclusive 0 \
+  --memory 0 --identity 0 \
+  --observation 'deterministic helper smoke test' \
+  --time 12:34)
+grep -Fq '## Retro -- 12:34 UTC' <<<"$log_output" || { echo "REGRESSION: log helper omitted timestamp" >&2; exit 1; }
+grep -Fq '**Result**: DRY-RUN' <<<"$log_output" || { echo "REGRESSION: log helper omitted dry-run result" >&2; exit 1; }
+
+report=$(mktemp)
+cat > "$report" <<'REPORT'
+## Session signals
+- signal
+
+## Hypotheses
+| ID | Subsystem | Hypothesis | Evidence for | Evidence against | Verdict | Confidence | Promotion |
+|----|-----------|------------|--------------|------------------|---------|------------|-----------|
+| H1 | memory scaffolding | Retro deterministic helpers can be validated. | helper scripts exist | none found in-session | supported | medium | MEMORY |
+
+## Promotion candidates
+Proposed MEMORY.md addition(s):
+- 2026-06-18: Retro deterministic helpers can be validated. [memory scaffolding · medium · proceduralize] — probe: memory-scaffolding-20260618 | basis: helper scripts exist
+
+Proposed IDENTITY.md addition(s):
+- none
+
+## Log entry
+- rendered log
+
+STATUS: RETRO-DONE
+REPORT
+"$PI_DIR/scripts/validate-retro-report.sh" "$report" >/dev/null
+rm -f "$report"
+
+echo "PASS: retro deterministic schema and self-contained helper contract are present" >&2
+exit 0


### PR DESCRIPTION
Closes #443.

## Summary
- Add a schema-backed deterministic report contract for `/retro`.
- Add self-contained `/retro` helper scripts for log rendering, report validation, and duplicate-memory checks.
- Clarify dry-run semantics: dry-run writes only the required retro log entry, never MEMORY.md/IDENTITY.md.
- Fix promotion templates to include triage tags and probe ids.
- Add `retro-deterministic-contract` eval coverage.

## Verification
- `bash evals/probes/retro-deterministic-contract.sh`
- `bash .claude/skills/eval/run.sh` — 50 PASS
- `pnpm run test:scripts` — 275 PASS
