### PR TITLE
FROM task/457-preserve-dirty-workspace TO development

### DIFF
--- a/.claude/protected-paths.txt
+++ b/.claude/protected-paths.txt
@@ -15,7 +15,7 @@
 # --- Orchestrator skills (.claude/skills/) ---
 release
 ci-status
-cloudflared-tunnel
+cloudflared
 agent-browser
 prd
 ralph
@@ -39,7 +39,7 @@ Makefile
 
 # --- Install / runtime scripts wired into the Dockerfile or sourced at boot ---
 install/banner.sh
-install/cloudflared-tunnel.sh
+.claude/skills/cloudflared/scripts/run.sh
 .devcontainer/entrypoint.sh
 .devcontainer/Dockerfile
 

--- a/.claude/skills/agent-browser/SKILL.md
+++ b/.claude/skills/agent-browser/SKILL.md
@@ -123,7 +123,7 @@ agent-browser close
 
 ### Step 2d — DNS resolution check (tunnel hostnames)
 
-If the URL contains a hostname served by a tunnel or reverse proxy, the container's DNS may not resolve it yet. Check and fix:
+If the URL contains a hostname served by a Cloudflared tunnel or custom DNS route, the container's DNS may not resolve it yet. Check and fix:
 
 ```bash
 HOSTNAME=$(echo "$URL" | sed 's|https\?://||; s|/.*||; s|:.*||')

--- a/.claude/skills/cloudflared/SKILL.md
+++ b/.claude/skills/cloudflared/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: cloudflared
+description: |
+  Start or explain a Cloudflared tunnel for a sandbox app port. Cloudflared is
+  the default public sharing method for Open Harness previews; this skill
+  replaces generic sharing guidance with a portable pointer to the installed
+  cloudflared CLI and tmux process convention.
+  TRIGGER when: asked to share a local app publicly, expose a sandbox port,
+  make localhost reachable from another machine, open a preview URL, or run
+  cloudflared.
+argument-hint: "<port> [--host 127.0.0.1] [--name <slug>] [--session <name>]"
+allowed-tools: Bash, Read
+---
+
+# Cloudflared
+
+Use Cloudflared as the default public tunnel for sandbox app previews. Prefer a
+Cloudflare quick tunnel for temporary sharing; use a named tunnel only when the
+operator explicitly needs a stable hostname or Cloudflare Access policy.
+
+## Arguments
+
+Arguments received: `$ARGUMENTS`
+
+- `PORT`: first positional argument; required (example: `3000`)
+- `--host`: local upstream host; default `127.0.0.1`
+- `--name`: optional slug for the tmux/log suffix; default is the port
+- `--session`: optional tmux session name override; default `cloudflared-<slug>`
+
+If `PORT` is missing, ask which local port to tunnel.
+
+## Quick tunnel flow
+
+Run inside the sandbox, after the app is already listening locally:
+
+```bash
+bash "$CLAUDE_SKILL_DIR/scripts/run.sh" $ARGUMENTS
+```
+
+The script verifies `cloudflared`, `tmux`, and the local upstream, starts a
+Cloudflare quick tunnel in `tmux`, waits for the generated URL, and prints
+inspect/log/stop commands.
+
+If the upstream check fails, fix the app bind/listen state first. Many dev
+servers must listen on `0.0.0.0` inside the container to be reachable through the
+tunnel.
+
+## Stable hostname path
+
+For durable public URLs, do not invent a separate access layer. Use Cloudflare's
+named tunnel flow and store credentials in the existing `~/.cloudflared` volume:
+
+```bash
+cloudflared tunnel login
+cloudflared tunnel create <name>
+cloudflared tunnel route dns <name> <hostname>
+cloudflared tunnel run <name>
+```
+
+If the app is sensitive, require Cloudflare Access or another authentication gate
+before sharing the URL. Quick tunnel URLs are public bearer URLs.
+
+## Troubleshooting
+
+### `cloudflared tunnel login` says `cert.pem` already exists
+
+Treat an existing `~/.cloudflared/cert.pem` as a likely valid login, not an error
+to delete. First check whether Cloudflared can already see tunnels:
+
+```bash
+cloudflared tunnel list
+```
+
+If that works, do not run `cloudflared tunnel login` again. The existing
+certificate is already usable.
+
+Only replace the certificate when the operator intentionally wants to switch
+Cloudflare accounts. Back it up first, and leave existing tunnel credential JSON
+files in place unless explicitly removing those tunnels:
+
+```bash
+mkdir -p ~/.cloudflared/backups
+mv ~/.cloudflared/cert.pem ~/.cloudflared/backups/cert.pem.$(date -u +%Y%m%dT%H%M%SZ).bak
+cloudflared tunnel login
+```
+
+Quick tunnels from `/cloudflared <port>` do not require login, so this warning is
+only relevant to named tunnels and durable hostnames.

--- a/.claude/skills/cloudflared/scripts/run.sh
+++ b/.claude/skills/cloudflared/scripts/run.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: cloudflared skill <port> [--host 127.0.0.1] [--name <slug>] [--session <name>]
+
+Starts a Cloudflare quick tunnel for a local sandbox app port in tmux.
+USAGE
+}
+
+if [[ $# -lt 1 || "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  usage
+  exit 0
+fi
+
+PORT=""
+HOST="127.0.0.1"
+NAME=""
+SESSION=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --host)
+      HOST="${2:-}"
+      shift 2
+      ;;
+    --name)
+      NAME="${2:-}"
+      shift 2
+      ;;
+    --session)
+      SESSION="${2:-}"
+      shift 2
+      ;;
+    --*)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+    *)
+      if [[ -n "$PORT" ]]; then
+        echo "Unexpected extra positional argument: $1" >&2
+        usage >&2
+        exit 2
+      fi
+      PORT="$1"
+      shift
+      ;;
+  esac
+done
+
+if [[ -z "$PORT" || ! "$PORT" =~ ^[0-9]+$ ]]; then
+  echo "PORT is required and must be numeric." >&2
+  usage >&2
+  exit 2
+fi
+
+if [[ -z "$HOST" ]]; then
+  echo "--host cannot be empty." >&2
+  exit 2
+fi
+
+if ! command -v cloudflared >/dev/null 2>&1; then
+  echo "cloudflared is not installed or not in PATH." >&2
+  exit 127
+fi
+
+if ! command -v tmux >/dev/null 2>&1; then
+  echo "tmux is not installed or not in PATH." >&2
+  exit 127
+fi
+
+SLUG="${NAME:-$PORT}"
+SESSION="${SESSION:-cloudflared-$SLUG}"
+LOG="/tmp/${SESSION}.log"
+UPSTREAM="http://${HOST}:${PORT}"
+
+if ! curl -fsS "$UPSTREAM" >/dev/null 2>&1; then
+  cat >&2 <<EOF
+Upstream did not respond: $UPSTREAM
+Start the app first, then retry. Some dev servers must listen on 0.0.0.0 inside the container.
+EOF
+  exit 1
+fi
+
+tmux kill-session -t "$SESSION" 2>/dev/null || true
+tmux new-session -d -s "$SESSION" \
+  "cloudflared tunnel --url '$UPSTREAM' 2>&1 | tee '$LOG'"
+
+printf 'Started %s for %s\n' "$SESSION" "$UPSTREAM"
+printf 'Log: %s\n' "$LOG"
+printf 'Waiting for trycloudflare URL...\n'
+
+for _ in {1..20}; do
+  URL=$(tmux capture-pane -t "$SESSION" -p 2>/dev/null | grep -Eo 'https://[-a-zA-Z0-9]+\.trycloudflare\.com' | tail -1 || true)
+  if [[ -n "$URL" ]]; then
+    printf 'URL: %s\n' "$URL"
+    printf '\nInspect: tmux attach -t %q\n' "$SESSION"
+    printf 'Logs:    tail -f %q\n' "$LOG"
+    printf 'Stop:    tmux kill-session -t %q\n' "$SESSION"
+    exit 0
+  fi
+  sleep 1
+done
+
+cat >&2 <<EOF
+Tunnel started, but no trycloudflare URL appeared yet.
+Inspect with: tmux attach -t '$SESSION'
+Log file: $LOG
+EOF
+exit 1

--- a/.claude/skills/skill-builder/SKILL.md
+++ b/.claude/skills/skill-builder/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: skill-builder
+description: |
+  Author and refine Claude Code skills (.claude/skills/*/SKILL.md) the harness
+  way — the evolving pointer to skill best practices (replaces the deprecated
+  skill-builder agent). Covers skill-vs-command-vs-agent, frontmatter, progressive
+  disclosure, argument wiring, side-effect handling, and a validation checklist;
+  defers the full field schema to references/skill-authoring.md.
+  TRIGGER when: asked to create/build/scaffold a new skill, fix/review/audit an
+  existing skill, "make a /command", convert an agent to a skill, or check a skill
+  against best practices.
+argument-hint: "[skill-name | description of the skill]"
+allowed-tools: Read, Write, Edit, Glob, Grep, Bash
+---
+
+# Skill Builder
+
+The harness's pointer for authoring skills. Keep **this** file lean — the
+exhaustive frontmatter schema and field reference live in
+`references/skill-authoring.md`. (That split is itself the practice this skill
+exists to enforce: concise SKILL.md, detail in `references/`.)
+
+## Skill vs command vs agent
+
+- **Skill** — `.claude/skills/<name>/SKILL.md` (+ optional `scripts/`,
+  `references/`, `assets/`). Invocable as `/<name>`; Claude can also auto-invoke
+  from the `description`. **Default choice.**
+- **Command** — single `.claude/commands/<name>.md`. Merged into skills, same
+  frontmatter; pick a skill unless you truly want one bare file.
+- **Agent** — `.claude/agents/<name>.md`: a *forked sub-agent* with its own tool
+  list and isolated context. Use only when you need an isolated context/persona,
+  not just a playbook. (Skill *authoring* itself moved from an agent to this skill.)
+
+## Protocol
+
+1. **Scope** — one sentence: what it does, who invokes it (Claude vs user), what
+   "done" looks like. Decide **task skill** (does a thing) vs **reference skill**
+   (knowledge Claude consults inline).
+2. **Survey** — `Glob .claude/skills/**/SKILL.md`; open the closest existing skill
+   and match its shape and tone. Reuse conventions; don't reinvent.
+3. **Frontmatter** — `name` (lowercase-kebab, ≤64), `description` with the TRIGGERs
+   **front-loaded** (the description is what matching sees — *not* the body). Add
+   only the optional fields the skill actually needs (see reference).
+4. **Body** — imperative instructions *for Claude*, not prose for a human. Put the
+   most critical rules first (they survive compaction). Examples beat description.
+5. **Bundle, don't inline** — deterministic/repeated logic goes in a `scripts/` file
+   the skill calls; long reference material goes in `references/`. SKILL.md < 500 lines.
+6. **Validate** — run the checklist below. If it takes args, *wire* them. If it
+   shells out, run the script once.
+
+## Get these right (lessons we've paid for)
+
+- **`argument-hint` must be real and accurate.** If the skill takes
+  `up|down|restart`, say so — never `"(no args)"` on a skill that has args.
+- **Wire `$ARGUMENTS`.** A task skill that takes an action must pass it through
+  (e.g. `bash ${CLAUDE_SKILL_DIR}/run.sh $ARGUMENTS`), not merely *describe*
+  commands a human would type.
+- **Imperative body.** "Run X, then report Y" — not "This skill launches X."
+- **Side effects → opt-in.** Skills that deploy/commit/send/destroy should consider
+  `disable-model-invocation: true` (user must type `/name`) and narrow
+  `allowed-tools` (`Bash(git commit *)`) rather than blanket `Bash`.
+- **`model` only when justified.** Omit to inherit the session model; set `sonnet`/
+  `haiku` only for clearly mechanical skills.
+- **Self-contained > coupled.** Put logic inside the skill dir (a `scripts/` file),
+  not in the harness `Makefile` or some sibling location.
+
+## Validation checklist
+
+- [ ] `.claude/skills/<name>/SKILL.md` exists; `name` lowercase-kebab, ≤64 chars
+- [ ] `description` states WHEN to use, triggers front-loaded, combined (+`when_to_use`) ≤1,536 chars
+- [ ] Body is imperative; most-critical rules first; ≥1 realistic example when behavior is non-obvious
+- [ ] `argument-hint` matches the args the body consumes; `$ARGUMENTS`/`$N` actually wired
+- [ ] SKILL.md < 500 lines; detail pushed to `references/`; repeated logic in `scripts/`
+- [ ] Side-effecting? decided on `disable-model-invocation` + narrowed `allowed-tools`
+- [ ] `model` / `context: fork` set only when justified (else omit/inherit)
+- [ ] Matches the conventions and tone of neighboring skills
+
+## Full reference
+
+`references/skill-authoring.md` — complete frontmatter schema + per-field reference,
+discovery priority & precedence, context lifecycle (compaction budget), shell
+injection, string substitutions, operator access controls, and size-tiered templates.

--- a/.claude/skills/skill-builder/references/skill-authoring.md
+++ b/.claude/skills/skill-builder/references/skill-authoring.md
@@ -1,0 +1,254 @@
+# Skill Authoring — Full Reference
+
+Deep reference for `/skill-builder`. The actionable protocol + checklist live in
+`../SKILL.md`; this file is the long tail (progressive-disclosure level 3 — loaded
+only when you need it).
+
+## Contents
+
+1. [What skills are](#what-skills-are)
+2. [Skills vs commands vs agents](#skills-vs-commands-vs-agents)
+3. [Discovery & precedence](#discovery--precedence)
+4. [Directory structure & resource types](#directory-structure--resource-types)
+5. [Frontmatter schema](#frontmatter-schema)
+6. [Field reference](#field-reference)
+7. [Progressive disclosure & the listing budget](#progressive-disclosure--the-listing-budget)
+8. [Context lifecycle (compaction)](#context-lifecycle-compaction)
+9. [Shell injection](#shell-injection)
+10. [String substitutions](#string-substitutions)
+11. [Operator access controls](#operator-access-controls)
+12. [Size-tiered templates](#size-tiered-templates)
+13. [Common pitfalls](#common-pitfalls)
+
+---
+
+## What skills are
+
+Skills are **modular packages** that extend Claude through specialized knowledge,
+workflows, and tool integrations — domain-specific onboarding guides. They are
+**self-contained folders**, **dynamically loaded** when relevant, and are *not*
+slash commands or agents (though a skill does expose `/<name>`).
+
+Default assumption: **"Claude is already very smart."** Don't explain what Claude
+knows; capture the domain-specific things it doesn't.
+
+## Skills vs commands vs agents
+
+| Artifact | Location | Structure | Use it for |
+|----------|----------|-----------|------------|
+| **Skill** | `.claude/skills/*/SKILL.md` | Folder + resources | Contextual knowledge, workflows, slash commands. **Default.** |
+| **Command** | `.claude/commands/*.md` | Single file | Same as a skill minus supporting files. Merged into skills; if a skill and command share a name, the **skill wins**. |
+| **Agent** | `.claude/agents/*.md` | Single file | A forked sub-agent with its own tools/persona and isolated context. |
+
+Task skill vs reference skill:
+
+| Type | Invocation | Body shape | Signal |
+|------|-----------|-----------|--------|
+| **Reference** | Claude auto-loads inline from `description`/`paths` | Conventions, patterns ("when writing API endpoints, …") | usually no `disable-model-invocation` |
+| **Task** | User types `/<name>` to make Claude *do* it | Numbered procedure, often side-effecting | often `disable-model-invocation: true` |
+
+## Discovery & precedence
+
+When skills share a name, highest-priority source wins:
+
+1. **Enterprise/managed** (highest) — pushed via managed settings
+2. **Personal** — `~/.claude/skills/` (all projects)
+3. **Project** — `.claude/skills/` (this repo, version-controlled)
+
+- **Plugin skills** are namespaced `<plugin>:<skill>` and sit outside this chain.
+- **Live change detection**: adding/editing/removing a skill under an *existing*
+  `.claude/skills/` takes effect within the session. Creating a top-level
+  `.claude/skills/` that didn't exist at session start needs a restart.
+- **Nested discovery**: reading a file under `packages/x/` also discovers
+  `packages/x/.claude/skills/` (monorepo-per-package skills).
+- **`--add-dir`**: `.claude/skills/` *is* loaded from added dirs (other `.claude/`
+  config is not).
+
+## Directory structure & resource types
+
+```
+skill-name/
+├── SKILL.md         # Required: instructions + metadata
+├── scripts/         # Optional: deterministic executable logic, run on demand
+├── references/      # Optional: docs loaded contextually (schemas, APIs, policies)
+└── assets/          # Optional: output-ready files (templates) — NOT loaded in context
+```
+
+| Dir | Purpose | Context loading |
+|-----|---------|-----------------|
+| `scripts/` | Deterministic, repeated tasks | On demand (executed, not read into context) |
+| `references/` | Schemas, APIs, policies | Contextual (read when needed) |
+| `assets/` | Templates, boilerplate, images | Never loaded |
+
+## Frontmatter schema
+
+```yaml
+---
+name: skill-name                  # Optional: defaults to dir name. lowercase/numbers/hyphens, ≤64.
+description: |                     # Recommended: when/why to use — used for matching.
+  Front-loaded description. Put TRIGGERS here, not in the body.
+when_to_use: |                    # Optional: extra trigger phrases / example requests.
+  - "review the PR"
+argument-hint: "[issue-number]"   # Optional: autocomplete hint in the / menu.
+arguments: [issue, branch]        # Optional: named positional args → $issue / $branch.
+disable-model-invocation: false   # Optional: true = only manual /invoke; also blocks subagent preload.
+user-invocable: true              # Optional: false = hide from / menu (Claude can still invoke).
+allowed-tools: Read Grep Bash     # Optional: pre-approve while active (does NOT restrict).
+model: sonnet                     # Optional: opus|sonnet|haiku, full ID, or inherit. This turn only.
+effort: high                      # Optional: low|medium|high|xhigh|max (model-dependent).
+context: fork                     # Optional: run in isolated subagent (body BECOMES the prompt).
+agent: Explore                    # Optional: subagent type when context: fork.
+paths:                            # Optional: globs — auto-load on matching files.
+  - "src/api/**/*.ts"
+shell: bash                       # Optional: bash (default) or powershell.
+hooks:                            # Optional: lifecycle hooks scoped to this skill.
+  PreToolUse:
+    - matcher: "Bash"
+      hooks: [{ type: command, command: "./scripts/validate.sh" }]
+---
+```
+
+**All fields optional**; only `description` is *recommended* (else matching falls
+back to the first body paragraph). **Triggers go in `description`/`when_to_use`,
+never only in the body** — the body loads only after invocation.
+
+## Field reference
+
+- **name** — display name; defaults to dir name. lowercase/numbers/hyphens, ≤64.
+- **description** — what + when. `description` + `when_to_use` is truncated at
+  **1,536 chars** in the listing; front-load the key use case.
+- **when_to_use** — appended to `description` in the listing (same 1,536 cap).
+- **argument-hint** — placeholder in autocomplete (`[issue-number]`, `[file] [format]`).
+  Must reflect the args the body actually consumes.
+- **arguments** — named positional args; `arguments: [issue, branch]` → `$issue`,
+  `$branch`. YAML list or space-separated string.
+- **disable-model-invocation** — `true` removes the skill from Claude's invocable set
+  (description not in context); only `/name` works. Also blocks subagent preload.
+- **user-invocable** — `false` hides from `/` menu; Claude can still auto-invoke.
+  (Does NOT block programmatic Skill-tool access — use `disable-model-invocation`.)
+- **allowed-tools** — pre-approves tools while active. **Does not restrict** — use
+  permission deny rules to actually block. Narrow it (`Bash(git add *)`).
+- **model** — override for the rest of the turn; session model resumes next prompt.
+  Same values as `/model`, plus `inherit`.
+- **effort** — `low|medium|high|xhigh|max`; defaults to session.
+- **context: fork** — runs in an isolated subagent; **the body becomes the prompt**
+  (a reference-only skill with no task returns nothing when forked).
+- **agent** — subagent type when `context: fork` (`Explore`, `Plan`,
+  `general-purpose`, or any `.claude/agents/<name>`). Default `general-purpose`.
+- **paths** — auto-load when Claude reads matching files (rule-style globs).
+- **shell** — `bash` (default) or `powershell` (needs `CLAUDE_CODE_USE_POWERSHELL_TOOL=1`).
+- **hooks** — `settings.json` hook schema, scoped to this skill's lifecycle.
+
+## Progressive disclosure & the listing budget
+
+Three levels of context loading:
+
+| Level | Content | Size |
+|-------|---------|------|
+| 1 | Metadata (name + description) — always available | ~100 words |
+| 2 | SKILL.md body — when triggered | < 5k words |
+| 3 | Bundled resources — as needed | variable |
+
+Descriptions share a per-session budget (~1% of context window, fallback 8,000
+chars; raise with `SLASH_COMMAND_TOOL_CHAR_BUDGET`). Over budget → descriptions get
+truncated (names always survive). If a skill stops being picked, trim its
+description so the keywords survive.
+
+## Context lifecycle (compaction)
+
+1. On invoke, the full SKILL.md enters the conversation as one message.
+2. On auto-compaction, the first **5,000 tokens** of each skill are re-attached.
+3. Re-attached skills share a **25,000-token** budget; over it, older/less-relevant
+   skills are dropped.
+4. Earlier-invoked skills in long sessions are likelier to be evicted.
+
+Implications: put the **most critical instructions at the top**; keep the first
+~2,000 words essential; push tables/examples/nice-to-haves later; self-contained
+skills survive eviction best.
+
+## Shell injection
+
+Embed live shell output that runs **before** Claude sees the content (stdout
+replaces the placeholder at load time).
+
+- Inline: `` The latest commit is: !`git log -1 --oneline` ``
+- Multiline: a fenced block opened with `!` runs each line.
+
+Guidelines: runs in project root; controlled by the `shell` field; keep fast (it
+delays loading); failures yield empty output (stderr suppressed). Use for dynamic
+context (git state, versions, running services).
+
+## String substitutions
+
+| Variable | Expands to |
+|----------|-----------|
+| `$ARGUMENTS` | All args as typed. If absent from the body, args are appended as `ARGUMENTS: <value>`. |
+| `$ARGUMENTS[N]` / `$N` | Arg at index N (0-based); shell-style quoting applies. |
+| `$name` | Named arg from `arguments: [issue, branch]` → `$issue`, `$branch`. |
+| `${CLAUDE_SESSION_ID}` | Current session ID. |
+| `${CLAUDE_EFFORT}` | Current effort (`low…max`) — adapt instructions to it. |
+| `${CLAUDE_SKILL_DIR}` | Directory containing SKILL.md — use to reference bundled scripts CWD-independently. |
+
+## Operator access controls
+
+User/org-level (not authoring options, but design with them in mind):
+
+| Mechanism | Effect |
+|-----------|--------|
+| `permissions.deny: ["Skill"]` | Disables ALL skills. |
+| `permissions.allow: ["Skill(commit)", "Skill(review-pr *)"]` | Allowlist by name / `name *` prefix. |
+| `permissions.deny: ["Skill(deploy *)"]` | Denylist by name / prefix. |
+| `disable-model-invocation: true` | Removes the skill from Claude's invocable set. |
+| `disableSkillShellExecution: true` | Disables `` !`cmd` `` / ` ```! ` blocks (managed/bundled skills unaffected). |
+
+For side-effecting skills prefer `disable-model-invocation: true` (user opts in by
+typing `/name`) + narrow `allowed-tools`, not blanket Bash.
+
+## Size-tiered templates
+
+**Simple (~13 lines)** — pure guidance, no frontmatter beyond `description`:
+
+```markdown
+---
+name: skill-name
+description: Brief description of when to use this skill.
+---
+When [doing X], always:
+1. **Step**: …
+2. **Step**: …
+```
+
+**Medium (~66–125 lines)** — purpose + instructions + examples + small reference:
+
+```markdown
+---
+name: skill-name
+description: What it does and when to use it.
+---
+# Skill Name
+[Purpose.]
+## Instructions
+1. …
+## Examples
+User: "[request]"
+Assistant: [behavior]
+## Reference
+| Option | Description |
+```
+
+**Complex (200+ lines)** — add architecture, domain sections, important-notes; push
+the bulk into `references/` so SKILL.md stays < 500 lines.
+
+## Common pitfalls
+
+1. **Over-explaining** — Claude is smart; cover only domain specifics.
+2. **Triggers in the body** — they belong in `description`/`when_to_use`.
+3. **Mismatched degrees of freedom** — exact steps for fragile/critical ops; room
+   for flexible tasks.
+4. **Missing examples** — examples convey style better than prose.
+5. **Deep nesting** — keep references one level from SKILL.md; no reference chains.
+6. **Excessive length** — target < 5k words / < 500 lines; use progressive disclosure.
+7. **Inert args** — declaring `argument-hint`/`arguments` but never consuming
+   `$ARGUMENTS`/`$N` in the body.
+8. **Coupling out of the skill dir** — logic belongs in the skill's `scripts/`, not
+   in the Makefile or a sibling location.

--- a/.pi/prompts/review.md
+++ b/.pi/prompts/review.md
@@ -1,4 +1,4 @@
-Review the staged or recent changes for:
+/goal Review for:
 
 - Correctness — logic errors, wrong assumptions, missed cases
 - Security — injection, auth, secret handling, OWASP top-10
@@ -8,3 +8,5 @@ Review the staged or recent changes for:
 
 Report findings as a punch list. Cite `file:line` for each issue.
 Skip generic advice; focus on what is actually wrong in this diff.
+
+Definition of done is merged or closed open (not in draft) PR's that pass /pr-audt. Do this via /delegate but use an Advisor to reconcile merge order and conflict resolution. 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,6 +146,7 @@ flowchart LR
 | `/watchdog` | Generic stuck/stale automation watchdog. Current primary action: inspect autopilot draft PRs, complete stale/stuck branches, and remove draft only after the PR is green/mergeable/clean; also kills tmux sessions frozen at usage-limit/resume prompts and reaps completed autopilot PR sessions only after the PR is terminal and the pane is idle. Never merges. |
 | `/health-check` | Triage host memory/disk/Docker before starting a stack; rank reclaim levers by safety×yield, prune build cache, confirm destructive removal |
 | `/agent-browser` | Open a URL headless for screenshots / preview checks |
+| `/cloudflared` | Start a Cloudflared tunnel for a sandbox app port; default public sharing path for previews |
 | `/interview` | Adaptive pre-work clarifier — batches 2–4 task-specific questions via `AskUserQuestion`, then proceeds |
 | `/imagine` | One-shot draft PRD sketch from a fuzzy scenario → `.claude/specs/<slug>/spec.md` (gitignored scratch, includes mermaid diagram); feeds `/ship-spec --plan <path>` |
 | `/prd` | Generate a new PRD from a feature description |
@@ -170,15 +171,15 @@ flowchart LR
 Provision / destroy / repair are plain `docker compose` commands — see
 the `Lifecycle` section above. There is no dedicated skill.
 
-## Exposing apps
+## Sharing app previews
 
-There is no first-class exposure tool. For external access, stand up
-your own reverse proxy (nginx/Caddy/Traefik) or tunnel (cloudflared,
-ngrok, tailscale-funnel) in front of the sandbox — the base ships
-without any of these.
+Cloudflared is the default method for public access to sandbox app
+previews. Use the `/cloudflared` skill to start a tunnel for a local app
+port and report the generated URL.
 
-Long-running apps inside the sandbox go in named tmux sessions, related
-apps as stacked panes — see `context/rules/sandbox-processes.md`.
+Long-running apps and tunnels inside the sandbox go in named tmux
+sessions, related apps as stacked panes — see
+`context/rules/sandbox-processes.md`.
 
 ## What You Do
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 - **One project, one sandbox.** A single container scoped to a single repo. The agent owns its branch and its workspace; you keep your laptop clean.
 - **Agents that work while you sleep.** A tiny croner runtime reads `crons/*.md` markdown and wakes the agent on a schedule.
 - **Host dependencies: Docker + Git.** No Node, no Python, no toolchain rot on your laptop.
-- **Composable infra.** Cherry-pick Cloudflare tunnels, SSH, Caddy gateway, or pack-supplied services via Compose overlays.
+- **Cloudflared previews.** Share sandbox app ports through Cloudflared tunnels; SSH and pack-supplied services remain opt-in Compose overlays.
 - **Slack-ready.** The in-tree Pi extension at `.pi/extensions/slack/` bridges Slack to a Pi agent — see [docs/integrations/slack.md](docs/integrations/slack.md).
 - **Multi-agent? Add a pack.** Other multi-agent setups ship as separate packs — see [`@ryaneggz/mifune`](https://github.com/ryaneggz/mifune).
 

--- a/context/rules/sandbox-processes.md
+++ b/context/rules/sandbox-processes.md
@@ -17,7 +17,7 @@ Format: `<category>-<identifier>` (kebab-case inside each segment).
 | Category | Example | Purpose |
 |----------|---------|---------|
 | `app-` | `app-docs`, `app-api` | User dev servers |
-| `expose-public-` | `expose-public-3000` | Cloudflare quick tunnels (auto-created) |
+| `cloudflared-` | `cloudflared-3000` | Cloudflare tunnels for shared previews |
 | `agent-` | `agent-watcher`, `agent-batch` | Headless / long-running agent processes. Interactive CLIs (`claude`, `codex`, `opencode`) are normally foreground in a terminal or VS Code, not detached in tmux. |
 | `client-` | `client-slack`, `client-discord` | External-surface clients that bridge an in-sandbox agent to a third-party UI |
 | `cron-` | `cron-heartbeat`, `cron-autopilot-0613-1805`, `cron-system` | Scheduled cron jobs and the cron runtime. |

--- a/docs/connecting.md
+++ b/docs/connecting.md
@@ -66,27 +66,19 @@ Nothing else is published to the host. The `127.0.0.1` binding ensures port 1455
 
 All other container ports (3000, 3773, etc.) are only reachable via VSCode's auto-forwarding or a manual `ssh -L` tunnel.
 
-## Opt-in public exposure
+## Public sharing with Cloudflared
 
-If you need a port reachable beyond your laptop — for example, to share a preview with a teammate — there are two opt-in paths:
+If you need a port reachable beyond your laptop — for example, to share a preview with a teammate — use Cloudflared. The sandbox image includes the `cloudflared` CLI and persists credentials in `~/.cloudflared` when you use named tunnels.
 
-**1. Compose overlay binding `0.0.0.0`**
+For temporary previews, run the `/cloudflared` skill against the local app port. It starts a Cloudflare quick tunnel in a named tmux session and reports the generated public URL:
 
-Add a custom compose file that binds the port on all interfaces and merge it in via `compose.overrides:` in `harness.yaml` (tracked) or `composeOverrides[]` in `config.json` (user-local, gitignored):
-
-```yaml
-# docker-compose.my-expose.yml
-services:
-  sandbox:
-    ports:
-      - "0.0.0.0:3000:3000"
+```text
+/cloudflared 3000
 ```
 
-This is NOT the default; you opt in explicitly. Be aware that binding to `0.0.0.0` exposes the port on the host's public interface.
+Quick tunnel URLs are public bearer URLs. For sensitive apps, add Cloudflare Access or another authentication gate before sharing the URL.
 
-**2. External tunnel**
-
-The harness ships no built-in tunnel tool. For public access, bring your own: `cloudflared`, `ngrok`, `tailscale funnel`, or an nginx/Caddy reverse proxy. Start the tunnel inside the sandbox in a named tmux session (see [tmux conventions](#tmux-session-naming)).
+Avoid binding app ports to `0.0.0.0` on the host unless you explicitly need host-level publishing. The default public-sharing path is a Cloudflared tunnel that keeps the app bound locally inside the sandbox.
 
 ## tmux session naming
 
@@ -97,6 +89,7 @@ All long-running processes inside the sandbox run in named tmux sessions. The na
 | `client-` | `client-slack`, `client-discord` | External-surface clients bridging an in-sandbox agent |
 | `agent-` | `agent-watcher`, `agent-batch` | Headless / long-running agent processes (interactive CLIs are foreground, not tmux) |
 | `app-` | `app-docs`, `app-api` | Dev servers |
+| `cloudflared-` | `cloudflared-3000` | Cloudflare tunnels for shared previews |
 
 For the full convention see [`context/rules/sandbox-processes.md`](https://github.com/mifunedev/openharness/blob/development/context/rules/sandbox-processes.md).
 

--- a/docs/harnesses/hermes.md
+++ b/docs/harnesses/hermes.md
@@ -221,22 +221,23 @@ dashboard (and the `.env` secrets it reads) to the LAN without auth.
 
 ### Remote access
 
-To reach the dashboard from another machine:
+To reach the dashboard from another machine, use `/cloudflared 9119` to
+start a Cloudflared tunnel for the loopback bind. The tunnel handles TLS;
+the dashboard itself stays on loopback.
 
-- **Tunnel (recommended)** — put cloudflared or tailscale-funnel in front
-  of the loopback bind. The tunnel handles auth and TLS; the dashboard
-  itself stays on loopback.
-- **Non-loopback bind (advanced)** — if you must expose via `--host 0.0.0.0`,
-  the upstream fail-closed auth gate requires credentials. Set at minimum:
+For sensitive dashboards, add Cloudflare Access or another authentication
+gate before sharing the URL. If you intentionally change Hermes to a
+non-loopback bind with `--host 0.0.0.0`, the upstream fail-closed auth gate
+requires credentials. Set at minimum:
 
-  ```env
-  HERMES_DASHBOARD_BASIC_AUTH_USERNAME=admin
-  HERMES_DASHBOARD_BASIC_AUTH_PASSWORD=change-me   # plain-text, or use _HASH
-  HERMES_DASHBOARD_SECRET=a-random-32-char-string   # session signing key
-  ```
+```env
+HERMES_DASHBOARD_BASIC_AUTH_USERNAME=admin
+HERMES_DASHBOARD_BASIC_AUTH_PASSWORD=change-me   # plain-text, or use _HASH
+HERMES_DASHBOARD_SECRET=a-random-32-char-string   # session signing key
+```
 
-  OAuth is also supported via `HERMES_DASHBOARD_OAUTH_CLIENT_ID` and related
-  vars — see upstream Hermes documentation for the full list.
+OAuth is also supported via `HERMES_DASHBOARD_OAUTH_CLIENT_ID` and related
+vars — see upstream Hermes documentation for the full list.
 
 
 ## Banner status

--- a/docs/harnesses/t3code.md
+++ b/docs/harnesses/t3code.md
@@ -56,7 +56,7 @@ Open the printed pairing URL in your host browser. Reattach to the session at an
 tmux attach -t agent-t3code
 ```
 
-If you can't reach `localhost:3773` from the host, expose port 3773 from the sandbox container (compose overlay or `docker run -p 3773:3773`), or front it with a Cloudflare tunnel (`cloudflared`).
+If you need to share the T3 Code UI beyond your attached host session, use `/cloudflared 3773` to start a Cloudflared tunnel for the local port.
 
 ## Tips
 

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -17,7 +17,7 @@ Key capabilities:
 - **One project, one sandbox.** A single container scoped to a single repo and branch. The agent owns its workspace; your laptop stays clean.
 - **Markdown-defined crons.** `crons/*.md` files declare schedules; an in-container croner runtime fires the bodies as agent prompts so the agent can work autonomously while you focus on other things.
 - **Host dependencies: Docker + Git.** No Node, no Python, and no toolchain maintenance required on your laptop.
-- **Composable infra.** Cloudflare tunnels, SSH, and pack-supplied services are opt-in Docker Compose overlays.
+- **Cloudflared previews.** Share sandbox app ports through Cloudflared tunnels; SSH and pack-supplied services remain opt-in Docker Compose overlays.
 - **Multi-agent? Add a pack.** Slack-driven Pi+Mom and similar multi-agent setups ship as separate harness packs (e.g. [`@ryaneggz/mifune`](https://github.com/ryaneggz/mifune)).
 
 ## How it works


### PR DESCRIPTION
Closes #457.

## Summary
- Preserve non-memory local dirty workspace changes in a pushed branch before cleaning `development`.
- Add the Cloudflared Claude skill plus preview-sharing docs/process updates.
- Add the skill-builder Claude skill and preserve the local Pi review prompt edits.

## Verification
- Byte-equivalence check passed before cleanup for the non-memory dirty files preserved on this branch.
- Public PR diff was rechecked after amendment: no `memory/` paths are included.
