### PR TITLE
FROM feat/445-preserve-active-cron-worktrees TO development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Update policy and release automation live in [`/git`](.claude/skills/git/SKILL.m
 ### Changed
 - `/retro` now uses a report schema plus skill-local helper scripts for deterministic hypothesis validation, duplicate-memory checks, and log rendering ([#443](https://github.com/mifunedev/openharness/issues/443)).
 ### Fixed
+- Cron worktree pruning now preserves a live early-run tmux session whose name still matches its cron worktree basename, preventing active autopilot checkouts from disappearing before branch rename ([#445](https://github.com/mifunedev/openharness/issues/445)).
 ### Removed
 ### Deprecated
 ### Security

--- a/evals/RESULTS.md
+++ b/evals/RESULTS.md
@@ -6,55 +6,55 @@ probe id; git history is the time series.** Schema and exit-code semantics are i
 
 | probe | tier | last-run (UTC) | status | source |
 |-------|------|----------------|--------|--------|
-| agent-browser-cli | A | 2026-06-18 20:55 | PASS | memory/MEMORY.md 2026-06-07 (agent-browser 0.8.5 CLI) |
-| autopilot-executor-toggle | A | 2026-06-18 20:55 | PASS | conversation 2026-06-13 (autopilot delegate-advisor executor) |
-| autopilot-no-pr-session-close | A | 2026-06-18 20:55 | PASS | issue #209 (autopilot no-PR tmux session closure) 2026-06-16 |
-| autopilot-open-pr-reference-dedupe | A | 2026-06-18 20:55 | PASS | issue #437 — autopilot must not start duplicate work when open PRs reference the same issue without linked-PR metadata |
-| autopilot-pi-agent | A | 2026-06-18 20:55 | PASS | issue #116 (autopilot Pi tmux alignment) 2026-06-14; issue #118 (attachable Pi TUI tmux) 2026-06-14; issue #126 (kept Pi overlap lock release) 2026-06-14; issue #142 (worktree-by-default, skip→worktree) 2026-06-14 |
-| autopilot-preflight-gate | A | 2026-06-18 20:55 | PASS | issue #194 (deterministic autopilot caps preflight gate) 2026-06-15 |
-| autopilot-upstream-default | A | 2026-06-18 20:55 | PASS | issue #420 — future autopilots must target canonical repo, not personal fork |
-| autopilot-worktree-log-root | A | 2026-06-18 20:55 | PASS | issue #152 (persist autopilot worktree logs) 2026-06-15 |
-| boot-lint-glob | A | 2026-06-18 20:55 | PASS | issue #90, issue #120 |
-| capability-benchmark-schema | A | 2026-06-18 20:55 | PASS | issue #167 — capability benchmark instrument |
-| clean-restore | A | 2026-06-18 20:55 | PASS | issue #63 (autopilot-stray-wip-guard) 2026-06-12; issue #81 (owned-paths-zsh-split) 2026-06-13 |
-| cleanup-tasks-scoped-guard | A | 2026-06-18 20:55 | PASS | issue #85 |
-| cleanup-tasks-worktree-grooming | A | 2026-06-18 20:55 | PASS | issue #168 |
-| cron-claude-codex-fallback | A | 2026-06-18 20:55 | PASS | conversation 2026-06-12 (default Codex fallback for crons) |
-| cron-watchdog | A | 2026-06-18 20:55 | PASS | issue #130 (cron runtime watchdog) 2026-06-14 |
-| curl-bash-safe-alternatives | A | 2026-06-18 20:55 | PASS | vet-run/vet integration — public curl|bash examples need review-first alternatives |
-| datasets-schema | A | 2026-06-18 20:55 | PASS | issue #196 — evals/datasets verifiable trajectory corpus (Repo2RLEnv-inspired) |
-| devtcp-hook | A | 2026-06-18 20:55 | PASS | memory/MEMORY.md 2026-06-10 (zsh /dev/tcp) |
-| drift-check-cron-staleness-glob | A | 2026-06-18 20:55 | PASS | issue #98; issue #225 (restart-required cron frontmatter/config drift) |
-| eval-ci-gate | A | 2026-06-18 20:55 | PASS | #103 — eval probe suite gated in CI |
-| eval-gate | A | 2026-06-18 20:55 | PASS | memory/MEMORY.md 2026-06-11 (eval-gate) |
-| eval-results-atomic | A | 2026-06-18 20:55 | PASS | issue #83 (eval-results-atomic-write) |
-| eval-runner-exit | A | 2026-06-18 20:55 | PASS | memory/MEMORY.md 2026-06-11 (eval-runner-exit) #29 |
-| git-skill | A | 2026-06-18 20:55 | PASS | conversation 2026-06-15 — rules are not always supported; git workflow must be the /git skill |
-| harness-audit-empty-output-gate | A | 2026-06-18 20:55 | PASS | issue #246 — /harness-audit must fail closed on empty auditor outputs |
-| harness-audit-memory-path | A | 2026-06-18 20:55 | PASS | issue #183 — /harness-audit must inspect the active worktree, not a hardcoded root |
-| harness-audit-shared-memory | A | 2026-06-18 20:55 | PASS | issue #432 — /harness-audit must load durable memory from shared log root in cron worktrees |
-| harness-ci-core-paths | A | 2026-06-18 20:55 | PASS | #165 — core sandbox config files must trigger harness CI |
-| harness-ci-hooks-paths | A | 2026-06-18 20:55 | PASS | issue #202 — credential/security hook changes must trigger harness CI |
-| health-check-docker-stats | A | 2026-06-18 20:55 | PASS | memory/MEMORY.md 2026-06-10 (docker stats vs ps Size) |
-| locked-append-critical-path | A | 2026-06-18 20:55 | PASS | issue #204 (lock shared runtime log appends) 2026-06-15 |
-| loop-benchmark-gate | A | 2026-06-18 20:55 | PASS | issue #179 — wire the executable-loop `benchmark` node (close the cycle) |
-| loop-handoff-consistency | A | 2026-06-18 20:55 | PASS | context/rules/loop.md § 4 (executable-loop Handoff convention) |
-| loop-repeat-gate | A | 2026-06-18 20:55 | PASS | issue #173 — wire the executable-loop `repeat` node (cycle-closing edge) |
-| memory-gitignore-claim | A | 2026-06-18 20:55 | PASS | issue #101 |
-| next-dev-prod | A | 2026-06-18 20:55 | PASS | memory/MEMORY.md 2026-06-04 |
-| orchestrate-contract | A | 2026-06-18 20:55 | PASS | issue #160 — /orchestrate contract; issue #175 — reserved /loop command rename |
-| owned-surface-guard | A | 2026-06-18 20:55 | PASS | issue #63 (autopilot-stray-wip-guard) 2026-06-12; issue #81 (owned-paths-zsh-split) 2026-06-13 |
-| pnpm-audit-ci-gate | A | 2026-06-18 20:55 | PASS | issue #171 — pnpm security audits must run in CI |
-| pr-audit-duplicate-issue-refs | A | 2026-06-18 20:55 | PASS | issue #439 — /pr-audit must flag duplicate open PRs that reference the same issue |
-| ralph-fallback-order | A | 2026-06-18 20:55 | PASS | conversation 2026-06-12 (Ralph default fallback order) |
-| retro-deterministic-contract | A | 2026-06-18 20:55 | PASS | issue #443 — /retro deterministic output and self-contained helper contract |
-| rl-delegation-write-worker | A | 2026-06-18 20:55 | PASS | memory/MEMORY.md 2026-06-10 (rl-delegation) #57 |
-| ship-spec-ready-finalization | A | 2026-06-18 20:55 | PASS | issue #134 — /ship-spec must finalize ready PRs after gates, not stop at draft scaffold |
-| skill-paths | A | 2026-06-18 20:55 | PASS | issue #43 — stale path references; extended by issue #69 — apps/->packages/ rename guard |
-| submitted-by-trailers | A | 2026-06-18 20:55 | PASS | conversation 2026-06-12 (commit attribution trailers) |
-| watchdog-completed-session-reap | A | 2026-06-18 20:55 | PASS | issue #235 (completed autopilot PR session reaping) |
-| watchdog-draft-prs | A | 2026-06-18 20:55 | PASS | conversation 2026-06-15 (generic watchdog + stale draft PR recovery) |
-| watchdog-stuck-sessions | A | 2026-06-18 20:55 | PASS | issue #240 (Codex zero-credit stuck autopilot sessions) 2026-06-17 |
-| wiki-readme-index | A | 2026-06-18 20:55 | PASS | issue #132 — wiki README index drift guard |
+| agent-browser-cli | A | 2026-06-18 21:11 | PASS | memory/MEMORY.md 2026-06-07 (agent-browser 0.8.5 CLI) |
+| autopilot-executor-toggle | A | 2026-06-18 21:11 | PASS | conversation 2026-06-13 (autopilot delegate-advisor executor) |
+| autopilot-no-pr-session-close | A | 2026-06-18 21:11 | PASS | issue #209 (autopilot no-PR tmux session closure) 2026-06-16 |
+| autopilot-open-pr-reference-dedupe | A | 2026-06-18 21:11 | PASS | issue #437 — autopilot must not start duplicate work when open PRs reference the same issue without linked-PR metadata |
+| autopilot-pi-agent | A | 2026-06-18 21:11 | PASS | issue #116 (autopilot Pi tmux alignment) 2026-06-14; issue #118 (attachable Pi TUI tmux) 2026-06-14; issue #126 (kept Pi overlap lock release) 2026-06-14; issue #142 (worktree-by-default, skip→worktree) 2026-06-14 |
+| autopilot-preflight-gate | A | 2026-06-18 21:11 | PASS | issue #194 (deterministic autopilot caps preflight gate) 2026-06-15 |
+| autopilot-upstream-default | A | 2026-06-18 21:11 | PASS | issue #420 — future autopilots must target canonical repo, not personal fork |
+| autopilot-worktree-log-root | A | 2026-06-18 21:11 | PASS | issue #152 (persist autopilot worktree logs) 2026-06-15 |
+| boot-lint-glob | A | 2026-06-18 21:11 | PASS | issue #90, issue #120 |
+| capability-benchmark-schema | A | 2026-06-18 21:11 | PASS | issue #167 — capability benchmark instrument |
+| clean-restore | A | 2026-06-18 21:11 | PASS | issue #63 (autopilot-stray-wip-guard) 2026-06-12; issue #81 (owned-paths-zsh-split) 2026-06-13 |
+| cleanup-tasks-scoped-guard | A | 2026-06-18 21:11 | PASS | issue #85 |
+| cleanup-tasks-worktree-grooming | A | 2026-06-18 21:11 | PASS | issue #168 |
+| cron-claude-codex-fallback | A | 2026-06-18 21:11 | PASS | conversation 2026-06-12 (default Codex fallback for crons) |
+| cron-watchdog | A | 2026-06-18 21:11 | PASS | issue #130 (cron runtime watchdog) 2026-06-14 |
+| curl-bash-safe-alternatives | A | 2026-06-18 21:11 | PASS | vet-run/vet integration — public curl|bash examples need review-first alternatives |
+| datasets-schema | A | 2026-06-18 21:11 | PASS | issue #196 — evals/datasets verifiable trajectory corpus (Repo2RLEnv-inspired) |
+| devtcp-hook | A | 2026-06-18 21:11 | PASS | memory/MEMORY.md 2026-06-10 (zsh /dev/tcp) |
+| drift-check-cron-staleness-glob | A | 2026-06-18 21:11 | PASS | issue #98; issue #225 (restart-required cron frontmatter/config drift) |
+| eval-ci-gate | A | 2026-06-18 21:11 | PASS | #103 — eval probe suite gated in CI |
+| eval-gate | A | 2026-06-18 21:11 | PASS | memory/MEMORY.md 2026-06-11 (eval-gate) |
+| eval-results-atomic | A | 2026-06-18 21:11 | PASS | issue #83 (eval-results-atomic-write) |
+| eval-runner-exit | A | 2026-06-18 21:11 | PASS | memory/MEMORY.md 2026-06-11 (eval-runner-exit) #29 |
+| git-skill | A | 2026-06-18 21:11 | PASS | conversation 2026-06-15 — rules are not always supported; git workflow must be the /git skill |
+| harness-audit-empty-output-gate | A | 2026-06-18 21:11 | PASS | issue #246 — /harness-audit must fail closed on empty auditor outputs |
+| harness-audit-memory-path | A | 2026-06-18 21:11 | PASS | issue #183 — /harness-audit must inspect the active worktree, not a hardcoded root |
+| harness-audit-shared-memory | A | 2026-06-18 21:11 | PASS | issue #432 — /harness-audit must load durable memory from shared log root in cron worktrees |
+| harness-ci-core-paths | A | 2026-06-18 21:11 | PASS | #165 — core sandbox config files must trigger harness CI |
+| harness-ci-hooks-paths | A | 2026-06-18 21:11 | PASS | issue #202 — credential/security hook changes must trigger harness CI |
+| health-check-docker-stats | A | 2026-06-18 21:11 | PASS | memory/MEMORY.md 2026-06-10 (docker stats vs ps Size) |
+| locked-append-critical-path | A | 2026-06-18 21:11 | PASS | issue #204 (lock shared runtime log appends) 2026-06-15 |
+| loop-benchmark-gate | A | 2026-06-18 21:11 | PASS | issue #179 — wire the executable-loop `benchmark` node (close the cycle) |
+| loop-handoff-consistency | A | 2026-06-18 21:11 | PASS | context/rules/loop.md § 4 (executable-loop Handoff convention) |
+| loop-repeat-gate | A | 2026-06-18 21:11 | PASS | issue #173 — wire the executable-loop `repeat` node (cycle-closing edge) |
+| memory-gitignore-claim | A | 2026-06-18 21:11 | PASS | issue #101 |
+| next-dev-prod | A | 2026-06-18 21:11 | PASS | memory/MEMORY.md 2026-06-04 |
+| orchestrate-contract | A | 2026-06-18 21:11 | PASS | issue #160 — /orchestrate contract; issue #175 — reserved /loop command rename |
+| owned-surface-guard | A | 2026-06-18 21:11 | PASS | issue #63 (autopilot-stray-wip-guard) 2026-06-12; issue #81 (owned-paths-zsh-split) 2026-06-13 |
+| pnpm-audit-ci-gate | A | 2026-06-18 21:11 | PASS | issue #171 — pnpm security audits must run in CI |
+| pr-audit-duplicate-issue-refs | A | 2026-06-18 21:11 | PASS | issue #439 — /pr-audit must flag duplicate open PRs that reference the same issue |
+| ralph-fallback-order | A | 2026-06-18 21:11 | PASS | conversation 2026-06-12 (Ralph default fallback order) |
+| retro-deterministic-contract | A | 2026-06-18 21:11 | PASS | issue #443 — /retro deterministic output and self-contained helper contract |
+| rl-delegation-write-worker | A | 2026-06-18 21:11 | PASS | memory/MEMORY.md 2026-06-10 (rl-delegation) #57 |
+| ship-spec-ready-finalization | A | 2026-06-18 21:11 | PASS | issue #134 — /ship-spec must finalize ready PRs after gates, not stop at draft scaffold |
+| skill-paths | A | 2026-06-18 21:11 | PASS | issue #43 — stale path references; extended by issue #69 — apps/->packages/ rename guard |
+| submitted-by-trailers | A | 2026-06-18 21:11 | PASS | conversation 2026-06-12 (commit attribution trailers) |
+| watchdog-completed-session-reap | A | 2026-06-18 21:11 | PASS | issue #235 (completed autopilot PR session reaping) |
+| watchdog-draft-prs | A | 2026-06-18 21:11 | PASS | conversation 2026-06-15 (generic watchdog + stale draft PR recovery) |
+| watchdog-stuck-sessions | A | 2026-06-18 21:11 | PASS | issue #240 (Codex zero-credit stuck autopilot sessions) 2026-06-17 |
+| wiki-readme-index | A | 2026-06-18 21:11 | PASS | issue #132 — wiki README index drift guard |
 
 <!-- benchmark: pass-rate = PASS / (PASS + REGRESSION + TIMEOUT); SKIPPED excluded -->

--- a/scripts/__tests__/cron-runtime.test.ts
+++ b/scripts/__tests__/cron-runtime.test.ts
@@ -51,6 +51,7 @@ import {
   scheduleAll,
   sighupHandler,
   tmuxSessionName,
+  worktreeInUse,
 } from "../cron-runtime";
 
 // Mock only appendFileSync (the log() writer) as a no-op spy so reloadBody's
@@ -1103,6 +1104,14 @@ describe("fallback worktree pruning", () => {
     expect(state.dirty).toBe(true);
     expect(state.changes).toContain("?? uncommitted.txt");
     expect(state.ref).not.toBe("unknown");
+  });
+
+  it("treats a matching live tmux session name as fallback worktree liveness", () => {
+    const wt = path.join(tmp, "repo", ".worktrees", "cron", "cron-autopilot-0618-1505");
+
+    expect(worktreeInUse(wt, [], ["cron-autopilot-0618-1505"])).toBe(true);
+    expect(worktreeInUse(wt, [path.join(wt, "nested")], [])).toBe(true);
+    expect(worktreeInUse(wt, [path.join(tmp, "elsewhere")], ["autopilot-feat-445-example"])).toBe(false);
   });
 
   it("preserves dirty dead fallback worktrees but removes clean dead ones", () => {

--- a/scripts/cron-runtime.ts
+++ b/scripts/cron-runtime.ts
@@ -583,11 +583,10 @@ function detectBaseRef(remote = "origin"): string | null {
   return null;
 }
 
-// Absolute working directory of every live tmux pane. This is how worktree
-// liveness is judged — NOT by matching the worktree dir name to a tmux session
-// name. Autopilot RENAMES its session (cron-autopilot-<ts> → autopilot-<branch>)
-// and ship-spec runs its build in a SEPARATE Advisor session (agent-ship-<slug>),
-// so a name match would falsely declare an active worktree dead and delete it.
+// Absolute working directory of every live tmux pane. This remains the primary
+// liveness signal because autopilot may rename its session
+// (cron-autopilot-<ts> → autopilot-<branch>) and ship-spec may run work inside a
+// separate Advisor session (agent-ship-<slug>).
 function livePaneCwds(): string[] {
   const r = spawnSync("tmux", ["list-panes", "-a", "-F", "#{pane_current_path}"], {
     encoding: "utf-8",
@@ -596,11 +595,28 @@ function livePaneCwds(): string[] {
   return r.stdout.split("\n").map((s) => s.trim()).filter(Boolean);
 }
 
+function liveTmuxSessionNames(): string[] {
+  const r = spawnSync("tmux", ["ls", "-F", "#{session_name}"], { encoding: "utf-8" });
+  if (r.status !== 0 || !r.stdout) return [];
+  return r.stdout.split("\n").map((s) => s.trim()).filter(Boolean);
+}
+
 // A worktree is "in use" iff some live tmux pane is working inside it (its own
-// dir or a descendant).
-function worktreeInUse(wtPath: string, cwds: string[]): boolean {
+// dir or a descendant), OR the cron-created session still has the same name as
+// the worktree basename. The basename fallback protects early-run Pi sessions
+// before autopilot renames cron-autopilot-<ts> to autopilot-<branch>; it is only
+// a fallback, so renamed Advisor/autopilot sessions still rely on pane-cwd
+// liveness and cannot keep arbitrary stale worktrees alive by name accident.
+export function worktreeInUse(
+  wtPath: string,
+  cwds: string[],
+  sessionNames: string[] = liveTmuxSessionNames(),
+): boolean {
   const abs = path.resolve(wtPath);
-  return cwds.some((p) => p === abs || p.startsWith(abs + path.sep));
+  return (
+    cwds.some((p) => p === abs || p.startsWith(abs + path.sep)) ||
+    sessionNames.includes(path.basename(abs))
+  );
 }
 
 export interface FallbackWorktreeState {
@@ -658,11 +674,12 @@ export function pruneAndCountFallbackWorktrees(id: string): number {
     return 0;
   }
   const cwds = livePaneCwds();
+  const sessionNames = liveTmuxSessionNames();
   let live = 0;
   for (const name of names) {
     if (!name.startsWith(`cron-${id}-`)) continue;
     const wt = path.join(dir, name);
-    if (worktreeInUse(wt, cwds)) {
+    if (worktreeInUse(wt, cwds, sessionNames)) {
       live++;
       continue;
     }


### PR DESCRIPTION
## Selection rationale

Research selection: queue was empty; /harness-audit ranked this finding #1 by impact among harness-infra candidates after the active cron-created `$CRON_WORKTREE` disappeared during this very run. First-principles rationale: autopilot's safety model depends on isolated worktrees remaining available for attach/recovery until the run reaches a terminal PR state. Filed as #445.

---

## Summary
- Preserve a cron fallback worktree when a live tmux session still matches the worktree basename.
- Keep pane-current-path liveness as the primary signal for renamed autopilot/advisor sessions.
- Add unit coverage for the basename-session fallback.
- Refresh `evals/RESULTS.md` after a green eval run.

## Tests
- `pnpm vitest run scripts/__tests__/cron-runtime.test.ts`
- `pnpm test:scripts`
- `bash .claude/skills/eval/run.sh`

Closes #445
