### PR TITLE
FROM skill/459-tree-sandbox-skill TO development

### DIFF
--- a/.claude/skills/repo-layout/SKILL.md
+++ b/.claude/skills/repo-layout/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: repo-layout
+description: |
+  Create a concise, descriptive repository layout premap using the sandbox
+  `tree` CLI, optimized for agent handoff before exact file reads.
+  Verifies `tree` is installed and filters noisy directories by default.
+  TRIGGER when: asked to premap a repo, map repository structure for an agent,
+  inspect folder structure, show a concise directory tree, or understand repo layout.
+argument-hint: "[path] [--depth N|--raw tree-options]"
+allowed-tools: Bash
+---
+
+# Repo Layout
+
+Create a concise, descriptive directory premap for agent orientation.
+
+## Instructions
+
+Arguments received: `$ARGUMENTS`
+
+1. Run the skill-local wrapper; do not hand-roll `tree` flags:
+   ```bash
+   bash "${CLAUDE_SKILL_DIR}/scripts/run.sh" $ARGUMENTS
+   ```
+2. Default mode is optimized for handoff: depth 1, directories first, noisy
+   paths ignored, plus short descriptions of recognizable harness areas.
+3. Use `--depth N`/`-L N` only when the first map is too shallow.
+4. Use `--raw ...` only when native `tree` output is explicitly needed.
+5. Treat the premap as orientation, not evidence. Follow it with `Read`, `Grep`,
+   or `rg` on selected files.
+
+## Examples
+
+```text
+/repo-layout
+/repo-layout packages --depth 2
+/repo-layout .claude/skills -L 1
+/repo-layout --raw -L 2 -a .
+```

--- a/.claude/skills/repo-layout/scripts/run.sh
+++ b/.claude/skills/repo-layout/scripts/run.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+IGNORE_PATTERN='.git|node_modules|.pnpm-store|.worktrees|dist|build|coverage|.next|.cache|__pycache__'
+DEPTH=1
+FILE_LIMIT=40
+TARGET='.'
+RAW=false
+RAW_ARGS=()
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  /repo-layout [path] [--depth N]
+  /repo-layout [path] [-L N]
+  /repo-layout --raw [tree-options]
+
+Default mode prints a concise, descriptive agent premap: a bounded tree plus short notes about recognizable harness areas. Raw mode passes arguments directly to tree.
+USAGE
+}
+
+describe_path() {
+  case "$1" in
+    .claude) echo "Claude-facing skills, agents, hooks, and project rules." ;;
+    .codex) echo "Codex-facing symlinks/config that mirror Claude surfaces." ;;
+    .devcontainer) echo "Sandbox image, compose files, and container entrypoint." ;;
+    .github) echo "GitHub Actions, issue templates, and repository automation." ;;
+    .pi) echo "Pi runtime config, extensions, prompts, and skill symlink." ;;
+    AGENTS.md|CLAUDE.md) echo "Root orchestrator instructions and operating boundaries." ;;
+    CHANGELOG.md) echo "Unreleased/release notes required for user-visible changes." ;;
+    Makefile) echo "Host lifecycle shortcuts for sandbox create/shell/destroy." ;;
+    README.md) echo "Human-facing project overview and quick start." ;;
+    context) echo "Always-loaded voice, identity, tools, user, and rules context." ;;
+    crons) echo "Markdown-defined autonomous schedules run by cron-runtime." ;;
+    docs) echo "Docusaurus documentation for operators and harness users." ;;
+    evals) echo "Deterministic regression probes and capability benchmark data." ;;
+    install) echo "Boot/install shell assets copied into the sandbox image." ;;
+    packages) echo "Workspace packages such as docs and the oh CLI." ;;
+    scripts) echo "Harness automation, runtime, and test-covered helper scripts." ;;
+    tasks) echo "/ship-spec and Ralph task artifacts for in-flight work." ;;
+    wiki) echo "LLM-readable source-backed knowledge base entries." ;;
+    workspace) echo "Seed files bind-mounted into the managed agent workspace." ;;
+    *) return 1 ;;
+  esac
+}
+
+if ! command -v tree >/dev/null 2>&1; then
+  cat >&2 <<'MSG'
+ERROR: tree is not installed in this sandbox.
+This repo-layout skill uses the Debian `tree` package. Rebuild the sandbox after this change lands, or install `tree` locally for this session.
+MSG
+  exit 127
+fi
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    --raw)
+      RAW=true
+      shift
+      RAW_ARGS=("$@")
+      break
+      ;;
+    --depth|-L)
+      if [ "$#" -lt 2 ]; then
+        echo "ERROR: $1 requires a numeric depth" >&2
+        exit 2
+      fi
+      DEPTH="$2"
+      shift 2
+      ;;
+    --depth=*)
+      DEPTH="${1#--depth=}"
+      shift
+      ;;
+    -L*)
+      DEPTH="${1#-L}"
+      shift
+      ;;
+    --)
+      shift
+      if [ "$#" -gt 0 ]; then TARGET="$1"; fi
+      break
+      ;;
+    -*)
+      echo "ERROR: unsupported premap option: $1 (use --raw to pass native tree options)" >&2
+      exit 2
+      ;;
+    *)
+      TARGET="$1"
+      shift
+      ;;
+  esac
+done
+
+if [ "$RAW" = true ]; then
+  if [ "${#RAW_ARGS[@]}" -eq 0 ]; then
+    exec tree -L "$DEPTH" --dirsfirst --filelimit "$FILE_LIMIT" -a -I "$IGNORE_PATTERN" "$TARGET"
+  fi
+  exec tree "${RAW_ARGS[@]}"
+fi
+
+case "$DEPTH" in
+  ''|*[!0-9]*) echo "ERROR: depth must be a positive integer" >&2; exit 2 ;;
+  0) echo "ERROR: depth must be greater than zero" >&2; exit 2 ;;
+esac
+
+if [ ! -e "$TARGET" ]; then
+  echo "ERROR: path not found: $TARGET" >&2
+  exit 1
+fi
+
+printf "# Agent premap: \`%s\`\n\n" "$TARGET"
+printf '_Concise map for orientation only; read files for evidence._\n\n'
+printf '```text\n'
+tree -L "$DEPTH" --dirsfirst --filelimit "$FILE_LIMIT" -a -I "$IGNORE_PATTERN" "$TARGET"
+printf '```\n\n'
+
+printf '## Key areas\n\n'
+key_count=0
+while IFS= read -r entry; do
+  name="$(basename "$entry")"
+  if desc="$(describe_path "$name")"; then
+    printf -- "- \`%s\` - %s\n" "$entry" "$desc"
+    key_count=$((key_count + 1))
+  fi
+done < <(find "$TARGET" -mindepth 1 -maxdepth 1 2>/dev/null | sort)
+
+if [ "$key_count" -eq 0 ]; then
+  printf -- "- No known harness landmarks at this level; inspect likely files with \`rg --files %q | head\`.\n" "$TARGET"
+fi
+
+printf '\n## Good next reads\n\n'
+read_count=0
+for candidate in \
+  "$TARGET/AGENTS.md" \
+  "$TARGET/CLAUDE.md" \
+  "$TARGET/README.md" \
+  "$TARGET/package.json" \
+  "$TARGET/Makefile" \
+  "$TARGET/wiki/README.md"; do
+  if [ -e "$candidate" ]; then
+    printf -- "- \`%s\`\n" "$candidate"
+    read_count=$((read_count + 1))
+  fi
+done
+if [ "$read_count" -eq 0 ]; then
+  printf -- "- Use \`rg --files %q | head -40\` to choose precise files.\n" "$TARGET"
+fi

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -5,7 +5,7 @@ ENV TZ=America/Los_Angeles
 # ─── System packages ────────────────────────────────────────────────
 RUN apt-get update && apt-get install -y --no-install-recommends \
     openssh-client build-essential ca-certificates curl wget sudo gosu git jq gnupg \
-    lsb-release nano ripgrep tmux unzip bash-completion procps less \
+    lsb-release nano ripgrep tree tmux unzip bash-completion procps less \
     iproute2 zsh cron \
  && rm -rf /var/lib/apt/lists/*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Update policy and release automation live in [`/git`](.claude/skills/git/SKILL.m
 ## [Unreleased]
 
 ### Added
+- Sandbox images now include the `tree` CLI, and `/repo-layout` provides a concise, descriptive premap skill for agent handoff ([#459](https://github.com/mifunedev/openharness/issues/459)).
 - `pi-dynamic-workflows` is now a default project-local Pi package pinned to the upstream `v1.0.1` commit, with docs for the `workflow` tool's deterministic JavaScript fan-out model and package-pin test coverage ([#451](https://github.com/mifunedev/openharness/issues/451)).
 - `retro-deterministic-contract` eval probe guards that `/retro` keeps schema-backed output, self-contained helper scripts, and synchronized `.pi`/`.claude` skill copies ([#443](https://github.com/mifunedev/openharness/issues/443)).
 ### Changed

--- a/evals/RESULTS.md
+++ b/evals/RESULTS.md
@@ -6,56 +6,57 @@ probe id; git history is the time series.** Schema and exit-code semantics are i
 
 | probe | tier | last-run (UTC) | status | source |
 |-------|------|----------------|--------|--------|
-| agent-browser-cli | A | 2026-06-19 04:59 | PASS | memory/MEMORY.md 2026-06-07 (agent-browser 0.8.5 CLI) |
-| autopilot-executor-toggle | A | 2026-06-19 04:59 | PASS | conversation 2026-06-13 (autopilot delegate-advisor executor) |
-| autopilot-no-pr-session-close | A | 2026-06-19 04:59 | PASS | issue #209 (autopilot no-PR tmux session closure) 2026-06-16 |
-| autopilot-open-pr-reference-dedupe | A | 2026-06-19 04:59 | PASS | issue #437 — autopilot must not start duplicate work when open PRs reference the same issue without linked-PR metadata |
-| autopilot-pi-agent | A | 2026-06-19 04:59 | PASS | issue #116 (autopilot Pi tmux alignment) 2026-06-14; issue #118 (attachable Pi TUI tmux) 2026-06-14; issue #126 (kept Pi overlap lock release) 2026-06-14; issue #142 (worktree-by-default, skip→worktree) 2026-06-14 |
-| autopilot-preflight-gate | A | 2026-06-19 04:59 | PASS | issue #194 (deterministic autopilot caps preflight gate) 2026-06-15 |
-| autopilot-upstream-default | A | 2026-06-19 04:59 | PASS | issue #420 — future autopilots must target canonical repo, not personal fork |
-| autopilot-worktree-log-root | A | 2026-06-19 04:59 | PASS | issue #152 (persist autopilot worktree logs) 2026-06-15 |
-| boot-lint-glob | A | 2026-06-19 04:59 | PASS | issue #90, issue #120 |
-| capability-benchmark-schema | A | 2026-06-19 04:59 | PASS | issue #167 — capability benchmark instrument |
-| clean-restore | A | 2026-06-19 04:59 | PASS | issue #63 (autopilot-stray-wip-guard) 2026-06-12; issue #81 (owned-paths-zsh-split) 2026-06-13 |
-| cleanup-tasks-scoped-guard | A | 2026-06-19 04:59 | PASS | issue #85 |
-| cleanup-tasks-worktree-grooming | A | 2026-06-19 04:59 | PASS | issue #168 |
-| cron-claude-codex-fallback | A | 2026-06-19 04:59 | PASS | conversation 2026-06-12 (default Codex fallback for crons) |
-| cron-watchdog | A | 2026-06-19 04:59 | PASS | issue #130 (cron runtime watchdog) 2026-06-14 |
-| curl-bash-safe-alternatives | A | 2026-06-19 04:59 | PASS | vet-run/vet integration — public curl|bash examples need review-first alternatives |
-| datasets-schema | A | 2026-06-19 04:59 | PASS | issue #196 — evals/datasets verifiable trajectory corpus (Repo2RLEnv-inspired) |
-| devtcp-hook | A | 2026-06-19 04:59 | PASS | memory/MEMORY.md 2026-06-10 (zsh /dev/tcp) |
-| docs-build-fast-path | A | 2026-06-19 04:59 | PASS | #455 — docs builds must stay out of fast harness/eval/release gates |
-| drift-check-cron-staleness-glob | A | 2026-06-19 04:59 | PASS | issue #98; issue #225 (restart-required cron frontmatter/config drift) |
-| eval-ci-gate | A | 2026-06-19 04:59 | PASS | #103 — eval probe suite gated in CI |
-| eval-gate | A | 2026-06-19 04:59 | PASS | memory/MEMORY.md 2026-06-11 (eval-gate) |
-| eval-results-atomic | A | 2026-06-19 04:59 | PASS | issue #83 (eval-results-atomic-write) |
-| eval-runner-exit | A | 2026-06-19 04:59 | PASS | memory/MEMORY.md 2026-06-11 (eval-runner-exit) #29 |
-| git-skill | A | 2026-06-19 04:59 | PASS | conversation 2026-06-15 — rules are not always supported; git workflow must be the /git skill |
-| harness-audit-empty-output-gate | A | 2026-06-19 04:59 | PASS | issue #246 — /harness-audit must fail closed on empty auditor outputs |
-| harness-audit-memory-path | A | 2026-06-19 04:59 | PASS | issue #183 — /harness-audit must inspect the active worktree, not a hardcoded root |
-| harness-audit-shared-memory | A | 2026-06-19 04:59 | PASS | issue #432 — /harness-audit must load durable memory from shared log root in cron worktrees |
-| harness-ci-core-paths | A | 2026-06-19 04:59 | PASS | #165 — core sandbox config files must trigger harness CI |
-| harness-ci-hooks-paths | A | 2026-06-19 04:59 | PASS | issue #202 — credential/security hook changes must trigger harness CI |
-| health-check-docker-stats | A | 2026-06-19 04:59 | PASS | memory/MEMORY.md 2026-06-10 (docker stats vs ps Size) |
-| locked-append-critical-path | A | 2026-06-19 04:59 | PASS | issue #204 (lock shared runtime log appends) 2026-06-15 |
-| loop-benchmark-gate | A | 2026-06-19 04:59 | PASS | issue #179 — wire the executable-loop `benchmark` node (close the cycle) |
-| loop-handoff-consistency | A | 2026-06-19 04:59 | PASS | context/rules/loop.md § 4 (executable-loop Handoff convention) |
-| loop-repeat-gate | A | 2026-06-19 04:59 | PASS | issue #173 — wire the executable-loop `repeat` node (cycle-closing edge) |
-| memory-gitignore-claim | A | 2026-06-19 04:59 | PASS | issue #101 |
-| next-dev-prod | A | 2026-06-19 04:59 | PASS | memory/MEMORY.md 2026-06-04 |
-| orchestrate-contract | A | 2026-06-19 04:59 | PASS | issue #160 — /orchestrate contract; issue #175 — reserved /loop command rename |
-| owned-surface-guard | A | 2026-06-19 04:59 | PASS | issue #63 (autopilot-stray-wip-guard) 2026-06-12; issue #81 (owned-paths-zsh-split) 2026-06-13 |
-| pnpm-audit-ci-gate | A | 2026-06-19 04:59 | PASS | issue #171 — pnpm security audits must run in CI |
-| pr-audit-duplicate-issue-refs | A | 2026-06-19 04:59 | PASS | issue #439 — /pr-audit must flag duplicate open PRs that reference the same issue |
-| ralph-fallback-order | A | 2026-06-19 04:59 | PASS | conversation 2026-06-12 (Ralph default fallback order) |
-| retro-deterministic-contract | A | 2026-06-19 04:59 | PASS | issue #443 — /retro deterministic output and self-contained helper contract |
-| rl-delegation-write-worker | A | 2026-06-19 04:59 | PASS | memory/MEMORY.md 2026-06-10 (rl-delegation) #57 |
-| ship-spec-ready-finalization | A | 2026-06-19 04:59 | PASS | issue #134 — /ship-spec must finalize ready PRs after gates, not stop at draft scaffold |
-| skill-paths | A | 2026-06-19 04:59 | PASS | issue #43 — stale path references; extended by issue #69 — apps/->packages/ rename guard |
-| submitted-by-trailers | A | 2026-06-19 04:59 | PASS | conversation 2026-06-12 (commit attribution trailers) |
-| watchdog-completed-session-reap | A | 2026-06-19 04:59 | PASS | issue #235 (completed autopilot PR session reaping) |
-| watchdog-draft-prs | A | 2026-06-19 04:59 | PASS | conversation 2026-06-15 (generic watchdog + stale draft PR recovery) |
-| watchdog-stuck-sessions | A | 2026-06-19 04:59 | PASS | issue #240 (Codex zero-credit stuck autopilot sessions) 2026-06-17 |
-| wiki-readme-index | A | 2026-06-19 04:59 | PASS | issue #132 — wiki README index drift guard |
+| agent-browser-cli | A | 2026-06-19 05:55 | PASS | memory/MEMORY.md 2026-06-07 (agent-browser 0.8.5 CLI) |
+| autopilot-executor-toggle | A | 2026-06-19 05:55 | PASS | conversation 2026-06-13 (autopilot delegate-advisor executor) |
+| autopilot-no-pr-session-close | A | 2026-06-19 05:55 | PASS | issue #209 (autopilot no-PR tmux session closure) 2026-06-16 |
+| autopilot-open-pr-reference-dedupe | A | 2026-06-19 05:55 | PASS | issue #437 — autopilot must not start duplicate work when open PRs reference the same issue without linked-PR metadata |
+| autopilot-pi-agent | A | 2026-06-19 05:55 | PASS | issue #116 (autopilot Pi tmux alignment) 2026-06-14; issue #118 (attachable Pi TUI tmux) 2026-06-14; issue #126 (kept Pi overlap lock release) 2026-06-14; issue #142 (worktree-by-default, skip→worktree) 2026-06-14 |
+| autopilot-preflight-gate | A | 2026-06-19 05:55 | PASS | issue #194 (deterministic autopilot caps preflight gate) 2026-06-15 |
+| autopilot-upstream-default | A | 2026-06-19 05:55 | PASS | issue #420 — future autopilots must target canonical repo, not personal fork |
+| autopilot-worktree-log-root | A | 2026-06-19 05:55 | PASS | issue #152 (persist autopilot worktree logs) 2026-06-15 |
+| boot-lint-glob | A | 2026-06-19 05:55 | PASS | issue #90, issue #120 |
+| capability-benchmark-schema | A | 2026-06-19 05:55 | PASS | issue #167 — capability benchmark instrument |
+| clean-restore | A | 2026-06-19 05:55 | PASS | issue #63 (autopilot-stray-wip-guard) 2026-06-12; issue #81 (owned-paths-zsh-split) 2026-06-13 |
+| cleanup-tasks-scoped-guard | A | 2026-06-19 05:55 | PASS | issue #85 |
+| cleanup-tasks-worktree-grooming | A | 2026-06-19 05:55 | PASS | issue #168 |
+| cron-claude-codex-fallback | A | 2026-06-19 05:55 | PASS | conversation 2026-06-12 (default Codex fallback for crons) |
+| cron-watchdog | A | 2026-06-19 05:55 | PASS | issue #130 (cron runtime watchdog) 2026-06-14 |
+| curl-bash-safe-alternatives | A | 2026-06-19 05:55 | PASS | vet-run/vet integration — public curl|bash examples need review-first alternatives |
+| datasets-schema | A | 2026-06-19 05:55 | PASS | issue #196 — evals/datasets verifiable trajectory corpus (Repo2RLEnv-inspired) |
+| devtcp-hook | A | 2026-06-19 05:55 | PASS | memory/MEMORY.md 2026-06-10 (zsh /dev/tcp) |
+| docs-build-fast-path | A | 2026-06-19 05:55 | PASS | #455 — docs builds must stay out of fast harness/eval/release gates |
+| drift-check-cron-staleness-glob | A | 2026-06-19 05:55 | PASS | issue #98; issue #225 (restart-required cron frontmatter/config drift) |
+| eval-ci-gate | A | 2026-06-19 05:55 | PASS | #103 — eval probe suite gated in CI |
+| eval-gate | A | 2026-06-19 05:55 | PASS | memory/MEMORY.md 2026-06-11 (eval-gate) |
+| eval-results-atomic | A | 2026-06-19 05:55 | PASS | issue #83 (eval-results-atomic-write) |
+| eval-runner-exit | A | 2026-06-19 05:55 | PASS | memory/MEMORY.md 2026-06-11 (eval-runner-exit) #29 |
+| git-skill | A | 2026-06-19 05:55 | PASS | conversation 2026-06-15 — rules are not always supported; git workflow must be the /git skill |
+| harness-audit-empty-output-gate | A | 2026-06-19 05:55 | PASS | issue #246 — /harness-audit must fail closed on empty auditor outputs |
+| harness-audit-memory-path | A | 2026-06-19 05:55 | PASS | issue #183 — /harness-audit must inspect the active worktree, not a hardcoded root |
+| harness-audit-shared-memory | A | 2026-06-19 05:55 | PASS | issue #432 — /harness-audit must load durable memory from shared log root in cron worktrees |
+| harness-ci-core-paths | A | 2026-06-19 05:55 | PASS | #165 — core sandbox config files must trigger harness CI |
+| harness-ci-hooks-paths | A | 2026-06-19 05:55 | PASS | issue #202 — credential/security hook changes must trigger harness CI |
+| health-check-docker-stats | A | 2026-06-19 05:55 | PASS | memory/MEMORY.md 2026-06-10 (docker stats vs ps Size) |
+| locked-append-critical-path | A | 2026-06-19 05:55 | PASS | issue #204 (lock shared runtime log appends) 2026-06-15 |
+| loop-benchmark-gate | A | 2026-06-19 05:55 | PASS | issue #179 — wire the executable-loop `benchmark` node (close the cycle) |
+| loop-handoff-consistency | A | 2026-06-19 05:55 | PASS | context/rules/loop.md § 4 (executable-loop Handoff convention) |
+| loop-repeat-gate | A | 2026-06-19 05:55 | PASS | issue #173 — wire the executable-loop `repeat` node (cycle-closing edge) |
+| memory-gitignore-claim | A | 2026-06-19 05:55 | PASS | issue #101 |
+| next-dev-prod | A | 2026-06-19 05:55 | PASS | memory/MEMORY.md 2026-06-04 |
+| orchestrate-contract | A | 2026-06-19 05:55 | PASS | issue #160 — /orchestrate contract; issue #175 — reserved /loop command rename |
+| owned-surface-guard | A | 2026-06-19 05:55 | PASS | issue #63 (autopilot-stray-wip-guard) 2026-06-12; issue #81 (owned-paths-zsh-split) 2026-06-13 |
+| pnpm-audit-ci-gate | A | 2026-06-19 05:55 | PASS | issue #171 — pnpm security audits must run in CI |
+| pr-audit-duplicate-issue-refs | A | 2026-06-19 05:55 | PASS | issue #439 — /pr-audit must flag duplicate open PRs that reference the same issue |
+| ralph-fallback-order | A | 2026-06-19 05:55 | PASS | conversation 2026-06-12 (Ralph default fallback order) |
+| repo-layout-skill | A | 2026-06-19 05:55 | PASS | issue #459 — sandbox tree CLI + concise descriptive /repo-layout agent premap skill |
+| retro-deterministic-contract | A | 2026-06-19 05:55 | PASS | issue #443 — /retro deterministic output and self-contained helper contract |
+| rl-delegation-write-worker | A | 2026-06-19 05:55 | PASS | memory/MEMORY.md 2026-06-10 (rl-delegation) #57 |
+| ship-spec-ready-finalization | A | 2026-06-19 05:55 | PASS | issue #134 — /ship-spec must finalize ready PRs after gates, not stop at draft scaffold |
+| skill-paths | A | 2026-06-19 05:55 | PASS | issue #43 — stale path references; extended by issue #69 — apps/->packages/ rename guard |
+| submitted-by-trailers | A | 2026-06-19 05:55 | PASS | conversation 2026-06-12 (commit attribution trailers) |
+| watchdog-completed-session-reap | A | 2026-06-19 05:55 | PASS | issue #235 (completed autopilot PR session reaping) |
+| watchdog-draft-prs | A | 2026-06-19 05:55 | PASS | conversation 2026-06-15 (generic watchdog + stale draft PR recovery) |
+| watchdog-stuck-sessions | A | 2026-06-19 05:55 | PASS | issue #240 (Codex zero-credit stuck autopilot sessions) 2026-06-17 |
+| wiki-readme-index | A | 2026-06-19 05:55 | PASS | issue #132 — wiki README index drift guard |
 
 <!-- benchmark: pass-rate = PASS / (PASS + REGRESSION + TIMEOUT); SKIPPED excluded -->

--- a/evals/probes/repo-layout-skill.sh
+++ b/evals/probes/repo-layout-skill.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# tier: A
+# source: issue #459 — sandbox tree CLI + concise descriptive /repo-layout agent premap skill
+# desc: sandbox Dockerfile installs tree and /repo-layout skill stays wired to a concise descriptive premap wrapper
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+fail() { echo "REGRESSION: $*" >&2; exit 1; }
+pass() { echo "PASS: $*" >&2; exit 0; }
+
+[[ -f .devcontainer/Dockerfile ]] || fail ".devcontainer/Dockerfile missing"
+grep -Eq '(^|[[:space:]])tree([[:space:]\\]|$)' .devcontainer/Dockerfile \
+  || fail "Dockerfile system package list does not include tree"
+
+[[ -f .claude/skills/repo-layout/SKILL.md ]] || fail "/repo-layout skill missing"
+[[ -x .claude/skills/repo-layout/scripts/run.sh ]] || fail "/repo-layout wrapper missing or not executable"
+[[ -L .pi/skills ]] || fail ".pi/skills must remain the symlinked Pi skill surface"
+[[ -f .pi/skills/repo-layout/SKILL.md ]] || fail "/repo-layout not visible through .pi/skills symlink"
+
+grep -q '^name: repo-layout$' .claude/skills/repo-layout/SKILL.md \
+  || fail "/repo-layout skill frontmatter name drifted"
+grep -q 'argument-hint: "\[path\] \[--depth N|--raw tree-options\]"' .claude/skills/repo-layout/SKILL.md \
+  || fail "/repo-layout argument-hint drifted"
+grep -Fq "\$ARGUMENTS" .claude/skills/repo-layout/SKILL.md \
+  || fail "/repo-layout skill no longer wires arguments"
+grep -q 'concise, descriptive' .claude/skills/repo-layout/SKILL.md \
+  || fail "/repo-layout skill no longer promises concise descriptive premap behavior"
+grep -q 'CLAUDE_SKILL_DIR.*/scripts/run.sh' .claude/skills/repo-layout/SKILL.md \
+  || fail "/repo-layout skill no longer invokes its bundled wrapper"
+
+grep -q 'command -v tree' .claude/skills/repo-layout/scripts/run.sh \
+  || fail "/repo-layout wrapper no longer checks for tree binary"
+grep -q "IGNORE_PATTERN=.*node_modules" .claude/skills/repo-layout/scripts/run.sh \
+  || fail "/repo-layout wrapper no longer filters noisy directories"
+grep -q '^DEPTH=1$' .claude/skills/repo-layout/scripts/run.sh \
+  || fail "/repo-layout wrapper default depth is no longer concise"
+grep -q '^FILE_LIMIT=40$' .claude/skills/repo-layout/scripts/run.sh \
+  || fail "/repo-layout wrapper no longer caps large directories"
+grep -q 'Agent premap' .claude/skills/repo-layout/scripts/run.sh \
+  || fail "/repo-layout wrapper no longer emits agent premap output"
+grep -q 'Key areas' .claude/skills/repo-layout/scripts/run.sh \
+  || fail "/repo-layout wrapper no longer emits descriptive key areas"
+grep -q 'Good next reads' .claude/skills/repo-layout/scripts/run.sh \
+  || fail "/repo-layout wrapper no longer suggests concise next reads"
+raw_exec="exec tree \"\${RAW_ARGS[@]}\""
+grep -Fq "$raw_exec" .claude/skills/repo-layout/scripts/run.sh \
+  || fail "/repo-layout wrapper raw mode no longer passes native tree args"
+
+pass "repo-layout skill and sandbox tree package contract intact"

--- a/tasks/tree-sandbox-skill/critique.md
+++ b/tasks/tree-sandbox-skill/critique.md
@@ -1,0 +1,51 @@
+# Critique — repo-layout-skill
+
+Generated 2026-06-19; reviews `prd.md` post-/prd, pre-/ralph.
+
+## Critic A — Implementer lens
+
+Initial review:
+
+```text
+CRITIC_A — IMPLEMENTER LENS
+[SEVERITY: H] [STORY: US-001] [FINDING] [PROTECTED-PATH] PRD proposes modifying `.devcontainer/Dockerfile`, a protected path, without an explicit override note. | [EVIDENCE: `.claude/protected-paths.txt` lists `.devcontainer/Dockerfile`; US-001 AC: “`.devcontainer/Dockerfile` includes `tree`…”] | Add an AC-level override note explaining why this protected-path edit is necessary and bounded to adding the Debian `tree` package only.
+[SEVERITY: M] [STORY: US-001] [FINDING] “Boot-path lint remains green” is not directly verifiable because no command or expected artifact is named. | [EVIDENCE: US-001 AC: “Boot-path lint remains green.”] | Replace with the exact lint/test command and expected pass condition.
+[SEVERITY: M] [STORY: US-001] [FINDING] Package verification is underspecified and may require network/package-index state that is not guaranteed locally. | [EVIDENCE: US-001 AC: “A verification command proves `tree` is present or resolvable from Debian bookworm packages.”] | Name the deterministic command, e.g. current binary smoke check plus static Dockerfile grep, or an explicit `apt-cache policy tree` check only if package indexes are available.
+[SEVERITY: M] [STORY: US-002] [FINDING] “Bounded tree” is vague; implementation could choose incompatible defaults. | [EVIDENCE: US-002 AC: “Running the script with no args produces a bounded tree for the current directory.”] | Specify the default bound, e.g. `tree -L 2 .` or equivalent, and whether hidden/gitignored directories are excluded.
+[SEVERITY: M] [STORY: US-002] [FINDING] Skill-builder dependency is assumed but not locatable under `.claude/skills`; checklist source is ambiguous. | [EVIDENCE: US-002 AC references “The skill-builder checklist”; `.claude/skills/skill-builder/SKILL.md` absent.] | Cite the canonical checklist path or include the required checklist items directly in the PRD.
+[SEVERITY: M] [STORY: US-003] [FINDING] Story combines three separable deliverables: changelog, wiki/raw entry, and generated wiki index/probe. | [EVIDENCE: US-003 AC list spans `CHANGELOG.md`, `wiki/repo-layout-skill.md`, `wiki/README.md`, and `evals/probes/wiki-readme-index.sh`.] | Split into documentation update and wiki indexing/verification stories, or explicitly state they are one atomic docs pass.
+[SEVERITY: M] [STORY: *] [FINDING] Wiki alignment is present but DeepWiki comparison is shallow; it references only the root page and no specific DeepWiki page/source evidence. | [EVIDENCE: `## Wiki Alignment` says “public DeepWiki root page… no dedicated `tree` page exists.”] | Name the exact relevant DeepWiki URL(s) checked and the source-file relationship being mirrored, or state that no deeper page exists after checking.
+```
+
+Recheck after PRD revision:
+
+```text
+CRITIC_A — IMPLEMENTER LENS RECHECK
+[SEVERITY: L] [STORY: *] No blocking findings remain. | [EVIDENCE: revised PRD] | Proceed.
+```
+
+## Critic B — User lens
+
+Initial review:
+
+```text
+CRITIC_B — USER LENS
+[SEVERITY: H] [STORY: US-001] [PROTECTED-PATH] Story requires modifying `.devcontainer/Dockerfile`, which is listed as protected, but the PRD has no override note explaining why this protected path must be changed. | [EVIDENCE: .claude/protected-paths.txt; PRD US-001] | Add an explicit protected-path override note to the PRD before implementation, scoped to adding the Debian `tree` package only.
+[SEVERITY: M] [STORY: US-002] `/tree` promises “safely renders” and forwards user-supplied args, but does not define safety bounds for explicit args; a user could reasonably expect output limits, ignored heavy dirs, or protection against massive repo dumps. | [EVIDENCE: PRD US-002 acceptance criteria] | Add default and explicit-arg guardrails: bounded default depth, documented pass-through behavior, and examples/warnings for large output.
+[SEVERITY: M] [STORY: US-001] “Next sandbox image build support” is the core user ask, but verification only proves local install/resolvability, not that the Dockerfile change actually works in a container build path. | [EVIDENCE: PRD Goals; Verification Plan] | Add a non-rebuild escape clause plus a stronger verification option, e.g. `docker build --target` or documented “not run due to cost” evidence if skipped.
+[SEVERITY: M] [STORY: US-003] Wiki alignment is strong conceptually, but the raw snapshot date is hard-coded to `2026-06-19`, which can drift from the actual implementation date and weaken source-first auditability. | [EVIDENCE: PRD Wiki Alignment] | Require the raw snapshot path to use the actual UTC implementation date or explain why `2026-06-19` is fixed.
+[SEVERITY: L] [STORY: *] Non-Goals do not explicitly exclude replacing existing mandatory file discovery workflows or changing agent tool-use policy, even though adding `/tree` could be misread as a preferred replacement for `find`/`read`. | [EVIDENCE: PRD Non-Goals; context/USER.md] | Add a Non-Goal: `/tree` is optional layout visualization only; it must not supersede required file-search/read conventions.
+```
+
+Recheck after PRD revision:
+
+```text
+CRITIC_B — USER LENS RECHECK
+[SEVERITY: L] [STORY: *] No blocking findings remain. | [EVIDENCE: revised PRD] | Proceed.
+```
+
+## Synthesis
+
+- **High-severity findings**: 0 unmitigated after recheck (2 initial protected-path findings were mitigated with a bounded `.devcontainer/Dockerfile` override in US-001).
+- **Medium-severity findings**: 0 unmitigated after recheck (specific commands/defaults/checklist path/story split/DeepWiki URL were added to the PRD).
+- **Recommendation**: PROCEED

--- a/tasks/tree-sandbox-skill/prd.json
+++ b/tasks/tree-sandbox-skill/prd.json
@@ -1,0 +1,68 @@
+{
+  "schemaVersion": 1,
+  "project": "Open Harness",
+  "branchName": "skill/459-tree-sandbox-skill",
+  "description": "Add first-class support for the Unix tree directory visualizer in sandbox builds and expose it through a concise, descriptive Claude repo-layout premap skill.",
+  "userStories": [
+    {
+      "id": "US-001",
+      "title": "Install tree in the sandbox image",
+      "description": "As a harness operator, I want the sandbox Docker image to install tree during image build so future sandboxes can inspect directory layouts without manual package installation.",
+      "acceptanceCriteria": [
+        "Protected-path override is honored: only add the Debian tree package to the existing .devcontainer/Dockerfile system package install list.",
+        ".devcontainer/Dockerfile includes tree in the existing apt-get install -y --no-install-recommends package list.",
+        "Verification proves next-build support with a Dockerfile package check and Debian bookworm package availability or build-path evidence.",
+        "Boot-path lint passes locally when available or via CI.",
+        "Typecheck passes"
+      ],
+      "priority": 1,
+      "passes": true,
+      "notes": "Completed on 2026-06-19; commit 5b6804f"
+    },
+    {
+      "id": "US-002",
+      "title": "Add the concise descriptive repo-layout skill",
+      "description": "As an agent, I want a /repo-layout skill that creates concise, descriptive directory premaps so layout summaries are optimized for handoff before exact file reads.",
+      "acceptanceCriteria": [
+        ".claude/skills/repo-layout/SKILL.md exists with name: repo-layout, front-loaded premap/repo-layout triggers, an accurate argument-hint, and concise imperative instructions.",
+        ".claude/skills/repo-layout/scripts/run.sh exists, is executable, verifies tree is installed before use, and supports default premap plus --raw native pass-through.",
+        "Running the script with no args uses concise defaults equivalent to tree -L 1 --dirsfirst --filelimit 40 -a with noisy directories ignored, then emits Key areas and Good next reads sections.",
+        "Running the script with --depth 2 or -L 2 adjusts premap depth; running with --raw -L 1 .claude/skills succeeds as native tree pass-through.",
+        "The skill-builder checklist is satisfied: lowercase-kebab name, front-loaded triggers, description under listing budget, body under 500 lines, bundled deterministic logic, and wired $ARGUMENTS.",
+        "Typecheck passes"
+      ],
+      "priority": 2,
+      "passes": true,
+      "notes": "Completed on 2026-06-19; renamed user-facing skill to repo-layout to avoid reserved tree collision; commit 165c8d4"
+    },
+    {
+      "id": "US-003",
+      "title": "Document tree support",
+      "description": "As a future agent, I want source-backed documentation for tree support so I know the sandbox image owns the binary and the skill owns the invocation pattern.",
+      "acceptanceCriteria": [
+        "CHANGELOG.md adds an Unreleased entry for sandbox tree support and the /repo-layout skill.",
+        "wiki/repo-layout-skill.md explains the relationship between .devcontainer/Dockerfile, .claude/skills/repo-layout/SKILL.md, and .claude/skills/repo-layout/scripts/run.sh with source-file references.",
+        "wiki/raw/<actual-utc-date>-repo-layout-skill.md captures the local and DeepWiki source notes used to create the entry.",
+        "Typecheck passes"
+      ],
+      "priority": 3,
+      "passes": true,
+      "notes": "Completed on 2026-06-19; commit 5b6804f"
+    },
+    {
+      "id": "US-004",
+      "title": "Index and verify the wiki entry",
+      "description": "As a maintainer, I want the wiki index to stay fresh after adding tree support so /wiki-query can find it later.",
+      "acceptanceCriteria": [
+        "wiki/README.md is regenerated or otherwise updated so the new wiki entry is indexed.",
+        "bash evals/probes/wiki-readme-index.sh passes.",
+        "bash evals/probes/repo-layout-skill.sh passes.",
+        "tasks/tree-sandbox-skill/prd.json parses successfully.",
+        "Typecheck passes"
+      ],
+      "priority": 4,
+      "passes": true,
+      "notes": "Completed on 2026-06-19; commit 5b6804f"
+    }
+  ]
+}

--- a/tasks/tree-sandbox-skill/prd.md
+++ b/tasks/tree-sandbox-skill/prd.md
@@ -1,0 +1,94 @@
+# PRD — Repo Layout Sandbox Tree Support
+
+## Introduction
+
+Add first-class support for the Unix `tree` directory visualizer in Open Harness as a concise, descriptive repository premap tool. The operator already has `tree` installed in the current local environment (`tree v2.1.0` at `/usr/bin/tree`); this work makes the next sandbox image build install the same class of tool and adds a Claude skill that produces concise, descriptive maps for agent handoff before exact file reads.
+
+## Goals
+
+- Ensure future sandbox image builds include the Debian `tree` package with no manual post-build install.
+- Add a self-contained `.claude/skills/repo-layout/` skill that runs `tree` through a skill-local script and produces concise, descriptive premap output with optional raw pass-through.
+- Document the tool/skill relationship in the wiki and changelog so future agents understand why `tree` is part of the sandbox toolchain.
+- Verify the skill and sandbox package declaration with deterministic local checks.
+
+## Non-Goals
+
+- Do not replace `find`, `rg`, or existing file-read workflows; `/repo-layout` is optional layout visualization only and must not supersede required search/read conventions.
+- Do not add a Node/Python wrapper around `tree`; the Debian package and a small shell wrapper are sufficient.
+- Do not require rebuilding or destroying the currently running sandbox during this task; acceptance is that the next image build installs `tree`.
+- Do not commit or alter `memory/` artifacts.
+
+## Current Evidence
+
+- `command -v tree` returns `/usr/bin/tree` in the current environment.
+- `tree --version` returns `tree v2.1.0 (c) 1996 - 2022 by Steve Baker, Thomas Moore, Francesc Rocher, Florian Sesser, Kyosuke Tokoro`.
+- `.devcontainer/Dockerfile` currently installs base packages in its first `apt-get install -y --no-install-recommends` block but does not include `tree`.
+
+## User Stories
+
+### US-001 — Install tree in the sandbox image
+
+As a harness operator, I want the sandbox Docker image to install `tree` during image build so that future sandboxes can inspect directory layouts without manual package installation.
+
+Acceptance criteria:
+
+- **Protected-path override**: `.devcontainer/Dockerfile` is listed in `.claude/protected-paths.txt`; this story is explicitly authorized to make the bounded edit of adding the Debian `tree` package to the existing system package install list and nothing else in that file.
+- `.devcontainer/Dockerfile` includes `tree` in the system package install list.
+- The package is installed with the existing `apt-get install -y --no-install-recommends` pattern.
+- Verification proves next-build support by running `grep -E 'apt-get install .*tree|^[[:space:]]*.*tree' .devcontainer/Dockerfile` and either a Debian package availability check (`apt-cache policy tree` or equivalent in a bookworm context) or a documented Docker build-path check.
+- `hadolint .devcontainer/Dockerfile` passes when available; otherwise the PR's Boot Path Lint CI check must pass.
+
+### US-002 — Add a tree Claude skill
+
+As an agent, I want a `/repo-layout` skill that creates concise, descriptive directory premaps so layout summaries are optimized for handoff before exact file reads.
+
+Acceptance criteria:
+
+- `.claude/skills/repo-layout/SKILL.md` exists with `name: repo-layout`, front-loaded triggers, an accurate `argument-hint`, and concise imperative instructions.
+- `.claude/skills/repo-layout/scripts/run.sh` exists, is executable, verifies `tree` is installed before use, and supports concise premap options and explicit `--raw` pass-through to the `tree` binary.
+- Running the script with no args executes a concise default equivalent to `tree -L 1 --dirsfirst --filelimit 40 -a -I '<noisy dirs>' .`, followed by short `Key areas` and `Good next reads` sections.
+- Running the script with `--depth 2` or `-L 2` adjusts premap depth; running with `--raw -L 1 .claude/skills` succeeds and is documented as intentional native `tree` pass-through.
+- The skill-builder checklist from `.worktrees/task/457-preserve-dirty-workspace/.claude/skills/skill-builder/SKILL.md` is satisfied: lowercase-kebab name, front-loaded triggers, description under the listing budget, body under 500 lines, bundled deterministic logic, and wired `$ARGUMENTS`.
+
+### US-003 — Document tree support
+
+As a future agent, I want source-backed documentation for tree support so that I know the sandbox image owns the binary and the skill owns the invocation pattern.
+
+Acceptance criteria:
+
+- `CHANGELOG.md` adds an Unreleased entry for sandbox `tree` support and the `/repo-layout` skill.
+- `wiki/repo-layout-skill.md` explains the relationship between `.devcontainer/Dockerfile`, `.claude/skills/repo-layout/SKILL.md`, and `.claude/skills/repo-layout/scripts/run.sh` with source-file references.
+- `wiki/raw/<actual-utc-date>-repo-layout-skill.md` captures the local/DeepWiki source notes used to create the entry.
+
+### US-004 — Index and verify the wiki entry
+
+As a maintainer, I want the wiki index to stay fresh after adding tree support so `/wiki-query` can find it later.
+
+Acceptance criteria:
+
+- `wiki/README.md` is regenerated or otherwise updated so the new wiki entry is indexed.
+- `bash evals/probes/wiki-readme-index.sh` passes.
+- `bash evals/probes/repo-layout-skill.sh` passes.
+
+## Wiki Alignment
+
+- **Impact**: REQUIRED
+- **Local entries**: create `wiki/repo-layout-skill.md` and raw snapshot `wiki/raw/2026-06-19-repo-layout-skill.md`.
+- **Spec alignment**: The wiki entry must teach that the sandbox image provides the `tree` binary for next builds while the `/repo-layout` skill provides the concise, descriptive agent-facing premap. It should cite the Dockerfile package block, the skill frontmatter/body, and the wrapper script.
+- **DeepWiki comparison**: Checked `https://deepwiki.com/mifunedev/openharness` on 2026-06-19. The root page frames the sandbox as a Docker container defined by `.devcontainer/docker-compose.yml` and lifecycle-managed by `Makefile`, and frames the skills system as capabilities under `.claude/skills/`; no dedicated `tree` page was found. This task should follow that DeepWiki-style source-first shape and connect the new tool to those two existing subsystems.
+- **Acceptance criteria**: US-003 requires the local wiki entry and DeepWiki-style source relationships; US-004 requires `wiki/README.md` freshness via `bash evals/probes/wiki-readme-index.sh`.
+
+## Verification Plan
+
+- Run the local current-version smoke check: `command -v tree && tree --version`.
+- Run `.claude/skills/repo-layout/scripts/run.sh` with no args and with `--depth 1 .claude/skills` and raw mode with `--raw -L 1 .claude/skills`.
+- Run shell syntax checks for the new script.
+- Verify `tree` appears in `.devcontainer/Dockerfile` and can be installed from Debian bookworm; if a full Docker image rebuild is skipped for cost/time, record that and rely on PR CI Boot Path Lint plus package availability evidence.
+- Parse `tasks/tree-sandbox-skill/prd.json` after `/ralph` conversion.
+- Run `bash evals/probes/wiki-readme-index.sh`.
+- Run `bash evals/probes/repo-layout-skill.sh`.
+- Run `pnpm run test:scripts` and `/eval` before final PR readiness.
+
+## Critique Resolution
+
+Critics initially flagged the `.devcontainer/Dockerfile` protected-path edit, vague verification language, ambiguous `/repo-layout` output bounds, missing skill-builder checklist provenance, combined docs/indexing scope, shallow DeepWiki citation, and optional-tool framing. The PRD now includes a bounded protected-path override for adding only the Debian `tree` package, explicit default `tree` options, pass-through guardrails, a cited skill-builder checklist source, split documentation/indexing stories, an exact DeepWiki URL check, and a non-goal that `/repo-layout` must not replace required search/read workflows. Recheck found no blocking findings; proceed.

--- a/tasks/tree-sandbox-skill/progress.txt
+++ b/tasks/tree-sandbox-skill/progress.txt
@@ -1,0 +1,83 @@
+# progress
+
+## Codebase Patterns
+
+- The `/repo-layout` skill uses a skill-local script so argument defaults, install checks, concise premap formatting, and raw pass-through stay deterministic; `.pi/skills` is a symlink to `.claude/skills`, so one tracked skill directory serves both Claude and Pi.
+
+## US-001 — 2026-06-19 05:49 UTC
+
+**Title**: Install tree in the sandbox image
+**Files changed**: `.devcontainer/Dockerfile`
+**Commit**: 5b6804f
+**Result**: PASS
+
+### What I did
+Added the Debian `tree` package to the existing no-recommends system package layer. Verified the local installed package is `tree v2.1.0` and Debian bookworm package metadata resolves `tree`.
+
+### Learnings for future iterations
+The Dockerfile is protected, so the PRD includes a bounded protected-path override for the package-list-only change.
+
+---
+
+## US-002 — 2026-06-19 05:49 UTC
+
+**Title**: Add the concise descriptive repo-layout skill
+**Files changed**: `.claude/skills/repo-layout/SKILL.md`, `.claude/skills/repo-layout/scripts/run.sh`
+**Commit**: 5b6804f
+**Result**: PASS
+
+### What I did
+Created `/repo-layout` as an agent premap skill. The wrapper verifies `tree`, defaults to a concise depth-1 map with noisy-directory ignores and file limits, adds descriptive key-area notes plus good next reads, and keeps native `tree` available behind explicit `--raw`.
+
+### Learnings for future iterations
+Default premap output should be concise and descriptive; deeper maps are opt-in via `--depth`/`-L`, and raw CLI output is opt-in via `--raw`.
+
+---
+
+## US-003 — 2026-06-19 05:49 UTC
+
+**Title**: Document tree support
+**Files changed**: `CHANGELOG.md`, `wiki/repo-layout-skill.md`, `wiki/raw/2026-06-19-repo-layout-skill.md`
+**Commit**: 5b6804f
+**Result**: PASS
+
+### What I did
+Added an Unreleased changelog entry and a source-backed wiki page explaining the sandbox binary layer and skill premap layer. Captured local and DeepWiki comparison notes in the raw snapshot.
+
+### Learnings for future iterations
+Small tool additions can still merit wiki coverage when they establish a reusable agent-facing workflow.
+
+---
+
+## US-004 — 2026-06-19 05:49 UTC
+
+**Title**: Index and verify the wiki entry
+**Files changed**: `wiki/README.md`, `evals/probes/repo-layout-skill.sh`, `evals/RESULTS.md`, `tasks/tree-sandbox-skill/prd.json`
+**Commit**: 5b6804f
+**Result**: PASS
+
+### What I did
+Regenerated the wiki index and added a tier-A probe that guards the Dockerfile package, symlinked Pi skill surface, concise descriptive premap contract, bounded defaults, and raw pass-through. Verified wiki index, probe, typecheck, build, script tests, and `/eval`.
+
+### Learnings for future iterations
+A static probe is enough to protect this contract without requiring an expensive sandbox image rebuild every local run.
+
+---
+
+
+## Rename follow-up — 2026-06-19 05:56 UTC
+
+**Title**: Avoid reserved `tree` skill collision
+**Files changed**: `.claude/skills/repo-layout/`, `evals/probes/repo-layout-skill.sh`, `wiki/repo-layout-skill.md`, task artifacts
+**Commit**: 165c8d4
+**Result**: PASS
+
+### What I did
+Renamed the user-facing skill from `/tree` to `/repo-layout` so the skill does not collide with any reserved or native `tree` surface. Kept Debian `tree` as the implementation detail and updated docs, wiki, probe, and task artifacts to describe concise descriptive repo-layout premaps.
+
+### Learnings for future iterations
+Prefer intent-based skill names over raw binary names when a CLI name could collide with reserved commands or future native tool surfaces.
+
+---
+
+STATUS: COMPLETE

--- a/tasks/tree-sandbox-skill/prompt.md
+++ b/tasks/tree-sandbox-skill/prompt.md
@@ -1,0 +1,106 @@
+# Ralph iteration — tree-sandbox-skill
+
+You are one iteration of a Ralph loop implementing the `tree-sandbox-skill` task. The full plan is in `tasks/tree-sandbox-skill/prd.md` and the structured task list is in `tasks/tree-sandbox-skill/prd.json`. The loop calls you again until `progress.txt` contains a line `STATUS: COMPLETE`.
+
+## Your job in one iteration
+
+Pick **one** user story, implement it, commit, mark it `passes: true`, and append a progress entry. Then exit. The next iteration handles the next story. Do not attempt multiple stories per iteration.
+
+## Steps every iteration
+
+1. **Read context** — in this order:
+   - `tasks/tree-sandbox-skill/prd.json` — find the lowest-`priority` story where `passes: false`. That is your story for this iteration.
+   - `tasks/tree-sandbox-skill/progress.txt` — read the "Codebase Patterns" section at the top (if any) and the most recent few iterations to see what's been done.
+   - `tasks/tree-sandbox-skill/critique.md` — if present, the critic findings the stories must satisfy.
+   - If `tasks/tree-sandbox-skill/prd.md` contains `## Wiki Alignment`, read it before choosing the story. When `Impact: REQUIRED`, the relevant story must keep wiki updates aligned with the PRD and the recorded DeepWiki comparison.
+   - `context/rules/wiki.md` when your story touches `wiki/` or the PRD's Wiki Alignment section says `Impact: REQUIRED`.
+   - `.claude/skills/git/SKILL.md` for branch + commit conventions.
+   - `.claude/rules/sandbox-processes.md` for tmux session conventions if your story spawns processes.
+   - `.claude/rules/advisor-model.md` for any critic-gated story.
+
+2. **Verify branch** — your branch is `<prefix>/<N>-tree-sandbox-skill` (per `prd.json` `branchName`). If `/ship-spec`'s Advisor launched you in an isolated worktree at `.worktrees/<prefix>/<N>-tree-sandbox-skill`, that directory already has the branch checked out — `cd` into it and skip the checkout below. Otherwise, if you are not on the branch:
+   ```bash
+   : "${SHIP_SPEC_REMOTE:?SHIP_SPEC_REMOTE must name the git remote that matches SHIP_SPEC_REPO}"
+   git fetch "$SHIP_SPEC_REMOTE" "${SHIP_SPEC_BASE:-development}"
+   git checkout -b <prefix>/<N>-tree-sandbox-skill "$SHIP_SPEC_REMOTE/${SHIP_SPEC_BASE:-development}" 2>/dev/null \
+     || git checkout <prefix>/<N>-tree-sandbox-skill
+   ```
+   Never push to `development` or `main` directly.
+
+3. **Implement the chosen story** — make the file changes, additions, deletions specified in the story's `acceptanceCriteria`. Confine the work to that story; resist scope creep.
+
+4. **Run quality checks** before commit:
+   ```bash
+   pnpm run type-check 2>/dev/null || true
+   pnpm run lint 2>/dev/null || true
+   pnpm run test 2>/dev/null || true
+   ```
+   If checks fail, fix them. Do not commit broken code.
+
+5. **Commit** with this message format (per `.claude/skills/git/SKILL.md`):
+   ```
+   <type>: US-459 — <story title>
+
+   Submitted-by: <active submitter>
+   ```
+   Where `<type>` is `task` for most stories, `feat` for net-new functionality, `fix` for bugs. Example: `task: US-001 — <story title>`. Stage only files touched by this story.
+   The `Submitted-by:` trailer is mandatory. It must name the model/agent that actually submits the commit, using the active harness identity when available (`$RALPH_HARNESS`, e.g. `Claude`, `Codex`, or `Pi`). If Ralph fell back from Claude to Codex, use `Submitted-by: Codex`.
+
+6. **Update `prd.json`** — set `passes: true` for the completed story, and set `notes` to a one-line summary including iteration number and date:
+   ```json
+   "notes": "Completed iteration 3 on <YYYY-MM-DD>; commit abc1234"
+   ```
+
+7. **Append to `progress.txt`** — append (never replace) using this format:
+   ```markdown
+   ## US-459 — <YYYY-MM-DD HH:MM UTC>
+
+   **Title**: <story title>
+   **Files changed**: <list>
+   **Commit**: <short SHA>
+   **Result**: PASS | BLOCKED | DEFERRED
+
+   ### What I did
+   <2-4 sentences>
+
+   ### Learnings for future iterations
+   <patterns, gotchas, useful context>
+
+   ---
+   ```
+
+8. **Codebase Patterns** — if you discovered a pattern other iterations should know (a non-obvious convention, a shared utility, a gotcha), append it to (or create) the `## Codebase Patterns` section at the **top** of `progress.txt`. Keep entries general and reusable, not story-specific.
+
+9. **Stop condition** — after step 7, check whether all stories in `prd.json` now have `passes: true`. If yes, append a final line on its own to `progress.txt`:
+   ```
+   STATUS: COMPLETE
+   ```
+   This terminates the Ralph loop. The runner reads for this exact whole-line string in **two** places — `progress.txt` (at the start of each iteration) and your iteration output (after each iteration) — so either channel ends the loop.
+
+10. **Signal completion in your output only when terminal** — when (and only when) you have just appended `STATUS: COMPLETE` to `progress.txt`, also print `STATUS: COMPLETE` as the sole content of your final line. This lets the runner exit even if the file write was missed. Never print that bare standalone line for any other reason; to refer to it in prose, call it "the completion marker."
+
+## Blocked or deferred stories
+
+If the chosen story cannot be completed this iteration:
+
+- **Blocked** (external dependency, missing context, ambiguity): append to `progress.txt` with `**Result**: BLOCKED` and an explanation. Do NOT mark `passes: true`. The next iteration will skip this story (find the next lowest-priority `passes: false` that isn't already BLOCKED in recent progress entries) or escalate.
+- **Deferred** (out of scope per the PRD's Non-Goals): append with `**Result**: DEFERRED`. Do NOT mark `passes: true`. The story stays for human review.
+
+## Critical rules
+
+- **One story per iteration.** Resist doing two.
+- **Never push** to `development` or `main`. Branch is `<prefix>/<N>-tree-sandbox-skill`.
+- **Never skip pre-commit hooks** (`--no-verify`).
+- **Never run `git clone` or `git init`** — you're already in a checkout.
+- **Confine writes** to repo-tracked paths. Do not write outside the repo or to `~/`.
+- **Phase ordering matters.** Stories are priority-ordered by dependency — implement them in `priority` order. If a story depends on an artifact a later story creates, it is mis-ordered; surface it rather than implementing out of order.
+- **CHANGELOG discipline.** Per `.claude/skills/git/SKILL.md`, every story with user-visible impact must add an entry under `## [Unreleased]` in the same commit. The PRD's individual stories spell out which `### Added`, `### Removed`, `### Changed` section to use.
+- **Wiki alignment discipline.** If the PRD says `Wiki Alignment` is `REQUIRED`, update the named wiki entries in the same implementation branch so they match the final spec behavior, preserve the DeepWiki comparison, and pass `bash evals/probes/wiki-readme-index.sh`.
+- **Don't modify completed stories** unless the current story explicitly requires it.
+
+## Reference
+
+- PRD: `tasks/tree-sandbox-skill/prd.md`
+- Structured stories: `tasks/tree-sandbox-skill/prd.json`
+- Branch: `<prefix>/<N>-tree-sandbox-skill`
+- Issue: #459

--- a/wiki/README.md
+++ b/wiki/README.md
@@ -26,6 +26,7 @@ Schema rule, frontmatter spec, and all authoring conventions: `context/rules/wik
 
 | Slug | Title | Tags | Updated |
 | --- | --- | --- | --- |
+| repo-layout-skill | Repo Layout Sandbox Tree Support | [sandbox, skills, cli, tree, devcontainer] | 2026-06-19 |
 | ci-build-gates | CI Build Gates | [ci, docs, build, eval, github-actions] | 2026-06-19 |
 | harness-audit | Harness Audit | [audit, skills, autopilot, memory, worktrees] | 2026-06-18 |
 | sandbox-auth-volumes | Sandbox Auth Volume Ownership | [sandbox, devcontainer, auth, docker, ownership] | 2026-06-16 |

--- a/wiki/raw/2026-06-19-repo-layout-skill.md
+++ b/wiki/raw/2026-06-19-repo-layout-skill.md
@@ -1,0 +1,23 @@
+# Raw source notes — tree sandbox skill
+
+Captured: 2026-06-19
+
+## Local current-version evidence
+
+```text
+$ command -v tree
+/usr/bin/tree
+$ tree --version
+tree v2.1.0 (c) 1996 - 2022 by Steve Baker, Thomas Moore, Francesc Rocher, Florian Sesser, Kyosuke Tokoro
+```
+
+## Local repository sources
+
+- `.devcontainer/Dockerfile` — Debian bookworm sandbox image package installation. The repo-layout support change adds `tree` to the initial `apt-get install -y --no-install-recommends` package list.
+- `.claude/skills/repo-layout/SKILL.md` — `/repo-layout` skill metadata and invocation instructions.
+- `.claude/skills/repo-layout/scripts/run.sh` — deterministic wrapper that checks for `tree`, applies concise descriptive premap defaults when no args are provided, and supports `--raw` native pass-through when explicitly requested.
+- `.pi/skills` — symlink to `../.claude/skills`, so the tracked Claude skill is also the Pi skill surface.
+
+## DeepWiki comparison
+
+Checked `https://deepwiki.com/mifunedev/openharness` on 2026-06-19. The root page frames the sandbox as a Docker container defined by `.devcontainer/docker-compose.yml` and lifecycle-managed by `Makefile`, and frames capabilities as Skills under `.claude/skills/`. No dedicated `tree` page was found. The local wiki entry mirrors DeepWiki's source-first style by tying the binary to the sandbox image and the concise descriptive premap invocation to the skills system.

--- a/wiki/repo-layout-skill.md
+++ b/wiki/repo-layout-skill.md
@@ -1,0 +1,43 @@
+---
+title: "Repo Layout Sandbox Tree Support"
+slug: repo-layout-skill
+tags: [sandbox, skills, cli, tree, devcontainer]
+created: 2026-06-19
+updated: 2026-06-19
+sources:
+  - raw/2026-06-19-repo-layout-skill.md
+related: [ci-build-gates]
+confidence: confirmed
+---
+
+# Repo Layout Sandbox Tree Support
+
+## Relevant Source Files
+- `.devcontainer/Dockerfile` — installs sandbox image system packages, including the new `tree` package.
+- `.claude/skills/repo-layout/SKILL.md` — defines when `/repo-layout` is loaded and how agents invoke the wrapper.
+- `.claude/skills/repo-layout/scripts/run.sh` — performs the install check, concise descriptive premap output, and explicit `--raw` pass-through.
+- `.pi/skills` — symlink that exposes tracked `.claude/skills/*` entries to Pi sessions.
+
+## Summary
+Open Harness treats `tree` as both sandbox toolchain inventory and an agent-facing skill. The sandbox image owns the binary for next builds, while `/repo-layout` owns the concise, descriptive premap shape agents should use before selecting exact files to read.
+
+## Detail
+The sandbox image is Debian bookworm (`.devcontainer/Dockerfile:1`) and installs base packages through a single `apt-get install -y --no-install-recommends` block (`.devcontainer/Dockerfile:6-10`). Adding `tree` to that block (`.devcontainer/Dockerfile:8`) means future `make sandbox` / devcontainer rebuilds include the CLI without a manual `apt install` step.
+
+The skill layer is separate from the binary layer. `/repo-layout` is discovered through frontmatter with `name: repo-layout`, trigger phrases for directory-tree and hierarchy requests, and an argument hint for `[path] [--depth N|--raw tree-options]` (`.claude/skills/repo-layout/SKILL.md:1-10`). Its body calls the skill-local wrapper with `$ARGUMENTS` (`.claude/skills/repo-layout/SKILL.md:19-24`), keeping argument wiring explicit rather than describing a command the operator must run manually.
+
+The wrapper first fails clearly if the current sandbox predates the image change and lacks `tree` (`.claude/skills/repo-layout/scripts/run.sh:4-10`). With no arguments it applies a concise default depth, directory-first ordering, a file limit, and noisy-directory ignores (`.claude/skills/repo-layout/scripts/run.sh:7-10`, `.claude/skills/repo-layout/scripts/run.sh:116-121`). It then adds short `Key areas` descriptions and `Good next reads` suggestions (`.claude/skills/repo-layout/scripts/run.sh:123-152`). Native `tree` flags remain available only through explicit `--raw` mode (`.claude/skills/repo-layout/scripts/run.sh:88-93`).
+
+## System Relationships
+
+```mermaid
+flowchart LR
+    Dockerfile[.devcontainer/Dockerfile\napt package: tree] --> Sandbox[Next sandbox image]
+    Sandbox --> Binary[/usr/bin/tree]
+    Skill[.claude/skills/repo-layout/SKILL.md] --> Wrapper[scripts/run.sh]
+    Wrapper --> Binary
+    Pi[.pi/skills symlink] --> Skill
+```
+
+## See Also
+- [[ci-build-gates]]


### PR DESCRIPTION
Closes #459.

## Summary
- Add Debian `tree` to the sandbox image package list for future builds.
- Add `/repo-layout`, a concise descriptive agent premap skill backed by the `tree` CLI and a skill-local wrapper.
- Avoid a reserved/native `/tree` name collision by making `tree` an implementation detail, not the skill name.
- Add `/ship-spec` artifacts, wiki/changelog coverage, and a tier-A eval probe guarding the contract.

## Verification
- `command -v tree && tree --version` → `/usr/bin/tree`, `tree v2.1.0`.
- `.claude/skills/repo-layout/scripts/run.sh` default concise premap smoke passed.
- `.claude/skills/repo-layout/scripts/run.sh .claude/skills --depth 1` passed.
- `.claude/skills/repo-layout/scripts/run.sh --raw -L 1 .claude/skills` passed.
- `test ! -e .claude/skills/tree` passed.
- `test -f .pi/skills/repo-layout/SKILL.md` passed.
- `shellcheck .claude/skills/repo-layout/scripts/run.sh evals/probes/repo-layout-skill.sh` passed.
- `bash evals/probes/repo-layout-skill.sh` passed.
- `bash evals/probes/wiki-readme-index.sh` passed.
- `node -e "JSON.parse(require('fs').readFileSync('tasks/tree-sandbox-skill/prd.json','utf8'))"` passed.
- `pnpm run typecheck` passed.
- `pnpm run build` passed.
- `pnpm run test:scripts` passed: 275 tests.
- `bash .claude/skills/eval/run.sh` passed: 52 probes.

## Note
A long local Docker image build smoke was stopped after clarification that `tree` is already installed locally and the main requirement is the optimized agent premap skill plus next-build package declaration. CI Boot Path Lint covers the Dockerfile path.
