### PR TITLE
FROM feat/451-dynamic-workflows-support TO development

### DIFF
--- a/.pi/extensions/__tests__/settings.test.ts
+++ b/.pi/extensions/__tests__/settings.test.ts
@@ -22,6 +22,7 @@ describe("project Pi settings", () => {
       "npm:@trevonistrevon/pi-loop@0.5.5",
       "npm:@guwidoe/pi-prompt-suggester@0.3.10",
       "npm:pi-autoresearch@1.6.0",
+      "git:github.com/Michaelliv/pi-dynamic-workflows@dbc6800d1f725f7439e51705e2664c59484afcd1",
     ]);
   });
 });

--- a/.pi/settings.json
+++ b/.pi/settings.json
@@ -23,6 +23,7 @@
     "npm:@tifan/pi-recap@0.4.2",
     "npm:@trevonistrevon/pi-loop@0.5.5",
     "npm:@guwidoe/pi-prompt-suggester@0.3.10",
-    "npm:pi-autoresearch@1.6.0"
+    "npm:pi-autoresearch@1.6.0",
+    "git:github.com/Michaelliv/pi-dynamic-workflows@dbc6800d1f725f7439e51705e2664c59484afcd1"
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Update policy and release automation live in [`/git`](.claude/skills/git/SKILL.m
 ## [Unreleased]
 
 ### Added
+- `pi-dynamic-workflows` is now a default project-local Pi package pinned to the upstream `v1.0.1` commit, with docs for the `workflow` tool's deterministic JavaScript fan-out model and package-pin test coverage ([#451](https://github.com/mifunedev/openharness/issues/451)).
 - `retro-deterministic-contract` eval probe guards that `/retro` keeps schema-backed output, self-contained helper scripts, and synchronized `.pi`/`.claude` skill copies ([#443](https://github.com/mifunedev/openharness/issues/443)).
 ### Changed
 - `/retro` now uses a report schema plus skill-local helper scripts for deterministic hypothesis validation, duplicate-memory checks, and log rendering ([#443](https://github.com/mifunedev/openharness/issues/443)).

--- a/docs/harnesses/pi.md
+++ b/docs/harnesses/pi.md
@@ -44,6 +44,7 @@ Open Harness loads these project-local Pi packages from `.pi/settings.json`:
 - [`@trevonistrevon/pi-loop`](https://pi.dev/packages/@trevonistrevon/pi-loop?name=monitor) — Monitor and loop tools for background command monitoring and scheduled re-wakes. Use `MonitorCreate`, `MonitorList`, and `MonitorStop` for long-running commands; use `/loop` or `LoopCreate` for cron/event-triggered follow-up prompts.
 - [`@guwidoe/pi-prompt-suggester`](https://github.com/guwidoe/pi-prompt-suggester) — intent-aware next-prompt suggestions after assistant completions. Suggestions can appear as ghost text in the editor, with `/suggesterSettings` for interactive configuration and `/suggester status` / `/suggester reseed` for inspection and manual reseeding.
 - [`pi-autoresearch`](../integrations/pi-autoresearch.md) — autonomous metric-optimization loops for Pi. Use `/skill:autoresearch-create` to create `.auto/` session files, run benchmark iterations, log keep/revert decisions, and inspect results through `/autoresearch export`.
+- [`pi-dynamic-workflows`](../integrations/pi-dynamic-workflows.md) — Claude-Code-style dynamic workflow orchestration for Pi, pinned to the upstream `v1.0.1` commit. It registers a `workflow` tool that lets the model write deterministic JavaScript workflows, fan out to isolated in-memory subagents, and synthesize the results.
 
 Pi installs missing project packages automatically on startup after the project is trusted. In Open Harness, start package-backed plan mode with:
 
@@ -51,7 +52,7 @@ Pi installs missing project packages automatically on startup after the project 
 pi --plan
 ```
 
-Outside this project, try the packages manually with `pi -e npm:@narumitw/pi-goal`, `pi -e npm:@narumitw/pi-plan-mode --plan`, `pi -e npm:@tifan/pi-recap`, `pi -e npm:@trevonistrevon/pi-loop`, `pi -e npm:@guwidoe/pi-prompt-suggester@0.3.10`, or `pi -e npm:pi-autoresearch@1.6.0`.
+Outside this project, try the packages manually with `pi -e npm:@narumitw/pi-goal`, `pi -e npm:@narumitw/pi-plan-mode --plan`, `pi -e npm:@tifan/pi-recap`, `pi -e npm:@trevonistrevon/pi-loop`, `pi -e npm:@guwidoe/pi-prompt-suggester@0.3.10`, `pi -e npm:pi-autoresearch@1.6.0`, or `pi -e git:github.com/Michaelliv/pi-dynamic-workflows@dbc6800d1f725f7439e51705e2664c59484afcd1`.
 
 ## Prompt suggestions
 
@@ -127,6 +128,12 @@ Auth is layered: the extension uses Pi's own `openai-codex` provider auth first,
 The default task runtime state lives under `.pi/tasks/`, which is gitignored. Leave the default for per-checkout task state; set `PI_TASKS=off` to disable task tracking; set `PI_TASKS=<named-list>` to select a named task list; or pass an explicit task-list path when you intentionally want a shared list outside the gitignored default.
 
 `pi-loop` detects `@tintinweb/pi-tasks` over Pi's event bus. Because Open Harness loads `pi-tasks` by default, `pi-loop` delegates task management to that package; its native fallback `TaskCreate`/`TaskList`/`TaskUpdate`/`TaskDelete` tools and `/tasks` command only register in projects where `pi-tasks` is absent.
+
+## Dynamic workflows
+
+Use the `workflow` tool when a Pi task benefits from deliberate fan-out: multi-perspective code review, repository audits, research sweeps, or analysis pipelines. The parent model writes a constrained JavaScript workflow that calls `agent()`, `parallel()`, `pipeline()`, and `phase()`; the extension runs it in a deterministic VM sandbox and reports live phase/subagent progress inline.
+
+See [Pi dynamic workflows](../integrations/pi-dynamic-workflows.md) for the workflow script shape, available globals, and safety constraints.
 
 ## Slack integration
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -165,7 +165,7 @@ Once installed, proceed to the [Quickstart](./quickstart) to authenticate inside
 
 The sandbox image ships a complete development environment. The required host dependencies are Docker with the Compose plugin and Git.
 
-Project-local Pi packages are loaded from `.pi/settings.json`; the defaults include `@tintinweb/pi-subagents`, `@tintinweb/pi-tasks`, `@narumitw/pi-goal`, `@narumitw/pi-plan-mode`, `@tifan/pi-recap` for `/recap` plus automatic idle/resume session summaries, `@trevonistrevon/pi-loop` for Monitor/Loop tools, `@guwidoe/pi-prompt-suggester` for next-prompt suggestions, and `pi-autoresearch` for autonomous metric-optimization loops.
+Project-local Pi packages are loaded from `.pi/settings.json`; the defaults include `@tintinweb/pi-subagents`, `@tintinweb/pi-tasks`, `@narumitw/pi-goal`, `@narumitw/pi-plan-mode`, `@tifan/pi-recap` for `/recap` plus automatic idle/resume session summaries, `@trevonistrevon/pi-loop` for Monitor/Loop tools, `@guwidoe/pi-prompt-suggester` for next-prompt suggestions, `pi-autoresearch` for autonomous metric-optimization loops, and `pi-dynamic-workflows` for workflow-script fan-out through isolated Pi subagents.
 
 ### Base image
 

--- a/docs/integrations/pi-dynamic-workflows.md
+++ b/docs/integrations/pi-dynamic-workflows.md
@@ -1,0 +1,90 @@
+---
+title: "Pi dynamic workflows"
+---
+
+# Pi dynamic workflows
+
+Open Harness enables [`pi-dynamic-workflows`](https://github.com/Michaelliv/pi-dynamic-workflows) as a default project-local Pi package. The package registers a `workflow` tool that lets the parent Pi agent write a small deterministic JavaScript workflow, fan work out to isolated in-memory subagents, and synthesize the results.
+
+Use it for multi-perspective codebase audits, fan-out research, large review sweeps, and parallel analysis where one sequential assistant turn would be too slow or too narrow.
+
+## Verify package support
+
+The package is pinned in `.pi/settings.json` to the upstream `v1.0.1` commit for supply-chain stability:
+
+```json
+"git:github.com/Michaelliv/pi-dynamic-workflows@dbc6800d1f725f7439e51705e2664c59484afcd1"
+```
+
+That commit corresponds to upstream tag `v1.0.1` / npm package `pi-dynamic-workflows@1.0.1`.
+
+Pi installs missing project packages automatically after the project is trusted. If you add the package during a running session, reload Pi resources:
+
+```text
+/reload
+```
+
+## Basic usage
+
+Ask Pi for a workflow in plain language:
+
+```text
+Run a workflow to inspect this repository and summarize the main modules.
+```
+
+The model can then call the package-provided `workflow` tool with a script shaped like:
+
+```js
+export const meta = {
+  name: 'inspect_project',
+  description: 'Inspect a repository and summarize the main modules',
+  phases: [{ title: 'Scan' }, { title: 'Analyze' }],
+}
+
+phase('Scan')
+const inventory = await agent('Inspect the repository structure.', {
+  label: 'repo inventory',
+})
+
+phase('Analyze')
+const summary = await agent(
+  'Summarize the main modules from this inventory:\n' + inventory,
+  { label: 'module summary' },
+)
+
+return { inventory, summary }
+```
+
+The live tool renderer reports phase and subagent progress inline. Press `Esc` to abort a running workflow; active subagents are cancelled and surfaced as skipped.
+
+## Workflow globals
+
+The workflow sandbox exposes these deterministic globals:
+
+| Global | Purpose |
+| --- | --- |
+| `agent(prompt, opts)` | Spawn one isolated in-memory Pi subagent and return its final text, or a validated object when `opts.schema` is provided. |
+| `parallel(thunks)` | Run an array of `() => agent(...)` thunks concurrently and return results in input order. |
+| `pipeline(items, ...stages)` | Fan items through sequential processing stages. |
+| `phase(title)` | Mark the current progress phase. |
+| `log(message)` | Append a workflow-level progress log line. |
+| `args` | Optional JSON value passed to the workflow tool. |
+| `cwd` / `process.cwd()` | Current working directory for subagents. |
+| `budget` | Token budget tracker with `total`, `spent()`, and `remaining()`. |
+
+## Determinism and safety notes
+
+Workflow scripts run in a Node `vm` sandbox. `Date`, `Math.random()`, `require`, dynamic `import`, filesystem APIs, network APIs, and dynamic metadata expressions are intentionally unavailable. This keeps metadata parseable and workflow execution reproducible while keeping subagent access mediated through Pi's normal tool and model runtime.
+
+For editor IntelliSense in reusable workflow files, add:
+
+```js
+/// <reference types="pi-dynamic-workflows/workflow" />
+```
+
+## See also
+
+- [`pi-dynamic-workflows` README](https://github.com/Michaelliv/pi-dynamic-workflows)
+- [`v1.0.1` source commit](https://github.com/Michaelliv/pi-dynamic-workflows/tree/dbc6800d1f725f7439e51705e2664c59484afcd1)
+- [Pi packages](../harnesses/pi.md#default-packages)
+- [Pi extensions](../harnesses/pi.md#slack-integration)

--- a/evals/RESULTS.md
+++ b/evals/RESULTS.md
@@ -6,55 +6,55 @@ probe id; git history is the time series.** Schema and exit-code semantics are i
 
 | probe | tier | last-run (UTC) | status | source |
 |-------|------|----------------|--------|--------|
-| agent-browser-cli | A | 2026-06-18 20:55 | PASS | memory/MEMORY.md 2026-06-07 (agent-browser 0.8.5 CLI) |
-| autopilot-executor-toggle | A | 2026-06-18 20:55 | PASS | conversation 2026-06-13 (autopilot delegate-advisor executor) |
-| autopilot-no-pr-session-close | A | 2026-06-18 20:55 | PASS | issue #209 (autopilot no-PR tmux session closure) 2026-06-16 |
-| autopilot-open-pr-reference-dedupe | A | 2026-06-18 20:55 | PASS | issue #437 — autopilot must not start duplicate work when open PRs reference the same issue without linked-PR metadata |
-| autopilot-pi-agent | A | 2026-06-18 20:55 | PASS | issue #116 (autopilot Pi tmux alignment) 2026-06-14; issue #118 (attachable Pi TUI tmux) 2026-06-14; issue #126 (kept Pi overlap lock release) 2026-06-14; issue #142 (worktree-by-default, skip→worktree) 2026-06-14 |
-| autopilot-preflight-gate | A | 2026-06-18 20:55 | PASS | issue #194 (deterministic autopilot caps preflight gate) 2026-06-15 |
-| autopilot-upstream-default | A | 2026-06-18 20:55 | PASS | issue #420 — future autopilots must target canonical repo, not personal fork |
-| autopilot-worktree-log-root | A | 2026-06-18 20:55 | PASS | issue #152 (persist autopilot worktree logs) 2026-06-15 |
-| boot-lint-glob | A | 2026-06-18 20:55 | PASS | issue #90, issue #120 |
-| capability-benchmark-schema | A | 2026-06-18 20:55 | PASS | issue #167 — capability benchmark instrument |
-| clean-restore | A | 2026-06-18 20:55 | PASS | issue #63 (autopilot-stray-wip-guard) 2026-06-12; issue #81 (owned-paths-zsh-split) 2026-06-13 |
-| cleanup-tasks-scoped-guard | A | 2026-06-18 20:55 | PASS | issue #85 |
-| cleanup-tasks-worktree-grooming | A | 2026-06-18 20:55 | PASS | issue #168 |
-| cron-claude-codex-fallback | A | 2026-06-18 20:55 | PASS | conversation 2026-06-12 (default Codex fallback for crons) |
-| cron-watchdog | A | 2026-06-18 20:55 | PASS | issue #130 (cron runtime watchdog) 2026-06-14 |
-| curl-bash-safe-alternatives | A | 2026-06-18 20:55 | PASS | vet-run/vet integration — public curl|bash examples need review-first alternatives |
-| datasets-schema | A | 2026-06-18 20:55 | PASS | issue #196 — evals/datasets verifiable trajectory corpus (Repo2RLEnv-inspired) |
-| devtcp-hook | A | 2026-06-18 20:55 | PASS | memory/MEMORY.md 2026-06-10 (zsh /dev/tcp) |
-| drift-check-cron-staleness-glob | A | 2026-06-18 20:55 | PASS | issue #98; issue #225 (restart-required cron frontmatter/config drift) |
-| eval-ci-gate | A | 2026-06-18 20:55 | PASS | #103 — eval probe suite gated in CI |
-| eval-gate | A | 2026-06-18 20:55 | PASS | memory/MEMORY.md 2026-06-11 (eval-gate) |
-| eval-results-atomic | A | 2026-06-18 20:55 | PASS | issue #83 (eval-results-atomic-write) |
-| eval-runner-exit | A | 2026-06-18 20:55 | PASS | memory/MEMORY.md 2026-06-11 (eval-runner-exit) #29 |
-| git-skill | A | 2026-06-18 20:55 | PASS | conversation 2026-06-15 — rules are not always supported; git workflow must be the /git skill |
-| harness-audit-empty-output-gate | A | 2026-06-18 20:55 | PASS | issue #246 — /harness-audit must fail closed on empty auditor outputs |
-| harness-audit-memory-path | A | 2026-06-18 20:55 | PASS | issue #183 — /harness-audit must inspect the active worktree, not a hardcoded root |
-| harness-audit-shared-memory | A | 2026-06-18 20:55 | PASS | issue #432 — /harness-audit must load durable memory from shared log root in cron worktrees |
-| harness-ci-core-paths | A | 2026-06-18 20:55 | PASS | #165 — core sandbox config files must trigger harness CI |
-| harness-ci-hooks-paths | A | 2026-06-18 20:55 | PASS | issue #202 — credential/security hook changes must trigger harness CI |
-| health-check-docker-stats | A | 2026-06-18 20:55 | PASS | memory/MEMORY.md 2026-06-10 (docker stats vs ps Size) |
-| locked-append-critical-path | A | 2026-06-18 20:55 | PASS | issue #204 (lock shared runtime log appends) 2026-06-15 |
-| loop-benchmark-gate | A | 2026-06-18 20:55 | PASS | issue #179 — wire the executable-loop `benchmark` node (close the cycle) |
-| loop-handoff-consistency | A | 2026-06-18 20:55 | PASS | context/rules/loop.md § 4 (executable-loop Handoff convention) |
-| loop-repeat-gate | A | 2026-06-18 20:55 | PASS | issue #173 — wire the executable-loop `repeat` node (cycle-closing edge) |
-| memory-gitignore-claim | A | 2026-06-18 20:55 | PASS | issue #101 |
-| next-dev-prod | A | 2026-06-18 20:55 | PASS | memory/MEMORY.md 2026-06-04 |
-| orchestrate-contract | A | 2026-06-18 20:55 | PASS | issue #160 — /orchestrate contract; issue #175 — reserved /loop command rename |
-| owned-surface-guard | A | 2026-06-18 20:55 | PASS | issue #63 (autopilot-stray-wip-guard) 2026-06-12; issue #81 (owned-paths-zsh-split) 2026-06-13 |
-| pnpm-audit-ci-gate | A | 2026-06-18 20:55 | PASS | issue #171 — pnpm security audits must run in CI |
-| pr-audit-duplicate-issue-refs | A | 2026-06-18 20:55 | PASS | issue #439 — /pr-audit must flag duplicate open PRs that reference the same issue |
-| ralph-fallback-order | A | 2026-06-18 20:55 | PASS | conversation 2026-06-12 (Ralph default fallback order) |
-| retro-deterministic-contract | A | 2026-06-18 20:55 | PASS | issue #443 — /retro deterministic output and self-contained helper contract |
-| rl-delegation-write-worker | A | 2026-06-18 20:55 | PASS | memory/MEMORY.md 2026-06-10 (rl-delegation) #57 |
-| ship-spec-ready-finalization | A | 2026-06-18 20:55 | PASS | issue #134 — /ship-spec must finalize ready PRs after gates, not stop at draft scaffold |
-| skill-paths | A | 2026-06-18 20:55 | PASS | issue #43 — stale path references; extended by issue #69 — apps/->packages/ rename guard |
-| submitted-by-trailers | A | 2026-06-18 20:55 | PASS | conversation 2026-06-12 (commit attribution trailers) |
-| watchdog-completed-session-reap | A | 2026-06-18 20:55 | PASS | issue #235 (completed autopilot PR session reaping) |
-| watchdog-draft-prs | A | 2026-06-18 20:55 | PASS | conversation 2026-06-15 (generic watchdog + stale draft PR recovery) |
-| watchdog-stuck-sessions | A | 2026-06-18 20:55 | PASS | issue #240 (Codex zero-credit stuck autopilot sessions) 2026-06-17 |
-| wiki-readme-index | A | 2026-06-18 20:55 | PASS | issue #132 — wiki README index drift guard |
+| agent-browser-cli | A | 2026-06-19 04:17 | PASS | memory/MEMORY.md 2026-06-07 (agent-browser 0.8.5 CLI) |
+| autopilot-executor-toggle | A | 2026-06-19 04:17 | PASS | conversation 2026-06-13 (autopilot delegate-advisor executor) |
+| autopilot-no-pr-session-close | A | 2026-06-19 04:17 | PASS | issue #209 (autopilot no-PR tmux session closure) 2026-06-16 |
+| autopilot-open-pr-reference-dedupe | A | 2026-06-19 04:17 | PASS | issue #437 — autopilot must not start duplicate work when open PRs reference the same issue without linked-PR metadata |
+| autopilot-pi-agent | A | 2026-06-19 04:17 | PASS | issue #116 (autopilot Pi tmux alignment) 2026-06-14; issue #118 (attachable Pi TUI tmux) 2026-06-14; issue #126 (kept Pi overlap lock release) 2026-06-14; issue #142 (worktree-by-default, skip→worktree) 2026-06-14 |
+| autopilot-preflight-gate | A | 2026-06-19 04:17 | PASS | issue #194 (deterministic autopilot caps preflight gate) 2026-06-15 |
+| autopilot-upstream-default | A | 2026-06-19 04:17 | PASS | issue #420 — future autopilots must target canonical repo, not personal fork |
+| autopilot-worktree-log-root | A | 2026-06-19 04:17 | PASS | issue #152 (persist autopilot worktree logs) 2026-06-15 |
+| boot-lint-glob | A | 2026-06-19 04:17 | PASS | issue #90, issue #120 |
+| capability-benchmark-schema | A | 2026-06-19 04:17 | PASS | issue #167 — capability benchmark instrument |
+| clean-restore | A | 2026-06-19 04:17 | PASS | issue #63 (autopilot-stray-wip-guard) 2026-06-12; issue #81 (owned-paths-zsh-split) 2026-06-13 |
+| cleanup-tasks-scoped-guard | A | 2026-06-19 04:17 | PASS | issue #85 |
+| cleanup-tasks-worktree-grooming | A | 2026-06-19 04:17 | PASS | issue #168 |
+| cron-claude-codex-fallback | A | 2026-06-19 04:17 | PASS | conversation 2026-06-12 (default Codex fallback for crons) |
+| cron-watchdog | A | 2026-06-19 04:17 | PASS | issue #130 (cron runtime watchdog) 2026-06-14 |
+| curl-bash-safe-alternatives | A | 2026-06-19 04:17 | PASS | vet-run/vet integration — public curl|bash examples need review-first alternatives |
+| datasets-schema | A | 2026-06-19 04:17 | PASS | issue #196 — evals/datasets verifiable trajectory corpus (Repo2RLEnv-inspired) |
+| devtcp-hook | A | 2026-06-19 04:17 | PASS | memory/MEMORY.md 2026-06-10 (zsh /dev/tcp) |
+| drift-check-cron-staleness-glob | A | 2026-06-19 04:17 | PASS | issue #98; issue #225 (restart-required cron frontmatter/config drift) |
+| eval-ci-gate | A | 2026-06-19 04:17 | PASS | #103 — eval probe suite gated in CI |
+| eval-gate | A | 2026-06-19 04:17 | PASS | memory/MEMORY.md 2026-06-11 (eval-gate) |
+| eval-results-atomic | A | 2026-06-19 04:17 | PASS | issue #83 (eval-results-atomic-write) |
+| eval-runner-exit | A | 2026-06-19 04:17 | PASS | memory/MEMORY.md 2026-06-11 (eval-runner-exit) #29 |
+| git-skill | A | 2026-06-19 04:17 | PASS | conversation 2026-06-15 — rules are not always supported; git workflow must be the /git skill |
+| harness-audit-empty-output-gate | A | 2026-06-19 04:17 | PASS | issue #246 — /harness-audit must fail closed on empty auditor outputs |
+| harness-audit-memory-path | A | 2026-06-19 04:17 | PASS | issue #183 — /harness-audit must inspect the active worktree, not a hardcoded root |
+| harness-audit-shared-memory | A | 2026-06-19 04:17 | PASS | issue #432 — /harness-audit must load durable memory from shared log root in cron worktrees |
+| harness-ci-core-paths | A | 2026-06-19 04:17 | PASS | #165 — core sandbox config files must trigger harness CI |
+| harness-ci-hooks-paths | A | 2026-06-19 04:17 | PASS | issue #202 — credential/security hook changes must trigger harness CI |
+| health-check-docker-stats | A | 2026-06-19 04:17 | PASS | memory/MEMORY.md 2026-06-10 (docker stats vs ps Size) |
+| locked-append-critical-path | A | 2026-06-19 04:17 | PASS | issue #204 (lock shared runtime log appends) 2026-06-15 |
+| loop-benchmark-gate | A | 2026-06-19 04:17 | PASS | issue #179 — wire the executable-loop `benchmark` node (close the cycle) |
+| loop-handoff-consistency | A | 2026-06-19 04:17 | PASS | context/rules/loop.md § 4 (executable-loop Handoff convention) |
+| loop-repeat-gate | A | 2026-06-19 04:17 | PASS | issue #173 — wire the executable-loop `repeat` node (cycle-closing edge) |
+| memory-gitignore-claim | A | 2026-06-19 04:17 | PASS | issue #101 |
+| next-dev-prod | A | 2026-06-19 04:17 | PASS | memory/MEMORY.md 2026-06-04 |
+| orchestrate-contract | A | 2026-06-19 04:17 | PASS | issue #160 — /orchestrate contract; issue #175 — reserved /loop command rename |
+| owned-surface-guard | A | 2026-06-19 04:17 | PASS | issue #63 (autopilot-stray-wip-guard) 2026-06-12; issue #81 (owned-paths-zsh-split) 2026-06-13 |
+| pnpm-audit-ci-gate | A | 2026-06-19 04:17 | PASS | issue #171 — pnpm security audits must run in CI |
+| pr-audit-duplicate-issue-refs | A | 2026-06-19 04:17 | PASS | issue #439 — /pr-audit must flag duplicate open PRs that reference the same issue |
+| ralph-fallback-order | A | 2026-06-19 04:17 | PASS | conversation 2026-06-12 (Ralph default fallback order) |
+| retro-deterministic-contract | A | 2026-06-19 04:17 | PASS | issue #443 — /retro deterministic output and self-contained helper contract |
+| rl-delegation-write-worker | A | 2026-06-19 04:17 | PASS | memory/MEMORY.md 2026-06-10 (rl-delegation) #57 |
+| ship-spec-ready-finalization | A | 2026-06-19 04:17 | PASS | issue #134 — /ship-spec must finalize ready PRs after gates, not stop at draft scaffold |
+| skill-paths | A | 2026-06-19 04:17 | PASS | issue #43 — stale path references; extended by issue #69 — apps/->packages/ rename guard |
+| submitted-by-trailers | A | 2026-06-19 04:17 | PASS | conversation 2026-06-12 (commit attribution trailers) |
+| watchdog-completed-session-reap | A | 2026-06-19 04:17 | PASS | issue #235 (completed autopilot PR session reaping) |
+| watchdog-draft-prs | A | 2026-06-19 04:17 | PASS | conversation 2026-06-15 (generic watchdog + stale draft PR recovery) |
+| watchdog-stuck-sessions | A | 2026-06-19 04:17 | PASS | issue #240 (Codex zero-credit stuck autopilot sessions) 2026-06-17 |
+| wiki-readme-index | A | 2026-06-19 04:17 | PASS | issue #132 — wiki README index drift guard |
 
 <!-- benchmark: pass-rate = PASS / (PASS + REGRESSION + TIMEOUT); SKIPPED excluded -->


### PR DESCRIPTION
Closes #451.

**Status: READY — implementation, local verification, CI, and /pr-audit promotable gates passed.**

## Summary
Adds support for https://github.com/Michaelliv/pi-dynamic-workflows by pinning the package as a default project-local Pi package and documenting its `workflow` tool.

## Changes
- Pin `git:github.com/Michaelliv/pi-dynamic-workflows@dbc6800d1f725f7439e51705e2664c59484afcd1` in `.pi/settings.json` (upstream `v1.0.1` commit / npm `1.0.1`).
- Update package-pin test coverage for the default Pi package list.
- Add `docs/integrations/pi-dynamic-workflows.md` with workflow usage, globals, determinism rules, and links.
- Update Pi harness and installation docs plus CHANGELOG.

## Verification
- `npm view pi-dynamic-workflows version name description repository.url --json`
- `git ls-remote https://github.com/Michaelliv/pi-dynamic-workflows.git HEAD refs/tags/*`
- Temp `pi install git:github.com/Michaelliv/pi-dynamic-workflows@dbc6800d1f725f7439e51705e2664c59484afcd1 --approve` completed successfully.
- `pnpm run test:scripts` — 275 passed
- `pnpm --dir packages/docs run build` — success
- `bash .claude/skills/eval/run.sh` — 50 PASS
- PR CI — green: Lint/Typecheck/Build/Test, Docs build, Boot Path Lint, Eval Probe Regression Gate. GitHub Pages deploy skipped as expected for PR context.
- `/pr-audit` gate — PR #452 is ready-for-review, CI PASS, MERGEABLE/CLEAN, no duplicate issue refs.

## Critique
- High-severity findings: 0
- Medium-severity findings: 0
- Recommendation: PROCEED

🤖 Generated with Pi via /ship-spec
