### PR TITLE
FROM feat/repo-context-map TO development

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,18 @@
 
 You are the harness orchestrator. You run at the project root. You do NOT write application code. Your sole purpose is to manage the sandboxed agent workspace.
 
+## Scope and local instructions
+
+This root `AGENTS.md` applies to the whole Open Harness repo unless a more local `AGENTS.md`/`CLAUDE.md` says otherwise.
+
+Assume agent harnesses may concatenate global, parent-directory, and current-directory context files; do not rely on automatic nearest-file-wins semantics. For Open Harness work, after discovering applicable context files, resolve conflicts by target-path specificity:
+
+- Before editing a subtree, check whether that directory or an ancestor below repo root contains another `AGENTS.md`/`CLAUDE.md`.
+- More local instructions take precedence for files in their subtree.
+- Within the same directory, `AGENTS.md` is canonical; `CLAUDE.md` is a provider-compatibility alias. If both are real files and conflict, stop and call out the conflict.
+- If context-file instructions conflict, follow the most specific file for the paths being edited and call out the conflict.
+- Launching an agent from repo root may not load deeper package/workspace context files; explicitly read them before work there, or restart/reload from that subdirectory when supported.
+
 ## Session start
 
 Read these files at the start of every session — they encode voice, principles, environment, and working-relationship patterns that don't belong in the always-loaded bootloader:
@@ -9,13 +21,14 @@ Read these files at the start of every session — they encode voice, principles
 - `context/SOUL.md` — voice and disposition
 - `context/IDENTITY.md` — operating principles + lessons learned (append-only)
 - `context/TOOLS.md` — environment inventory; skip rediscovery
+- `context/REPO_MAP.md` — source-map command, search routing, and low-signal folders to disregard
 - `context/USER.md` — working-relationship patterns; living document
 - `memory/MEMORY.md` — long-term lessons learned (append-only)
 - Today's `memory/<today>/log.md` if it exists (today = `date -u +%Y-%m-%d`) — recent session activity
 
 See `context/rules/memory.md` for the write-side Memory Improvement Protocol.
 
-Auto-loaded rules (no explicit read needed): `context/rules/*.md`.
+Some harnesses auto-load `context/rules/*.md`; when the current provider does not explicitly do so, read task-relevant rule files manually.
 
 ## Permissions
 
@@ -96,7 +109,7 @@ Remove the sandbox.
 
 ## Git Workflow
 
-Full provider-portable policy lives in `/git` (`.claude/skills/git/SKILL.md`). The table below is only the quick-reference subset.
+Full provider-portable policy lives in `/git` when slash skills are available; the skill is mirrored under provider-specific paths such as `.pi/skills/git/` and `.claude/skills/git/`. If slash skills are unavailable, read the relevant `SKILL.md` directly. The table below is only the quick-reference subset.
 
 | Item | Convention |
 |------|-----------|

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Update policy and release automation live in [`/git`](.claude/skills/git/SKILL.m
 ## [Unreleased]
 
 ### Added
+- `context/REPO_MAP.md` gives session-start agents a Git-tracked source-map command plus default keep/disregard paths for context loading, guarded by `repo-map-contract` plus the CB-004 repo-orientation A/B benchmark manifest/scorer ([#464](https://github.com/mifunedev/openharness/issues/464)).
 - `pi-dynamic-workflows` is now a default project-local Pi package pinned to the upstream `v1.0.1` commit, with docs for the `workflow` tool's deterministic JavaScript fan-out model and package-pin test coverage ([#451](https://github.com/mifunedev/openharness/issues/451)).
 - `retro-deterministic-contract` eval probe guards that `/retro` keeps schema-backed output, self-contained helper scripts, and synchronized `.pi`/`.claude` skill copies ([#443](https://github.com/mifunedev/openharness/issues/443)).
 ### Changed

--- a/context/README.md
+++ b/context/README.md
@@ -7,6 +7,7 @@ Seed files encoding voice, operating principles, environment inventory, and work
 - `SOUL.md` — voice and disposition
 - `IDENTITY.md` — operating principles and lessons learned (append-only)
 - `TOOLS.md` — environment inventory; skip tool rediscovery
+- `REPO_MAP.md` — source-map command plus default disregard/keep paths for context loading
 - `USER.md` — working-relationship patterns; living document
 - `rules/` — auto-loaded coding and process rules (canonical, tool-agnostic)
 

--- a/context/REPO_MAP.md
+++ b/context/REPO_MAP.md
@@ -1,0 +1,148 @@
+# Repository context map
+
+At session start, prefer Git's tracked file list over raw filesystem scans, then use the descriptions below to choose the first narrow search target.
+
+## Source-map command
+
+```bash
+repo=$(git rev-parse --show-toplevel)
+git -C "$repo" ls-files -- \
+  ':!:tasks/*/progress.txt' \
+  ':!:wiki/raw/*' \
+  ':!:evals/datasets/**/oracle/**' \
+  ':!:evals/datasets/**/diff.patch' \
+  ':!:evals/datasets/**/changed-files.txt'
+```
+
+Why: anchoring at `git rev-parse --show-toplevel` prevents subdirectory launches from silently mapping only a subtree. `git ls-files` requires no extra tooling and excludes vendor, generated, ignored, and runtime state by default while preserving hidden source dirs such as `.claude/`, `.pi/`, `.github/`, and `.devcontainer/`.
+
+## Session-start use
+
+1. Read this file after `context/TOOLS.md`.
+2. Use the source-map command only when orientation is needed; do not paste a raw filesystem tree into context.
+3. Pick one row from the search routing guide before running broad `rg`.
+4. When a routed directory has `README.md`, read that first.
+5. Disregard the folders in the skip table by default; open them only for listed exception cases.
+6. Prefer curated `wiki/*.md` and `memory/MEMORY.md` over raw logs/snapshots.
+
+## Performance caveat and acceptance metric
+
+Caveat: this file is a structural optimization, not benchmark proof by itself. It adds startup context; savings happen only when agents use it to avoid raw filesystem scans, vendor/generated reads, or broad repo search.
+
+Acceptance metric: compare at least 5 common orientation tasks with and without this file loaded. Track total input tokens, tool calls before the first relevant file, time to correct path, and accidental reads under disregard paths. Count the change successful only if median time/tool calls drop and total token spend breaks even or improves.
+
+## Context-file loading model
+
+Different harnesses load `AGENTS.md`/`CLAUDE.md` differently. For Open Harness work, treat discovered global/user, parent-directory, and current-directory context files as cumulative context, then resolve conflicts by target-path specificity. Do not rely on automatic nearest-file-wins semantics.
+
+Operational rule:
+
+- Launch cwd matters: starting an agent at repo root may load repo-level guidance, not deeper package/workspace guidance.
+- Before editing a subdirectory, check for local `AGENTS.md`/`CLAUDE.md` files in that path and its ancestors below repo root.
+- Treat more local files as more specific for their subtree when instructions conflict.
+- Within the same directory, `AGENTS.md` is canonical; `CLAUDE.md` is a provider-compatibility alias. If both are real files and conflict, stop and call out the conflict.
+- If a local context file changes mid-session, use the harness's documented reload command when available, restart from the intended cwd, or explicitly read the changed file before relying on it.
+- The helper below is repo-local only; also account for provider-global/user context files shown by the startup header or provider docs.
+
+Repo-local ancestor check helper:
+
+```bash
+target=${1:-.}
+case "$target" in /*) path=$target ;; *) path=$PWD/$target ;; esac
+
+# Resolve nearest existing ancestor so new files/dirs are safe.
+dir=$path
+[ -d "$dir" ] || dir=$(dirname "$dir")
+while [ ! -d "$dir" ] && [ "$dir" != "/" ]; do
+  dir=$(dirname "$dir")
+done
+
+dir=$(cd -P "$dir" && pwd) || exit 1
+repo=$(git -C "$dir" rev-parse --show-toplevel) || exit 1
+repo=$(cd -P "$repo" && pwd) || exit 1
+
+seen=""
+while :; do
+  for f in AGENTS.md CLAUDE.md; do
+    p="$dir/$f"
+    [ -f "$p" ] || continue
+    real=$(readlink -f "$p" 2>/dev/null || printf '%s' "$p")
+    case " $seen " in *" $real "*) continue ;; esac
+    seen="$seen $real"
+    case "$p" in "$repo"/*) printf '%s\n' "${p#$repo/}" ;; *) printf '%s\n' "$p" ;; esac
+  done
+  [ "$dir" = "$repo" ] && break
+  [ "$dir" = "/" ] && break
+  dir=$(dirname "$dir")
+done
+```
+
+## Search routing quick guide
+
+Use these routes before broad repo-wide search. If `Start here` names a directory and that directory has `README.md`, read the README first.
+
+| Intent | Start here | Why |
+|---|---|---|
+| Session role, permissions, startup load | `AGENTS.md`, `context/README.md`, `context/` | Defines orchestrator role, voice, session-start reads, and rules. |
+| Sandbox lifecycle, Docker, provisioning | `Makefile`, `.devcontainer/`, `harness.yaml`, `scripts/README.md`, `scripts/docker-compose.sh` | Owns container image, compose overlays, generated env, and lifecycle commands. |
+| Git/GitHub workflow, PRs, releases | `.pi/skills/git/`, `.pi/skills/pr-audit/`, `.pi/skills/ci-status/`, `.github/workflows/` | Canonical branch/PR/release conventions and CI gates. |
+| Cron/autopilot behavior | `crons/README.md`, `crons/`, `scripts/cron-runtime.ts`, `.pi/skills/autopilot/`, `scripts/autopilot-caps.sh` | Scheduled prompts, runtime supervision, caps, and watchdog flow. |
+| Eval/probe regressions | `evals/README.md`, `evals/probes/`, `.pi/skills/eval/` | Tier-A regression probes and eval runner contract. |
+| Task/spec implementation state | `tasks/README.md`, `tasks/<active-task>/` | PRD, critique, Ralph JSON, prompt, and task-specific artifacts. |
+| Docs/site/blog | `docs/`, `blog/`, `packages/docs/` | Source docs, Docusaurus site package, public content. |
+| CLI/package code | `packages/README.md`, `packages/*/src/`, `packages/*/package.json` | Workspace package source and package-local scripts/dependencies. |
+| Pi extensions and integration code | `.pi/extensions/`, `.pi/install/`, `.pi/settings.json` | Project-local Pi extensions, manifests, and Pi runtime config. |
+| Skill behavior | `.pi/skills/`, `.claude/skills/` | Provider-facing skill contracts; keep copies synchronized when both exist. |
+| Durable knowledge | `wiki/README.md`, `wiki/*.md`, `memory/MEMORY.md` | Curated wiki pages and long-term lessons; prefer these before raw logs. |
+| Agent workspace seed files | `workspace/AGENTS.md`, `workspace/CLAUDE.md` | Template files bind-mounted into the sandbox workspace. |
+
+## Disregard by default
+
+Ignore these unless the task explicitly targets them:
+
+| Path pattern | Why to skip first | Read only when |
+|---|---|---|
+| `.git/` | Git object database and refs; use `git` commands instead. | Debugging repository corruption. |
+| `.worktrees/`, `.claude/worktrees/` | Isolated branch checkouts that duplicate repo context. | Managing/removing worktrees or inspecting a specific branch. |
+| `node_modules/`, `.pnpm/`, `.pi/npm/node_modules/`, `.hermes/lsp/node_modules/` | Vendor dependencies; huge and low-signal. | Debugging dependency installation or package resolution. |
+| `packages/docs/build/`, `packages/docs/.docusaurus/`, `packages/oh/dist/` | Generated build output. | Verifying generated artifacts or deployment output. |
+| `packages/docs/node_modules/`, `packages/oh/node_modules/` | Package-local vendor dependencies. | Debugging package-local dependency state. |
+| `memory/YYYY-MM-DD/`, `memory/*/log.md` | High-churn session logs; noisy for broad context. | Loading today's required startup log or investigating a dated event. |
+| `memory/*/wiki-drafts/` | Draft knowledge proposals, not canonical wiki. | Promoting a draft via `/wiki-ingest --from-draft`. |
+| `wiki/raw/` | Immutable provenance snapshots; often verbose. | Verifying source provenance behind a curated `wiki/*.md` entry. |
+| `workspace/.slack/`, `workspace/.pi/`, `workspace/.ralph/`, `workspace/startup.sh` | Runtime state and local/sensitive sandbox artifacts. | Debugging Slack/Pi/Ralph runtime state or startup generation. |
+| `tasks/*/progress.txt` | Runtime progress sentinel; terse and stale-prone. | Checking a specific Ralph run status; prefer `tail` over full read. |
+| `evals/datasets/**/oracle/`, `evals/datasets/**/diff.patch`, `evals/datasets/**/changed-files.txt` | Expected-output fixtures, not active implementation guidance. | Updating/verifying a dataset oracle. |
+
+## On-demand search targets
+
+Do not load all of these at once. Pick the row that matches the task, read README files first when present, then search narrowly.
+
+| Path pattern | Contents | Best first use |
+|---|---|---|
+| `AGENTS.md` | Orchestrator identity, permissions, lifecycle, git workflow, skill map. | Confirm what this agent may do and required startup reads. |
+| `README.md` | User-facing project overview and quick orientation. | Understand product positioning or public claims. |
+| `Makefile` | Common lifecycle targets around sandbox creation, shell, ps, destroy. | Find operator commands and compose entry points. |
+| `package.json` | Root scripts for build/test/typecheck/docs/security audit. | Pick verification commands. |
+| `pnpm-workspace.yaml`, `pnpm-lock.yaml` | Workspace package layout and pinned dependency graph. | Debug workspace membership or dependency drift; avoid lockfile reads unless dependency state matters. |
+| `harness.yaml` | Harness runtime defaults such as autopilot caps and configured services. | Inspect operator-configurable behavior. |
+| `context/` | Voice, identity, tools, repo map, user collaboration, and rules. | Load operating principles and process constraints. |
+| `crons/` | Scheduled agent prompts and heartbeat/autopilot jobs. | Understand recurring automation behavior; read `crons/README.md` first. |
+| `scripts/` | Shell/TypeScript automation for install, cron runtime, health checks, Ralph, caps. | Find executable implementation behind docs/skills; read `scripts/README.md` first. |
+| `scripts/__tests__/` | Vitest coverage for harness scripts. | Locate targeted tests for script changes. |
+| `evals/probes/` | Deterministic regression probes used by `/eval` and CI. | Add or inspect behavior guards. |
+| `evals/capability/` | Capability benchmark specs/results distinct from regression probes. | Evaluate progress-ceiling tasks. |
+| `evals/datasets/` | Verifiable issue-to-PR trajectory datasets. | Inspect dataset prompts/manifests before oracle fixtures. |
+| `packages/*/src/` | Workspace package source code. | Change package behavior; read `packages/README.md` first. |
+| `packages/*/package.json` | Package-local scripts and dependencies. | Run package-specific build/test/typecheck. |
+| `docs/` | Docusaurus documentation source. | Update product docs. |
+| `blog/` | Blog posts and authors metadata. | Update long-form public writing. |
+| `wiki/*.md` | Curated internal knowledge pages. | Reuse durable research before reading raw sources; read `wiki/README.md` for index. |
+| `tasks/<active-task>/` | `prd.md`, `prd.json`, `critique.md`, `prompt.md`; `progress.txt` only for Ralph run status. | Verify task graph or implementation scope before reading runtime progress. |
+| `.github/workflows/` | CI, docs, release workflow definitions. | Debug/check GitHub Actions behavior. |
+| `.devcontainer/` | Sandbox Dockerfile, compose, devcontainer config, entrypoint. | Change sandbox image/runtime provisioning. |
+| `.pi/extensions/` | In-tree Pi extension source, especially Slack bridge. | Modify Pi integration behavior. |
+| `.pi/skills/`, `.claude/skills/` | Skill contracts for Pi and Claude providers. | Update slash-skill behavior; sync both copies when mirrored. |
+| `workspace/AGENTS.md` | Seed instructions copied into the agent workspace. | Change new sandbox agent identity/scaffold. |
+
+Rule: tracked source first; generated/vendor/runtime/history-heavy folders are context poison unless debugging that exact subsystem.

--- a/evals/RESULTS.md
+++ b/evals/RESULTS.md
@@ -48,6 +48,7 @@ probe id; git history is the time series.** Schema and exit-code semantics are i
 | pnpm-audit-ci-gate | A | 2026-06-19 04:59 | PASS | issue #171 — pnpm security audits must run in CI |
 | pr-audit-duplicate-issue-refs | A | 2026-06-19 04:59 | PASS | issue #439 — /pr-audit must flag duplicate open PRs that reference the same issue |
 | ralph-fallback-order | A | 2026-06-19 04:59 | PASS | conversation 2026-06-12 (Ralph default fallback order) |
+| repo-map-contract | A | 2026-06-19 07:23 | PASS | issue #464 — repo map must optimize orientation without adding a tree dependency or unmeasured performance claims |
 | retro-deterministic-contract | A | 2026-06-19 04:59 | PASS | issue #443 — /retro deterministic output and self-contained helper contract |
 | rl-delegation-write-worker | A | 2026-06-19 04:59 | PASS | memory/MEMORY.md 2026-06-10 (rl-delegation) #57 |
 | ship-spec-ready-finalization | A | 2026-06-19 04:59 | PASS | issue #134 — /ship-spec must finalize ready PRs after gates, not stop at draft scaffold |

--- a/evals/capability/README.md
+++ b/evals/capability/README.md
@@ -66,6 +66,7 @@ rubric above, by hand. There is no automated runner yet (see *Non-scope*).
 |---|---|
 | `README.md` | This spec — the instrument, axes, schema, and discipline. |
 | `tasks/CB-NNN-<slug>.md` | One spec per benchmark task: its deliverable, the per-axis rubric, and a pointer to the most-recent real instance. `NNN` is a zero-padded, never-reused id. |
+| `repo-orientation/tasks.json` | Held-out workload manifest for CB-004 repo-orientation A/B scoring. |
 | `RESULTS.md` | The scoreboard. House style mirrors [`../RESULTS.md`](../RESULTS.md): one row per task id, **overwrite the row** each run — git history is the time series, not appended rows. |
 
 A task spec may additionally cite concrete verifiable instances from the **datasets corpus** at [`../datasets/`](../datasets/) via an optional `datasets:` frontmatter array (e.g. `datasets: [DS-001, DS-002]`); the `datasets-schema` probe checks every such ref resolves to a real example folder.

--- a/evals/capability/RESULTS.md
+++ b/evals/capability/RESULTS.md
@@ -13,5 +13,6 @@ inspection (no automated runner yet).
 | CB-001 | 2026-06-15 | PASS | PARTIAL | PARTIAL | 1.33 | recent ready PRs (#147, #157, #163); autopilot ships unattended but cost / CI-trigger + zombie-session gaps observed |
 | CB-002 | 2026-06-15 | PARTIAL | PASS | PASS | 1.67 | /orchestrate dry-run walks the spine ideate→compress (10/12 nodes), honest-halt; full ring not yet closeable (benchmark node still unwired; repeat wired #173/#174) |
 | CB-003 | 2026-06-15 | PASS | PASS | PARTIAL | 1.67 | /retro compounds durable lessons (loop-node-name-pipe-trap, eval-results-new-probe-row); promotion orchestrator-gated |
+| CB-004 | 2026-06-19 | PARTIAL | PARTIAL | PARTIAL | 1.00 | repo-map contract + A/B manifest/scorer exist (#462), but no completed workload-mix token/tool/time benchmark yet |
 
-<!-- suite score = mean(1.33, 1.67, 1.67) = 1.56 / 2.00 · baseline 2026-06-15 by rubric inspection · PASS=2 PARTIAL=1 FAIL=0; SKIPPED a task only when the capability is absent from the eval environment -->
+<!-- suite score = mean(1.33, 1.67, 1.67, 1.00) = 1.42 / 2.00 · CB-004 added 2026-06-19 by rubric inspection · PASS=2 PARTIAL=1 FAIL=0; SKIPPED a task only when the capability is absent from the eval environment -->

--- a/evals/capability/repo-orientation/tasks.json
+++ b/evals/capability/repo-orientation/tasks.json
@@ -1,0 +1,92 @@
+{
+  "version": 1,
+  "id": "repo-orientation-efficiency",
+  "description": "A/B workload for proving whether context/REPO_MAP.md improves total repo-orientation economics after startup context cost.",
+  "startupContext": {
+    "path": "context/REPO_MAP.md",
+    "tokenEstimate": "ceil(bytes / 4)"
+  },
+  "thresholds": {
+    "minTasks": 6,
+    "maxRepoMapBytes": 12288,
+    "minOrientationToolCallDropPct": 20,
+    "minOrientationTimeDropPct": 15,
+    "maxExpectedTokenDelta": 0,
+    "maxPoisonPathReadDelta": 0
+  },
+  "workloadMix": [
+    {
+      "class": "no-orientation",
+      "weight": 0.25,
+      "description": "Sessions that pay startup cost but do not need repo navigation."
+    },
+    {
+      "class": "light-orientation",
+      "weight": 0.45,
+      "description": "Find one source area or policy surface."
+    },
+    {
+      "class": "deep-orientation",
+      "weight": 0.3,
+      "description": "Cross-cutting work that must navigate several source areas."
+    }
+  ],
+  "tasks": [
+    {
+      "id": "RO-001",
+      "class": "light-orientation",
+      "prompt": "Find the sandbox lifecycle and Docker provisioning entry points.",
+      "expected_paths": ["Makefile", ".devcontainer/", "scripts/docker-compose.sh"],
+      "forbidden_patterns": ["node_modules/", "wiki/raw/", "tasks/*/progress.txt"]
+    },
+    {
+      "id": "RO-002",
+      "class": "light-orientation",
+      "prompt": "Find the git workflow, PR title, branch, and target-base conventions.",
+      "expected_paths": ["AGENTS.md", ".pi/skills/git/", ".claude/skills/git/"],
+      "forbidden_patterns": ["node_modules/", "wiki/raw/", "memory/*/log.md"]
+    },
+    {
+      "id": "RO-003",
+      "class": "light-orientation",
+      "prompt": "Find the eval runner contract and the GitHub Actions gate that runs it.",
+      "expected_paths": ["evals/README.md", ".claude/skills/eval/run.sh", ".github/workflows/ci-harness.yml"],
+      "forbidden_patterns": ["node_modules/", "evals/datasets/**/oracle/", "wiki/raw/"]
+    },
+    {
+      "id": "RO-004",
+      "class": "light-orientation",
+      "prompt": "Find the Pi extension or integration source for Slack bridge work.",
+      "expected_paths": [".pi/extensions/", ".pi/settings.json", "docs/integrations/slack.md"],
+      "forbidden_patterns": [".pi/npm/node_modules/", "workspace/.slack/", "node_modules/"]
+    },
+    {
+      "id": "RO-005",
+      "class": "deep-orientation",
+      "prompt": "Find all surfaces needed to change new sandbox workspace seed instructions and verify the change.",
+      "expected_paths": ["workspace/AGENTS.md", "workspace/CLAUDE.md", "AGENTS.md", "evals/probes/"],
+      "forbidden_patterns": ["workspace/.pi/", "workspace/.ralph/", "workspace/.slack/", "node_modules/"]
+    },
+    {
+      "id": "RO-006",
+      "class": "deep-orientation",
+      "prompt": "Find the docs build configuration and explain why docs builds stay out of the fast harness gate.",
+      "expected_paths": ["package.json", "packages/docs/package.json", ".github/workflows/docs.yml", "evals/probes/docs-build-fast-path.sh"],
+      "forbidden_patterns": ["packages/docs/build/", "packages/docs/.docusaurus/", "packages/docs/node_modules/"]
+    },
+    {
+      "id": "RO-007",
+      "class": "no-orientation",
+      "prompt": "Check the current branch and working tree status without needing repo orientation.",
+      "expected_paths": [],
+      "forbidden_patterns": ["node_modules/", "wiki/raw/", "memory/*/log.md"]
+    },
+    {
+      "id": "RO-008",
+      "class": "no-orientation",
+      "prompt": "Report a known PR's GitHub status from PR metadata without reading repository files.",
+      "expected_paths": [],
+      "forbidden_patterns": ["node_modules/", "wiki/raw/", "tasks/*/progress.txt"]
+    }
+  ]
+}

--- a/evals/capability/tasks/CB-004-repo-orientation-efficiency.md
+++ b/evals/capability/tasks/CB-004-repo-orientation-efficiency.md
@@ -1,0 +1,43 @@
+---
+id: CB-004
+slug: repo-orientation-efficiency
+title: "Orient in the repository with fewer tokens and tool calls"
+axes: [success, cost-time, unattended]
+skills: [/eval, /benchmark, /context-audit]
+created: 2026-06-19
+---
+
+# CB-004 · Repo orientation efficiency
+
+## Task
+Given a fresh session and a common repository-orientation question, find the first correct source path faster and with less context waste by using `context/REPO_MAP.md` instead of raw filesystem scans or broad vendor/generated/runtime reads. The capability under test is whether startup-loaded repo guidance improves the whole harness's navigation efficiency, not merely whether the file exists.
+
+## Success signal
+- The repo-map contract probe is green: `bash .claude/skills/eval/run.sh --probe repo-map-contract` exits 0.
+- `evals/capability/repo-orientation/tasks.json` defines the held-out workload mix, including no-orientation sessions that still pay startup cost.
+- An A/B run compares at least 6 paired tasks with and without `context/REPO_MAP.md` loaded, covering no-orientation, light-orientation, and deep-orientation classes.
+- The A/B report tracks total input tokens, tool calls before the first relevant file, time to correct path, accidental reads under disregard paths, and answer correctness.
+- `scripts/repo-orientation-benchmark-score.mjs --report <report.json>` returns PASS: correctness equal or better, orientation median tool calls drop ≥20%, orientation median time drops ≥15%, poison-path reads do not increase, and expected token delta is ≤0 after counting repo-map startup cost.
+
+## Rubric
+| Axis | PASS | PARTIAL | FAIL |
+|------|------|---------|------|
+| success | Contract probe green and scorer PASS for a 6+ paired-task A/B report that covers the workload mix and shows equal/better correctness, lower median orientation time/tool calls, no increase in poison-path reads, and expected token delta ≤0 | Contract probe, manifest, and scorer exist, but no completed A/B report yet, or the scorer verdict is mixed/inconclusive | Contract probe fails, repo map is not startup-loaded, scorer is absent, or A/B scorer returns FAIL |
+| cost-time | Benchmark can be completed in one planned pass with no retries and a bounded task set | Manual tally or one retry needed to complete the A/B comparison | Repeated retries, unclear instrumentation, or unbounded measurement effort |
+| unattended | Benchmark run and report complete without human steering after task launch | One human nudge needed to clarify a route or metric | Human must manually author results or decide which evidence counts |
+
+## Evidence basis
+PR #462 adds the repo map, startup-load hook, source-map command, disregard/search routes, and the explicit performance caveat plus acceptance metric. The deterministic `repo-map-contract` probe guards the structural floor. The held-out workload lives in `evals/capability/repo-orientation/tasks.json`; the scorer lives in `scripts/repo-orientation-benchmark-score.mjs`. The total-system optimization claim requires that scorer to PASS on a real A/B report; until that run exists, the honest score is PARTIAL rather than PASS.
+
+The manifest includes orientation and no-orientation tasks so the benchmark accounts for sessions that pay startup cost but do not benefit from repo navigation.
+
+## Scoring method
+Run paired sessions or scripted agent trials for the same task set: baseline without `context/REPO_MAP.md` in startup context, treatment with it. Record per task: first relevant path, correctness, input tokens, tool-call count before that path, elapsed time, and any reads under disregard paths. Write the report as JSON with `runs[]` entries carrying `task`, `variant` (`baseline` or `treatment`), `correct`, `inputTokens`, `toolCallsToFirstRelevantFile`, `elapsedSeconds`, and `poisonPathReads`. Score it with:
+
+```bash
+node scripts/repo-orientation-benchmark-score.mjs \
+  --manifest evals/capability/repo-orientation/tasks.json \
+  --report <report.json>
+```
+
+PASS requires expected-value savings across the workload mix after counting repo-map startup cost. Do not count a raw `tree` or vendor/generated/runtime read as a successful low-cost route.

--- a/evals/probes/repo-map-contract.sh
+++ b/evals/probes/repo-map-contract.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# tier: A
+# source: issue #464 — repo map must optimize orientation without adding a tree dependency or unmeasured performance claims
+# desc: guards context/REPO_MAP.md as a tracked-source orientation contract: startup-loaded, repo-root anchored git ls-files command, no tree dependency, skip/search guidance, context-file precedence, source-map/helper smoke checks, size budget, and explicit A/B benchmark path
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+REPO_MAP="$ROOT/context/REPO_MAP.md"
+AGENTS="$ROOT/AGENTS.md"
+CONTEXT_README="$ROOT/context/README.md"
+MANIFEST="$ROOT/evals/capability/repo-orientation/tasks.json"
+SCORER="$ROOT/scripts/repo-orientation-benchmark-score.mjs"
+MAX_BYTES=12288
+
+fails=()
+
+[[ -f "$REPO_MAP" ]] || fails+=("context/REPO_MAP.md exists")
+[[ -f "$AGENTS" ]] || fails+=("AGENTS.md exists")
+[[ -f "$CONTEXT_README" ]] || fails+=("context/README.md exists")
+[[ -f "$MANIFEST" ]] || fails+=("repo-orientation benchmark manifest exists")
+[[ -x "$SCORER" ]] || fails+=("repo-orientation benchmark scorer exists and is executable")
+
+if [[ -f "$AGENTS" ]]; then
+  grep -Fq 'context/REPO_MAP.md' "$AGENTS" || fails+=("AGENTS.md startup reads include context/REPO_MAP.md")
+fi
+
+if [[ -f "$CONTEXT_README" ]]; then
+  grep -Fq 'REPO_MAP.md' "$CONTEXT_README" || fails+=("context/README.md lists REPO_MAP.md")
+fi
+
+if [[ -f "$REPO_MAP" ]]; then
+  bytes=$(wc -c <"$REPO_MAP" | tr -d ' ')
+  if (( bytes > MAX_BYTES )); then
+    fails+=("context/REPO_MAP.md is ${bytes} bytes, above ${MAX_BYTES}-byte startup budget")
+  fi
+
+  grep -Fq 'repo=$(git rev-parse --show-toplevel)' "$REPO_MAP" || fails+=("source-map command anchors at repo root")
+  grep -Fq 'git -C "$repo" ls-files' "$REPO_MAP" || fails+=("source-map command uses git -C repo ls-files")
+  grep -Fq 'do not paste a raw filesystem tree into context' "$REPO_MAP" || fails+=("session-start rule rejects raw filesystem tree")
+  grep -Fq 'When a routed directory has `README.md`, read that first.' "$REPO_MAP" || fails+=("README-first routing is documented")
+  grep -Fq 'AGENTS.md` is canonical; `CLAUDE.md` is a provider-compatibility alias' "$REPO_MAP" || fails+=("AGENTS canonical / CLAUDE alias rule documented")
+  grep -Fq 'target=${1:-.}' "$REPO_MAP" || fails+=("ancestor helper supports an explicit target")
+  grep -Fq 'while [ ! -d "$dir" ] && [ "$dir" != "/" ]' "$REPO_MAP" || fails+=("ancestor helper handles non-existent target paths")
+  grep -Fq 'Performance caveat and acceptance metric' "$REPO_MAP" || fails+=("performance caveat section present")
+  grep -Fq 'structural optimization, not benchmark proof by itself' "$REPO_MAP" || fails+=("performance caveat avoids unproven savings claim")
+  grep -Fq 'compare at least 5 common orientation tasks with and without this file loaded' "$REPO_MAP" || fails+=("acceptance metric requires A/B orientation tasks")
+  grep -Fq 'total input tokens' "$REPO_MAP" || fails+=("acceptance metric tracks total input tokens")
+  grep -Fq 'tool calls before the first relevant file' "$REPO_MAP" || fails+=("acceptance metric tracks tool-call cost")
+  grep -Fq 'accidental reads under disregard paths' "$REPO_MAP" || fails+=("acceptance metric tracks poison-path reads")
+  grep -Fq 'median time/tool calls drop' "$REPO_MAP" || fails+=("acceptance metric gates on median time/tool-call improvement")
+
+  for path in \
+    'node_modules/' \
+    '.pi/npm/node_modules/' \
+    'packages/docs/build/' \
+    'packages/oh/dist/' \
+    'wiki/raw/' \
+    'memory/*/log.md' \
+    'tasks/*/progress.txt' \
+    'evals/datasets/**/oracle/'; do
+    grep -Fq "$path" "$REPO_MAP" || fails+=("skip/disregard path documented: $path")
+  done
+
+  if grep -Eiq '(^|[^[:alnum:]_/-])tree([[:space:]]|$)' "$REPO_MAP"; then
+    # The only allowed reference is the prose warning against raw filesystem tree.
+    allowed=$(grep -Fi 'do not paste a raw filesystem tree into context' "$REPO_MAP" | wc -l | tr -d ' ')
+    total=$(grep -Eio '(^|[^[:alnum:]_/-])tree([[:space:]]|$)' "$REPO_MAP" | wc -l | tr -d ' ')
+    if [[ "$total" != "$allowed" ]]; then
+      fails+=("REPO_MAP.md must not introduce a tree command/dependency")
+    fi
+  fi
+
+  source_map="$({
+    cd "$ROOT/context"
+    repo=$(git rev-parse --show-toplevel)
+    git -C "$repo" ls-files -- \
+      ':!:tasks/*/progress.txt' \
+      ':!:wiki/raw/*' \
+      ':!:evals/datasets/**/oracle/**' \
+      ':!:evals/datasets/**/diff.patch' \
+      ':!:evals/datasets/**/changed-files.txt'
+  })"
+  for required in \
+    'AGENTS.md' \
+    '.github/workflows/ci-harness.yml' \
+    'context/REPO_MAP.md' \
+    'evals/probes/repo-map-contract.sh'; do
+    grep -Fxq "$required" <<<"$source_map" || fails+=("source-map smoke missing tracked root file: $required")
+  done
+  for forbidden_re in \
+    '(^|/)node_modules/' \
+    '^wiki/raw/' \
+    '^tasks/.*/progress\.txt$' \
+    '^evals/datasets/.*/oracle/' \
+    '^evals/datasets/.*/diff\.patch$' \
+    '^evals/datasets/.*/changed-files\.txt$'; do
+    if grep -Eq "$forbidden_re" <<<"$source_map"; then
+      fails+=("source-map smoke included forbidden pattern: $forbidden_re")
+    fi
+  done
+
+  helper=$(awk '
+    found && /^```$/ { exit }
+    found { print }
+    /^Repo-local ancestor check helper:/ { want=1; next }
+    want && /^```bash$/ { found=1 }
+  ' "$REPO_MAP")
+  if [[ -z "$helper" ]]; then
+    fails+=("could not extract ancestor helper from REPO_MAP.md")
+  else
+    run_helper() {
+      local target="$1"
+      (cd "$ROOT" && bash -c "$helper" _ "$target")
+    }
+    root_out=$(run_helper ".") || fails+=("ancestor helper failed for repo root")
+    grep -Fxq 'AGENTS.md' <<<"${root_out:-}" || fails+=("ancestor helper for . did not return AGENTS.md")
+
+    new_path_out=$(run_helper "workspace/new-dir/new-file.md") || fails+=("ancestor helper failed for new workspace path")
+    grep -Fxq 'workspace/AGENTS.md' <<<"${new_path_out:-}" || fails+=("ancestor helper for new workspace path missing workspace/AGENTS.md")
+    grep -Fxq 'AGENTS.md' <<<"${new_path_out:-}" || fails+=("ancestor helper for new workspace path missing root AGENTS.md")
+    if grep -Fxq 'workspace/CLAUDE.md' <<<"${new_path_out:-}"; then
+      fails+=("ancestor helper did not de-dupe workspace/CLAUDE.md symlink")
+    fi
+
+    absolute_out=$(run_helper "$ROOT") || fails+=("ancestor helper failed for absolute repo root")
+    grep -Fxq 'AGENTS.md' <<<"${absolute_out:-}" || fails+=("ancestor helper for absolute repo root did not return AGENTS.md")
+  fi
+fi
+
+if [[ -f "$SCORER" && -f "$MANIFEST" ]]; then
+  node "$SCORER" --manifest "$MANIFEST" --validate-only >/dev/null \
+    || fails+=("repo-orientation benchmark manifest/scorer validate-only failed")
+fi
+
+if (( ${#fails[@]} > 0 )); then
+  echo "REGRESSION: repo-map contract broken:" >&2
+  printf '  - %s\n' "${fails[@]}" >&2
+  exit 1
+fi
+
+echo "PASS: repo map contract is startup-loaded, git-ls-files based, context-aware, skip-guided, smoke-tested, size-bounded, and tied to an A/B benchmark" >&2
+exit 0

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -7,6 +7,7 @@ Provisioning, Ralph execution, and the cron runtime live here.
 | ----------------- | ------------------------------------------------------------------ |
 | `install.sh`      | Curl-piped installer — bootstraps a fresh harness checkout         |
 | `ralph.sh`        | Ralph loop runner: `scripts/ralph.sh [--harness=…] <taskdesc>`     |
+| `repo-orientation-benchmark-score.mjs` | Scores the CB-004 repo-orientation A/B benchmark report |
 | `cron-runtime.ts` | Croner runtime — scans `crons/*.md`, schedules, fires each job     |
 | `__tests__/`      | Vitest unit tests (`vitest.config.ts` at repo root targets this)   |
 

--- a/scripts/__tests__/repo-orientation-benchmark-score.test.ts
+++ b/scripts/__tests__/repo-orientation-benchmark-score.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const REPO_ROOT = path.resolve(__dirname, "../..");
+const SCRIPT = path.join(REPO_ROOT, "scripts", "repo-orientation-benchmark-score.mjs");
+const MANIFEST = path.join(REPO_ROOT, "evals", "capability", "repo-orientation", "tasks.json");
+
+function run(report: unknown) {
+  const tmp = mkdtempSync(path.join(tmpdir(), "repo-orientation-score-"));
+  try {
+    const reportPath = path.join(tmp, "report.json");
+    writeFileSync(reportPath, JSON.stringify(report, null, 2));
+    const result = spawnSync(
+      "node",
+      [SCRIPT, "--manifest", MANIFEST, "--report", reportPath, "--json"],
+      { encoding: "utf-8", cwd: REPO_ROOT },
+    );
+    return {
+      status: result.status ?? -1,
+      stdout: result.stdout ?? "",
+      stderr: result.stderr ?? "",
+      json: JSON.parse(result.stdout || "{}"),
+    };
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+}
+
+function manifestTasks(): Array<{ id: string; class: string }> {
+  const result = spawnSync("node", ["-e", `const m=require(${JSON.stringify(MANIFEST)}); console.log(JSON.stringify(m.tasks.map(({id, class: klass}) => ({id, class: klass}))));`], {
+    encoding: "utf-8",
+    cwd: REPO_ROOT,
+  });
+  expect(result.status).toBe(0);
+  return JSON.parse(result.stdout);
+}
+
+function reportFor(options: { orientationTreatmentTokens: number; noOrientationTreatmentTokens?: number }) {
+  const runs = [];
+  for (const task of manifestTasks()) {
+    const isNoOrientation = task.class === "no-orientation";
+    runs.push({
+      task: task.id,
+      variant: "baseline",
+      correct: true,
+      inputTokens: isNoOrientation ? 1000 : 9000,
+      toolCallsToFirstRelevantFile: isNoOrientation ? 1 : 10,
+      elapsedSeconds: isNoOrientation ? 5 : 100,
+      poisonPathReads: isNoOrientation ? [] : ["node_modules/example"],
+    });
+    runs.push({
+      task: task.id,
+      variant: "treatment",
+      correct: true,
+      inputTokens: isNoOrientation ? (options.noOrientationTreatmentTokens ?? 1000) : options.orientationTreatmentTokens,
+      toolCallsToFirstRelevantFile: isNoOrientation ? 1 : 5,
+      elapsedSeconds: isNoOrientation ? 5 : 60,
+      poisonPathReads: [],
+    });
+  }
+  return { startupTokens: 3000, runs };
+}
+
+describe("repo-orientation-benchmark-score.mjs", () => {
+  it("validates the shipped manifest", () => {
+    const result = spawnSync("node", [SCRIPT, "--manifest", MANIFEST, "--validate-only", "--json"], {
+      encoding: "utf-8",
+      cwd: REPO_ROOT,
+    });
+
+    expect(result.status).toBe(0);
+    expect(JSON.parse(result.stdout)).toMatchObject({ verdict: "VALID" });
+  });
+
+  it("passes when repo-map treatment wins after startup cost", () => {
+    const result = run(reportFor({ orientationTreatmentTokens: 2500 }));
+
+    expect(result.status).toBe(0);
+    expect(result.json.verdict).toBe("PASS");
+    expect(result.json.metrics.orientationToolCallDropPct).toBeGreaterThanOrEqual(20);
+    expect(result.json.metrics.expectedTokenDelta).toBeLessThanOrEqual(0);
+  });
+
+  it("fails when startup cost overwhelms orientation savings", () => {
+    const result = run(reportFor({ orientationTreatmentTokens: 7000 }));
+
+    expect(result.status).toBe(1);
+    expect(result.json.verdict).toBe("FAIL");
+    expect(result.json.reasons.join("\n")).toContain("expected token delta");
+  });
+
+  it("returns incomplete when a paired treatment run is missing", () => {
+    const complete = reportFor({ orientationTreatmentTokens: 2500 });
+    const missingTreatment = {
+      ...complete,
+      runs: complete.runs.filter((run) => !(run.task === "RO-001" && run.variant === "treatment")),
+    };
+
+    const result = run(missingTreatment);
+
+    expect(result.status).toBe(2);
+    expect(result.json.verdict).toBe("INCOMPLETE");
+    expect(result.json.failures.join("\n")).toContain("RO-001");
+  });
+});

--- a/scripts/repo-orientation-benchmark-score.mjs
+++ b/scripts/repo-orientation-benchmark-score.mjs
@@ -1,0 +1,351 @@
+#!/usr/bin/env node
+// Score the repo-orientation A/B benchmark described by CB-004.
+// Usage: node scripts/repo-orientation-benchmark-score.mjs --manifest <tasks.json> --report <runs.json>
+
+import { readFileSync, statSync } from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+function usage(exitCode = 64) {
+  const out = exitCode === 0 ? process.stdout : process.stderr;
+  out.write(
+    "usage: repo-orientation-benchmark-score.mjs --manifest <tasks.json> [--report <runs.json>] [--validate-only] [--json]\n",
+  );
+  process.exit(exitCode);
+}
+
+function parseArgs(argv) {
+  const args = {
+    manifest: "evals/capability/repo-orientation/tasks.json",
+    report: "",
+    validateOnly: false,
+    json: false,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    switch (arg) {
+      case "--manifest":
+        args.manifest = argv[++i] ?? "";
+        break;
+      case "--report":
+        args.report = argv[++i] ?? "";
+        break;
+      case "--validate-only":
+        args.validateOnly = true;
+        break;
+      case "--json":
+        args.json = true;
+        break;
+      case "-h":
+      case "--help":
+        usage(0);
+        break;
+      default:
+        process.stderr.write(`unknown arg: ${arg}\n`);
+        usage(64);
+    }
+  }
+  if (!args.manifest) usage(64);
+  return args;
+}
+
+function readJson(file) {
+  try {
+    return JSON.parse(readFileSync(file, "utf8"));
+  } catch (err) {
+    throw new Error(`could not read JSON ${file}: ${err.message}`);
+  }
+}
+
+function assertArray(value, label, failures) {
+  if (!Array.isArray(value)) {
+    failures.push(`${label} must be an array`);
+    return [];
+  }
+  return value;
+}
+
+function validateManifest(manifest, manifestPath) {
+  const failures = [];
+  if (manifest.version !== 1) failures.push("version must be 1");
+  if (manifest.id !== "repo-orientation-efficiency") {
+    failures.push("id must be repo-orientation-efficiency");
+  }
+
+  const thresholds = manifest.thresholds ?? {};
+  const minTasks = Number(thresholds.minTasks ?? 0);
+  const maxRepoMapBytes = Number(thresholds.maxRepoMapBytes ?? 0);
+  const minToolDrop = Number(thresholds.minOrientationToolCallDropPct ?? -1);
+  const minTimeDrop = Number(thresholds.minOrientationTimeDropPct ?? -1);
+  if (!Number.isFinite(minTasks) || minTasks < 5) failures.push("thresholds.minTasks must be >= 5");
+  if (!Number.isFinite(maxRepoMapBytes) || maxRepoMapBytes < 1) failures.push("thresholds.maxRepoMapBytes must be positive");
+  if (!Number.isFinite(minToolDrop) || minToolDrop < 0) failures.push("thresholds.minOrientationToolCallDropPct must be >= 0");
+  if (!Number.isFinite(minTimeDrop) || minTimeDrop < 0) failures.push("thresholds.minOrientationTimeDropPct must be >= 0");
+
+  const mix = assertArray(manifest.workloadMix, "workloadMix", failures);
+  const mixClasses = new Set();
+  let weightSum = 0;
+  for (const entry of mix) {
+    if (!entry || typeof entry !== "object") {
+      failures.push("each workloadMix entry must be an object");
+      continue;
+    }
+    if (typeof entry.class !== "string" || entry.class.length === 0) {
+      failures.push("each workloadMix entry needs a class");
+    } else {
+      mixClasses.add(entry.class);
+    }
+    const weight = Number(entry.weight);
+    if (!Number.isFinite(weight) || weight <= 0) {
+      failures.push(`workloadMix.${entry.class ?? "?"}.weight must be positive`);
+    } else {
+      weightSum += weight;
+    }
+  }
+  if (mix.length > 0 && Math.abs(weightSum - 1) > 0.001) {
+    failures.push(`workloadMix weights must sum to 1.0, got ${weightSum.toFixed(3)}`);
+  }
+  for (const required of ["no-orientation", "light-orientation", "deep-orientation"]) {
+    if (!mixClasses.has(required)) failures.push(`workloadMix missing required class ${required}`);
+  }
+
+  const tasks = assertArray(manifest.tasks, "tasks", failures);
+  const ids = new Set();
+  const classCounts = new Map();
+  for (const task of tasks) {
+    if (!task || typeof task !== "object") {
+      failures.push("each task must be an object");
+      continue;
+    }
+    if (typeof task.id !== "string" || !/^RO-[0-9]{3}$/.test(task.id)) {
+      failures.push(`task id must match RO-NNN: ${task.id ?? "<missing>"}`);
+    } else if (ids.has(task.id)) {
+      failures.push(`duplicate task id ${task.id}`);
+    } else {
+      ids.add(task.id);
+    }
+    if (typeof task.prompt !== "string" || task.prompt.length < 10) {
+      failures.push(`${task.id ?? "task"}: prompt must be a useful string`);
+    }
+    if (typeof task.class !== "string" || !mixClasses.has(task.class)) {
+      failures.push(`${task.id ?? "task"}: class must exist in workloadMix`);
+    } else {
+      classCounts.set(task.class, (classCounts.get(task.class) ?? 0) + 1);
+    }
+    if (!Array.isArray(task.expected_paths)) failures.push(`${task.id ?? "task"}: expected_paths must be an array`);
+    if (!Array.isArray(task.forbidden_patterns) || task.forbidden_patterns.length === 0) {
+      failures.push(`${task.id ?? "task"}: forbidden_patterns must be a non-empty array`);
+    }
+    if (task.class !== "no-orientation" && (!Array.isArray(task.expected_paths) || task.expected_paths.length === 0)) {
+      failures.push(`${task.id ?? "task"}: orientation tasks need at least one expected path`);
+    }
+  }
+  if (tasks.length < minTasks) failures.push(`tasks length ${tasks.length} below threshold ${minTasks}`);
+  for (const required of ["no-orientation", "light-orientation", "deep-orientation"]) {
+    if ((classCounts.get(required) ?? 0) === 0) failures.push(`tasks missing class ${required}`);
+  }
+
+  const repoRoot = path.resolve(path.dirname(manifestPath), "../../..");
+  const startupPath = manifest.startupContext?.path ?? "context/REPO_MAP.md";
+  const startupAbs = path.resolve(repoRoot, startupPath);
+  try {
+    const bytes = statSync(startupAbs).size;
+    if (bytes > maxRepoMapBytes) {
+      failures.push(`${startupPath} is ${bytes} bytes, above budget ${maxRepoMapBytes}`);
+    }
+  } catch (err) {
+    failures.push(`could not stat startup context ${startupPath}: ${err.message}`);
+  }
+
+  return { ok: failures.length === 0, failures };
+}
+
+function median(values) {
+  const nums = values.filter((value) => Number.isFinite(value)).sort((a, b) => a - b);
+  if (nums.length === 0) return NaN;
+  const mid = Math.floor(nums.length / 2);
+  return nums.length % 2 === 0 ? (nums[mid - 1] + nums[mid]) / 2 : nums[mid];
+}
+
+function mean(values) {
+  const nums = values.filter((value) => Number.isFinite(value));
+  if (nums.length === 0) return NaN;
+  return nums.reduce((sum, value) => sum + value, 0) / nums.length;
+}
+
+function pctDrop(baseline, treatment) {
+  if (!Number.isFinite(baseline) || !Number.isFinite(treatment) || baseline <= 0) return NaN;
+  return ((baseline - treatment) / baseline) * 100;
+}
+
+function summarizeRuns(runs) {
+  return {
+    count: runs.length,
+    correctnessRate: mean(runs.map((run) => (run.correct === true ? 1 : 0))),
+    inputTokens: mean(runs.map((run) => Number(run.inputTokens))),
+    toolCalls: mean(runs.map((run) => Number(run.toolCallsToFirstRelevantFile))),
+    elapsedSeconds: mean(runs.map((run) => Number(run.elapsedSeconds))),
+    poisonReads: mean(runs.map((run) => Array.isArray(run.poisonPathReads) ? run.poisonPathReads.length : 0)),
+  };
+}
+
+function scoreReport(manifest, manifestPath, report) {
+  const failures = [];
+  const tasksById = new Map(manifest.tasks.map((task) => [task.id, task]));
+  const runs = assertArray(report.runs, "report.runs", failures);
+  const startupTokens = Number(
+    report.startupTokens ??
+      Math.ceil(statSync(path.resolve(path.dirname(manifestPath), "../../..", manifest.startupContext?.path ?? "context/REPO_MAP.md")).size / 4),
+  );
+  if (!Number.isFinite(startupTokens) || startupTokens < 0) failures.push("startupTokens must be >= 0");
+
+  const grouped = new Map();
+  for (const run of runs) {
+    if (!run || typeof run !== "object") {
+      failures.push("each report run must be an object");
+      continue;
+    }
+    if (!tasksById.has(run.task)) failures.push(`unknown task in report: ${run.task ?? "<missing>"}`);
+    if (!["baseline", "treatment"].includes(run.variant)) {
+      failures.push(`${run.task ?? "run"}: variant must be baseline or treatment`);
+      continue;
+    }
+    for (const key of ["inputTokens", "toolCallsToFirstRelevantFile", "elapsedSeconds"]) {
+      const value = Number(run[key]);
+      if (!Number.isFinite(value) || value < 0) failures.push(`${run.task ?? "run"}: ${key} must be >= 0`);
+    }
+    if (typeof run.correct !== "boolean") failures.push(`${run.task ?? "run"}: correct must be boolean`);
+    const key = `${run.task}\u0000${run.variant}`;
+    if (!grouped.has(key)) grouped.set(key, []);
+    grouped.get(key).push(run);
+  }
+  if (failures.length > 0) return { verdict: "INVALID", exitCode: 2, failures };
+
+  const paired = [];
+  for (const task of manifest.tasks) {
+    const baseline = grouped.get(`${task.id}\u0000baseline`) ?? [];
+    const treatment = grouped.get(`${task.id}\u0000treatment`) ?? [];
+    if (baseline.length > 0 || treatment.length > 0) {
+      if (baseline.length === 0 || treatment.length === 0) {
+        failures.push(`${task.id}: report needs both baseline and treatment runs`);
+      } else {
+        paired.push({ task, baseline: summarizeRuns(baseline), treatment: summarizeRuns(treatment) });
+      }
+    }
+  }
+
+  const thresholds = manifest.thresholds;
+  if (paired.length < thresholds.minTasks) {
+    failures.push(`paired task count ${paired.length} below threshold ${thresholds.minTasks}`);
+  }
+  for (const required of ["no-orientation", "light-orientation", "deep-orientation"]) {
+    if (!paired.some((entry) => entry.task.class === required)) {
+      failures.push(`paired report missing class ${required}`);
+    }
+  }
+  if (failures.length > 0) return { verdict: "INCOMPLETE", exitCode: 2, failures };
+
+  const baselineCorrect = mean(paired.map((entry) => entry.baseline.correctnessRate));
+  const treatmentCorrect = mean(paired.map((entry) => entry.treatment.correctnessRate));
+  const baselinePoison = paired.reduce((sum, entry) => sum + entry.baseline.poisonReads, 0);
+  const treatmentPoison = paired.reduce((sum, entry) => sum + entry.treatment.poisonReads, 0);
+
+  const orientationPairs = paired.filter((entry) => entry.task.class !== "no-orientation");
+  const baselineTools = median(orientationPairs.map((entry) => entry.baseline.toolCalls));
+  const treatmentTools = median(orientationPairs.map((entry) => entry.treatment.toolCalls));
+  const baselineTime = median(orientationPairs.map((entry) => entry.baseline.elapsedSeconds));
+  const treatmentTime = median(orientationPairs.map((entry) => entry.treatment.elapsedSeconds));
+  const toolDropPct = pctDrop(baselineTools, treatmentTools);
+  const timeDropPct = pctDrop(baselineTime, treatmentTime);
+
+  const classWeights = new Map(manifest.workloadMix.map((entry) => [entry.class, Number(entry.weight)]));
+  const deltasByClass = new Map();
+  for (const entry of paired) {
+    const treatmentTotalTokens = entry.treatment.inputTokens + startupTokens;
+    const delta = treatmentTotalTokens - entry.baseline.inputTokens;
+    if (!deltasByClass.has(entry.task.class)) deltasByClass.set(entry.task.class, []);
+    deltasByClass.get(entry.task.class).push(delta);
+  }
+  let expectedTokenDelta = 0;
+  for (const [klass, weight] of classWeights) {
+    expectedTokenDelta += weight * mean(deltasByClass.get(klass) ?? []);
+  }
+
+  const reasons = [];
+  if (treatmentCorrect < baselineCorrect) reasons.push("treatment correctness is below baseline");
+  if (toolDropPct < thresholds.minOrientationToolCallDropPct) {
+    reasons.push(`orientation tool-call drop ${toolDropPct.toFixed(1)}% below threshold ${thresholds.minOrientationToolCallDropPct}%`);
+  }
+  if (timeDropPct < thresholds.minOrientationTimeDropPct) {
+    reasons.push(`orientation time drop ${timeDropPct.toFixed(1)}% below threshold ${thresholds.minOrientationTimeDropPct}%`);
+  }
+  if (expectedTokenDelta > thresholds.maxExpectedTokenDelta) {
+    reasons.push(`expected token delta ${expectedTokenDelta.toFixed(1)} above threshold ${thresholds.maxExpectedTokenDelta}`);
+  }
+  const poisonDelta = treatmentPoison - baselinePoison;
+  if (poisonDelta > thresholds.maxPoisonPathReadDelta) {
+    reasons.push(`poison-path read delta ${poisonDelta.toFixed(1)} above threshold ${thresholds.maxPoisonPathReadDelta}`);
+  }
+
+  const metrics = {
+    pairedTasks: paired.length,
+    startupTokens,
+    baselineCorrectness: Number(baselineCorrect.toFixed(3)),
+    treatmentCorrectness: Number(treatmentCorrect.toFixed(3)),
+    baselineOrientationToolCallsMedian: baselineTools,
+    treatmentOrientationToolCallsMedian: treatmentTools,
+    orientationToolCallDropPct: Number(toolDropPct.toFixed(1)),
+    baselineOrientationTimeMedian: baselineTime,
+    treatmentOrientationTimeMedian: treatmentTime,
+    orientationTimeDropPct: Number(timeDropPct.toFixed(1)),
+    baselinePoisonReads: baselinePoison,
+    treatmentPoisonReads: treatmentPoison,
+    poisonPathReadDelta: poisonDelta,
+    expectedTokenDelta: Number(expectedTokenDelta.toFixed(1)),
+  };
+
+  return {
+    verdict: reasons.length === 0 ? "PASS" : "FAIL",
+    exitCode: reasons.length === 0 ? 0 : 1,
+    reasons,
+    metrics,
+  };
+}
+
+function printResult(result, asJson) {
+  if (asJson) {
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    return;
+  }
+  process.stdout.write(`verdict: ${result.verdict}\n`);
+  if (result.metrics) {
+    for (const [key, value] of Object.entries(result.metrics)) {
+      process.stdout.write(`${key}: ${value}\n`);
+    }
+  }
+  const problems = result.failures ?? result.reasons ?? [];
+  for (const problem of problems) process.stdout.write(`- ${problem}\n`);
+}
+
+const args = parseArgs(process.argv.slice(2));
+let manifest;
+try {
+  manifest = readJson(args.manifest);
+  const validation = validateManifest(manifest, args.manifest);
+  if (!validation.ok) {
+    printResult({ verdict: "INVALID", failures: validation.failures }, args.json);
+    process.exit(2);
+  }
+  if (args.validateOnly) {
+    printResult({ verdict: "VALID", tasks: manifest.tasks.length }, args.json);
+    process.exit(0);
+  }
+  if (!args.report) usage(64);
+  const report = readJson(args.report);
+  const result = scoreReport(manifest, args.manifest, report);
+  printResult(result, args.json);
+  process.exit(result.exitCode);
+} catch (err) {
+  printResult({ verdict: "ERROR", failures: [err.message] }, args.json);
+  process.exit(2);
+}


### PR DESCRIPTION
Closes #464.

## Summary
- Add `context/REPO_MAP.md` as a session-start guide for Git-tracked source maps, search-routing hints, and described context keep/disregard paths.
- Anchor the source-map command at the repo root and document README-first search routing so subdirectory launches do not narrow context incorrectly.
- Document the general harness context-file model: assume `AGENTS.md`/`CLAUDE.md` files can be cumulative, launch cwd matters, and Open Harness resolves conflicts by target-path specificity.
- Harden the repo-local context helper for new paths, nested repos/worktrees, root targets, and `CLAUDE.md` symlink de-duplication.
- Add the performance caveat and acceptance metric: this is a structural optimization, not benchmark proof; success requires measured reductions in orientation time/tool calls with token spend breaking even or improving.
- Add `evals/probes/repo-map-contract.sh` so CI guards the repo-map contract: startup-load hook, repo-root `git ls-files`, no `tree` dependency, skip/search guidance, context-file precedence, source-map/helper smoke checks, size budget, and benchmark wiring.
- Add capability benchmark task `CB-004` for repo-orientation efficiency, plus `evals/capability/repo-orientation/tasks.json` and `scripts/repo-orientation-benchmark-score.mjs` for workload-mix A/B scoring.
- Keep CB-004 honestly `PARTIAL/PARTIAL/PARTIAL` until a real 6+ paired-task A/B report proves net expected-value token/tool/time savings after startup cost.

## Performance caveat
This change is expected to reduce exploratory token/tool spend on repo-orientation tasks by replacing raw filesystem scans with a tracked-source map and explicit skip/search routes. It is not yet benchmark-proven and adds startup context, so benefit depends on agents using it to avoid broader scans.

## Acceptance metric
Compare the held-out workload in `evals/capability/repo-orientation/tasks.json` with and without `context/REPO_MAP.md` loaded. Track:
- total input tokens
- tool calls before first relevant file
- time to correct path
- accidental reads under disregard paths
- correctness of the first path/answer

Pass only if `scripts/repo-orientation-benchmark-score.mjs --report <report.json>` returns PASS: correctness equal or better, orientation median tool calls drop ≥20%, orientation median time drops ≥15%, poison-path reads do not increase, and expected token delta is ≤0 after counting repo-map startup cost.

## Eval / benchmark coverage
- Floor: `repo-map-contract` probe is part of `/eval` and records PASS in `evals/RESULTS.md`.
- Static smoke: the probe runs the source-map command from `context/`, checks root files appear, poison paths stay absent, extracts/runs the ancestor helper, and enforces a 12KB repo-map budget.
- Ceiling: `CB-004 · Repo orientation efficiency` defines the total-system optimization benchmark. It is currently PARTIAL because the contract/manifest/scorer exist, but the A/B run has not yet proven savings.
- Scorer tests cover PASS, FAIL, INCOMPLETE, and manifest validation paths.

## Verification
- `git diff --check`
- `node scripts/repo-orientation-benchmark-score.mjs --manifest evals/capability/repo-orientation/tasks.json --validate-only --json`
- `bash evals/probes/repo-map-contract.sh`
- `bash evals/probes/capability-benchmark-schema.sh`
- `pnpm test:scripts -- scripts/__tests__/repo-orientation-benchmark-score.test.ts` — 279 tests PASS
- `bash .claude/skills/eval/run.sh` — 52 probes PASS, rc=0
- `repo=$(git rev-parse --show-toplevel); cd context; git -C "$repo" ls-files -- ':!:tasks/*/progress.txt' ':!:wiki/raw/*' ':!:evals/datasets/**/oracle/**' ':!:evals/datasets/**/diff.patch' ':!:evals/datasets/**/changed-files.txt' | head -10`
- Local ancestor-context helper smoke: `target=.` returned `AGENTS.md`; `target=workspace/new-dir/new-file.md` returned `workspace/AGENTS.md` and `AGENTS.md`
- `/pr-audit` scoped to repo-map PR #462
