### PR TITLE
FROM feat/455-docs-build-decoupling TO development

### DIFF
--- a/.claude/skills/ci-status/SKILL.md
+++ b/.claude/skills/ci-status/SKILL.md
@@ -104,7 +104,7 @@ For Eval Probe Regression Gate failures, immediately inspect the failed probe na
 - **FAIL**: Report the failing step, error message, and suggest a fix. Then fix the issue, commit, push, and run `/ci-status` again
 - **NO RUN**: No workflow's `on:` filter matched the push, or `PR_NUMBER` was set but `gh pr checks` returned no rows (the PR exists but no workflows were triggered yet). *(Note: the workflow names below reflect this harness's layout and may differ in other checkouts.)*
   - `ci-harness.yml` — push only: `packages/**`, `package.json`, `pnpm-lock.yaml`, `pnpm-workspace.yaml`, itself
-  - `docs.yml` — PR or push-to-main: `packages/docs/**`, `docs/**`, `blog/**`, itself
+  - `docs.yml` — push-to-main/master only: `packages/docs/**`, `docs/**`, `blog/**`, itself
   - `conciseness.yml` — push or PR: `workspace/*.md`, `workspace/.claude/rules/*.md`, itself
   - `release.yml` — tag push only
 
@@ -120,7 +120,7 @@ This project's CI (`CI: Harness`) runs these steps in order:
 2. Workspace package format check (`pnpm --filter './packages/**' -r --if-present run format:check`)
 3. Workspace package typecheck (`pnpm --filter './packages/**' -r --if-present run typecheck`)
 4. Standalone `packages/oh` typecheck (`npm --prefix packages/oh ci && npm --prefix packages/oh run typecheck`)
-5. Workspace package build (`pnpm --filter './packages/**' -r --if-present run build`)
+5. Fast harness build (`pnpm run build:harness`) — excludes Docusaurus/docs build; docs build/deploy happens only on `main`/`master` pushes through `docs.yml`
 6. Workspace package tests (`pnpm --filter './packages/**' -r --if-present run test`)
 7. Root script tests (`pnpm test:scripts`)
 8. Boot-path lint (`shellcheck .devcontainer/*.sh install/*.sh` and `hadolint .devcontainer/Dockerfile`)
@@ -135,7 +135,10 @@ pnpm --filter './packages/**' -r --if-present run lint
 pnpm --filter './packages/**' -r --if-present run format:check
 pnpm --filter './packages/**' -r --if-present run typecheck
 npm --prefix packages/oh ci && npm --prefix packages/oh run typecheck
-pnpm --filter './packages/**' -r --if-present run build
+pnpm run build:harness
 pnpm --filter './packages/**' -r --if-present run test
 pnpm test:scripts
+
+# Optional, manual docs validation only when intentionally editing docs:
+pnpm docs:build
 ```

--- a/.github/workflows/ci-harness.yml
+++ b/.github/workflows/ci-harness.yml
@@ -99,7 +99,7 @@ jobs:
           npm --prefix packages/oh run typecheck
 
       - name: Build
-        run: pnpm --filter './packages/**' -r --if-present run build
+        run: pnpm run build:harness
 
       - name: Test
         run: pnpm --filter './packages/**' -r --if-present run test

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,21 +1,15 @@
 name: "Docs: build & deploy"
 
 on:
-  pull_request:
-    paths:
-      - "packages/docs/**"
-      - "docs/**"
-      - "blog/**"
-      - ".github/workflows/docs.yml"
   push:
     branches:
       - main
+      - master
     paths:
       - "packages/docs/**"
       - "docs/**"
       - "blog/**"
       - ".github/workflows/docs.yml"
-  workflow_dispatch:
 
 permissions:
   contents: read
@@ -50,22 +44,22 @@ jobs:
         working-directory: packages/docs
         run: pnpm run build
 
-      # Pages deploy only runs on the canonical repo. Forks build-validate docs
-      # (the build job above) but skip deploy — they have no Pages site enabled,
-      # and configure-pages would fail with "Resource not accessible by integration".
+      # Pages deploy only runs on the canonical repo and release branches.
+      # The docs build job is intentionally limited to main/master pushes so PRs
+      # and release validation do not wait on Docusaurus.
       - name: Configure Pages
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'mifunedev/openharness'
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master') && github.repository == 'mifunedev/openharness'
         uses: actions/configure-pages@v5
 
       - name: Upload Pages artifact
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'mifunedev/openharness'
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master') && github.repository == 'mifunedev/openharness'
         uses: actions/upload-pages-artifact@v3
         with:
           path: packages/docs/build
 
   deploy:
     name: Deploy to GitHub Pages
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'mifunedev/openharness'
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master') && github.repository == 'mifunedev/openharness'
     needs: build
     runs-on: ubuntu-latest
     concurrency:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
           npm --prefix packages/oh run typecheck
 
       - name: Build
-        run: pnpm --filter './packages/**' -r --if-present run build
+        run: pnpm run build:harness
 
       - name: Test
         run: pnpm --filter './packages/**' -r --if-present run test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Update policy and release automation live in [`/git`](.claude/skills/git/SKILL.m
 - `pi-dynamic-workflows` is now a default project-local Pi package pinned to the upstream `v1.0.1` commit, with docs for the `workflow` tool's deterministic JavaScript fan-out model and package-pin test coverage ([#451](https://github.com/mifunedev/openharness/issues/451)).
 - `retro-deterministic-contract` eval probe guards that `/retro` keeps schema-backed output, self-contained helper scripts, and synchronized `.pi`/`.claude` skill copies ([#443](https://github.com/mifunedev/openharness/issues/443)).
 ### Changed
+- Docs builds now run automatically only from the docs workflow on `main`/`master` pushes; root build, Harness CI, release validation, and `/eval` stay on the fast non-docs path ([#455](https://github.com/mifunedev/openharness/issues/455)).
 - `/retro` now uses a report schema plus skill-local helper scripts for deterministic hypothesis validation, duplicate-memory checks, and log rendering ([#443](https://github.com/mifunedev/openharness/issues/443)).
 ### Fixed
 ### Removed

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -55,6 +55,24 @@ claude      # Claude Code
 codex       # OpenAI Codex CLI
 ```
 
+### Local validation
+
+Use the fast harness build for routine development:
+
+```bash
+pnpm run build          # fast non-docs build
+pnpm run test:scripts   # root script + .pi extension tests
+bash .claude/skills/eval/run.sh
+```
+
+Docs builds are intentionally excluded from fast local, PR, Harness CI, and release validation. Run them only when you explicitly need to validate the Docusaurus site:
+
+```bash
+pnpm docs:build
+```
+
+The automatic docs build/deploy gate runs only from `.github/workflows/docs.yml` on pushes to `main` or `master` that touch docs-site paths.
+
 ### Installing a harness pack
 
 Multi-agent setups (e.g. Pi+Mom Slack bot) ship as harness packs. Install one by cloning it into the workspace and following its README:

--- a/evals/RESULTS.md
+++ b/evals/RESULTS.md
@@ -6,55 +6,56 @@ probe id; git history is the time series.** Schema and exit-code semantics are i
 
 | probe | tier | last-run (UTC) | status | source |
 |-------|------|----------------|--------|--------|
-| agent-browser-cli | A | 2026-06-19 04:17 | PASS | memory/MEMORY.md 2026-06-07 (agent-browser 0.8.5 CLI) |
-| autopilot-executor-toggle | A | 2026-06-19 04:17 | PASS | conversation 2026-06-13 (autopilot delegate-advisor executor) |
-| autopilot-no-pr-session-close | A | 2026-06-19 04:17 | PASS | issue #209 (autopilot no-PR tmux session closure) 2026-06-16 |
-| autopilot-open-pr-reference-dedupe | A | 2026-06-19 04:17 | PASS | issue #437 — autopilot must not start duplicate work when open PRs reference the same issue without linked-PR metadata |
-| autopilot-pi-agent | A | 2026-06-19 04:17 | PASS | issue #116 (autopilot Pi tmux alignment) 2026-06-14; issue #118 (attachable Pi TUI tmux) 2026-06-14; issue #126 (kept Pi overlap lock release) 2026-06-14; issue #142 (worktree-by-default, skip→worktree) 2026-06-14 |
-| autopilot-preflight-gate | A | 2026-06-19 04:17 | PASS | issue #194 (deterministic autopilot caps preflight gate) 2026-06-15 |
-| autopilot-upstream-default | A | 2026-06-19 04:17 | PASS | issue #420 — future autopilots must target canonical repo, not personal fork |
-| autopilot-worktree-log-root | A | 2026-06-19 04:17 | PASS | issue #152 (persist autopilot worktree logs) 2026-06-15 |
-| boot-lint-glob | A | 2026-06-19 04:17 | PASS | issue #90, issue #120 |
-| capability-benchmark-schema | A | 2026-06-19 04:17 | PASS | issue #167 — capability benchmark instrument |
-| clean-restore | A | 2026-06-19 04:17 | PASS | issue #63 (autopilot-stray-wip-guard) 2026-06-12; issue #81 (owned-paths-zsh-split) 2026-06-13 |
-| cleanup-tasks-scoped-guard | A | 2026-06-19 04:17 | PASS | issue #85 |
-| cleanup-tasks-worktree-grooming | A | 2026-06-19 04:17 | PASS | issue #168 |
-| cron-claude-codex-fallback | A | 2026-06-19 04:17 | PASS | conversation 2026-06-12 (default Codex fallback for crons) |
-| cron-watchdog | A | 2026-06-19 04:17 | PASS | issue #130 (cron runtime watchdog) 2026-06-14 |
-| curl-bash-safe-alternatives | A | 2026-06-19 04:17 | PASS | vet-run/vet integration — public curl|bash examples need review-first alternatives |
-| datasets-schema | A | 2026-06-19 04:17 | PASS | issue #196 — evals/datasets verifiable trajectory corpus (Repo2RLEnv-inspired) |
-| devtcp-hook | A | 2026-06-19 04:17 | PASS | memory/MEMORY.md 2026-06-10 (zsh /dev/tcp) |
-| drift-check-cron-staleness-glob | A | 2026-06-19 04:17 | PASS | issue #98; issue #225 (restart-required cron frontmatter/config drift) |
-| eval-ci-gate | A | 2026-06-19 04:17 | PASS | #103 — eval probe suite gated in CI |
-| eval-gate | A | 2026-06-19 04:17 | PASS | memory/MEMORY.md 2026-06-11 (eval-gate) |
-| eval-results-atomic | A | 2026-06-19 04:17 | PASS | issue #83 (eval-results-atomic-write) |
-| eval-runner-exit | A | 2026-06-19 04:17 | PASS | memory/MEMORY.md 2026-06-11 (eval-runner-exit) #29 |
-| git-skill | A | 2026-06-19 04:17 | PASS | conversation 2026-06-15 — rules are not always supported; git workflow must be the /git skill |
-| harness-audit-empty-output-gate | A | 2026-06-19 04:17 | PASS | issue #246 — /harness-audit must fail closed on empty auditor outputs |
-| harness-audit-memory-path | A | 2026-06-19 04:17 | PASS | issue #183 — /harness-audit must inspect the active worktree, not a hardcoded root |
-| harness-audit-shared-memory | A | 2026-06-19 04:17 | PASS | issue #432 — /harness-audit must load durable memory from shared log root in cron worktrees |
-| harness-ci-core-paths | A | 2026-06-19 04:17 | PASS | #165 — core sandbox config files must trigger harness CI |
-| harness-ci-hooks-paths | A | 2026-06-19 04:17 | PASS | issue #202 — credential/security hook changes must trigger harness CI |
-| health-check-docker-stats | A | 2026-06-19 04:17 | PASS | memory/MEMORY.md 2026-06-10 (docker stats vs ps Size) |
-| locked-append-critical-path | A | 2026-06-19 04:17 | PASS | issue #204 (lock shared runtime log appends) 2026-06-15 |
-| loop-benchmark-gate | A | 2026-06-19 04:17 | PASS | issue #179 — wire the executable-loop `benchmark` node (close the cycle) |
-| loop-handoff-consistency | A | 2026-06-19 04:17 | PASS | context/rules/loop.md § 4 (executable-loop Handoff convention) |
-| loop-repeat-gate | A | 2026-06-19 04:17 | PASS | issue #173 — wire the executable-loop `repeat` node (cycle-closing edge) |
-| memory-gitignore-claim | A | 2026-06-19 04:17 | PASS | issue #101 |
-| next-dev-prod | A | 2026-06-19 04:17 | PASS | memory/MEMORY.md 2026-06-04 |
-| orchestrate-contract | A | 2026-06-19 04:17 | PASS | issue #160 — /orchestrate contract; issue #175 — reserved /loop command rename |
-| owned-surface-guard | A | 2026-06-19 04:17 | PASS | issue #63 (autopilot-stray-wip-guard) 2026-06-12; issue #81 (owned-paths-zsh-split) 2026-06-13 |
-| pnpm-audit-ci-gate | A | 2026-06-19 04:17 | PASS | issue #171 — pnpm security audits must run in CI |
-| pr-audit-duplicate-issue-refs | A | 2026-06-19 04:17 | PASS | issue #439 — /pr-audit must flag duplicate open PRs that reference the same issue |
-| ralph-fallback-order | A | 2026-06-19 04:17 | PASS | conversation 2026-06-12 (Ralph default fallback order) |
-| retro-deterministic-contract | A | 2026-06-19 04:17 | PASS | issue #443 — /retro deterministic output and self-contained helper contract |
-| rl-delegation-write-worker | A | 2026-06-19 04:17 | PASS | memory/MEMORY.md 2026-06-10 (rl-delegation) #57 |
-| ship-spec-ready-finalization | A | 2026-06-19 04:17 | PASS | issue #134 — /ship-spec must finalize ready PRs after gates, not stop at draft scaffold |
-| skill-paths | A | 2026-06-19 04:17 | PASS | issue #43 — stale path references; extended by issue #69 — apps/->packages/ rename guard |
-| submitted-by-trailers | A | 2026-06-19 04:17 | PASS | conversation 2026-06-12 (commit attribution trailers) |
-| watchdog-completed-session-reap | A | 2026-06-19 04:17 | PASS | issue #235 (completed autopilot PR session reaping) |
-| watchdog-draft-prs | A | 2026-06-19 04:17 | PASS | conversation 2026-06-15 (generic watchdog + stale draft PR recovery) |
-| watchdog-stuck-sessions | A | 2026-06-19 04:17 | PASS | issue #240 (Codex zero-credit stuck autopilot sessions) 2026-06-17 |
-| wiki-readme-index | A | 2026-06-19 04:17 | PASS | issue #132 — wiki README index drift guard |
+| agent-browser-cli | A | 2026-06-19 04:59 | PASS | memory/MEMORY.md 2026-06-07 (agent-browser 0.8.5 CLI) |
+| autopilot-executor-toggle | A | 2026-06-19 04:59 | PASS | conversation 2026-06-13 (autopilot delegate-advisor executor) |
+| autopilot-no-pr-session-close | A | 2026-06-19 04:59 | PASS | issue #209 (autopilot no-PR tmux session closure) 2026-06-16 |
+| autopilot-open-pr-reference-dedupe | A | 2026-06-19 04:59 | PASS | issue #437 — autopilot must not start duplicate work when open PRs reference the same issue without linked-PR metadata |
+| autopilot-pi-agent | A | 2026-06-19 04:59 | PASS | issue #116 (autopilot Pi tmux alignment) 2026-06-14; issue #118 (attachable Pi TUI tmux) 2026-06-14; issue #126 (kept Pi overlap lock release) 2026-06-14; issue #142 (worktree-by-default, skip→worktree) 2026-06-14 |
+| autopilot-preflight-gate | A | 2026-06-19 04:59 | PASS | issue #194 (deterministic autopilot caps preflight gate) 2026-06-15 |
+| autopilot-upstream-default | A | 2026-06-19 04:59 | PASS | issue #420 — future autopilots must target canonical repo, not personal fork |
+| autopilot-worktree-log-root | A | 2026-06-19 04:59 | PASS | issue #152 (persist autopilot worktree logs) 2026-06-15 |
+| boot-lint-glob | A | 2026-06-19 04:59 | PASS | issue #90, issue #120 |
+| capability-benchmark-schema | A | 2026-06-19 04:59 | PASS | issue #167 — capability benchmark instrument |
+| clean-restore | A | 2026-06-19 04:59 | PASS | issue #63 (autopilot-stray-wip-guard) 2026-06-12; issue #81 (owned-paths-zsh-split) 2026-06-13 |
+| cleanup-tasks-scoped-guard | A | 2026-06-19 04:59 | PASS | issue #85 |
+| cleanup-tasks-worktree-grooming | A | 2026-06-19 04:59 | PASS | issue #168 |
+| cron-claude-codex-fallback | A | 2026-06-19 04:59 | PASS | conversation 2026-06-12 (default Codex fallback for crons) |
+| cron-watchdog | A | 2026-06-19 04:59 | PASS | issue #130 (cron runtime watchdog) 2026-06-14 |
+| curl-bash-safe-alternatives | A | 2026-06-19 04:59 | PASS | vet-run/vet integration — public curl|bash examples need review-first alternatives |
+| datasets-schema | A | 2026-06-19 04:59 | PASS | issue #196 — evals/datasets verifiable trajectory corpus (Repo2RLEnv-inspired) |
+| devtcp-hook | A | 2026-06-19 04:59 | PASS | memory/MEMORY.md 2026-06-10 (zsh /dev/tcp) |
+| docs-build-fast-path | A | 2026-06-19 04:59 | PASS | #455 — docs builds must stay out of fast harness/eval/release gates |
+| drift-check-cron-staleness-glob | A | 2026-06-19 04:59 | PASS | issue #98; issue #225 (restart-required cron frontmatter/config drift) |
+| eval-ci-gate | A | 2026-06-19 04:59 | PASS | #103 — eval probe suite gated in CI |
+| eval-gate | A | 2026-06-19 04:59 | PASS | memory/MEMORY.md 2026-06-11 (eval-gate) |
+| eval-results-atomic | A | 2026-06-19 04:59 | PASS | issue #83 (eval-results-atomic-write) |
+| eval-runner-exit | A | 2026-06-19 04:59 | PASS | memory/MEMORY.md 2026-06-11 (eval-runner-exit) #29 |
+| git-skill | A | 2026-06-19 04:59 | PASS | conversation 2026-06-15 — rules are not always supported; git workflow must be the /git skill |
+| harness-audit-empty-output-gate | A | 2026-06-19 04:59 | PASS | issue #246 — /harness-audit must fail closed on empty auditor outputs |
+| harness-audit-memory-path | A | 2026-06-19 04:59 | PASS | issue #183 — /harness-audit must inspect the active worktree, not a hardcoded root |
+| harness-audit-shared-memory | A | 2026-06-19 04:59 | PASS | issue #432 — /harness-audit must load durable memory from shared log root in cron worktrees |
+| harness-ci-core-paths | A | 2026-06-19 04:59 | PASS | #165 — core sandbox config files must trigger harness CI |
+| harness-ci-hooks-paths | A | 2026-06-19 04:59 | PASS | issue #202 — credential/security hook changes must trigger harness CI |
+| health-check-docker-stats | A | 2026-06-19 04:59 | PASS | memory/MEMORY.md 2026-06-10 (docker stats vs ps Size) |
+| locked-append-critical-path | A | 2026-06-19 04:59 | PASS | issue #204 (lock shared runtime log appends) 2026-06-15 |
+| loop-benchmark-gate | A | 2026-06-19 04:59 | PASS | issue #179 — wire the executable-loop `benchmark` node (close the cycle) |
+| loop-handoff-consistency | A | 2026-06-19 04:59 | PASS | context/rules/loop.md § 4 (executable-loop Handoff convention) |
+| loop-repeat-gate | A | 2026-06-19 04:59 | PASS | issue #173 — wire the executable-loop `repeat` node (cycle-closing edge) |
+| memory-gitignore-claim | A | 2026-06-19 04:59 | PASS | issue #101 |
+| next-dev-prod | A | 2026-06-19 04:59 | PASS | memory/MEMORY.md 2026-06-04 |
+| orchestrate-contract | A | 2026-06-19 04:59 | PASS | issue #160 — /orchestrate contract; issue #175 — reserved /loop command rename |
+| owned-surface-guard | A | 2026-06-19 04:59 | PASS | issue #63 (autopilot-stray-wip-guard) 2026-06-12; issue #81 (owned-paths-zsh-split) 2026-06-13 |
+| pnpm-audit-ci-gate | A | 2026-06-19 04:59 | PASS | issue #171 — pnpm security audits must run in CI |
+| pr-audit-duplicate-issue-refs | A | 2026-06-19 04:59 | PASS | issue #439 — /pr-audit must flag duplicate open PRs that reference the same issue |
+| ralph-fallback-order | A | 2026-06-19 04:59 | PASS | conversation 2026-06-12 (Ralph default fallback order) |
+| retro-deterministic-contract | A | 2026-06-19 04:59 | PASS | issue #443 — /retro deterministic output and self-contained helper contract |
+| rl-delegation-write-worker | A | 2026-06-19 04:59 | PASS | memory/MEMORY.md 2026-06-10 (rl-delegation) #57 |
+| ship-spec-ready-finalization | A | 2026-06-19 04:59 | PASS | issue #134 — /ship-spec must finalize ready PRs after gates, not stop at draft scaffold |
+| skill-paths | A | 2026-06-19 04:59 | PASS | issue #43 — stale path references; extended by issue #69 — apps/->packages/ rename guard |
+| submitted-by-trailers | A | 2026-06-19 04:59 | PASS | conversation 2026-06-12 (commit attribution trailers) |
+| watchdog-completed-session-reap | A | 2026-06-19 04:59 | PASS | issue #235 (completed autopilot PR session reaping) |
+| watchdog-draft-prs | A | 2026-06-19 04:59 | PASS | conversation 2026-06-15 (generic watchdog + stale draft PR recovery) |
+| watchdog-stuck-sessions | A | 2026-06-19 04:59 | PASS | issue #240 (Codex zero-credit stuck autopilot sessions) 2026-06-17 |
+| wiki-readme-index | A | 2026-06-19 04:59 | PASS | issue #132 — wiki README index drift guard |
 
 <!-- benchmark: pass-rate = PASS / (PASS + REGRESSION + TIMEOUT); SKIPPED excluded -->

--- a/evals/probes/docs-build-fast-path.sh
+++ b/evals/probes/docs-build-fast-path.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# tier: A
+# source: #455 — docs builds must stay out of fast harness/eval/release gates
+# desc: Docusaurus builds run automatically only from docs.yml on main/master pushes
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PACKAGE_JSON="$ROOT/package.json"
+CI_WORKFLOW="$ROOT/.github/workflows/ci-harness.yml"
+DOCS_WORKFLOW="$ROOT/.github/workflows/docs.yml"
+RELEASE_WORKFLOW="$ROOT/.github/workflows/release.yml"
+EVAL_RUNNER="$ROOT/.claude/skills/eval/run.sh"
+PROBES_DIR="$ROOT/evals/probes"
+SELF="$ROOT/evals/probes/docs-build-fast-path.sh"
+
+for f in "$PACKAGE_JSON" "$CI_WORKFLOW" "$DOCS_WORKFLOW" "$RELEASE_WORKFLOW" "$EVAL_RUNNER"; do
+  [[ -f "$f" ]] || { echo "SKIPPED: missing required file $f" >&2; exit 2; }
+done
+
+script_value() {
+  local key="$1"
+  node -e 'const fs=require("fs"); const pkg=JSON.parse(fs.readFileSync(process.argv[1],"utf8")); console.log((pkg.scripts && pkg.scripts[process.argv[2]]) || "")' "$PACKAGE_JSON" "$key"
+}
+
+failures=()
+
+root_build="$(script_value build)"
+root_setup="$(script_value setup)"
+build_harness="$(script_value build:harness)"
+docs_build="$(script_value docs:build)"
+
+for pair in "build:$root_build" "setup:$root_setup"; do
+  key="${pair%%:*}"
+  value="${pair#*:}"
+  if grep -Eiq 'docusaurus|docs:build|packages/docs|@openharness/docs' <<<"$value"; then
+    failures+=("package.json scripts.$key enters docs build path: $value")
+  fi
+done
+
+if [[ "$root_build" != "pnpm run build:harness" ]]; then
+  failures+=("package.json scripts.build must delegate to pnpm run build:harness")
+fi
+if ! grep -Fq -- "--filter '!@openharness/docs'" <<<"$build_harness"; then
+  failures+=("package.json scripts.build:harness must explicitly exclude @openharness/docs")
+fi
+if grep -Eiq 'docusaurus|docs:build|packages/docs' <<<"$build_harness"; then
+  failures+=("package.json scripts.build:harness must not invoke Docusaurus/docs build: $build_harness")
+fi
+if [[ "$docs_build" != "pnpm --dir packages/docs build" ]]; then
+  failures+=("package.json scripts.docs:build must remain the explicit manual docs build command")
+fi
+
+workflow_build_run() {
+  local file="$1"
+  awk '
+    /^[[:space:]]+- name: Build[[:space:]]*$/ { in_build=1; next }
+    in_build && /^[[:space:]]+- name:/ { exit }
+    in_build && /^[[:space:]]*run:/ {
+      line=$0
+      sub(/^[[:space:]]*run:[[:space:]]*/, "", line)
+      print line
+      exit
+    }
+  ' "$file"
+}
+
+ci_build="$(workflow_build_run "$CI_WORKFLOW")"
+release_build="$(workflow_build_run "$RELEASE_WORKFLOW")"
+if [[ "$ci_build" != "pnpm run build:harness" ]]; then
+  failures+=("ci-harness.yml Build step must run pnpm run build:harness, got: ${ci_build:-<missing>}")
+fi
+if [[ "$release_build" != "pnpm run build:harness" ]]; then
+  failures+=("release.yml Build step must run pnpm run build:harness, got: ${release_build:-<missing>}")
+fi
+
+if grep -Eq '^[[:space:]]*pull_request:' "$DOCS_WORKFLOW"; then
+  failures+=("docs.yml must not run docs builds on pull_request")
+fi
+if grep -Eq '^[[:space:]]*workflow_dispatch:' "$DOCS_WORKFLOW"; then
+  failures+=("docs.yml must not expose manual workflow_dispatch docs builds")
+fi
+for branch in main master; do
+  if ! awk '/^[[:space:]]+branches:/{in_br=1; next} in_br && /^[[:space:]]+-[[:space:]]*/{gsub(/["'"'"']/, ""); print} in_br && /^[[:space:]]+[A-Za-z0-9_-]+:/{exit}' "$DOCS_WORKFLOW" | grep -Eq "^[[:space:]]*-[[:space:]]*$branch$"; then
+    failures+=("docs.yml push.branches must include $branch")
+  fi
+done
+if ! awk '
+  /^[[:space:]]+- name: Build site[[:space:]]*$/ { in_build=1; next }
+  in_build && /^[[:space:]]+- name:/ { exit }
+  in_build { print }
+' "$DOCS_WORKFLOW" | grep -Fq 'working-directory: packages/docs'; then
+  failures+=("docs.yml Build site step must run from packages/docs")
+fi
+if ! awk '
+  /^[[:space:]]+- name: Build site[[:space:]]*$/ { in_build=1; next }
+  in_build && /^[[:space:]]+- name:/ { exit }
+  in_build { print }
+' "$DOCS_WORKFLOW" | grep -Fq 'run: pnpm run build'; then
+  failures+=("docs.yml Build site step must run pnpm run build")
+fi
+if ! grep -Eq "refs/heads/(main|master)" "$DOCS_WORKFLOW"; then
+  failures+=("docs.yml deploy guards must be scoped to main/master refs")
+fi
+
+if grep -REn 'docusaurus build|pnpm (run )?docs:build|pnpm --dir packages/docs build' "$EVAL_RUNNER" "$PROBES_DIR" --exclude='docs-build-fast-path.sh' >/tmp/docs-build-fast-path-grep.txt; then
+  failures+=("eval runner/probes must not invoke docs build commands: $(tr '\n' ';' </tmp/docs-build-fast-path-grep.txt)")
+fi
+
+if (( ${#failures[@]} == 0 )); then
+  echo "PASS: docs build is confined to docs.yml main/master pushes and explicit pnpm docs:build" >&2
+  exit 0
+fi
+
+printf 'REGRESSION: %s\n' "${failures[@]}" >&2
+exit 1

--- a/package.json
+++ b/package.json
@@ -6,8 +6,9 @@
   "type": "module",
   "packageManager": "pnpm@10.33.0",
   "scripts": {
-    "setup": "pnpm install && pnpm -r --if-present run build",
-    "build": "pnpm -r --if-present run build",
+    "setup": "pnpm install && pnpm run build",
+    "build": "pnpm run build:harness",
+    "build:harness": "pnpm --filter './packages/**' --filter '!@openharness/docs' -r --if-present run build && (test -d packages/oh/node_modules || npm --prefix packages/oh ci --ignore-scripts) && npm --prefix packages/oh run build",
     "test": "pnpm -r --if-present run test && vitest run",
     "test:scripts": "vitest run",
     "lint": "pnpm -r --if-present run lint",

--- a/tasks/docs-build-decoupling/critique.md
+++ b/tasks/docs-build-decoupling/critique.md
@@ -34,6 +34,10 @@ CRITIC_B — USER LENS
 
 [SEVERITY: L] [STORY: US-004] Wiki usefulness needed an operator-facing quick reference. | [EVIDENCE: US-004 and Wiki Alignment] | Mitigated in PRD: US-004 requires a command/gate table.
 
+## Operator clarification
+
+After initial scaffold, the operator clarified: docs build should **only** happen automatically on merges to `main`. This supersedes the earlier assumption that docs PR and release validation should keep building Docusaurus. The PRD was revised so automatic docs builds are removed from PR/Harness CI/release paths and retained only in `docs.yml` on `push` to `main`; explicit local `pnpm docs:build` remains a manual operator escape hatch.
+
 ## Synthesis
 
 - **High-severity findings**: 0

--- a/tasks/docs-build-decoupling/critique.md
+++ b/tasks/docs-build-decoupling/critique.md
@@ -1,0 +1,42 @@
+# Critique — docs-build-decoupling
+
+Generated 2026-06-19; reviews `prd.md` post-/prd, pre-/ralph.
+
+## Critic A — Implementer lens
+
+CRITIC_A — IMPLEMENTER LENS
+
+[SEVERITY: M] [STORY: US-001] `@openharness/oh` is not currently in `pnpm-workspace.yaml`, so a pnpm workspace filter alone could fail or silently skip the intended non-docs build. | [EVIDENCE: `pnpm-workspace.yaml`; `packages/oh/package.json`; US-001 AC] | Mitigated in PRD: fast build must include future non-docs pnpm workspace packages except `@openharness/docs`, plus explicit `npm --prefix packages/oh run build` for the standalone package.
+
+[SEVERITY: M] [STORY: US-001] `setup` wording could conflate the post-install build script with lifecycle hooks. | [EVIDENCE: root `setup`; `packages/oh` `prepare`] | Mitigated in PRD: setup must not run `@openharness/docs` / Docusaurus by default, while install lifecycle behavior is allowed.
+
+[SEVERITY: M] [STORY: US-003] The probe semantics were vague; static grep checks can false-positive or false-negative unless the contract is explicit. | [EVIDENCE: US-003 AC; `.claude/skills/eval/run.sh`] | Mitigated in PRD: US-003 now names exact forbidden patterns and required positive checks.
+
+[SEVERITY: M] [STORY: US-002] Release could accidentally call the newly-fast build command and lose docs coverage. | [EVIDENCE: `.github/workflows/release.yml` Build step; US-002 AC] | Mitigated in PRD: release validation must call `pnpm run build:all`.
+
+[SEVERITY: L] [STORY: US-004] Wiki schema requires a `sources:` entry with raw provenance. | [EVIDENCE: `context/rules/wiki.md`; US-004 AC] | Mitigated in PRD: US-004 now requires `wiki/raw/<date>-ci-build-gates.md` provenance.
+
+[SEVERITY: L] [STORY: US-004] `wiki/README.md` should be regenerated using the canonical deterministic behavior, not manually approximated. | [EVIDENCE: `context/rules/wiki.md` README index freshness] | Mitigated in PRD: US-004 requires canonical `/wiki-lint`-equivalent deterministic ordering.
+
+[SEVERITY: L] [STORY: US-001] Root docs aliases were preserved, but package-local docs scripts were not explicitly protected. | [EVIDENCE: root `package.json`; `packages/docs/package.json`; US-001 AC] | Mitigated in PRD: US-001 requires `packages/docs` build/start/serve scripts remain intact.
+
+## Critic B — User lens
+
+CRITIC_B — USER LENS
+
+[SEVERITY: M] [STORY: US-001] Fast build scope was under-specified for future non-doc packages and could hard-code today's package set. | [EVIDENCE: US-001 AC] | Mitigated in PRD: fast build is defined as all buildable pnpm workspace packages except `@openharness/docs`, plus the current npm-standalone `packages/oh` build.
+
+[SEVERITY: M] [STORY: US-002] Full-build command name and migration points were ambiguous. | [EVIDENCE: Goals; US-001/US-002 AC] | Mitigated in PRD: full build is explicitly `pnpm run build:all`; release must call it.
+
+[SEVERITY: M] [STORY: *] No rollback or escape hatch was specified if docs failures become invisible for non-doc PRs that still affect docs indirectly. | [EVIDENCE: Goals/Non-Goals] | Mitigated in PRD: US-002 documents `pnpm docs:build`, `pnpm build:all`, and the rollback path.
+
+[SEVERITY: L] [STORY: US-003] Probe could become grep-based false confidence without precise forbidden commands/files. | [EVIDENCE: US-003 AC] | Mitigated in PRD: US-003 now names exact detection contract.
+
+[SEVERITY: L] [STORY: US-004] Wiki usefulness needed an operator-facing quick reference. | [EVIDENCE: US-004 and Wiki Alignment] | Mitigated in PRD: US-004 requires a command/gate table.
+
+## Synthesis
+
+- **High-severity findings**: 0
+- **Medium-severity findings**: 7, all mitigated in the PRD before issue/implementation.
+- **Low-severity findings**: 5, all mitigated in the PRD before issue/implementation.
+- **Recommendation**: PROCEED

--- a/tasks/docs-build-decoupling/prd.json
+++ b/tasks/docs-build-decoupling/prd.json
@@ -18,7 +18,7 @@
       ],
       "priority": 1,
       "passes": true,
-      "notes": "Completed implementation on 2026-06-19; commit e41abd4"
+      "notes": "Completed implementation on 2026-06-19; commit 3503101"
     },
     {
       "id": "US-002",
@@ -35,7 +35,7 @@
       ],
       "priority": 2,
       "passes": true,
-      "notes": "Completed implementation on 2026-06-19; commit e41abd4"
+      "notes": "Completed implementation on 2026-06-19; commit 3503101"
     },
     {
       "id": "US-003",
@@ -51,7 +51,7 @@
       ],
       "priority": 3,
       "passes": true,
-      "notes": "Completed implementation on 2026-06-19; commit e41abd4"
+      "notes": "Completed implementation on 2026-06-19; commit 3503101"
     },
     {
       "id": "US-004",
@@ -68,7 +68,7 @@
       ],
       "priority": 4,
       "passes": true,
-      "notes": "Completed implementation on 2026-06-19; commit e41abd4"
+      "notes": "Completed implementation on 2026-06-19; commit 3503101"
     }
   ]
 }

--- a/tasks/docs-build-decoupling/prd.json
+++ b/tasks/docs-build-decoupling/prd.json
@@ -2,15 +2,14 @@
   "schemaVersion": 1,
   "project": "Open Harness",
   "branchName": "feat/455-docs-build-decoupling",
-  "description": "Decouple slow Docusaurus docs builds from fast harness development and PR validation loops while keeping docs-specific and release gates intact.",
+  "description": "Decouple slow Docusaurus docs builds from fast harness development, pull-request, and release validation loops so automatic docs builds run only on pushes to main or master.",
   "userStories": [
     {
       "id": "US-001",
-      "title": "Split fast and full build scripts",
-      "description": "As a harness operator, I want pnpm build to represent the fast non-docs harness build so routine validation does not run Docusaurus unless requested.",
+      "title": "Split fast build from docs build",
+      "description": "As a harness operator, I want pnpm build to represent the fast non-docs harness build so routine validation does not run Docusaurus unless I explicitly request it.",
       "acceptanceCriteria": [
         "Root package.json changes build to run the fast non-docs build path: all future buildable pnpm workspace packages except @openharness/docs, plus packages/oh via npm --prefix packages/oh run build.",
-        "Root package.json adds build:all, which runs all pnpm workspace package builds including @openharness/docs, then builds packages/oh.",
         "Root setup uses the fast build path and does not invoke @openharness/docs or docusaurus build by default.",
         "Existing root docs:build, docs:dev, and docs:serve scripts remain available, and packages/docs build/start/serve scripts remain intact.",
         "pnpm run build succeeds without running docusaurus build.",
@@ -18,49 +17,48 @@
         "Tests pass."
       ],
       "priority": 1,
-      "passes": false,
-      "notes": ""
+      "passes": true,
+      "notes": "Completed implementation on 2026-06-19; commit e41abd4"
     },
     {
       "id": "US-002",
-      "title": "Keep docs builds in intentional CI gates only",
-      "description": "As a maintainer, I want Harness CI to use the fast non-docs build while docs and release workflows retain full docs build coverage.",
+      "title": "Run docs build only on main/master-push docs workflow",
+      "description": "As a maintainer, I want automatic docs builds to run only after merge/promote to main or master, not during PR, Harness CI, or release validation.",
       "acceptanceCriteria": [
         ".github/workflows/ci-harness.yml Build step calls the fast non-docs build path and cannot run @openharness/docs build through packages/**.",
-        ".github/workflows/docs.yml continues to run pnpm run build from packages/docs.",
-        ".github/workflows/release.yml calls pnpm run build:all so release validation continues to include docs.",
-        ".claude/skills/ci-status/SKILL.md and .pi/skills/ci-status/SKILL.md document the revised Harness CI build command and distinguish it from docs/release build coverage.",
-        "Operator escape hatch is documented: pnpm run docs:build for docs-only validation and pnpm run build:all for full release-style validation; rollback path is restoring Harness CI Build to the broad packages/** build command.",
+        ".github/workflows/docs.yml has no pull_request trigger and no workflow_dispatch trigger; it builds docs only on push to main or master with existing docs path filters.",
+        ".github/workflows/release.yml Build step calls the fast non-docs build path and does not run Docusaurus.",
+        ".claude/skills/ci-status/SKILL.md and .pi/skills/ci-status/SKILL.md document that PR/Harness CI and release validation use the fast build, while docs build/deploy happens only on main/master pushes through docs.yml.",
+        "Operator escape hatch is documented: run pnpm docs:build only when intentionally validating docs locally; rollback path is restoring docs workflow PR/manual triggers and broad build gating.",
         "Typecheck passes.",
         "Tests pass."
       ],
       "priority": 2,
-      "passes": false,
-      "notes": ""
+      "passes": true,
+      "notes": "Completed implementation on 2026-06-19; commit e41abd4"
     },
     {
       "id": "US-003",
       "title": "Add a regression probe for build-gate separation",
-      "description": "As a future agent, I want a fast deterministic eval probe that flags accidental Docusaurus build reintroduction into /eval, root fast build, or Harness CI.",
+      "description": "As a future agent, I want a fast deterministic eval probe that flags accidental Docusaurus build reintroduction into /eval, root fast build, Harness CI, release validation, or PR docs workflows.",
       "acceptanceCriteria": [
         "Add evals/probes/docs-build-fast-path.sh.",
-        "The probe uses exact static invariants for root build/setup, Harness CI Build, eval runner/probe files, docs workflow, and release validation.",
-        "The probe passes when root pnpm build and .github/workflows/ci-harness.yml exclude @openharness/docs/Docusaurus from the fast build path.",
-        "The probe passes only if .github/workflows/docs.yml still runs pnpm run build from packages/docs and release validation calls pnpm run build:all.",
+        "The probe uses exact static invariants for root build/setup, Harness CI Build, release Build, eval runner/probe files, and docs workflow triggers.",
+        "The probe passes only if .github/workflows/docs.yml builds docs on push to main or master and has no pull_request or workflow_dispatch trigger.",
         "bash evals/probes/docs-build-fast-path.sh passes.",
         "/eval passes.",
         "Tests pass."
       ],
       "priority": 3,
-      "passes": false,
-      "notes": ""
+      "passes": true,
+      "notes": "Completed implementation on 2026-06-19; commit e41abd4"
     },
     {
       "id": "US-004",
       "title": "Document the gate split in docs and wiki",
       "description": "As an operator and future agent, I want the docs-build gate split recorded in human docs and the source-backed wiki so the tradeoff is not re-derived.",
       "acceptanceCriteria": [
-        "Human-facing docs say pnpm build is fast/non-docs, pnpm docs:build validates docs, and pnpm run build:all performs full release-style validation.",
+        "Human-facing docs say pnpm build is fast/non-docs, pnpm docs:build is manual/explicit, and automatic docs build/deploy happens only on main/master pushes through docs.yml.",
         "CHANGELOG.md has an Unreleased entry for the build-gate change.",
         "wiki/raw/<yyyy-mm-dd>-ci-build-gates.md and wiki/ci-build-gates.md exist with relevant source files, line-cited claims, a quick command/gate table, system relationships, and See Also.",
         "wiki/README.md is refreshed using canonical deterministic ordering and includes ci-build-gates.",
@@ -69,8 +67,8 @@
         "Tests pass."
       ],
       "priority": 4,
-      "passes": false,
-      "notes": ""
+      "passes": true,
+      "notes": "Completed implementation on 2026-06-19; commit e41abd4"
     }
   ]
 }

--- a/tasks/docs-build-decoupling/prd.json
+++ b/tasks/docs-build-decoupling/prd.json
@@ -1,0 +1,76 @@
+{
+  "schemaVersion": 1,
+  "project": "Open Harness",
+  "branchName": "feat/455-docs-build-decoupling",
+  "description": "Decouple slow Docusaurus docs builds from fast harness development and PR validation loops while keeping docs-specific and release gates intact.",
+  "userStories": [
+    {
+      "id": "US-001",
+      "title": "Split fast and full build scripts",
+      "description": "As a harness operator, I want pnpm build to represent the fast non-docs harness build so routine validation does not run Docusaurus unless requested.",
+      "acceptanceCriteria": [
+        "Root package.json changes build to run the fast non-docs build path: all future buildable pnpm workspace packages except @openharness/docs, plus packages/oh via npm --prefix packages/oh run build.",
+        "Root package.json adds build:all, which runs all pnpm workspace package builds including @openharness/docs, then builds packages/oh.",
+        "Root setup uses the fast build path and does not invoke @openharness/docs or docusaurus build by default.",
+        "Existing root docs:build, docs:dev, and docs:serve scripts remain available, and packages/docs build/start/serve scripts remain intact.",
+        "pnpm run build succeeds without running docusaurus build.",
+        "Typecheck passes.",
+        "Tests pass."
+      ],
+      "priority": 1,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-002",
+      "title": "Keep docs builds in intentional CI gates only",
+      "description": "As a maintainer, I want Harness CI to use the fast non-docs build while docs and release workflows retain full docs build coverage.",
+      "acceptanceCriteria": [
+        ".github/workflows/ci-harness.yml Build step calls the fast non-docs build path and cannot run @openharness/docs build through packages/**.",
+        ".github/workflows/docs.yml continues to run pnpm run build from packages/docs.",
+        ".github/workflows/release.yml calls pnpm run build:all so release validation continues to include docs.",
+        ".claude/skills/ci-status/SKILL.md and .pi/skills/ci-status/SKILL.md document the revised Harness CI build command and distinguish it from docs/release build coverage.",
+        "Operator escape hatch is documented: pnpm run docs:build for docs-only validation and pnpm run build:all for full release-style validation; rollback path is restoring Harness CI Build to the broad packages/** build command.",
+        "Typecheck passes.",
+        "Tests pass."
+      ],
+      "priority": 2,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-003",
+      "title": "Add a regression probe for build-gate separation",
+      "description": "As a future agent, I want a fast deterministic eval probe that flags accidental Docusaurus build reintroduction into /eval, root fast build, or Harness CI.",
+      "acceptanceCriteria": [
+        "Add evals/probes/docs-build-fast-path.sh.",
+        "The probe uses exact static invariants for root build/setup, Harness CI Build, eval runner/probe files, docs workflow, and release validation.",
+        "The probe passes when root pnpm build and .github/workflows/ci-harness.yml exclude @openharness/docs/Docusaurus from the fast build path.",
+        "The probe passes only if .github/workflows/docs.yml still runs pnpm run build from packages/docs and release validation calls pnpm run build:all.",
+        "bash evals/probes/docs-build-fast-path.sh passes.",
+        "/eval passes.",
+        "Tests pass."
+      ],
+      "priority": 3,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-004",
+      "title": "Document the gate split in docs and wiki",
+      "description": "As an operator and future agent, I want the docs-build gate split recorded in human docs and the source-backed wiki so the tradeoff is not re-derived.",
+      "acceptanceCriteria": [
+        "Human-facing docs say pnpm build is fast/non-docs, pnpm docs:build validates docs, and pnpm run build:all performs full release-style validation.",
+        "CHANGELOG.md has an Unreleased entry for the build-gate change.",
+        "wiki/raw/<yyyy-mm-dd>-ci-build-gates.md and wiki/ci-build-gates.md exist with relevant source files, line-cited claims, a quick command/gate table, system relationships, and See Also.",
+        "wiki/README.md is refreshed using canonical deterministic ordering and includes ci-build-gates.",
+        "bash evals/probes/wiki-readme-index.sh passes.",
+        "Typecheck passes.",
+        "Tests pass."
+      ],
+      "priority": 4,
+      "passes": false,
+      "notes": ""
+    }
+  ]
+}

--- a/tasks/docs-build-decoupling/prd.md
+++ b/tasks/docs-build-decoupling/prd.md
@@ -1,0 +1,93 @@
+# Docs Build Decoupling PRD
+
+## Introduction
+
+Open Harness currently treats Docusaurus documentation builds as part of broad workspace build gates. The adversarial review found that `/eval` itself does not run a docs build, but root `pnpm build`, Harness CI, and release validation all use broad `packages/**` build filters that include `@openharness/docs`. This makes fast harness validation wait on Docusaurus even when the change is not a docs-site change.
+
+This task decouples slow docs builds from fast development and Harness CI paths while preserving explicit docs validation in the docs workflow and release validation.
+
+## Goals
+
+- Keep `/eval` and fast Harness CI free of Docusaurus build work.
+- Make root `pnpm build` a fast non-docs build path, with an explicit `pnpm run build:all` command for release-style validation.
+- Preserve docs build coverage in `.github/workflows/docs.yml` and release validation.
+- Document the new gate split for operators and future agents.
+- Add a lightweight eval probe that prevents docs builds from silently re-entering the fast path.
+
+## Non-Goals
+
+- Do not remove the docs workflow or weaken docs PR validation for `packages/docs/**`, `docs/**`, or `blog/**` changes.
+- Do not remove docs build from release validation.
+- Do not change Docusaurus configuration or docs content beyond describing the gate split.
+- Do not add `packages/oh` to the pnpm workspace; it remains npm-standalone and is built through `npm --prefix packages/oh run build`.
+- Do not vendor or modify third-party tooling.
+
+## User Stories
+
+### US-001 — Split fast and full build scripts
+
+As a harness operator, I want `pnpm build` to represent the fast non-docs harness build so routine validation does not run Docusaurus unless requested.
+
+Acceptance criteria:
+
+- Root `package.json` changes `build` to run the fast non-docs build path: all future buildable pnpm workspace packages except `@openharness/docs`, plus the npm-standalone `packages/oh` build via `npm --prefix packages/oh run build`.
+- Root `package.json` adds `build:all`, which runs all pnpm workspace package builds including `@openharness/docs`, then builds the npm-standalone `packages/oh` package.
+- Root `setup` uses the fast build path and does not invoke `@openharness/docs` / `docusaurus build` by default; install lifecycle behavior is allowed as long as Docusaurus is not run.
+- Existing root `docs:build`, `docs:dev`, and `docs:serve` scripts remain available, and `packages/docs` `build`, `start`, and `serve` scripts remain intact.
+- `pnpm run build` succeeds without running `docusaurus build`.
+- Typecheck passes.
+- Tests pass.
+
+### US-002 — Keep docs builds in intentional CI gates only
+
+As a maintainer, I want Harness CI to use the fast non-docs build while docs and release workflows retain full docs build coverage.
+
+Acceptance criteria:
+
+- `.github/workflows/ci-harness.yml` Build step calls the fast non-docs build path and cannot run `@openharness/docs` build through `packages/**`.
+- `.github/workflows/docs.yml` continues to run `pnpm run build` from `packages/docs`.
+- `.github/workflows/release.yml` calls `pnpm run build:all` so release validation continues to include docs.
+- `.claude/skills/ci-status/SKILL.md` and `.pi/skills/ci-status/SKILL.md` document the revised Harness CI build command and distinguish it from docs/release build coverage.
+- Operator escape hatch is documented: run `pnpm run docs:build` for docs-only validation and `pnpm run build:all` for full release-style validation; rollback is restoring Harness CI Build to the broad `pnpm --filter './packages/**' -r --if-present run build` command.
+- Typecheck passes.
+- Tests pass.
+
+### US-003 — Add a regression probe for build-gate separation
+
+As a future agent, I want a fast deterministic eval probe that flags accidental Docusaurus build reintroduction into `/eval`, root fast build, or Harness CI.
+
+Acceptance criteria:
+
+- Add `evals/probes/docs-build-fast-path.sh`.
+- The probe uses exact static invariants rather than vague runtime inference: root `build`/`setup` must not contain `docusaurus`, `docs:build`, `packages/docs`, or `@openharness/docs`; Harness CI Build must call the fast build path; eval runner/probes must not invoke `docusaurus build`, `pnpm run docs:build`, or `pnpm --dir packages/docs build` outside this probe's own forbidden-pattern checks.
+- The probe passes when root `pnpm build` and `.github/workflows/ci-harness.yml` exclude `@openharness/docs`/Docusaurus from the fast build path.
+- The probe passes only if `.github/workflows/docs.yml` still runs `pnpm run build` from `packages/docs` and release validation calls `pnpm run build:all`.
+- `bash evals/probes/docs-build-fast-path.sh` passes.
+- `/eval` passes.
+- Tests pass.
+
+### US-004 — Document the gate split in docs and wiki
+
+As an operator and future agent, I want the docs-build gate split recorded in human docs and the source-backed wiki so the tradeoff is not re-derived.
+
+Acceptance criteria:
+
+- Add or update human-facing docs to say `pnpm build` is fast/non-docs, `pnpm docs:build` validates the docs site, and `pnpm run build:all` performs full release-style validation.
+- Add a `CHANGELOG.md` Unreleased entry for the build-gate change.
+- Add `wiki/raw/<yyyy-mm-dd>-ci-build-gates.md` provenance and `wiki/ci-build-gates.md` with relevant source files, line-cited claims, a quick command/gate table, system relationships, and `## See Also`.
+- Refresh `wiki/README.md` using canonical `/wiki-lint`-equivalent deterministic ordering so the wiki index includes the new/updated entry.
+- `bash evals/probes/wiki-readme-index.sh` passes.
+- Typecheck passes.
+- Tests pass.
+
+## Wiki Alignment
+
+- **Impact**: REQUIRED
+- **Local entries**: create `wiki/ci-build-gates.md` and refresh `wiki/README.md`.
+- **Spec alignment**: The wiki entry must explain the split between fast harness validation (`pnpm build`, Harness CI, `/eval`) and intentional docs validation (`pnpm docs:build`, docs workflow, release validation). It must preserve the goals and non-goals above, especially that docs/release gates stay intact.
+- **DeepWiki comparison**: No dedicated public DeepWiki page for this narrow CI/build-gate split was found during local review. The entry should follow the DeepWiki-style shape from `context/rules/wiki.md`: relevant source files first, concrete source-backed claims, a system relationship diagram/table, and `## See Also` navigation.
+- **Acceptance criteria**: US-004 must create or update the local wiki entry, include relevant source files and line-cited claims, record the DeepWiki comparison gap, include system relationships, and pass `bash evals/probes/wiki-readme-index.sh`.
+
+## Critique resolution
+
+Critics will review this PRD before implementation. Medium/low findings are resolved in `tasks/docs-build-decoupling/critique.md`; high findings halt before implementation.

--- a/tasks/docs-build-decoupling/prd.md
+++ b/tasks/docs-build-decoupling/prd.md
@@ -2,66 +2,63 @@
 
 ## Introduction
 
-Open Harness currently treats Docusaurus documentation builds as part of broad workspace build gates. The adversarial review found that `/eval` itself does not run a docs build, but root `pnpm build`, Harness CI, and release validation all use broad `packages/**` build filters that include `@openharness/docs`. This makes fast harness validation wait on Docusaurus even when the change is not a docs-site change.
+Open Harness currently lets Docusaurus documentation builds enter broad validation paths. The adversarial review found that `/eval` itself does not run a docs build, but root build scripts, Harness CI, release validation, and the docs workflow can all pull Docusaurus into routine development feedback. The operator clarified the product rule: docs builds should happen automatically **only on merges to `main` or `master`**.
 
-This task decouples slow docs builds from fast development and Harness CI paths while preserving explicit docs validation in the docs workflow and release validation.
+This task removes docs builds from fast development, pull-request, and release validation gates while keeping the docs site build/deploy on `main`/`master` pushes. Explicit local `pnpm docs:build` remains available for a human who intentionally wants to validate the docs site.
 
 ## Goals
 
-- Keep `/eval` and fast Harness CI free of Docusaurus build work.
-- Make root `pnpm build` a fast non-docs build path, with an explicit `pnpm run build:all` command for release-style validation.
-- Preserve docs build coverage in `.github/workflows/docs.yml` and release validation.
+- Keep `/eval`, root `pnpm build`, Harness CI, pull-request checks, and release validation free of automatic Docusaurus build work.
+- Make `.github/workflows/docs.yml` build docs only on `push` to `main` or `master`, i.e. after a merge/promote to the release branch.
+- Preserve explicit local docs commands (`pnpm docs:build`, `pnpm docs:dev`, `pnpm docs:serve`) for intentional human use.
 - Document the new gate split for operators and future agents.
-- Add a lightweight eval probe that prevents docs builds from silently re-entering the fast path.
+- Add a lightweight eval probe that prevents docs builds from silently re-entering fast or release gates.
 
 ## Non-Goals
 
-- Do not remove the docs workflow or weaken docs PR validation for `packages/docs/**`, `docs/**`, or `blog/**` changes.
-- Do not remove docs build from release validation.
+- Do not remove local docs build/dev/serve commands.
 - Do not change Docusaurus configuration or docs content beyond describing the gate split.
 - Do not add `packages/oh` to the pnpm workspace; it remains npm-standalone and is built through `npm --prefix packages/oh run build`.
-- Do not vendor or modify third-party tooling.
+- Do not try to prove docs correctness in `/eval`; the automatic docs build belongs only to the `main`/`master` push docs workflow.
 
 ## User Stories
 
-### US-001 — Split fast and full build scripts
+### US-001 — Split fast build from docs build
 
-As a harness operator, I want `pnpm build` to represent the fast non-docs harness build so routine validation does not run Docusaurus unless requested.
+As a harness operator, I want `pnpm build` to represent the fast non-docs harness build so routine validation does not run Docusaurus unless I explicitly request it.
 
 Acceptance criteria:
 
 - Root `package.json` changes `build` to run the fast non-docs build path: all future buildable pnpm workspace packages except `@openharness/docs`, plus the npm-standalone `packages/oh` build via `npm --prefix packages/oh run build`.
-- Root `package.json` adds `build:all`, which runs all pnpm workspace package builds including `@openharness/docs`, then builds the npm-standalone `packages/oh` package.
 - Root `setup` uses the fast build path and does not invoke `@openharness/docs` / `docusaurus build` by default; install lifecycle behavior is allowed as long as Docusaurus is not run.
 - Existing root `docs:build`, `docs:dev`, and `docs:serve` scripts remain available, and `packages/docs` `build`, `start`, and `serve` scripts remain intact.
 - `pnpm run build` succeeds without running `docusaurus build`.
 - Typecheck passes.
 - Tests pass.
 
-### US-002 — Keep docs builds in intentional CI gates only
+### US-002 — Run docs build only on main/master-push docs workflow
 
-As a maintainer, I want Harness CI to use the fast non-docs build while docs and release workflows retain full docs build coverage.
+As a maintainer, I want automatic docs builds to run only after merge/promote to `main` or `master`, not during PR, Harness CI, or release validation.
 
 Acceptance criteria:
 
 - `.github/workflows/ci-harness.yml` Build step calls the fast non-docs build path and cannot run `@openharness/docs` build through `packages/**`.
-- `.github/workflows/docs.yml` continues to run `pnpm run build` from `packages/docs`.
-- `.github/workflows/release.yml` calls `pnpm run build:all` so release validation continues to include docs.
-- `.claude/skills/ci-status/SKILL.md` and `.pi/skills/ci-status/SKILL.md` document the revised Harness CI build command and distinguish it from docs/release build coverage.
-- Operator escape hatch is documented: run `pnpm run docs:build` for docs-only validation and `pnpm run build:all` for full release-style validation; rollback is restoring Harness CI Build to the broad `pnpm --filter './packages/**' -r --if-present run build` command.
+- `.github/workflows/docs.yml` has no `pull_request` trigger and no `workflow_dispatch` trigger; it builds docs only on `push` to `main` or `master` with its existing docs path filters.
+- `.github/workflows/release.yml` Build step calls the fast non-docs build path and does not run Docusaurus.
+- `.claude/skills/ci-status/SKILL.md` and `.pi/skills/ci-status/SKILL.md` document that PR/Harness CI and release validation use the fast build, while docs build/deploy happens only on `main`/`master` pushes through `docs.yml`.
+- Operator escape hatch is documented: run `pnpm docs:build` only when intentionally validating docs locally; rollback path is restoring the docs workflow PR/manual triggers and broad build gating.
 - Typecheck passes.
 - Tests pass.
 
 ### US-003 — Add a regression probe for build-gate separation
 
-As a future agent, I want a fast deterministic eval probe that flags accidental Docusaurus build reintroduction into `/eval`, root fast build, or Harness CI.
+As a future agent, I want a fast deterministic eval probe that flags accidental Docusaurus build reintroduction into `/eval`, root fast build, Harness CI, release validation, or PR docs workflows.
 
 Acceptance criteria:
 
 - Add `evals/probes/docs-build-fast-path.sh`.
-- The probe uses exact static invariants rather than vague runtime inference: root `build`/`setup` must not contain `docusaurus`, `docs:build`, `packages/docs`, or `@openharness/docs`; Harness CI Build must call the fast build path; eval runner/probes must not invoke `docusaurus build`, `pnpm run docs:build`, or `pnpm --dir packages/docs build` outside this probe's own forbidden-pattern checks.
-- The probe passes when root `pnpm build` and `.github/workflows/ci-harness.yml` exclude `@openharness/docs`/Docusaurus from the fast build path.
-- The probe passes only if `.github/workflows/docs.yml` still runs `pnpm run build` from `packages/docs` and release validation calls `pnpm run build:all`.
+- The probe uses exact static invariants: root `build`/`setup` must not contain `docusaurus`, `docs:build`, `packages/docs`, or `@openharness/docs`; Harness CI and release Build steps must call the fast build path; eval runner/probe files must not invoke `docusaurus build`, `pnpm run docs:build`, or `pnpm --dir packages/docs build` outside this probe's own forbidden-pattern checks.
+- The probe passes only if `.github/workflows/docs.yml` builds docs on `push` to `main` or `master` and has no `pull_request` or `workflow_dispatch` trigger.
 - `bash evals/probes/docs-build-fast-path.sh` passes.
 - `/eval` passes.
 - Tests pass.
@@ -72,10 +69,10 @@ As an operator and future agent, I want the docs-build gate split recorded in hu
 
 Acceptance criteria:
 
-- Add or update human-facing docs to say `pnpm build` is fast/non-docs, `pnpm docs:build` validates the docs site, and `pnpm run build:all` performs full release-style validation.
+- Human-facing docs say `pnpm build` is fast/non-docs, `pnpm docs:build` is manual/explicit, and automatic docs build/deploy happens only on `main`/`master` pushes through `docs.yml`.
 - Add a `CHANGELOG.md` Unreleased entry for the build-gate change.
 - Add `wiki/raw/<yyyy-mm-dd>-ci-build-gates.md` provenance and `wiki/ci-build-gates.md` with relevant source files, line-cited claims, a quick command/gate table, system relationships, and `## See Also`.
-- Refresh `wiki/README.md` using canonical `/wiki-lint`-equivalent deterministic ordering so the wiki index includes the new/updated entry.
+- Refresh `wiki/README.md` using canonical deterministic ordering so the wiki index includes the new/updated entry.
 - `bash evals/probes/wiki-readme-index.sh` passes.
 - Typecheck passes.
 - Tests pass.
@@ -84,10 +81,10 @@ Acceptance criteria:
 
 - **Impact**: REQUIRED
 - **Local entries**: create `wiki/ci-build-gates.md` and refresh `wiki/README.md`.
-- **Spec alignment**: The wiki entry must explain the split between fast harness validation (`pnpm build`, Harness CI, `/eval`) and intentional docs validation (`pnpm docs:build`, docs workflow, release validation). It must preserve the goals and non-goals above, especially that docs/release gates stay intact.
+- **Spec alignment**: The wiki entry must explain the split between fast harness validation (`pnpm build`, Harness CI, release validation, `/eval`) and docs validation (`docs.yml` on `main`/`master` push only; local `pnpm docs:build` only by explicit operator choice). It must preserve the goals and non-goals above, especially that PR and release gates no longer build docs automatically.
 - **DeepWiki comparison**: No dedicated public DeepWiki page for this narrow CI/build-gate split was found during local review. The entry should follow the DeepWiki-style shape from `context/rules/wiki.md`: relevant source files first, concrete source-backed claims, a system relationship diagram/table, and `## See Also` navigation.
 - **Acceptance criteria**: US-004 must create or update the local wiki entry, include relevant source files and line-cited claims, record the DeepWiki comparison gap, include system relationships, and pass `bash evals/probes/wiki-readme-index.sh`.
 
 ## Critique resolution
 
-Critics will review this PRD before implementation. Medium/low findings are resolved in `tasks/docs-build-decoupling/critique.md`; high findings halt before implementation.
+Critics reviewed the first PRD draft before implementation. Medium/low findings are resolved in `tasks/docs-build-decoupling/critique.md`. The operator's clarification that docs builds should run automatically only on merges to `main` or `master` supersedes the earlier release/docs-PR coverage assumption and is reflected in this revised PRD.

--- a/tasks/docs-build-decoupling/progress.txt
+++ b/tasks/docs-build-decoupling/progress.txt
@@ -1,0 +1,2 @@
+# progress
+

--- a/tasks/docs-build-decoupling/progress.txt
+++ b/tasks/docs-build-decoupling/progress.txt
@@ -4,7 +4,7 @@
 
 **Title**: Split fast build from docs build
 **Files changed**: package.json
-**Commit**: 6a5997d
+**Commit**: 3503101
 **Result**: PASS
 
 ### What I did
@@ -19,7 +19,7 @@ Changed the root build path to delegate to `build:harness`, which excludes `@ope
 
 **Title**: Run docs build only on main/master-push docs workflow
 **Files changed**: .github/workflows/ci-harness.yml, .github/workflows/docs.yml, .github/workflows/release.yml, .claude/skills/ci-status/SKILL.md, docs/contributing.md
-**Commit**: 6a5997d
+**Commit**: 3503101
 **Result**: PASS
 
 ### What I did
@@ -34,7 +34,7 @@ Automatic docs validation is a deploy-time gate, not a PR or release-validation 
 
 **Title**: Add a regression probe for build-gate separation
 **Files changed**: evals/probes/docs-build-fast-path.sh, evals/RESULTS.md
-**Commit**: 6a5997d
+**Commit**: 3503101
 **Result**: PASS
 
 ### What I did
@@ -49,7 +49,7 @@ Use explicit static invariants for CI topology changes instead of relying on slo
 
 **Title**: Document the gate split in docs and wiki
 **Files changed**: docs/contributing.md, CHANGELOG.md, wiki/raw/2026-06-19-ci-build-gates.md, wiki/ci-build-gates.md, wiki/README.md
-**Commit**: 6a5997d
+**Commit**: 3503101
 **Result**: PASS
 
 ### What I did

--- a/tasks/docs-build-decoupling/progress.txt
+++ b/tasks/docs-build-decoupling/progress.txt
@@ -1,2 +1,63 @@
 # progress
 
+## US-001 — 2026-06-19 23:04 UTC
+
+**Title**: Split fast build from docs build
+**Files changed**: package.json
+**Commit**: 6a5997d
+**Result**: PASS
+
+### What I did
+Changed the root build path to delegate to `build:harness`, which excludes `@openharness/docs` and builds the standalone `packages/oh` package. Kept explicit docs commands available for manual operator use.
+
+### Learnings for future iterations
+`packages/oh` is npm-standalone rather than part of `pnpm-workspace.yaml`, so fast build scripts must invoke it through `npm --prefix packages/oh`.
+
+---
+
+## US-002 — 2026-06-19 23:04 UTC
+
+**Title**: Run docs build only on main/master-push docs workflow
+**Files changed**: .github/workflows/ci-harness.yml, .github/workflows/docs.yml, .github/workflows/release.yml, .claude/skills/ci-status/SKILL.md, docs/contributing.md
+**Commit**: 6a5997d
+**Result**: PASS
+
+### What I did
+Moved Harness CI and release validation to the fast build path. Restricted the docs workflow to pushes on `main` or `master`, removed PR/manual triggers, and updated operator guidance.
+
+### Learnings for future iterations
+Automatic docs validation is a deploy-time gate, not a PR or release-validation gate. Use `pnpm docs:build` only as an explicit local escape hatch.
+
+---
+
+## US-003 — 2026-06-19 23:04 UTC
+
+**Title**: Add a regression probe for build-gate separation
+**Files changed**: evals/probes/docs-build-fast-path.sh, evals/RESULTS.md
+**Commit**: 6a5997d
+**Result**: PASS
+
+### What I did
+Added a Tier-A eval probe that statically guards the fast build path, CI Harness build, release build, eval probes, and docs workflow triggers. The full eval suite now includes `docs-build-fast-path` as a new passing probe.
+
+### Learnings for future iterations
+Use explicit static invariants for CI topology changes instead of relying on slow runtime builds to prove absence.
+
+---
+
+## US-004 — 2026-06-19 23:04 UTC
+
+**Title**: Document the gate split in docs and wiki
+**Files changed**: docs/contributing.md, CHANGELOG.md, wiki/raw/2026-06-19-ci-build-gates.md, wiki/ci-build-gates.md, wiki/README.md
+**Commit**: 6a5997d
+**Result**: PASS
+
+### What I did
+Documented the fast/non-docs build split in contributing docs and changelog. Added a source-backed wiki entry with a quick gate table and refreshed the wiki index.
+
+### Learnings for future iterations
+When a validation gate intentionally removes coverage from a fast path, document both the automatic gate and the explicit manual escape hatch.
+
+---
+
+STATUS: COMPLETE

--- a/tasks/docs-build-decoupling/prompt.md
+++ b/tasks/docs-build-decoupling/prompt.md
@@ -1,0 +1,106 @@
+# Ralph iteration — docs-build-decoupling
+
+You are one iteration of a Ralph loop implementing the `docs-build-decoupling` task. The full plan is in `tasks/docs-build-decoupling/prd.md` and the structured task list is in `tasks/docs-build-decoupling/prd.json`. The loop calls you again until `progress.txt` contains a line `STATUS: COMPLETE`.
+
+## Your job in one iteration
+
+Pick **one** user story, implement it, commit, mark it `passes: true`, and append a progress entry. Then exit. The next iteration handles the next story. Do not attempt multiple stories per iteration.
+
+## Steps every iteration
+
+1. **Read context** — in this order:
+   - `tasks/docs-build-decoupling/prd.json` — find the lowest-`priority` story where `passes: false`. That is your story for this iteration.
+   - `tasks/docs-build-decoupling/progress.txt` — read the "Codebase Patterns" section at the top (if any) and the most recent few iterations to see what's been done.
+   - `tasks/docs-build-decoupling/critique.md` — if present, the critic findings the stories must satisfy.
+   - If `tasks/docs-build-decoupling/prd.md` contains `## Wiki Alignment`, read it before choosing the story. When `Impact: REQUIRED`, the relevant story must keep wiki updates aligned with the PRD and the recorded DeepWiki comparison.
+   - `context/rules/wiki.md` when your story touches `wiki/` or the PRD's Wiki Alignment section says `Impact: REQUIRED`.
+   - `.claude/skills/git/SKILL.md` for branch + commit conventions.
+   - `.claude/rules/sandbox-processes.md` for tmux session conventions if your story spawns processes.
+   - `.claude/rules/advisor-model.md` for any critic-gated story.
+
+2. **Verify branch** — your branch is `<prefix>/<N>-docs-build-decoupling` (per `prd.json` `branchName`). If `/ship-spec`'s Advisor launched you in an isolated worktree at `.worktrees/<prefix>/<N>-docs-build-decoupling`, that directory already has the branch checked out — `cd` into it and skip the checkout below. Otherwise, if you are not on the branch:
+   ```bash
+   : "${SHIP_SPEC_REMOTE:?SHIP_SPEC_REMOTE must name the git remote that matches SHIP_SPEC_REPO}"
+   git fetch "$SHIP_SPEC_REMOTE" "${SHIP_SPEC_BASE:-development}"
+   git checkout -b <prefix>/<N>-docs-build-decoupling "$SHIP_SPEC_REMOTE/${SHIP_SPEC_BASE:-development}" 2>/dev/null \
+     || git checkout <prefix>/<N>-docs-build-decoupling
+   ```
+   Never push to `development` or `main` directly.
+
+3. **Implement the chosen story** — make the file changes, additions, deletions specified in the story's `acceptanceCriteria`. Confine the work to that story; resist scope creep.
+
+4. **Run quality checks** before commit:
+   ```bash
+   pnpm run type-check 2>/dev/null || true
+   pnpm run lint 2>/dev/null || true
+   pnpm run test 2>/dev/null || true
+   ```
+   If checks fail, fix them. Do not commit broken code.
+
+5. **Commit** with this message format (per `.claude/skills/git/SKILL.md`):
+   ```
+   <type>: US-455 — <story title>
+
+   Submitted-by: <active submitter>
+   ```
+   Where `<type>` is `task` for most stories, `feat` for net-new functionality, `fix` for bugs. Example: `task: US-001 — <story title>`. Stage only files touched by this story.
+   The `Submitted-by:` trailer is mandatory. It must name the model/agent that actually submits the commit, using the active harness identity when available (`$RALPH_HARNESS`, e.g. `Claude`, `Codex`, or `Pi`). If Ralph fell back from Claude to Codex, use `Submitted-by: Codex`.
+
+6. **Update `prd.json`** — set `passes: true` for the completed story, and set `notes` to a one-line summary including iteration number and date:
+   ```json
+   "notes": "Completed iteration 3 on <YYYY-MM-DD>; commit abc1234"
+   ```
+
+7. **Append to `progress.txt`** — append (never replace) using this format:
+   ```markdown
+   ## US-455 — <YYYY-MM-DD HH:MM UTC>
+
+   **Title**: <story title>
+   **Files changed**: <list>
+   **Commit**: <short SHA>
+   **Result**: PASS | BLOCKED | DEFERRED
+
+   ### What I did
+   <2-4 sentences>
+
+   ### Learnings for future iterations
+   <patterns, gotchas, useful context>
+
+   ---
+   ```
+
+8. **Codebase Patterns** — if you discovered a pattern other iterations should know (a non-obvious convention, a shared utility, a gotcha), append it to (or create) the `## Codebase Patterns` section at the **top** of `progress.txt`. Keep entries general and reusable, not story-specific.
+
+9. **Stop condition** — after step 7, check whether all stories in `prd.json` now have `passes: true`. If yes, append a final line on its own to `progress.txt`:
+   ```
+   STATUS: COMPLETE
+   ```
+   This terminates the Ralph loop. The runner reads for this exact whole-line string in **two** places — `progress.txt` (at the start of each iteration) and your iteration output (after each iteration) — so either channel ends the loop.
+
+10. **Signal completion in your output only when terminal** — when (and only when) you have just appended `STATUS: COMPLETE` to `progress.txt`, also print `STATUS: COMPLETE` as the sole content of your final line. This lets the runner exit even if the file write was missed. Never print that bare standalone line for any other reason; to refer to it in prose, call it "the completion marker."
+
+## Blocked or deferred stories
+
+If the chosen story cannot be completed this iteration:
+
+- **Blocked** (external dependency, missing context, ambiguity): append to `progress.txt` with `**Result**: BLOCKED` and an explanation. Do NOT mark `passes: true`. The next iteration will skip this story (find the next lowest-priority `passes: false` that isn't already BLOCKED in recent progress entries) or escalate.
+- **Deferred** (out of scope per the PRD's Non-Goals): append with `**Result**: DEFERRED`. Do NOT mark `passes: true`. The story stays for human review.
+
+## Critical rules
+
+- **One story per iteration.** Resist doing two.
+- **Never push** to `development` or `main`. Branch is `<prefix>/<N>-docs-build-decoupling`.
+- **Never skip pre-commit hooks** (`--no-verify`).
+- **Never run `git clone` or `git init`** — you're already in a checkout.
+- **Confine writes** to repo-tracked paths. Do not write outside the repo or to `~/`.
+- **Phase ordering matters.** Stories are priority-ordered by dependency — implement them in `priority` order. If a story depends on an artifact a later story creates, it is mis-ordered; surface it rather than implementing out of order.
+- **CHANGELOG discipline.** Per `.claude/skills/git/SKILL.md`, every story with user-visible impact must add an entry under `## [Unreleased]` in the same commit. The PRD's individual stories spell out which `### Added`, `### Removed`, `### Changed` section to use.
+- **Wiki alignment discipline.** If the PRD says `Wiki Alignment` is `REQUIRED`, update the named wiki entries in the same implementation branch so they match the final spec behavior, preserve the DeepWiki comparison, and pass `bash evals/probes/wiki-readme-index.sh`.
+- **Don't modify completed stories** unless the current story explicitly requires it.
+
+## Reference
+
+- PRD: `tasks/docs-build-decoupling/prd.md`
+- Structured stories: `tasks/docs-build-decoupling/prd.json`
+- Branch: `<prefix>/<N>-docs-build-decoupling`
+- Issue: #455

--- a/wiki/README.md
+++ b/wiki/README.md
@@ -26,6 +26,7 @@ Schema rule, frontmatter spec, and all authoring conventions: `context/rules/wik
 
 | Slug | Title | Tags | Updated |
 | --- | --- | --- | --- |
+| ci-build-gates | CI Build Gates | [ci, docs, build, eval, github-actions] | 2026-06-19 |
 | harness-audit | Harness Audit | [audit, skills, autopilot, memory, worktrees] | 2026-06-18 |
 | sandbox-auth-volumes | Sandbox Auth Volume Ownership | [sandbox, devcontainer, auth, docker, ownership] | 2026-06-16 |
 | cron-runtime | Cron Runtime | [cron, runtime, scheduler, drift-check, automation, open-harness] | 2026-06-16 |

--- a/wiki/ci-build-gates.md
+++ b/wiki/ci-build-gates.md
@@ -1,0 +1,55 @@
+---
+title: "CI Build Gates"
+slug: ci-build-gates
+tags: [ci, docs, build, eval, github-actions]
+created: 2026-06-19
+updated: 2026-06-19
+sources:
+  - raw/2026-06-19-ci-build-gates.md
+related: [cron-runtime]
+confidence: confirmed
+---
+
+# CI Build Gates
+
+## Relevant Source Files
+- `package.json` — root scripts define the fast build and explicit docs commands.
+- `.github/workflows/ci-harness.yml` — PR/push Harness CI uses the fast build.
+- `.github/workflows/docs.yml` — automatic docs build/deploy is isolated to `main`/`master` pushes.
+- `.github/workflows/release.yml` — release validation uses the fast non-docs build.
+- `.claude/skills/eval/run.sh` — `/eval` runs probe scripts, not Docusaurus.
+- `evals/probes/docs-build-fast-path.sh` — guards the split.
+
+## Summary
+Open Harness separates fast harness validation from docs-site validation. Root build, Harness CI, release validation, and `/eval` avoid Docusaurus; automatic docs build/deploy happens only when `docs.yml` runs on `main` or `master` pushes.
+
+## Detail
+`package.json:9-11` makes `pnpm run build` delegate to `build:harness`, which excludes `@openharness/docs` and builds the standalone `packages/oh` package. Manual docs commands remain explicit at `package.json:20-22`, so an operator can run `pnpm docs:build` only when they intentionally want Docusaurus feedback.
+
+Harness CI installs dependencies, then its Build step calls `pnpm run build:harness` (`.github/workflows/ci-harness.yml:84-102`). Release validation uses the same fast Build step (`.github/workflows/release.yml:38-56`), so release tags do not build docs automatically. The docs workflow is the sole automatic Docusaurus path: it triggers on pushes to `main` and `master` with docs path filters (`.github/workflows/docs.yml:3-12`) and runs `pnpm run build` in `packages/docs` (`.github/workflows/docs.yml:43-45`). Deploy guards are also scoped to `main`/`master` refs (`.github/workflows/docs.yml:50-62`).
+
+`/eval` remains a fast regression floor: its runner executes each `evals/probes/*.sh` with a timeout (`.claude/skills/eval/run.sh:84-95`) rather than invoking package builds. The `docs-build-fast-path` probe keeps Docusaurus out of the fast path.
+
+| Gate | Command / trigger | Builds docs? |
+| --- | --- | --- |
+| Fast local build | `pnpm run build` | No |
+| Manual docs check | `pnpm docs:build` | Yes, explicit only |
+| Harness CI | `pnpm run build:harness` | No |
+| Release validation | `pnpm run build:harness` | No |
+| Docs workflow | push to `main`/`master` docs paths | Yes |
+| `/eval` | `bash .claude/skills/eval/run.sh` | No |
+
+## System Relationships
+
+```mermaid
+flowchart TD
+    Dev[Developer / PR] --> Fast[pnpm run build / CI build:harness]
+    Fast --> NoDocs[No Docusaurus]
+    Eval[/eval probes/] --> NoDocs
+    Release[release validation] --> Fast
+    MainPush[push to main/master touching docs paths] --> DocsWorkflow[docs.yml]
+    DocsWorkflow --> Docusaurus[Docusaurus build + Pages deploy]
+```
+
+## See Also
+- [[cron-runtime]]

--- a/wiki/raw/2026-06-19-ci-build-gates.md
+++ b/wiki/raw/2026-06-19-ci-build-gates.md
@@ -1,0 +1,16 @@
+# CI Build Gates source snapshot — 2026-06-19
+
+This local provenance snapshot captures the source-backed facts used by `wiki/ci-build-gates.md` for issue #455.
+
+## Source files
+
+- `package.json`: root scripts define `setup`, `build`, `build:harness`, and explicit docs commands.
+- `.github/workflows/ci-harness.yml`: Harness CI Build step calls the fast build path.
+- `.github/workflows/docs.yml`: Docs build/deploy workflow triggers only on pushes to `main` or `master` with docs path filters, then runs Docusaurus from `packages/docs`.
+- `.github/workflows/release.yml`: release validation Build step calls the fast build path.
+- `.claude/skills/eval/run.sh`: eval runner executes probe scripts with short timeouts; docs build is not part of the runner.
+- `evals/probes/docs-build-fast-path.sh`: regression guard for this split.
+
+## Decision
+
+Automatic docs builds belong only to the docs workflow on `main`/`master` pushes. Root build, Harness CI, release validation, and `/eval` use fast non-docs validation. Manual `pnpm docs:build` remains available when an operator intentionally wants to validate the Docusaurus site.


### PR DESCRIPTION
Closes #455.

**Status: READY — implementation, local verification, CI, wiki, and /pr-audit promotable gates passed.**

## Summary
Decouples Docusaurus docs builds from fast local, PR, Harness CI, release, and `/eval` validation paths. Automatic docs build/deploy now runs only from `docs.yml` on pushes to `main` or `master` that touch docs-site paths; `pnpm docs:build` remains the explicit manual escape hatch.

## Stories
1. Split fast build from docs build — complete
2. Run docs build only on main/master-push docs workflow — complete
3. Add a regression probe for build-gate separation — complete
4. Document the gate split in docs and wiki — complete

## Verification
- `pnpm run build` — passed; output did not include `docusaurus build`
- `pnpm run typecheck` — passed
- `pnpm run test:scripts` — 275 passed
- `bash evals/probes/docs-build-fast-path.sh` — passed
- `bash evals/probes/wiki-readme-index.sh` — passed
- `bash .claude/skills/eval/run.sh` — 51 PASS
- PR CI — green: Lint/Typecheck/Build/Test, Boot Path Lint, Eval Probe Regression Gate. No docs-build PR check was triggered by design.
- `/pr-audit` gate — PR #456 is ready-for-review, CI PASS, MERGEABLE/CLEAN, no duplicate issue refs.

## Critique
- High-severity findings: 0
- Medium-severity findings: 7 (mitigated in PRD)
- Operator clarification: docs builds should run automatically only on `main`/`master` pushes.
- Recommendation: PROCEED

🤖 Generated with Pi via /ship-spec
