### PR TITLE
FROM feat/447-harden-heartbeat-log-appends TO development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,12 @@ Update policy and release automation live in [`/git`](.claude/skills/git/SKILL.m
 ## [Unreleased]
 
 ### Added
+- `heartbeat-logging-contract` eval probe guards that heartbeat runs keep structured memory logs and locked liveness appends ([#447](https://github.com/mifunedev/openharness/issues/447)).
 - `retro-deterministic-contract` eval probe guards that `/retro` keeps schema-backed output, self-contained helper scripts, and synchronized `.pi`/`.claude` skill copies ([#443](https://github.com/mifunedev/openharness/issues/443)).
 ### Changed
 - `/retro` now uses a report schema plus skill-local helper scripts for deterministic hypothesis validation, duplicate-memory checks, and log rendering ([#443](https://github.com/mifunedev/openharness/issues/443)).
 ### Fixed
+- Heartbeat instructions now compute memory-log timestamps explicitly and route both memory/liveness writes through `scripts/locked-append.sh` instead of raw shared-log appends ([#447](https://github.com/mifunedev/openharness/issues/447)).
 ### Removed
 ### Deprecated
 ### Security

--- a/crons/heartbeat.md
+++ b/crons/heartbeat.md
@@ -64,13 +64,36 @@ that catches anything time-sensitive without doing real work.
   include in reply as `NUDGE: <action>` (and `WATCHING: ...` for active or
   open-PR items) and note in `memory/<today>/log.md`. Clean watchdog run → no
   extra output.
-- Append the result to `memory/<today>/log.md` either way.
-- **Mandatory closing step (do this even after long action chains):**
-  append one liveness line to `crons/.cron.log`:
-  `printf '[%s] heartbeat: %s\n' "$(date -Iseconds)" "<status>" >> crons/.cron.log`
+- **Memory log contract (do this either way):** run a shell block that computes
+  `TODAY` and `HEARTBEAT_TIME`, then append a structured record to
+  `memory/$TODAY/log.md` through `scripts/locked-append.sh`. Do not paste shell
+  expressions into the markdown heading; the log must contain the computed time,
+  never a literal `$(date ...)` string.
+
+  ```bash
+  TODAY=$(date -u +%Y-%m-%d)
+  HEARTBEAT_TIME=$(date -u +%H:%M)
+  mkdir -p "memory/$TODAY"
+  scripts/locked-append.sh "memory/$TODAY/log.md" <<EOF
+
+  ## Heartbeat -- $HEARTBEAT_TIME UTC
+  - **Result**: <OK | ACTION | WATCHING | DRIFT | NUDGE | STALE-RALPH>
+  - **Action**: <one-line summary of action taken, or "nothing pressing">
+  - **Observation**: <one sentence with the most important signal>
+  EOF
+  ```
+
+- **Mandatory closing step (do this even after long action chains):** append one
+  liveness line to `crons/.cron.log` through `scripts/locked-append.sh`:
+
+  ```bash
+  STATUS="<status>"
+  printf '[%s] heartbeat: %s\n' "$(date -Iseconds)" "$STATUS" | scripts/locked-append.sh crons/.cron.log
+  ```
+
   where `<status>` is one of `OK`, `OK (N watching)`, `OK (stale ralph: <name>)`,
-  `OK (resolved: <item-snippet>)`, `OK (watchdog: <summary>)`. This is the cron's only liveness
-  signal — it MUST execute every pulse regardless of what else happened.
+  `OK (resolved: <item-snippet>)`, `OK (watchdog: <summary>)`. This is the cron's
+  only liveness signal — it MUST execute every pulse regardless of what else happened.
 
 ## Active items
 

--- a/evals/RESULTS.md
+++ b/evals/RESULTS.md
@@ -6,55 +6,56 @@ probe id; git history is the time series.** Schema and exit-code semantics are i
 
 | probe | tier | last-run (UTC) | status | source |
 |-------|------|----------------|--------|--------|
-| agent-browser-cli | A | 2026-06-18 20:55 | PASS | memory/MEMORY.md 2026-06-07 (agent-browser 0.8.5 CLI) |
-| autopilot-executor-toggle | A | 2026-06-18 20:55 | PASS | conversation 2026-06-13 (autopilot delegate-advisor executor) |
-| autopilot-no-pr-session-close | A | 2026-06-18 20:55 | PASS | issue #209 (autopilot no-PR tmux session closure) 2026-06-16 |
-| autopilot-open-pr-reference-dedupe | A | 2026-06-18 20:55 | PASS | issue #437 — autopilot must not start duplicate work when open PRs reference the same issue without linked-PR metadata |
-| autopilot-pi-agent | A | 2026-06-18 20:55 | PASS | issue #116 (autopilot Pi tmux alignment) 2026-06-14; issue #118 (attachable Pi TUI tmux) 2026-06-14; issue #126 (kept Pi overlap lock release) 2026-06-14; issue #142 (worktree-by-default, skip→worktree) 2026-06-14 |
-| autopilot-preflight-gate | A | 2026-06-18 20:55 | PASS | issue #194 (deterministic autopilot caps preflight gate) 2026-06-15 |
-| autopilot-upstream-default | A | 2026-06-18 20:55 | PASS | issue #420 — future autopilots must target canonical repo, not personal fork |
-| autopilot-worktree-log-root | A | 2026-06-18 20:55 | PASS | issue #152 (persist autopilot worktree logs) 2026-06-15 |
-| boot-lint-glob | A | 2026-06-18 20:55 | PASS | issue #90, issue #120 |
-| capability-benchmark-schema | A | 2026-06-18 20:55 | PASS | issue #167 — capability benchmark instrument |
-| clean-restore | A | 2026-06-18 20:55 | PASS | issue #63 (autopilot-stray-wip-guard) 2026-06-12; issue #81 (owned-paths-zsh-split) 2026-06-13 |
-| cleanup-tasks-scoped-guard | A | 2026-06-18 20:55 | PASS | issue #85 |
-| cleanup-tasks-worktree-grooming | A | 2026-06-18 20:55 | PASS | issue #168 |
-| cron-claude-codex-fallback | A | 2026-06-18 20:55 | PASS | conversation 2026-06-12 (default Codex fallback for crons) |
-| cron-watchdog | A | 2026-06-18 20:55 | PASS | issue #130 (cron runtime watchdog) 2026-06-14 |
-| curl-bash-safe-alternatives | A | 2026-06-18 20:55 | PASS | vet-run/vet integration — public curl|bash examples need review-first alternatives |
-| datasets-schema | A | 2026-06-18 20:55 | PASS | issue #196 — evals/datasets verifiable trajectory corpus (Repo2RLEnv-inspired) |
-| devtcp-hook | A | 2026-06-18 20:55 | PASS | memory/MEMORY.md 2026-06-10 (zsh /dev/tcp) |
-| drift-check-cron-staleness-glob | A | 2026-06-18 20:55 | PASS | issue #98; issue #225 (restart-required cron frontmatter/config drift) |
-| eval-ci-gate | A | 2026-06-18 20:55 | PASS | #103 — eval probe suite gated in CI |
-| eval-gate | A | 2026-06-18 20:55 | PASS | memory/MEMORY.md 2026-06-11 (eval-gate) |
-| eval-results-atomic | A | 2026-06-18 20:55 | PASS | issue #83 (eval-results-atomic-write) |
-| eval-runner-exit | A | 2026-06-18 20:55 | PASS | memory/MEMORY.md 2026-06-11 (eval-runner-exit) #29 |
-| git-skill | A | 2026-06-18 20:55 | PASS | conversation 2026-06-15 — rules are not always supported; git workflow must be the /git skill |
-| harness-audit-empty-output-gate | A | 2026-06-18 20:55 | PASS | issue #246 — /harness-audit must fail closed on empty auditor outputs |
-| harness-audit-memory-path | A | 2026-06-18 20:55 | PASS | issue #183 — /harness-audit must inspect the active worktree, not a hardcoded root |
-| harness-audit-shared-memory | A | 2026-06-18 20:55 | PASS | issue #432 — /harness-audit must load durable memory from shared log root in cron worktrees |
-| harness-ci-core-paths | A | 2026-06-18 20:55 | PASS | #165 — core sandbox config files must trigger harness CI |
-| harness-ci-hooks-paths | A | 2026-06-18 20:55 | PASS | issue #202 — credential/security hook changes must trigger harness CI |
-| health-check-docker-stats | A | 2026-06-18 20:55 | PASS | memory/MEMORY.md 2026-06-10 (docker stats vs ps Size) |
-| locked-append-critical-path | A | 2026-06-18 20:55 | PASS | issue #204 (lock shared runtime log appends) 2026-06-15 |
-| loop-benchmark-gate | A | 2026-06-18 20:55 | PASS | issue #179 — wire the executable-loop `benchmark` node (close the cycle) |
-| loop-handoff-consistency | A | 2026-06-18 20:55 | PASS | context/rules/loop.md § 4 (executable-loop Handoff convention) |
-| loop-repeat-gate | A | 2026-06-18 20:55 | PASS | issue #173 — wire the executable-loop `repeat` node (cycle-closing edge) |
-| memory-gitignore-claim | A | 2026-06-18 20:55 | PASS | issue #101 |
-| next-dev-prod | A | 2026-06-18 20:55 | PASS | memory/MEMORY.md 2026-06-04 |
-| orchestrate-contract | A | 2026-06-18 20:55 | PASS | issue #160 — /orchestrate contract; issue #175 — reserved /loop command rename |
-| owned-surface-guard | A | 2026-06-18 20:55 | PASS | issue #63 (autopilot-stray-wip-guard) 2026-06-12; issue #81 (owned-paths-zsh-split) 2026-06-13 |
-| pnpm-audit-ci-gate | A | 2026-06-18 20:55 | PASS | issue #171 — pnpm security audits must run in CI |
-| pr-audit-duplicate-issue-refs | A | 2026-06-18 20:55 | PASS | issue #439 — /pr-audit must flag duplicate open PRs that reference the same issue |
-| ralph-fallback-order | A | 2026-06-18 20:55 | PASS | conversation 2026-06-12 (Ralph default fallback order) |
-| retro-deterministic-contract | A | 2026-06-18 20:55 | PASS | issue #443 — /retro deterministic output and self-contained helper contract |
-| rl-delegation-write-worker | A | 2026-06-18 20:55 | PASS | memory/MEMORY.md 2026-06-10 (rl-delegation) #57 |
-| ship-spec-ready-finalization | A | 2026-06-18 20:55 | PASS | issue #134 — /ship-spec must finalize ready PRs after gates, not stop at draft scaffold |
-| skill-paths | A | 2026-06-18 20:55 | PASS | issue #43 — stale path references; extended by issue #69 — apps/->packages/ rename guard |
-| submitted-by-trailers | A | 2026-06-18 20:55 | PASS | conversation 2026-06-12 (commit attribution trailers) |
-| watchdog-completed-session-reap | A | 2026-06-18 20:55 | PASS | issue #235 (completed autopilot PR session reaping) |
-| watchdog-draft-prs | A | 2026-06-18 20:55 | PASS | conversation 2026-06-15 (generic watchdog + stale draft PR recovery) |
-| watchdog-stuck-sessions | A | 2026-06-18 20:55 | PASS | issue #240 (Codex zero-credit stuck autopilot sessions) 2026-06-17 |
-| wiki-readme-index | A | 2026-06-18 20:55 | PASS | issue #132 — wiki README index drift guard |
+| agent-browser-cli | A | 2026-06-19 02:14 | PASS | memory/MEMORY.md 2026-06-07 (agent-browser 0.8.5 CLI) |
+| autopilot-executor-toggle | A | 2026-06-19 02:14 | PASS | conversation 2026-06-13 (autopilot delegate-advisor executor) |
+| autopilot-no-pr-session-close | A | 2026-06-19 02:14 | PASS | issue #209 (autopilot no-PR tmux session closure) 2026-06-16 |
+| autopilot-open-pr-reference-dedupe | A | 2026-06-19 02:14 | PASS | issue #437 — autopilot must not start duplicate work when open PRs reference the same issue without linked-PR metadata |
+| autopilot-pi-agent | A | 2026-06-19 02:14 | PASS | issue #116 (autopilot Pi tmux alignment) 2026-06-14; issue #118 (attachable Pi TUI tmux) 2026-06-14; issue #126 (kept Pi overlap lock release) 2026-06-14; issue #142 (worktree-by-default, skip→worktree) 2026-06-14 |
+| autopilot-preflight-gate | A | 2026-06-19 02:14 | PASS | issue #194 (deterministic autopilot caps preflight gate) 2026-06-15 |
+| autopilot-upstream-default | A | 2026-06-19 02:14 | PASS | issue #420 — future autopilots must target canonical repo, not personal fork |
+| autopilot-worktree-log-root | A | 2026-06-19 02:14 | PASS | issue #152 (persist autopilot worktree logs) 2026-06-15 |
+| boot-lint-glob | A | 2026-06-19 02:14 | PASS | issue #90, issue #120 |
+| capability-benchmark-schema | A | 2026-06-19 02:14 | PASS | issue #167 — capability benchmark instrument |
+| clean-restore | A | 2026-06-19 02:14 | PASS | issue #63 (autopilot-stray-wip-guard) 2026-06-12; issue #81 (owned-paths-zsh-split) 2026-06-13 |
+| cleanup-tasks-scoped-guard | A | 2026-06-19 02:14 | PASS | issue #85 |
+| cleanup-tasks-worktree-grooming | A | 2026-06-19 02:14 | PASS | issue #168 |
+| cron-claude-codex-fallback | A | 2026-06-19 02:14 | PASS | conversation 2026-06-12 (default Codex fallback for crons) |
+| cron-watchdog | A | 2026-06-19 02:14 | PASS | issue #130 (cron runtime watchdog) 2026-06-14 |
+| curl-bash-safe-alternatives | A | 2026-06-19 02:14 | PASS | vet-run/vet integration — public curl|bash examples need review-first alternatives |
+| datasets-schema | A | 2026-06-19 02:14 | PASS | issue #196 — evals/datasets verifiable trajectory corpus (Repo2RLEnv-inspired) |
+| devtcp-hook | A | 2026-06-19 02:14 | PASS | memory/MEMORY.md 2026-06-10 (zsh /dev/tcp) |
+| drift-check-cron-staleness-glob | A | 2026-06-19 02:14 | PASS | issue #98; issue #225 (restart-required cron frontmatter/config drift) |
+| eval-ci-gate | A | 2026-06-19 02:14 | PASS | #103 — eval probe suite gated in CI |
+| eval-gate | A | 2026-06-19 02:14 | PASS | memory/MEMORY.md 2026-06-11 (eval-gate) |
+| eval-results-atomic | A | 2026-06-19 02:14 | PASS | issue #83 (eval-results-atomic-write) |
+| eval-runner-exit | A | 2026-06-19 02:14 | PASS | memory/MEMORY.md 2026-06-11 (eval-runner-exit) #29 |
+| git-skill | A | 2026-06-19 02:14 | PASS | conversation 2026-06-15 — rules are not always supported; git workflow must be the /git skill |
+| harness-audit-empty-output-gate | A | 2026-06-19 02:14 | PASS | issue #246 — /harness-audit must fail closed on empty auditor outputs |
+| harness-audit-memory-path | A | 2026-06-19 02:14 | PASS | issue #183 — /harness-audit must inspect the active worktree, not a hardcoded root |
+| harness-audit-shared-memory | A | 2026-06-19 02:14 | PASS | issue #432 — /harness-audit must load durable memory from shared log root in cron worktrees |
+| harness-ci-core-paths | A | 2026-06-19 02:14 | PASS | #165 — core sandbox config files must trigger harness CI |
+| harness-ci-hooks-paths | A | 2026-06-19 02:14 | PASS | issue #202 — credential/security hook changes must trigger harness CI |
+| health-check-docker-stats | A | 2026-06-19 02:14 | PASS | memory/MEMORY.md 2026-06-10 (docker stats vs ps Size) |
+| heartbeat-logging-contract | A | 2026-06-19 02:14 | PASS | issue #447 (heartbeat log append hardening) 2026-06-18 |
+| locked-append-critical-path | A | 2026-06-19 02:14 | PASS | issue #204 (lock shared runtime log appends) 2026-06-15 |
+| loop-benchmark-gate | A | 2026-06-19 02:14 | PASS | issue #179 — wire the executable-loop `benchmark` node (close the cycle) |
+| loop-handoff-consistency | A | 2026-06-19 02:14 | PASS | context/rules/loop.md § 4 (executable-loop Handoff convention) |
+| loop-repeat-gate | A | 2026-06-19 02:14 | PASS | issue #173 — wire the executable-loop `repeat` node (cycle-closing edge) |
+| memory-gitignore-claim | A | 2026-06-19 02:14 | PASS | issue #101 |
+| next-dev-prod | A | 2026-06-19 02:14 | PASS | memory/MEMORY.md 2026-06-04 |
+| orchestrate-contract | A | 2026-06-19 02:14 | PASS | issue #160 — /orchestrate contract; issue #175 — reserved /loop command rename |
+| owned-surface-guard | A | 2026-06-19 02:14 | PASS | issue #63 (autopilot-stray-wip-guard) 2026-06-12; issue #81 (owned-paths-zsh-split) 2026-06-13 |
+| pnpm-audit-ci-gate | A | 2026-06-19 02:14 | PASS | issue #171 — pnpm security audits must run in CI |
+| pr-audit-duplicate-issue-refs | A | 2026-06-19 02:14 | PASS | issue #439 — /pr-audit must flag duplicate open PRs that reference the same issue |
+| ralph-fallback-order | A | 2026-06-19 02:14 | PASS | conversation 2026-06-12 (Ralph default fallback order) |
+| retro-deterministic-contract | A | 2026-06-19 02:14 | PASS | issue #443 — /retro deterministic output and self-contained helper contract |
+| rl-delegation-write-worker | A | 2026-06-19 02:14 | PASS | memory/MEMORY.md 2026-06-10 (rl-delegation) #57 |
+| ship-spec-ready-finalization | A | 2026-06-19 02:14 | PASS | issue #134 — /ship-spec must finalize ready PRs after gates, not stop at draft scaffold |
+| skill-paths | A | 2026-06-19 02:14 | PASS | issue #43 — stale path references; extended by issue #69 — apps/->packages/ rename guard |
+| submitted-by-trailers | A | 2026-06-19 02:14 | PASS | conversation 2026-06-12 (commit attribution trailers) |
+| watchdog-completed-session-reap | A | 2026-06-19 02:14 | PASS | issue #235 (completed autopilot PR session reaping) |
+| watchdog-draft-prs | A | 2026-06-19 02:14 | PASS | conversation 2026-06-15 (generic watchdog + stale draft PR recovery) |
+| watchdog-stuck-sessions | A | 2026-06-19 02:14 | PASS | issue #240 (Codex zero-credit stuck autopilot sessions) 2026-06-17 |
+| wiki-readme-index | A | 2026-06-19 02:14 | PASS | issue #132 — wiki README index drift guard |
 
 <!-- benchmark: pass-rate = PASS / (PASS + REGRESSION + TIMEOUT); SKIPPED excluded -->

--- a/evals/probes/heartbeat-logging-contract.sh
+++ b/evals/probes/heartbeat-logging-contract.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# tier: A
+# source: issue #447 (heartbeat log append hardening) 2026-06-18
+# desc: heartbeat prompt uses structured memory logs and locked liveness appends
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+HEARTBEAT="$ROOT/crons/heartbeat.md"
+HELPER="$ROOT/scripts/locked-append.sh"
+
+missing=()
+[[ -f "$HEARTBEAT" ]] || { echo "SKIPPED: missing $HEARTBEAT" >&2; exit 2; }
+[[ -x "$HELPER" ]] || { echo "SKIPPED: missing executable $HELPER" >&2; exit 2; }
+
+grep -Fq 'Memory log contract' "$HEARTBEAT" || missing+=("heartbeat defines an explicit memory log contract")
+grep -Fq 'HEARTBEAT_TIME=$(date -u +%H:%M)' "$HEARTBEAT" || missing+=("heartbeat computes HEARTBEAT_TIME before writing memory log")
+grep -Fq 'scripts/locked-append.sh "memory/$TODAY/log.md"' "$HEARTBEAT" || missing+=("heartbeat memory log uses scripts/locked-append.sh")
+grep -Fq -- '- **Result**:' "$HEARTBEAT" || missing+=("heartbeat memory template includes Result field")
+grep -Fq -- '- **Action**:' "$HEARTBEAT" || missing+=("heartbeat memory template includes Action field")
+grep -Fq -- '- **Observation**:' "$HEARTBEAT" || missing+=("heartbeat memory template includes Observation field")
+grep -Fq 'scripts/locked-append.sh crons/.cron.log' "$HEARTBEAT" || missing+=("heartbeat liveness line uses scripts/locked-append.sh")
+
+# Regression guard for the old race-prone shared log append.
+grep -Fq '>> crons/.cron.log' "$HEARTBEAT" && missing+=("heartbeat must not append liveness with raw >>")
+
+# Regression guard for the observed malformed memory heading. The liveness shell
+# command may legitimately contain $(date -Iseconds); the memory heading must not.
+grep -Fq '## Heartbeat -- $(date' "$HEARTBEAT" && missing+=("heartbeat memory heading must not contain literal date command")
+
+if (( ${#missing[@]} )); then
+  printf 'REGRESSION: heartbeat logging contract missing: %s\n' "${missing[*]}" >&2
+  exit 1
+fi
+
+echo "PASS: heartbeat prompt uses structured memory logs and locked liveness appends" >&2
+exit 0


### PR DESCRIPTION
## Selection rationale

Research selection: the only open `autopilot` issue (#445) already had open PR #446 on `feat/445-preserve-active-cron-worktrees`, so no queue item was actionable. `/harness-audit` ranked heartbeat log integrity as the top fresh survivor (Explorer found literal `$(date ...)` heartbeat log headings; Critic found raw shared-log appends), so this run filed and built #447.

---

## Summary
- harden `crons/heartbeat.md` with an explicit structured memory-log contract
- route heartbeat memory and liveness writes through `scripts/locked-append.sh`
- add `heartbeat-logging-contract` eval probe and refresh `evals/RESULTS.md`

## Verification
- `bash evals/probes/heartbeat-logging-contract.sh`
- `bash .claude/skills/eval/run.sh`
- `pnpm test:scripts`

Closes #447
