### PR TITLE
FROM feat/449-add-sandbox-image-build-ci TO development

### DIFF
--- a/.github/workflows/sandbox-boot-guard.yml
+++ b/.github/workflows/sandbox-boot-guard.yml
@@ -1,0 +1,71 @@
+name: "CI: Sandbox Boot Guard"
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - development
+      - main
+    paths:
+      - ".devcontainer/**"
+      - "install/**"
+      - "workspace/**"
+      - "packages/oh/**"
+      - "scripts/docker-compose.sh"
+      - "scripts/harness-config.sh"
+      - "Makefile"
+      - "harness.yaml"
+      - ".dockerignore"
+      - ".github/workflows/sandbox-boot-guard.yml"
+  pull_request:
+    paths:
+      - ".devcontainer/**"
+      - "install/**"
+      - "workspace/**"
+      - "packages/oh/**"
+      - "scripts/docker-compose.sh"
+      - "scripts/harness-config.sh"
+      - "Makefile"
+      - "harness.yaml"
+      - ".dockerignore"
+      - ".github/workflows/sandbox-boot-guard.yml"
+
+concurrency:
+  group: sandbox-boot-guard-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  sandbox-boot-guard:
+    name: Validate sandbox compose and image build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Docker diagnostics
+        run: |
+          docker --version
+          docker compose version
+
+      # Sandbox boot guard only: validate the local devcontainer substrate.
+      # This job never logs in, pushes an image, or publishes release artifacts.
+      - name: Validate base compose configuration
+        run: bash scripts/docker-compose.sh config --quiet
+
+      - name: Validate Hermes dashboard compose overlay
+        env:
+          HERMES_DASHBOARD: "true"
+        run: bash scripts/docker-compose.sh config --quiet
+
+      - name: Build sandbox image locally
+        run: |
+          docker build \
+            --file .devcontainer/Dockerfile \
+            --tag openharness-sandbox-boot-guard:${{ github.sha }} \
+            .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Update policy and release automation live in [`/git`](.claude/skills/git/SKILL.m
 ## [Unreleased]
 
 ### Added
+- `sandbox-boot-guard` CI workflow validates the sandbox compose configuration and locally builds the devcontainer image for boot-path changes, guarded by the `sandbox-boot-guard-ci` eval probe ([#449](https://github.com/mifunedev/openharness/issues/449)).
 - `retro-deterministic-contract` eval probe guards that `/retro` keeps schema-backed output, self-contained helper scripts, and synchronized `.pi`/`.claude` skill copies ([#443](https://github.com/mifunedev/openharness/issues/443)).
 ### Changed
 - `/retro` now uses a report schema plus skill-local helper scripts for deterministic hypothesis validation, duplicate-memory checks, and log rendering ([#443](https://github.com/mifunedev/openharness/issues/443)).

--- a/evals/RESULTS.md
+++ b/evals/RESULTS.md
@@ -6,55 +6,56 @@ probe id; git history is the time series.** Schema and exit-code semantics are i
 
 | probe | tier | last-run (UTC) | status | source |
 |-------|------|----------------|--------|--------|
-| agent-browser-cli | A | 2026-06-18 20:55 | PASS | memory/MEMORY.md 2026-06-07 (agent-browser 0.8.5 CLI) |
-| autopilot-executor-toggle | A | 2026-06-18 20:55 | PASS | conversation 2026-06-13 (autopilot delegate-advisor executor) |
-| autopilot-no-pr-session-close | A | 2026-06-18 20:55 | PASS | issue #209 (autopilot no-PR tmux session closure) 2026-06-16 |
-| autopilot-open-pr-reference-dedupe | A | 2026-06-18 20:55 | PASS | issue #437 — autopilot must not start duplicate work when open PRs reference the same issue without linked-PR metadata |
-| autopilot-pi-agent | A | 2026-06-18 20:55 | PASS | issue #116 (autopilot Pi tmux alignment) 2026-06-14; issue #118 (attachable Pi TUI tmux) 2026-06-14; issue #126 (kept Pi overlap lock release) 2026-06-14; issue #142 (worktree-by-default, skip→worktree) 2026-06-14 |
-| autopilot-preflight-gate | A | 2026-06-18 20:55 | PASS | issue #194 (deterministic autopilot caps preflight gate) 2026-06-15 |
-| autopilot-upstream-default | A | 2026-06-18 20:55 | PASS | issue #420 — future autopilots must target canonical repo, not personal fork |
-| autopilot-worktree-log-root | A | 2026-06-18 20:55 | PASS | issue #152 (persist autopilot worktree logs) 2026-06-15 |
-| boot-lint-glob | A | 2026-06-18 20:55 | PASS | issue #90, issue #120 |
-| capability-benchmark-schema | A | 2026-06-18 20:55 | PASS | issue #167 — capability benchmark instrument |
-| clean-restore | A | 2026-06-18 20:55 | PASS | issue #63 (autopilot-stray-wip-guard) 2026-06-12; issue #81 (owned-paths-zsh-split) 2026-06-13 |
-| cleanup-tasks-scoped-guard | A | 2026-06-18 20:55 | PASS | issue #85 |
-| cleanup-tasks-worktree-grooming | A | 2026-06-18 20:55 | PASS | issue #168 |
-| cron-claude-codex-fallback | A | 2026-06-18 20:55 | PASS | conversation 2026-06-12 (default Codex fallback for crons) |
-| cron-watchdog | A | 2026-06-18 20:55 | PASS | issue #130 (cron runtime watchdog) 2026-06-14 |
-| curl-bash-safe-alternatives | A | 2026-06-18 20:55 | PASS | vet-run/vet integration — public curl|bash examples need review-first alternatives |
-| datasets-schema | A | 2026-06-18 20:55 | PASS | issue #196 — evals/datasets verifiable trajectory corpus (Repo2RLEnv-inspired) |
-| devtcp-hook | A | 2026-06-18 20:55 | PASS | memory/MEMORY.md 2026-06-10 (zsh /dev/tcp) |
-| drift-check-cron-staleness-glob | A | 2026-06-18 20:55 | PASS | issue #98; issue #225 (restart-required cron frontmatter/config drift) |
-| eval-ci-gate | A | 2026-06-18 20:55 | PASS | #103 — eval probe suite gated in CI |
-| eval-gate | A | 2026-06-18 20:55 | PASS | memory/MEMORY.md 2026-06-11 (eval-gate) |
-| eval-results-atomic | A | 2026-06-18 20:55 | PASS | issue #83 (eval-results-atomic-write) |
-| eval-runner-exit | A | 2026-06-18 20:55 | PASS | memory/MEMORY.md 2026-06-11 (eval-runner-exit) #29 |
-| git-skill | A | 2026-06-18 20:55 | PASS | conversation 2026-06-15 — rules are not always supported; git workflow must be the /git skill |
-| harness-audit-empty-output-gate | A | 2026-06-18 20:55 | PASS | issue #246 — /harness-audit must fail closed on empty auditor outputs |
-| harness-audit-memory-path | A | 2026-06-18 20:55 | PASS | issue #183 — /harness-audit must inspect the active worktree, not a hardcoded root |
-| harness-audit-shared-memory | A | 2026-06-18 20:55 | PASS | issue #432 — /harness-audit must load durable memory from shared log root in cron worktrees |
-| harness-ci-core-paths | A | 2026-06-18 20:55 | PASS | #165 — core sandbox config files must trigger harness CI |
-| harness-ci-hooks-paths | A | 2026-06-18 20:55 | PASS | issue #202 — credential/security hook changes must trigger harness CI |
-| health-check-docker-stats | A | 2026-06-18 20:55 | PASS | memory/MEMORY.md 2026-06-10 (docker stats vs ps Size) |
-| locked-append-critical-path | A | 2026-06-18 20:55 | PASS | issue #204 (lock shared runtime log appends) 2026-06-15 |
-| loop-benchmark-gate | A | 2026-06-18 20:55 | PASS | issue #179 — wire the executable-loop `benchmark` node (close the cycle) |
-| loop-handoff-consistency | A | 2026-06-18 20:55 | PASS | context/rules/loop.md § 4 (executable-loop Handoff convention) |
-| loop-repeat-gate | A | 2026-06-18 20:55 | PASS | issue #173 — wire the executable-loop `repeat` node (cycle-closing edge) |
-| memory-gitignore-claim | A | 2026-06-18 20:55 | PASS | issue #101 |
-| next-dev-prod | A | 2026-06-18 20:55 | PASS | memory/MEMORY.md 2026-06-04 |
-| orchestrate-contract | A | 2026-06-18 20:55 | PASS | issue #160 — /orchestrate contract; issue #175 — reserved /loop command rename |
-| owned-surface-guard | A | 2026-06-18 20:55 | PASS | issue #63 (autopilot-stray-wip-guard) 2026-06-12; issue #81 (owned-paths-zsh-split) 2026-06-13 |
-| pnpm-audit-ci-gate | A | 2026-06-18 20:55 | PASS | issue #171 — pnpm security audits must run in CI |
-| pr-audit-duplicate-issue-refs | A | 2026-06-18 20:55 | PASS | issue #439 — /pr-audit must flag duplicate open PRs that reference the same issue |
-| ralph-fallback-order | A | 2026-06-18 20:55 | PASS | conversation 2026-06-12 (Ralph default fallback order) |
-| retro-deterministic-contract | A | 2026-06-18 20:55 | PASS | issue #443 — /retro deterministic output and self-contained helper contract |
-| rl-delegation-write-worker | A | 2026-06-18 20:55 | PASS | memory/MEMORY.md 2026-06-10 (rl-delegation) #57 |
-| ship-spec-ready-finalization | A | 2026-06-18 20:55 | PASS | issue #134 — /ship-spec must finalize ready PRs after gates, not stop at draft scaffold |
-| skill-paths | A | 2026-06-18 20:55 | PASS | issue #43 — stale path references; extended by issue #69 — apps/->packages/ rename guard |
-| submitted-by-trailers | A | 2026-06-18 20:55 | PASS | conversation 2026-06-12 (commit attribution trailers) |
-| watchdog-completed-session-reap | A | 2026-06-18 20:55 | PASS | issue #235 (completed autopilot PR session reaping) |
-| watchdog-draft-prs | A | 2026-06-18 20:55 | PASS | conversation 2026-06-15 (generic watchdog + stale draft PR recovery) |
-| watchdog-stuck-sessions | A | 2026-06-18 20:55 | PASS | issue #240 (Codex zero-credit stuck autopilot sessions) 2026-06-17 |
-| wiki-readme-index | A | 2026-06-18 20:55 | PASS | issue #132 — wiki README index drift guard |
+| agent-browser-cli | A | 2026-06-19 03:55 | PASS | memory/MEMORY.md 2026-06-07 (agent-browser 0.8.5 CLI) |
+| autopilot-executor-toggle | A | 2026-06-19 03:55 | PASS | conversation 2026-06-13 (autopilot delegate-advisor executor) |
+| autopilot-no-pr-session-close | A | 2026-06-19 03:55 | PASS | issue #209 (autopilot no-PR tmux session closure) 2026-06-16 |
+| autopilot-open-pr-reference-dedupe | A | 2026-06-19 03:55 | PASS | issue #437 — autopilot must not start duplicate work when open PRs reference the same issue without linked-PR metadata |
+| autopilot-pi-agent | A | 2026-06-19 03:55 | PASS | issue #116 (autopilot Pi tmux alignment) 2026-06-14; issue #118 (attachable Pi TUI tmux) 2026-06-14; issue #126 (kept Pi overlap lock release) 2026-06-14; issue #142 (worktree-by-default, skip→worktree) 2026-06-14 |
+| autopilot-preflight-gate | A | 2026-06-19 03:55 | PASS | issue #194 (deterministic autopilot caps preflight gate) 2026-06-15 |
+| autopilot-upstream-default | A | 2026-06-19 03:55 | PASS | issue #420 — future autopilots must target canonical repo, not personal fork |
+| autopilot-worktree-log-root | A | 2026-06-19 03:55 | PASS | issue #152 (persist autopilot worktree logs) 2026-06-15 |
+| boot-lint-glob | A | 2026-06-19 03:55 | PASS | issue #90, issue #120 |
+| capability-benchmark-schema | A | 2026-06-19 03:55 | PASS | issue #167 — capability benchmark instrument |
+| clean-restore | A | 2026-06-19 03:55 | PASS | issue #63 (autopilot-stray-wip-guard) 2026-06-12; issue #81 (owned-paths-zsh-split) 2026-06-13 |
+| cleanup-tasks-scoped-guard | A | 2026-06-19 03:55 | PASS | issue #85 |
+| cleanup-tasks-worktree-grooming | A | 2026-06-19 03:55 | PASS | issue #168 |
+| cron-claude-codex-fallback | A | 2026-06-19 03:55 | PASS | conversation 2026-06-12 (default Codex fallback for crons) |
+| cron-watchdog | A | 2026-06-19 03:55 | PASS | issue #130 (cron runtime watchdog) 2026-06-14 |
+| curl-bash-safe-alternatives | A | 2026-06-19 03:55 | PASS | vet-run/vet integration — public curl|bash examples need review-first alternatives |
+| datasets-schema | A | 2026-06-19 03:55 | PASS | issue #196 — evals/datasets verifiable trajectory corpus (Repo2RLEnv-inspired) |
+| devtcp-hook | A | 2026-06-19 03:55 | PASS | memory/MEMORY.md 2026-06-10 (zsh /dev/tcp) |
+| drift-check-cron-staleness-glob | A | 2026-06-19 03:55 | PASS | issue #98; issue #225 (restart-required cron frontmatter/config drift) |
+| eval-ci-gate | A | 2026-06-19 03:55 | PASS | #103 — eval probe suite gated in CI |
+| eval-gate | A | 2026-06-19 03:55 | PASS | memory/MEMORY.md 2026-06-11 (eval-gate) |
+| eval-results-atomic | A | 2026-06-19 03:55 | PASS | issue #83 (eval-results-atomic-write) |
+| eval-runner-exit | A | 2026-06-19 03:55 | PASS | memory/MEMORY.md 2026-06-11 (eval-runner-exit) #29 |
+| git-skill | A | 2026-06-19 03:55 | PASS | conversation 2026-06-15 — rules are not always supported; git workflow must be the /git skill |
+| harness-audit-empty-output-gate | A | 2026-06-19 03:55 | PASS | issue #246 — /harness-audit must fail closed on empty auditor outputs |
+| harness-audit-memory-path | A | 2026-06-19 03:55 | PASS | issue #183 — /harness-audit must inspect the active worktree, not a hardcoded root |
+| harness-audit-shared-memory | A | 2026-06-19 03:55 | PASS | issue #432 — /harness-audit must load durable memory from shared log root in cron worktrees |
+| harness-ci-core-paths | A | 2026-06-19 03:55 | PASS | #165 — core sandbox config files must trigger harness CI |
+| harness-ci-hooks-paths | A | 2026-06-19 03:55 | PASS | issue #202 — credential/security hook changes must trigger harness CI |
+| health-check-docker-stats | A | 2026-06-19 03:55 | PASS | memory/MEMORY.md 2026-06-10 (docker stats vs ps Size) |
+| locked-append-critical-path | A | 2026-06-19 03:55 | PASS | issue #204 (lock shared runtime log appends) 2026-06-15 |
+| loop-benchmark-gate | A | 2026-06-19 03:55 | PASS | issue #179 — wire the executable-loop `benchmark` node (close the cycle) |
+| loop-handoff-consistency | A | 2026-06-19 03:55 | PASS | context/rules/loop.md § 4 (executable-loop Handoff convention) |
+| loop-repeat-gate | A | 2026-06-19 03:55 | PASS | issue #173 — wire the executable-loop `repeat` node (cycle-closing edge) |
+| memory-gitignore-claim | A | 2026-06-19 03:55 | PASS | issue #101 |
+| next-dev-prod | A | 2026-06-19 03:55 | PASS | memory/MEMORY.md 2026-06-04 |
+| orchestrate-contract | A | 2026-06-19 03:55 | PASS | issue #160 — /orchestrate contract; issue #175 — reserved /loop command rename |
+| owned-surface-guard | A | 2026-06-19 03:55 | PASS | issue #63 (autopilot-stray-wip-guard) 2026-06-12; issue #81 (owned-paths-zsh-split) 2026-06-13 |
+| pnpm-audit-ci-gate | A | 2026-06-19 03:55 | PASS | issue #171 — pnpm security audits must run in CI |
+| pr-audit-duplicate-issue-refs | A | 2026-06-19 03:55 | PASS | issue #439 — /pr-audit must flag duplicate open PRs that reference the same issue |
+| ralph-fallback-order | A | 2026-06-19 03:55 | PASS | conversation 2026-06-12 (Ralph default fallback order) |
+| retro-deterministic-contract | A | 2026-06-19 03:55 | PASS | issue #443 — /retro deterministic output and self-contained helper contract |
+| rl-delegation-write-worker | A | 2026-06-19 03:55 | PASS | memory/MEMORY.md 2026-06-10 (rl-delegation) #57 |
+| sandbox-boot-guard-ci | A | 2026-06-19 03:55 | PASS | issue #449 (sandbox image build CI guard) 2026-06-19 |
+| ship-spec-ready-finalization | A | 2026-06-19 03:55 | PASS | issue #134 — /ship-spec must finalize ready PRs after gates, not stop at draft scaffold |
+| skill-paths | A | 2026-06-19 03:55 | PASS | issue #43 — stale path references; extended by issue #69 — apps/->packages/ rename guard |
+| submitted-by-trailers | A | 2026-06-19 03:55 | PASS | conversation 2026-06-12 (commit attribution trailers) |
+| watchdog-completed-session-reap | A | 2026-06-19 03:55 | PASS | issue #235 (completed autopilot PR session reaping) |
+| watchdog-draft-prs | A | 2026-06-19 03:55 | PASS | conversation 2026-06-15 (generic watchdog + stale draft PR recovery) |
+| watchdog-stuck-sessions | A | 2026-06-19 03:55 | PASS | issue #240 (Codex zero-credit stuck autopilot sessions) 2026-06-17 |
+| wiki-readme-index | A | 2026-06-19 03:55 | PASS | issue #132 — wiki README index drift guard |
 
 <!-- benchmark: pass-rate = PASS / (PASS + REGRESSION + TIMEOUT); SKIPPED excluded -->

--- a/evals/probes/sandbox-boot-guard-ci.sh
+++ b/evals/probes/sandbox-boot-guard-ci.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# tier: A
+# source: issue #449 (sandbox image build CI guard) 2026-06-19
+# desc: PR CI must validate sandbox compose config and locally build the devcontainer image without registry writes.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WORKFLOW="$ROOT/.github/workflows/sandbox-boot-guard.yml"
+
+if [[ ! -f "$WORKFLOW" ]]; then
+  echo "REGRESSION sandbox boot guard workflow missing" >&2
+  exit 1
+fi
+
+text="$(cat "$WORKFLOW")"
+missing=()
+
+has() { grep -Fq -- "$1" <<<"$text" || missing+=("$2"); }
+has_regex() { grep -Eq -- "$1" <<<"$text" || missing+=("$2"); }
+
+has 'name: "CI: Sandbox Boot Guard"' "workflow name"
+has_regex '^[[:space:]]*contents:[[:space:]]*read[[:space:]]*$' "read-only contents permission"
+has_regex '^[[:space:]]*pull_request:[[:space:]]*$' "pull_request trigger"
+has_regex '^[[:space:]]*workflow_dispatch:[[:space:]]*$' "manual trigger"
+has '".devcontainer/**"' "devcontainer path filter"
+has '"install/**"' "install path filter"
+has '"workspace/**"' "workspace path filter"
+has '"packages/oh/**"' "oh package path filter"
+has '"scripts/docker-compose.sh"' "compose wrapper path filter"
+has '"scripts/harness-config.sh"' "harness config helper path filter"
+has '"Makefile"' "Makefile path filter"
+has '"harness.yaml"' "harness config path filter"
+has '".dockerignore"' "dockerignore path filter"
+has '".github/workflows/sandbox-boot-guard.yml"' "workflow self path filter"
+has 'persist-credentials: false' "checkout token persistence disabled"
+has 'bash scripts/docker-compose.sh config --quiet' "base compose config validation"
+has 'HERMES_DASHBOARD: "true"' "Hermes overlay validation env"
+has 'docker build \' "local docker build step"
+has '--file .devcontainer/Dockerfile' "devcontainer Dockerfile build target"
+has '--tag openharness-sandbox-boot-guard:${{ github.sha }}' "local CI image tag"
+has 'Sandbox boot guard only' "comment explaining non-release intent"
+
+if grep -Eq 'docker[[:space:]]+push|--push([[:space:]]|$)|docker/login-action|docker/login|ghcr\.io|[[:alnum:]._-]+\.[[:alnum:]._-]+/.+:.+|packages:[[:space:]]*write|secrets\.' <<<"$text"; then
+  echo "REGRESSION sandbox boot guard must not push/login/write packages/use secrets" >&2
+  exit 1
+fi
+
+if (( ${#missing[@]} )); then
+  printf 'REGRESSION sandbox boot guard CI contract missing: %s\n' "${missing[*]}" >&2
+  exit 1
+fi
+
+echo "PASS sandbox boot guard validates compose config and locally builds the devcontainer image without registry writes" >&2
+exit 0


### PR DESCRIPTION
## Selection rationale

Research selection: open autopilot issues #445 and #447 already had active PR/session dedupe guards, so the queue had no fresh actionable ticket. `/harness-audit` ranked this CI gap as the top surviving harness-infra finding: PR CI validated shell/hadolint but never built the devcontainer image or validated the compose stack, letting sandbox boot breakage merge undetected. Filed as #449 and built in this run.

---

## Summary
- add `CI: Sandbox Boot Guard` workflow for boot-path changes
- validate base + Hermes overlay compose config via `scripts/docker-compose.sh config --quiet`
- locally build `.devcontainer/Dockerfile` without registry login, pushes, package writes, or secrets
- add `sandbox-boot-guard-ci` eval probe guarding the workflow contract

## Verification
- `bash evals/probes/sandbox-boot-guard-ci.sh`
- `bash scripts/docker-compose.sh config --quiet`
- `HERMES_DASHBOARD=true bash scripts/docker-compose.sh config --quiet`
- `pnpm test:scripts`
- `bash .claude/skills/eval/run.sh` — 51 PASS
- `docker build --file .devcontainer/Dockerfile --tag openharness-sandbox-boot-guard:local .`

Closes #449
