### PR TITLE
FROM feat/453-ignore-stale-legacy-system-cron TO development

### DIFF
--- a/.devcontainer/entrypoint.sh
+++ b/.devcontainer/entrypoint.sh
@@ -358,17 +358,19 @@ mkdir -p "$CRONS_PATH"
 # Bind-mounted; sandbox UID is synced to host UID above, so no chown.
 if [ -f "$HARNESS/scripts/cron-runtime.ts" ] && command -v tmux &>/dev/null; then
   if gosu sandbox tmux has-session -t system-cron 2>/dev/null; then
-    echo "[entrypoint] legacy system-cron tmux session detected — not starting cron-system or cron-watchdog; kill system-cron and restart/relaunch the sandbox when ready to migrate"
-  else
-    cat > /tmp/cron-watchdog.sh <<'CRON_WATCHDOG'
+    echo "[entrypoint] legacy system-cron tmux session detected — stopping it before starting cron-watchdog"
+    gosu sandbox tmux kill-session -t system-cron 2>/dev/null || true
+  fi
+
+  cat > /tmp/cron-watchdog.sh <<'CRON_WATCHDOG'
 #!/usr/bin/env bash
 set -u
 HARNESS="${HARNESS:-/home/sandbox/harness}"
 INTERVAL="${CRON_WATCHDOG_INTERVAL:-60}"
 while true; do
   if tmux has-session -t system-cron 2>/dev/null; then
-    echo "[$(date -Iseconds)] legacy system-cron detected; watchdog exiting"
-    exit 0
+    echo "[$(date -Iseconds)] legacy system-cron detected; stopping it before supervising cron-system"
+    tmux kill-session -t system-cron 2>/dev/null || true
   fi
   if ! tmux has-session -t cron-system 2>/dev/null; then
     echo "[$(date -Iseconds)] cron-system missing; starting cron-runtime.ts"
@@ -378,16 +380,15 @@ while true; do
   sleep "$INTERVAL"
 done
 CRON_WATCHDOG
-    chmod 755 /tmp/cron-watchdog.sh
-    chown -h "$(sandbox_ownership)" /tmp/cron-watchdog.sh 2>/dev/null || true
+  chmod 755 /tmp/cron-watchdog.sh
+  chown -h "$(sandbox_ownership)" /tmp/cron-watchdog.sh 2>/dev/null || true
 
-    if gosu sandbox tmux has-session -t cron-watchdog 2>/dev/null; then
-      echo "[entrypoint] cron-watchdog tmux session already running — skipping"
-    else
-      gosu sandbox tmux new-session -d -s cron-watchdog \
-        "HARNESS=$HARNESS CRON_WATCHDOG_INTERVAL=${CRON_WATCHDOG_INTERVAL:-60} bash /tmp/cron-watchdog.sh 2>&1 | tee /tmp/cron-watchdog.log"
-      echo "[entrypoint] cron-watchdog tmux session started (supervises cron-system)"
-    fi
+  if gosu sandbox tmux has-session -t cron-watchdog 2>/dev/null; then
+    echo "[entrypoint] cron-watchdog tmux session already running — skipping"
+  else
+    gosu sandbox tmux new-session -d -s cron-watchdog \
+      "HARNESS=$HARNESS CRON_WATCHDOG_INTERVAL=${CRON_WATCHDOG_INTERVAL:-60} bash /tmp/cron-watchdog.sh 2>&1 | tee /tmp/cron-watchdog.log"
+    echo "[entrypoint] cron-watchdog tmux session started (supervises cron-system)"
   fi
 fi
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Update policy and release automation live in [`/git`](.claude/skills/git/SKILL.m
 ### Changed
 - `/retro` now uses a report schema plus skill-local helper scripts for deterministic hypothesis validation, duplicate-memory checks, and log rendering ([#443](https://github.com/mifunedev/openharness/issues/443)).
 ### Fixed
+- Devcontainer boot now stops stale legacy `system-cron` tmux sessions before starting `cron-watchdog`/`cron-system`, avoiding unhealthy migrated sandboxes ([#453](https://github.com/mifunedev/openharness/issues/453)).
 ### Removed
 ### Deprecated
 ### Security

--- a/crons/README.md
+++ b/crons/README.md
@@ -40,9 +40,9 @@ Body becomes the agent prompt at fire time.
 - Migration note: older sandboxes used runtime session `system-cron` and
   autopilot run sessions/markers named `autopilot-*`. New sandboxes use
   `cron-system` and `cron-autopilot-*`. During the transition, heartbeat scans
-  and sweeps both old and new autopilot names. To complete migration, kill the
-  legacy `system-cron` session once, then restart/relaunch the sandbox so the
-  entrypoint starts `cron-system` without running duplicate cron runtimes.
+  and sweeps both old and new autopilot names. On boot, the entrypoint stops a
+  stale legacy `system-cron` session before starting `cron-watchdog`, so
+  operators no longer need a manual kill/restart migration step.
 - Disable a job by setting `enabled: false` — do not delete the file
   (preserves history).
 - Runtime artefacts in this directory (`.cron.log`, `.pid`) are
@@ -106,7 +106,7 @@ returns before generating a shell wrapper or spawning an agent.
 
 ## tmux sessions
 
-The devcontainer entrypoint starts `cron-watchdog`, a tmux supervisor that checks for `cron-system` and starts `scripts/cron-runtime.ts` whenever the runtime session is absent. Inspect it with `tmux attach -t cron-watchdog`; watchdog output tees to `/tmp/cron-watchdog.log`, and the runtime still tees to `/tmp/cron-system.log`. During migration, a legacy `system-cron` session blocks both `cron-watchdog` and `cron-system`; kill `system-cron` and restart/relaunch the sandbox to complete the migration.
+The devcontainer entrypoint starts `cron-watchdog`, a tmux supervisor that checks for `cron-system` and starts `scripts/cron-runtime.ts` whenever the runtime session is absent. Inspect it with `tmux attach -t cron-watchdog`; watchdog output tees to `/tmp/cron-watchdog.log`, and the runtime still tees to `/tmp/cron-system.log`. During migration, a stale legacy `system-cron` session is stopped automatically before modern cron supervision starts.
 
 A job with `tmux: true` in its frontmatter runs each fire in its own detached tmux session instead of an in-process child, so the user can attach to a run, read its scrollback, and reattach later.
 

--- a/evals/RESULTS.md
+++ b/evals/RESULTS.md
@@ -6,55 +6,55 @@ probe id; git history is the time series.** Schema and exit-code semantics are i
 
 | probe | tier | last-run (UTC) | status | source |
 |-------|------|----------------|--------|--------|
-| agent-browser-cli | A | 2026-06-18 20:55 | PASS | memory/MEMORY.md 2026-06-07 (agent-browser 0.8.5 CLI) |
-| autopilot-executor-toggle | A | 2026-06-18 20:55 | PASS | conversation 2026-06-13 (autopilot delegate-advisor executor) |
-| autopilot-no-pr-session-close | A | 2026-06-18 20:55 | PASS | issue #209 (autopilot no-PR tmux session closure) 2026-06-16 |
-| autopilot-open-pr-reference-dedupe | A | 2026-06-18 20:55 | PASS | issue #437 — autopilot must not start duplicate work when open PRs reference the same issue without linked-PR metadata |
-| autopilot-pi-agent | A | 2026-06-18 20:55 | PASS | issue #116 (autopilot Pi tmux alignment) 2026-06-14; issue #118 (attachable Pi TUI tmux) 2026-06-14; issue #126 (kept Pi overlap lock release) 2026-06-14; issue #142 (worktree-by-default, skip→worktree) 2026-06-14 |
-| autopilot-preflight-gate | A | 2026-06-18 20:55 | PASS | issue #194 (deterministic autopilot caps preflight gate) 2026-06-15 |
-| autopilot-upstream-default | A | 2026-06-18 20:55 | PASS | issue #420 — future autopilots must target canonical repo, not personal fork |
-| autopilot-worktree-log-root | A | 2026-06-18 20:55 | PASS | issue #152 (persist autopilot worktree logs) 2026-06-15 |
-| boot-lint-glob | A | 2026-06-18 20:55 | PASS | issue #90, issue #120 |
-| capability-benchmark-schema | A | 2026-06-18 20:55 | PASS | issue #167 — capability benchmark instrument |
-| clean-restore | A | 2026-06-18 20:55 | PASS | issue #63 (autopilot-stray-wip-guard) 2026-06-12; issue #81 (owned-paths-zsh-split) 2026-06-13 |
-| cleanup-tasks-scoped-guard | A | 2026-06-18 20:55 | PASS | issue #85 |
-| cleanup-tasks-worktree-grooming | A | 2026-06-18 20:55 | PASS | issue #168 |
-| cron-claude-codex-fallback | A | 2026-06-18 20:55 | PASS | conversation 2026-06-12 (default Codex fallback for crons) |
-| cron-watchdog | A | 2026-06-18 20:55 | PASS | issue #130 (cron runtime watchdog) 2026-06-14 |
-| curl-bash-safe-alternatives | A | 2026-06-18 20:55 | PASS | vet-run/vet integration — public curl|bash examples need review-first alternatives |
-| datasets-schema | A | 2026-06-18 20:55 | PASS | issue #196 — evals/datasets verifiable trajectory corpus (Repo2RLEnv-inspired) |
-| devtcp-hook | A | 2026-06-18 20:55 | PASS | memory/MEMORY.md 2026-06-10 (zsh /dev/tcp) |
-| drift-check-cron-staleness-glob | A | 2026-06-18 20:55 | PASS | issue #98; issue #225 (restart-required cron frontmatter/config drift) |
-| eval-ci-gate | A | 2026-06-18 20:55 | PASS | #103 — eval probe suite gated in CI |
-| eval-gate | A | 2026-06-18 20:55 | PASS | memory/MEMORY.md 2026-06-11 (eval-gate) |
-| eval-results-atomic | A | 2026-06-18 20:55 | PASS | issue #83 (eval-results-atomic-write) |
-| eval-runner-exit | A | 2026-06-18 20:55 | PASS | memory/MEMORY.md 2026-06-11 (eval-runner-exit) #29 |
-| git-skill | A | 2026-06-18 20:55 | PASS | conversation 2026-06-15 — rules are not always supported; git workflow must be the /git skill |
-| harness-audit-empty-output-gate | A | 2026-06-18 20:55 | PASS | issue #246 — /harness-audit must fail closed on empty auditor outputs |
-| harness-audit-memory-path | A | 2026-06-18 20:55 | PASS | issue #183 — /harness-audit must inspect the active worktree, not a hardcoded root |
-| harness-audit-shared-memory | A | 2026-06-18 20:55 | PASS | issue #432 — /harness-audit must load durable memory from shared log root in cron worktrees |
-| harness-ci-core-paths | A | 2026-06-18 20:55 | PASS | #165 — core sandbox config files must trigger harness CI |
-| harness-ci-hooks-paths | A | 2026-06-18 20:55 | PASS | issue #202 — credential/security hook changes must trigger harness CI |
-| health-check-docker-stats | A | 2026-06-18 20:55 | PASS | memory/MEMORY.md 2026-06-10 (docker stats vs ps Size) |
-| locked-append-critical-path | A | 2026-06-18 20:55 | PASS | issue #204 (lock shared runtime log appends) 2026-06-15 |
-| loop-benchmark-gate | A | 2026-06-18 20:55 | PASS | issue #179 — wire the executable-loop `benchmark` node (close the cycle) |
-| loop-handoff-consistency | A | 2026-06-18 20:55 | PASS | context/rules/loop.md § 4 (executable-loop Handoff convention) |
-| loop-repeat-gate | A | 2026-06-18 20:55 | PASS | issue #173 — wire the executable-loop `repeat` node (cycle-closing edge) |
-| memory-gitignore-claim | A | 2026-06-18 20:55 | PASS | issue #101 |
-| next-dev-prod | A | 2026-06-18 20:55 | PASS | memory/MEMORY.md 2026-06-04 |
-| orchestrate-contract | A | 2026-06-18 20:55 | PASS | issue #160 — /orchestrate contract; issue #175 — reserved /loop command rename |
-| owned-surface-guard | A | 2026-06-18 20:55 | PASS | issue #63 (autopilot-stray-wip-guard) 2026-06-12; issue #81 (owned-paths-zsh-split) 2026-06-13 |
-| pnpm-audit-ci-gate | A | 2026-06-18 20:55 | PASS | issue #171 — pnpm security audits must run in CI |
-| pr-audit-duplicate-issue-refs | A | 2026-06-18 20:55 | PASS | issue #439 — /pr-audit must flag duplicate open PRs that reference the same issue |
-| ralph-fallback-order | A | 2026-06-18 20:55 | PASS | conversation 2026-06-12 (Ralph default fallback order) |
-| retro-deterministic-contract | A | 2026-06-18 20:55 | PASS | issue #443 — /retro deterministic output and self-contained helper contract |
-| rl-delegation-write-worker | A | 2026-06-18 20:55 | PASS | memory/MEMORY.md 2026-06-10 (rl-delegation) #57 |
-| ship-spec-ready-finalization | A | 2026-06-18 20:55 | PASS | issue #134 — /ship-spec must finalize ready PRs after gates, not stop at draft scaffold |
-| skill-paths | A | 2026-06-18 20:55 | PASS | issue #43 — stale path references; extended by issue #69 — apps/->packages/ rename guard |
-| submitted-by-trailers | A | 2026-06-18 20:55 | PASS | conversation 2026-06-12 (commit attribution trailers) |
-| watchdog-completed-session-reap | A | 2026-06-18 20:55 | PASS | issue #235 (completed autopilot PR session reaping) |
-| watchdog-draft-prs | A | 2026-06-18 20:55 | PASS | conversation 2026-06-15 (generic watchdog + stale draft PR recovery) |
-| watchdog-stuck-sessions | A | 2026-06-18 20:55 | PASS | issue #240 (Codex zero-credit stuck autopilot sessions) 2026-06-17 |
-| wiki-readme-index | A | 2026-06-18 20:55 | PASS | issue #132 — wiki README index drift guard |
+| agent-browser-cli | A | 2026-06-19 04:19 | PASS | memory/MEMORY.md 2026-06-07 (agent-browser 0.8.5 CLI) |
+| autopilot-executor-toggle | A | 2026-06-19 04:19 | PASS | conversation 2026-06-13 (autopilot delegate-advisor executor) |
+| autopilot-no-pr-session-close | A | 2026-06-19 04:19 | PASS | issue #209 (autopilot no-PR tmux session closure) 2026-06-16 |
+| autopilot-open-pr-reference-dedupe | A | 2026-06-19 04:19 | PASS | issue #437 — autopilot must not start duplicate work when open PRs reference the same issue without linked-PR metadata |
+| autopilot-pi-agent | A | 2026-06-19 04:19 | PASS | issue #116 (autopilot Pi tmux alignment) 2026-06-14; issue #118 (attachable Pi TUI tmux) 2026-06-14; issue #126 (kept Pi overlap lock release) 2026-06-14; issue #142 (worktree-by-default, skip→worktree) 2026-06-14 |
+| autopilot-preflight-gate | A | 2026-06-19 04:19 | PASS | issue #194 (deterministic autopilot caps preflight gate) 2026-06-15 |
+| autopilot-upstream-default | A | 2026-06-19 04:19 | PASS | issue #420 — future autopilots must target canonical repo, not personal fork |
+| autopilot-worktree-log-root | A | 2026-06-19 04:19 | PASS | issue #152 (persist autopilot worktree logs) 2026-06-15 |
+| boot-lint-glob | A | 2026-06-19 04:19 | PASS | issue #90, issue #120 |
+| capability-benchmark-schema | A | 2026-06-19 04:19 | PASS | issue #167 — capability benchmark instrument |
+| clean-restore | A | 2026-06-19 04:19 | PASS | issue #63 (autopilot-stray-wip-guard) 2026-06-12; issue #81 (owned-paths-zsh-split) 2026-06-13 |
+| cleanup-tasks-scoped-guard | A | 2026-06-19 04:19 | PASS | issue #85 |
+| cleanup-tasks-worktree-grooming | A | 2026-06-19 04:19 | PASS | issue #168 |
+| cron-claude-codex-fallback | A | 2026-06-19 04:19 | PASS | conversation 2026-06-12 (default Codex fallback for crons) |
+| cron-watchdog | A | 2026-06-19 04:19 | PASS | issues #130/#453 (cron runtime watchdog + legacy system-cron reaping) 2026-06-19 |
+| curl-bash-safe-alternatives | A | 2026-06-19 04:19 | PASS | vet-run/vet integration — public curl|bash examples need review-first alternatives |
+| datasets-schema | A | 2026-06-19 04:19 | PASS | issue #196 — evals/datasets verifiable trajectory corpus (Repo2RLEnv-inspired) |
+| devtcp-hook | A | 2026-06-19 04:19 | PASS | memory/MEMORY.md 2026-06-10 (zsh /dev/tcp) |
+| drift-check-cron-staleness-glob | A | 2026-06-19 04:19 | PASS | issue #98; issue #225 (restart-required cron frontmatter/config drift) |
+| eval-ci-gate | A | 2026-06-19 04:19 | PASS | #103 — eval probe suite gated in CI |
+| eval-gate | A | 2026-06-19 04:19 | PASS | memory/MEMORY.md 2026-06-11 (eval-gate) |
+| eval-results-atomic | A | 2026-06-19 04:19 | PASS | issue #83 (eval-results-atomic-write) |
+| eval-runner-exit | A | 2026-06-19 04:19 | PASS | memory/MEMORY.md 2026-06-11 (eval-runner-exit) #29 |
+| git-skill | A | 2026-06-19 04:19 | PASS | conversation 2026-06-15 — rules are not always supported; git workflow must be the /git skill |
+| harness-audit-empty-output-gate | A | 2026-06-19 04:19 | PASS | issue #246 — /harness-audit must fail closed on empty auditor outputs |
+| harness-audit-memory-path | A | 2026-06-19 04:19 | PASS | issue #183 — /harness-audit must inspect the active worktree, not a hardcoded root |
+| harness-audit-shared-memory | A | 2026-06-19 04:19 | PASS | issue #432 — /harness-audit must load durable memory from shared log root in cron worktrees |
+| harness-ci-core-paths | A | 2026-06-19 04:19 | PASS | #165 — core sandbox config files must trigger harness CI |
+| harness-ci-hooks-paths | A | 2026-06-19 04:19 | PASS | issue #202 — credential/security hook changes must trigger harness CI |
+| health-check-docker-stats | A | 2026-06-19 04:19 | PASS | memory/MEMORY.md 2026-06-10 (docker stats vs ps Size) |
+| locked-append-critical-path | A | 2026-06-19 04:19 | PASS | issue #204 (lock shared runtime log appends) 2026-06-15 |
+| loop-benchmark-gate | A | 2026-06-19 04:19 | PASS | issue #179 — wire the executable-loop `benchmark` node (close the cycle) |
+| loop-handoff-consistency | A | 2026-06-19 04:19 | PASS | context/rules/loop.md § 4 (executable-loop Handoff convention) |
+| loop-repeat-gate | A | 2026-06-19 04:19 | PASS | issue #173 — wire the executable-loop `repeat` node (cycle-closing edge) |
+| memory-gitignore-claim | A | 2026-06-19 04:19 | PASS | issue #101 |
+| next-dev-prod | A | 2026-06-19 04:19 | PASS | memory/MEMORY.md 2026-06-04 |
+| orchestrate-contract | A | 2026-06-19 04:19 | PASS | issue #160 — /orchestrate contract; issue #175 — reserved /loop command rename |
+| owned-surface-guard | A | 2026-06-19 04:19 | PASS | issue #63 (autopilot-stray-wip-guard) 2026-06-12; issue #81 (owned-paths-zsh-split) 2026-06-13 |
+| pnpm-audit-ci-gate | A | 2026-06-19 04:19 | PASS | issue #171 — pnpm security audits must run in CI |
+| pr-audit-duplicate-issue-refs | A | 2026-06-19 04:19 | PASS | issue #439 — /pr-audit must flag duplicate open PRs that reference the same issue |
+| ralph-fallback-order | A | 2026-06-19 04:19 | PASS | conversation 2026-06-12 (Ralph default fallback order) |
+| retro-deterministic-contract | A | 2026-06-19 04:19 | PASS | issue #443 — /retro deterministic output and self-contained helper contract |
+| rl-delegation-write-worker | A | 2026-06-19 04:19 | PASS | memory/MEMORY.md 2026-06-10 (rl-delegation) #57 |
+| ship-spec-ready-finalization | A | 2026-06-19 04:19 | PASS | issue #134 — /ship-spec must finalize ready PRs after gates, not stop at draft scaffold |
+| skill-paths | A | 2026-06-19 04:19 | PASS | issue #43 — stale path references; extended by issue #69 — apps/->packages/ rename guard |
+| submitted-by-trailers | A | 2026-06-19 04:19 | PASS | conversation 2026-06-12 (commit attribution trailers) |
+| watchdog-completed-session-reap | A | 2026-06-19 04:19 | PASS | issue #235 (completed autopilot PR session reaping) |
+| watchdog-draft-prs | A | 2026-06-19 04:19 | PASS | conversation 2026-06-15 (generic watchdog + stale draft PR recovery) |
+| watchdog-stuck-sessions | A | 2026-06-19 04:19 | PASS | issue #240 (Codex zero-credit stuck autopilot sessions) 2026-06-17 |
+| wiki-readme-index | A | 2026-06-19 04:19 | PASS | issue #132 — wiki README index drift guard |
 
 <!-- benchmark: pass-rate = PASS / (PASS + REGRESSION + TIMEOUT); SKIPPED excluded -->

--- a/evals/probes/cron-watchdog.sh
+++ b/evals/probes/cron-watchdog.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # tier: A
-# source: issue #130 (cron runtime watchdog) 2026-06-14
-# desc: devcontainer entrypoint starts a cron-watchdog tmux supervisor that restarts cron-system if the cron runtime session dies.
+# source: issues #130/#453 (cron runtime watchdog + legacy system-cron reaping) 2026-06-19
+# desc: devcontainer entrypoint starts a cron-watchdog tmux supervisor that restarts cron-system and reaps stale legacy system-cron sessions.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
@@ -20,17 +20,19 @@ grep -Fq 'tmux new-session -d -s cron-system' "$ENTRYPOINT" || missing+=("watchd
 grep -Fq 'node --experimental-strip-types scripts/cron-runtime.ts' "$ENTRYPOINT" || missing+=("watchdog launches cron-runtime.ts")
 grep -Fq '/tmp/cron-system.log' "$ENTRYPOINT" || missing+=("cron-system log path retained")
 grep -Fq '/tmp/cron-watchdog.log' "$ENTRYPOINT" || missing+=("watchdog log path present")
-grep -Fq 'tmux has-session -t system-cron' "$ENTRYPOINT" || missing+=("legacy system-cron guard retained")
-grep -Fq 'not starting cron-system or cron-watchdog' "$ENTRYPOINT" || missing+=("legacy guard blocks both sessions")
-grep -Fq 'legacy system-cron detected; watchdog exiting' "$ENTRYPOINT" || missing+=("watchdog exits if legacy session appears")
+grep -Fq 'tmux has-session -t system-cron' "$ENTRYPOINT" || missing+=("legacy system-cron detection retained")
+grep -Fq 'legacy system-cron tmux session detected — stopping it before starting cron-watchdog' "$ENTRYPOINT" || missing+=("entrypoint reaps stale legacy session before watchdog startup")
+grep -Fq 'legacy system-cron detected; stopping it before supervising cron-system' "$ENTRYPOINT" || missing+=("watchdog reaps legacy session if it reappears")
+! grep -Fq 'not starting cron-system or cron-watchdog' "$ENTRYPOINT" || missing+=("legacy guard must not block both sessions")
+! grep -Fq 'legacy system-cron detected; watchdog exiting' "$ENTRYPOINT" || missing+=("watchdog must not exit if legacy session appears")
 
 grep -Fq 'devcontainer entrypoint cron supervision' "$TESTS" || missing+=("vitest covers cron supervision")
-grep -Fq 'preserves the legacy system-cron migration guard' "$TESTS" || missing+=("vitest covers legacy guard")
+grep -Fq 'reaps stale legacy system-cron instead of blocking modern cron supervision' "$TESTS" || missing+=("vitest covers legacy reaping")
 
 if (( ${#missing[@]} )); then
   printf 'REGRESSION: cron watchdog contract missing: %s\n' "${missing[*]}" >&2
   exit 1
 fi
 
-echo "PASS: entrypoint starts cron-watchdog and preserves cron-system/system-cron contracts" >&2
+echo "PASS: entrypoint starts cron-watchdog and reaps stale legacy system-cron sessions" >&2
 exit 0

--- a/scripts/__tests__/entrypoint.test.ts
+++ b/scripts/__tests__/entrypoint.test.ts
@@ -172,11 +172,14 @@ describe("devcontainer entrypoint cron supervision", () => {
     expect(text).toContain("/tmp/cron-watchdog.log");
   });
 
-  it("preserves the legacy system-cron migration guard", () => {
+  it("reaps stale legacy system-cron instead of blocking modern cron supervision", () => {
     const text = entrypoint();
 
     expect(text).toContain("tmux has-session -t system-cron");
-    expect(text).toContain("not starting cron-system or cron-watchdog");
-    expect(text).toContain("legacy system-cron detected; watchdog exiting");
+    expect(text).toContain("legacy system-cron tmux session detected — stopping it before starting cron-watchdog");
+    expect(text).toContain("tmux kill-session -t system-cron");
+    expect(text).toContain("legacy system-cron detected; stopping it before supervising cron-system");
+    expect(text).not.toContain("not starting cron-system or cron-watchdog");
+    expect(text).not.toContain("watchdog exiting");
   });
 });


### PR DESCRIPTION
## Selection rationale

Research selection: queue had no actionable ticket without an open PR; /harness-audit ranked startup reliability as a high-leverage harness-infra area. The top fresh, scoped survivor was the legacy `system-cron` boot blocker: stale pre-migration tmux state suppressed modern `cron-watchdog` / `cron-system` startup and left sandboxes unhealthy. Filed as #453 and built this run.

---

## Summary

- stop stale legacy `system-cron` before starting `cron-watchdog`
- make the watchdog reap `system-cron` if it reappears instead of exiting
- update cron docs and the `cron-watchdog` eval probe for the new migration-safe contract

## Verification

- `bash -n .devcontainer/entrypoint.sh`
- `bash -n scripts/sandbox-healthcheck.sh`
- `bash -n evals/probes/cron-watchdog.sh`
- `pnpm vitest run scripts/__tests__/entrypoint.test.ts scripts/__tests__/sandbox-healthcheck.test.ts`
- `pnpm test:scripts`
- `bash .claude/skills/eval/run.sh`

Closes #453
