### PR TITLE
FROM feat/461-keep-slack-tokens-out-of TO development

### DIFF
--- a/.devcontainer/entrypoint.sh
+++ b/.devcontainer/entrypoint.sh
@@ -396,8 +396,9 @@ fi
 # SLACK_APP_TOKEN and SLACK_BOT_TOKEN are set AND `pi` is installed for
 # the sandbox user, restore the session that `oh config slack` created.
 # Treat the Compose env file as data, not shell: extract only the Slack
-# keys the bridge needs and shell-quote each value before passing them to
-# the child `pi` process.
+# keys the bridge needs. Keep token values out of the tmux command string
+# by writing a sandbox-owned, mode-600 runtime env file that the child shell
+# sources and removes before launching `pi`.
 SLACK_ENV="$HARNESS/.devcontainer/.env"
 if [ -f "$SLACK_ENV" ] && command -v tmux &>/dev/null; then
   SLACK_APP_TOKEN=$(grep -E '^SLACK_APP_TOKEN=' "$SLACK_ENV" | tail -1 | cut -d= -f2-)
@@ -407,12 +408,23 @@ if [ -f "$SLACK_ENV" ] && command -v tmux &>/dev/null; then
   if [ -n "$SLACK_APP_TOKEN" ] && [ -n "$SLACK_BOT_TOKEN" ] \
      && gosu sandbox bash -lc 'command -v pi' &>/dev/null; then
     if ! gosu sandbox tmux has-session -t client-slack 2>/dev/null; then
-      SLACK_ENV_ARGS="SLACK_APP_TOKEN=$(shell_quote "$SLACK_APP_TOKEN") SLACK_BOT_TOKEN=$(shell_quote "$SLACK_BOT_TOKEN")"
-      [ -n "$SLACK_ALLOW_USERS" ] && SLACK_ENV_ARGS="$SLACK_ENV_ARGS SLACK_ALLOW_USERS=$(shell_quote "$SLACK_ALLOW_USERS")"
-      [ -n "$SLACK_ALLOW_CHANNELS" ] && SLACK_ENV_ARGS="$SLACK_ENV_ARGS SLACK_ALLOW_CHANNELS=$(shell_quote "$SLACK_ALLOW_CHANNELS")"
-      gosu sandbox tmux new-session -d -s client-slack \
-        "env $SLACK_ENV_ARGS pi 2>&1 | tee /tmp/client-slack.log"
-      echo "[entrypoint] client-slack tmux session started (Slack bridge)"
+      SLACK_RUNTIME_ENV=$(mktemp /tmp/client-slack-env.XXXXXX)
+      {
+        printf 'SLACK_APP_TOKEN=%s\n' "$(shell_quote "$SLACK_APP_TOKEN")"
+        printf 'SLACK_BOT_TOKEN=%s\n' "$(shell_quote "$SLACK_BOT_TOKEN")"
+        [ -n "$SLACK_ALLOW_USERS" ] && printf 'SLACK_ALLOW_USERS=%s\n' "$(shell_quote "$SLACK_ALLOW_USERS")"
+        [ -n "$SLACK_ALLOW_CHANNELS" ] && printf 'SLACK_ALLOW_CHANNELS=%s\n' "$(shell_quote "$SLACK_ALLOW_CHANNELS")"
+      } > "$SLACK_RUNTIME_ENV"
+      chmod 600 "$SLACK_RUNTIME_ENV"
+      chown "$(sandbox_ownership)" "$SLACK_RUNTIME_ENV" 2>/dev/null || true
+      if gosu sandbox tmux new-session -d -s client-slack \
+        "bash -c 'trap '\''rm -f \"\$1\"'\'' EXIT; set -a; . \"\$1\"; set +a; pi 2>&1 | tee /tmp/client-slack.log' -- $(shell_quote "$SLACK_RUNTIME_ENV")"; then
+        echo "[entrypoint] client-slack tmux session started (Slack bridge)"
+      else
+        rm -f "$SLACK_RUNTIME_ENV"
+        echo "[entrypoint] client-slack tmux session failed to start"
+        exit 1
+      fi
     else
       echo "[entrypoint] client-slack tmux session already running — skipping"
     fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Update policy and release automation live in [`/git`](.claude/skills/git/SKILL.m
 ### Removed
 ### Deprecated
 ### Security
+- `client-slack` restore now keeps Slack token values out of the tmux command string by sourcing a permission-restricted runtime env file before launching `pi` ([#461](https://github.com/mifunedev/openharness/issues/461)).
 
 ## [2026.6.18] - 2026-06-18
 

--- a/evals/RESULTS.md
+++ b/evals/RESULTS.md
@@ -6,56 +6,56 @@ probe id; git history is the time series.** Schema and exit-code semantics are i
 
 | probe | tier | last-run (UTC) | status | source |
 |-------|------|----------------|--------|--------|
-| agent-browser-cli | A | 2026-06-19 04:59 | PASS | memory/MEMORY.md 2026-06-07 (agent-browser 0.8.5 CLI) |
-| autopilot-executor-toggle | A | 2026-06-19 04:59 | PASS | conversation 2026-06-13 (autopilot delegate-advisor executor) |
-| autopilot-no-pr-session-close | A | 2026-06-19 04:59 | PASS | issue #209 (autopilot no-PR tmux session closure) 2026-06-16 |
-| autopilot-open-pr-reference-dedupe | A | 2026-06-19 04:59 | PASS | issue #437 — autopilot must not start duplicate work when open PRs reference the same issue without linked-PR metadata |
-| autopilot-pi-agent | A | 2026-06-19 04:59 | PASS | issue #116 (autopilot Pi tmux alignment) 2026-06-14; issue #118 (attachable Pi TUI tmux) 2026-06-14; issue #126 (kept Pi overlap lock release) 2026-06-14; issue #142 (worktree-by-default, skip→worktree) 2026-06-14 |
-| autopilot-preflight-gate | A | 2026-06-19 04:59 | PASS | issue #194 (deterministic autopilot caps preflight gate) 2026-06-15 |
-| autopilot-upstream-default | A | 2026-06-19 04:59 | PASS | issue #420 — future autopilots must target canonical repo, not personal fork |
-| autopilot-worktree-log-root | A | 2026-06-19 04:59 | PASS | issue #152 (persist autopilot worktree logs) 2026-06-15 |
-| boot-lint-glob | A | 2026-06-19 04:59 | PASS | issue #90, issue #120 |
-| capability-benchmark-schema | A | 2026-06-19 04:59 | PASS | issue #167 — capability benchmark instrument |
-| clean-restore | A | 2026-06-19 04:59 | PASS | issue #63 (autopilot-stray-wip-guard) 2026-06-12; issue #81 (owned-paths-zsh-split) 2026-06-13 |
-| cleanup-tasks-scoped-guard | A | 2026-06-19 04:59 | PASS | issue #85 |
-| cleanup-tasks-worktree-grooming | A | 2026-06-19 04:59 | PASS | issue #168 |
-| cron-claude-codex-fallback | A | 2026-06-19 04:59 | PASS | conversation 2026-06-12 (default Codex fallback for crons) |
-| cron-watchdog | A | 2026-06-19 04:59 | PASS | issue #130 (cron runtime watchdog) 2026-06-14 |
-| curl-bash-safe-alternatives | A | 2026-06-19 04:59 | PASS | vet-run/vet integration — public curl|bash examples need review-first alternatives |
-| datasets-schema | A | 2026-06-19 04:59 | PASS | issue #196 — evals/datasets verifiable trajectory corpus (Repo2RLEnv-inspired) |
-| devtcp-hook | A | 2026-06-19 04:59 | PASS | memory/MEMORY.md 2026-06-10 (zsh /dev/tcp) |
-| docs-build-fast-path | A | 2026-06-19 04:59 | PASS | #455 — docs builds must stay out of fast harness/eval/release gates |
-| drift-check-cron-staleness-glob | A | 2026-06-19 04:59 | PASS | issue #98; issue #225 (restart-required cron frontmatter/config drift) |
-| eval-ci-gate | A | 2026-06-19 04:59 | PASS | #103 — eval probe suite gated in CI |
-| eval-gate | A | 2026-06-19 04:59 | PASS | memory/MEMORY.md 2026-06-11 (eval-gate) |
-| eval-results-atomic | A | 2026-06-19 04:59 | PASS | issue #83 (eval-results-atomic-write) |
-| eval-runner-exit | A | 2026-06-19 04:59 | PASS | memory/MEMORY.md 2026-06-11 (eval-runner-exit) #29 |
-| git-skill | A | 2026-06-19 04:59 | PASS | conversation 2026-06-15 — rules are not always supported; git workflow must be the /git skill |
-| harness-audit-empty-output-gate | A | 2026-06-19 04:59 | PASS | issue #246 — /harness-audit must fail closed on empty auditor outputs |
-| harness-audit-memory-path | A | 2026-06-19 04:59 | PASS | issue #183 — /harness-audit must inspect the active worktree, not a hardcoded root |
-| harness-audit-shared-memory | A | 2026-06-19 04:59 | PASS | issue #432 — /harness-audit must load durable memory from shared log root in cron worktrees |
-| harness-ci-core-paths | A | 2026-06-19 04:59 | PASS | #165 — core sandbox config files must trigger harness CI |
-| harness-ci-hooks-paths | A | 2026-06-19 04:59 | PASS | issue #202 — credential/security hook changes must trigger harness CI |
-| health-check-docker-stats | A | 2026-06-19 04:59 | PASS | memory/MEMORY.md 2026-06-10 (docker stats vs ps Size) |
-| locked-append-critical-path | A | 2026-06-19 04:59 | PASS | issue #204 (lock shared runtime log appends) 2026-06-15 |
-| loop-benchmark-gate | A | 2026-06-19 04:59 | PASS | issue #179 — wire the executable-loop `benchmark` node (close the cycle) |
-| loop-handoff-consistency | A | 2026-06-19 04:59 | PASS | context/rules/loop.md § 4 (executable-loop Handoff convention) |
-| loop-repeat-gate | A | 2026-06-19 04:59 | PASS | issue #173 — wire the executable-loop `repeat` node (cycle-closing edge) |
-| memory-gitignore-claim | A | 2026-06-19 04:59 | PASS | issue #101 |
-| next-dev-prod | A | 2026-06-19 04:59 | PASS | memory/MEMORY.md 2026-06-04 |
-| orchestrate-contract | A | 2026-06-19 04:59 | PASS | issue #160 — /orchestrate contract; issue #175 — reserved /loop command rename |
-| owned-surface-guard | A | 2026-06-19 04:59 | PASS | issue #63 (autopilot-stray-wip-guard) 2026-06-12; issue #81 (owned-paths-zsh-split) 2026-06-13 |
-| pnpm-audit-ci-gate | A | 2026-06-19 04:59 | PASS | issue #171 — pnpm security audits must run in CI |
-| pr-audit-duplicate-issue-refs | A | 2026-06-19 04:59 | PASS | issue #439 — /pr-audit must flag duplicate open PRs that reference the same issue |
-| ralph-fallback-order | A | 2026-06-19 04:59 | PASS | conversation 2026-06-12 (Ralph default fallback order) |
-| retro-deterministic-contract | A | 2026-06-19 04:59 | PASS | issue #443 — /retro deterministic output and self-contained helper contract |
-| rl-delegation-write-worker | A | 2026-06-19 04:59 | PASS | memory/MEMORY.md 2026-06-10 (rl-delegation) #57 |
-| ship-spec-ready-finalization | A | 2026-06-19 04:59 | PASS | issue #134 — /ship-spec must finalize ready PRs after gates, not stop at draft scaffold |
-| skill-paths | A | 2026-06-19 04:59 | PASS | issue #43 — stale path references; extended by issue #69 — apps/->packages/ rename guard |
-| submitted-by-trailers | A | 2026-06-19 04:59 | PASS | conversation 2026-06-12 (commit attribution trailers) |
-| watchdog-completed-session-reap | A | 2026-06-19 04:59 | PASS | issue #235 (completed autopilot PR session reaping) |
-| watchdog-draft-prs | A | 2026-06-19 04:59 | PASS | conversation 2026-06-15 (generic watchdog + stale draft PR recovery) |
-| watchdog-stuck-sessions | A | 2026-06-19 04:59 | PASS | issue #240 (Codex zero-credit stuck autopilot sessions) 2026-06-17 |
-| wiki-readme-index | A | 2026-06-19 04:59 | PASS | issue #132 — wiki README index drift guard |
+| agent-browser-cli | A | 2026-06-19 06:17 | PASS | memory/MEMORY.md 2026-06-07 (agent-browser 0.8.5 CLI) |
+| autopilot-executor-toggle | A | 2026-06-19 06:17 | PASS | conversation 2026-06-13 (autopilot delegate-advisor executor) |
+| autopilot-no-pr-session-close | A | 2026-06-19 06:17 | PASS | issue #209 (autopilot no-PR tmux session closure) 2026-06-16 |
+| autopilot-open-pr-reference-dedupe | A | 2026-06-19 06:17 | PASS | issue #437 — autopilot must not start duplicate work when open PRs reference the same issue without linked-PR metadata |
+| autopilot-pi-agent | A | 2026-06-19 06:17 | PASS | issue #116 (autopilot Pi tmux alignment) 2026-06-14; issue #118 (attachable Pi TUI tmux) 2026-06-14; issue #126 (kept Pi overlap lock release) 2026-06-14; issue #142 (worktree-by-default, skip→worktree) 2026-06-14 |
+| autopilot-preflight-gate | A | 2026-06-19 06:17 | PASS | issue #194 (deterministic autopilot caps preflight gate) 2026-06-15 |
+| autopilot-upstream-default | A | 2026-06-19 06:17 | PASS | issue #420 — future autopilots must target canonical repo, not personal fork |
+| autopilot-worktree-log-root | A | 2026-06-19 06:17 | PASS | issue #152 (persist autopilot worktree logs) 2026-06-15 |
+| boot-lint-glob | A | 2026-06-19 06:17 | PASS | issue #90, issue #120 |
+| capability-benchmark-schema | A | 2026-06-19 06:17 | PASS | issue #167 — capability benchmark instrument |
+| clean-restore | A | 2026-06-19 06:17 | PASS | issue #63 (autopilot-stray-wip-guard) 2026-06-12; issue #81 (owned-paths-zsh-split) 2026-06-13 |
+| cleanup-tasks-scoped-guard | A | 2026-06-19 06:17 | PASS | issue #85 |
+| cleanup-tasks-worktree-grooming | A | 2026-06-19 06:17 | PASS | issue #168 |
+| cron-claude-codex-fallback | A | 2026-06-19 06:17 | PASS | conversation 2026-06-12 (default Codex fallback for crons) |
+| cron-watchdog | A | 2026-06-19 06:17 | PASS | issue #130 (cron runtime watchdog) 2026-06-14 |
+| curl-bash-safe-alternatives | A | 2026-06-19 06:17 | PASS | vet-run/vet integration — public curl|bash examples need review-first alternatives |
+| datasets-schema | A | 2026-06-19 06:17 | PASS | issue #196 — evals/datasets verifiable trajectory corpus (Repo2RLEnv-inspired) |
+| devtcp-hook | A | 2026-06-19 06:17 | PASS | memory/MEMORY.md 2026-06-10 (zsh /dev/tcp) |
+| docs-build-fast-path | A | 2026-06-19 06:17 | PASS | #455 — docs builds must stay out of fast harness/eval/release gates |
+| drift-check-cron-staleness-glob | A | 2026-06-19 06:17 | PASS | issue #98; issue #225 (restart-required cron frontmatter/config drift) |
+| eval-ci-gate | A | 2026-06-19 06:17 | PASS | #103 — eval probe suite gated in CI |
+| eval-gate | A | 2026-06-19 06:17 | PASS | memory/MEMORY.md 2026-06-11 (eval-gate) |
+| eval-results-atomic | A | 2026-06-19 06:17 | PASS | issue #83 (eval-results-atomic-write) |
+| eval-runner-exit | A | 2026-06-19 06:17 | PASS | memory/MEMORY.md 2026-06-11 (eval-runner-exit) #29 |
+| git-skill | A | 2026-06-19 06:17 | PASS | conversation 2026-06-15 — rules are not always supported; git workflow must be the /git skill |
+| harness-audit-empty-output-gate | A | 2026-06-19 06:17 | PASS | issue #246 — /harness-audit must fail closed on empty auditor outputs |
+| harness-audit-memory-path | A | 2026-06-19 06:17 | PASS | issue #183 — /harness-audit must inspect the active worktree, not a hardcoded root |
+| harness-audit-shared-memory | A | 2026-06-19 06:17 | PASS | issue #432 — /harness-audit must load durable memory from shared log root in cron worktrees |
+| harness-ci-core-paths | A | 2026-06-19 06:17 | PASS | #165 — core sandbox config files must trigger harness CI |
+| harness-ci-hooks-paths | A | 2026-06-19 06:17 | PASS | issue #202 — credential/security hook changes must trigger harness CI |
+| health-check-docker-stats | A | 2026-06-19 06:17 | PASS | memory/MEMORY.md 2026-06-10 (docker stats vs ps Size) |
+| locked-append-critical-path | A | 2026-06-19 06:17 | PASS | issue #204 (lock shared runtime log appends) 2026-06-15 |
+| loop-benchmark-gate | A | 2026-06-19 06:17 | PASS | issue #179 — wire the executable-loop `benchmark` node (close the cycle) |
+| loop-handoff-consistency | A | 2026-06-19 06:17 | PASS | context/rules/loop.md § 4 (executable-loop Handoff convention) |
+| loop-repeat-gate | A | 2026-06-19 06:17 | PASS | issue #173 — wire the executable-loop `repeat` node (cycle-closing edge) |
+| memory-gitignore-claim | A | 2026-06-19 06:17 | PASS | issue #101 |
+| next-dev-prod | A | 2026-06-19 06:17 | PASS | memory/MEMORY.md 2026-06-04 |
+| orchestrate-contract | A | 2026-06-19 06:17 | PASS | issue #160 — /orchestrate contract; issue #175 — reserved /loop command rename |
+| owned-surface-guard | A | 2026-06-19 06:17 | PASS | issue #63 (autopilot-stray-wip-guard) 2026-06-12; issue #81 (owned-paths-zsh-split) 2026-06-13 |
+| pnpm-audit-ci-gate | A | 2026-06-19 06:17 | PASS | issue #171 — pnpm security audits must run in CI |
+| pr-audit-duplicate-issue-refs | A | 2026-06-19 06:17 | PASS | issue #439 — /pr-audit must flag duplicate open PRs that reference the same issue |
+| ralph-fallback-order | A | 2026-06-19 06:17 | PASS | conversation 2026-06-12 (Ralph default fallback order) |
+| retro-deterministic-contract | A | 2026-06-19 06:17 | PASS | issue #443 — /retro deterministic output and self-contained helper contract |
+| rl-delegation-write-worker | A | 2026-06-19 06:17 | PASS | memory/MEMORY.md 2026-06-10 (rl-delegation) #57 |
+| ship-spec-ready-finalization | A | 2026-06-19 06:17 | PASS | issue #134 — /ship-spec must finalize ready PRs after gates, not stop at draft scaffold |
+| skill-paths | A | 2026-06-19 06:17 | PASS | issue #43 — stale path references; extended by issue #69 — apps/->packages/ rename guard |
+| submitted-by-trailers | A | 2026-06-19 06:17 | PASS | conversation 2026-06-12 (commit attribution trailers) |
+| watchdog-completed-session-reap | A | 2026-06-19 06:17 | PASS | issue #235 (completed autopilot PR session reaping) |
+| watchdog-draft-prs | A | 2026-06-19 06:17 | PASS | conversation 2026-06-15 (generic watchdog + stale draft PR recovery) |
+| watchdog-stuck-sessions | A | 2026-06-19 06:17 | PASS | issue #240 (Codex zero-credit stuck autopilot sessions) 2026-06-17 |
+| wiki-readme-index | A | 2026-06-19 06:17 | PASS | issue #132 — wiki README index drift guard |
 
 <!-- benchmark: pass-rate = PASS / (PASS + REGRESSION + TIMEOUT); SKIPPED excluded -->

--- a/scripts/__tests__/entrypoint.test.ts
+++ b/scripts/__tests__/entrypoint.test.ts
@@ -60,10 +60,11 @@ describe("devcontainer entrypoint Slack restore", () => {
 
     expect(text).not.toContain("source $SLACK_ENV");
     expect(text).not.toContain("set -a; source");
-    expect(text).toContain('SLACK_ENV_ARGS="SLACK_APP_TOKEN=$(shell_quote "$SLACK_APP_TOKEN") SLACK_BOT_TOKEN=$(shell_quote "$SLACK_BOT_TOKEN")"');
-    expect(text).toContain('SLACK_ENV_ARGS="$SLACK_ENV_ARGS SLACK_ALLOW_USERS=$(shell_quote "$SLACK_ALLOW_USERS")"');
-    expect(text).toContain('SLACK_ENV_ARGS="$SLACK_ENV_ARGS SLACK_ALLOW_CHANNELS=$(shell_quote "$SLACK_ALLOW_CHANNELS")"');
-    expect(text).toContain("env $SLACK_ENV_ARGS pi");
+    expect(text).toContain("SLACK_RUNTIME_ENV=$(mktemp /tmp/client-slack-env.XXXXXX)");
+    expect(text).toContain('printf \'SLACK_APP_TOKEN=%s\\n\' "$(shell_quote "$SLACK_APP_TOKEN")"');
+    expect(text).toContain('printf \'SLACK_BOT_TOKEN=%s\\n\' "$(shell_quote "$SLACK_BOT_TOKEN")"');
+    expect(text).toContain("chmod 600 \"$SLACK_RUNTIME_ENV\"");
+    expect(text).toContain("bash -c");
     expect(text).toContain("/tmp/client-slack.log");
   });
 
@@ -117,6 +118,7 @@ describe("devcontainer entrypoint Slack restore", () => {
         "-c",
         [
           "set -euo pipefail",
+          entrypointFunction("sandbox_ownership"),
           entrypointFunction("shell_quote"),
           'gosu() { local user="$1"; shift; "$@"; }',
           slackRestoreBlock(),
@@ -136,7 +138,12 @@ describe("devcontainer entrypoint Slack restore", () => {
 
     const tmuxLines = readFileSync(tmuxArgs, "utf8").trim().split("\n");
     const tmuxCommand = tmuxLines[tmuxLines.length - 1] ?? "";
-    expect(tmuxCommand).toContain("env SLACK_APP_TOKEN=");
+    expect(tmuxCommand).toContain("bash -c");
+    expect(tmuxCommand).toContain("/tmp/client-slack.log");
+    expect(tmuxCommand).not.toContain("xapp token; touch $PWNED");
+    expect(tmuxCommand).not.toContain("xoxb'quoted");
+    expect(tmuxCommand).not.toContain("U_ALLOWED; touch $PWNED");
+    expect(tmuxCommand).not.toContain("C_ALLOWED C_SECOND");
 
     execFileSync("bash", ["-c", tmuxCommand], {
       env: {

--- a/tasks/keep-slack-tokens-out-of/critique.md
+++ b/tasks/keep-slack-tokens-out-of/critique.md
@@ -1,0 +1,22 @@
+# Critique — keep-slack-tokens-out-of
+
+Generated 2026-06-19; reviews `prd.md` post-/prd, pre-/ralph.
+
+## Critic A — Implementer lens
+
+CRITIC_A — IMPLEMENTER LENS
+[SEVERITY: M] [STORY: US-001] Runtime handoff could break sandbox-user readability if the temp file remains root-owned | [EVIDENCE: US-001 runtime env file AC] | chown the file to the numeric sandbox owner while keeping mode 600; test through the captured tmux command.
+[SEVERITY: M] [STORY: US-001] Cleanup path could leave secret material in /tmp if tmux launch fails or pi exits | [EVIDENCE: US-001 sources/removes runtime env file AC] | add child-shell trap and parent failure cleanup.
+[SEVERITY: L] [STORY: US-002] Wiki update can drift from exact source lines | [EVIDENCE: Wiki Alignment] | cite relevant files and keep the entry concise.
+
+## Critic B — User lens
+
+CRITIC_B — USER LENS
+[SEVERITY: M] [STORY: US-001] User expects Slack restart behavior to stay unchanged, not merely become safer | [EVIDENCE: Goals + Non-Goals] | keep session name, required-token gate, pi detection, and log path stable.
+[SEVERITY: L] [STORY: US-002] Tests should prove both privacy and functional delivery | [EVIDENCE: US-002 AC] | assert token values are absent from tmux argv and still arrive in the fake pi process.
+
+## Synthesis
+
+- **High-severity findings**: 0
+- **Medium-severity findings**: 3
+- **Recommendation**: PROCEED — mitigations are captured in US-001/US-002 acceptance criteria.

--- a/tasks/keep-slack-tokens-out-of/prd.json
+++ b/tasks/keep-slack-tokens-out-of/prd.json
@@ -1,0 +1,36 @@
+{
+  "schemaVersion": 1,
+  "project": "Open Harness",
+  "branchName": "feat/461-keep-slack-tokens-out-of",
+  "description": "Keep Slack bridge tokens out of tmux argv when restoring the client-slack session.",
+  "userStories": [
+    {
+      "id": "US-001",
+      "title": "Runtime env handoff",
+      "description": "As a sandbox operator, I want the client-slack restore path to pass Slack tokens through a permission-restricted runtime env file so secrets are inherited by pi without appearing in tmux argv.",
+      "acceptanceCriteria": [
+        ".devcontainer/entrypoint.sh no longer builds an env SLACK_APP_TOKEN command string.",
+        "The restore path writes only the required Slack keys to a temporary mode-600 runtime env file owned by the sandbox user.",
+        "The tmux command string contains only the runtime env file path, sources and removes it inside the child shell, then runs pi with /tmp/client-slack.log logging.",
+        "Existing start conditions remain unchanged."
+      ],
+      "priority": 1,
+      "passes": true,
+      "notes": "Implemented in this branch; verified by entrypoint test."
+    },
+    {
+      "id": "US-002",
+      "title": "Regression coverage and docs",
+      "description": "As a future maintainer, I want tests and durable docs to capture the secret-handling invariant.",
+      "acceptanceCriteria": [
+        "scripts/__tests__/entrypoint.test.ts proves fixture token values are absent from the tmux command string.",
+        "The test proves pi receives the original Slack values and malicious-looking fixture content is not evaluated.",
+        "CHANGELOG.md records the security fix.",
+        "wiki/sandbox-auth-volumes.md documents the runtime env handoff and wiki/README.md stays indexed."
+      ],
+      "priority": 2,
+      "passes": true,
+      "notes": "Implemented in this branch; verified by entrypoint test and wiki-readme-index probe."
+    }
+  ]
+}

--- a/tasks/keep-slack-tokens-out-of/prd.md
+++ b/tasks/keep-slack-tokens-out-of/prd.md
@@ -1,0 +1,51 @@
+# PRD — Keep Slack Tokens Out of tmux argv
+
+## Summary
+
+Harden the devcontainer `client-slack` restore path so Slack token values never appear in the tmux launch command while preserving the existing Slack bridge restart behavior.
+
+## Goals
+
+- Keep `SLACK_APP_TOKEN`, `SLACK_BOT_TOKEN`, and optional Slack allow-list values out of process argv / tmux command strings.
+- Preserve the existing `client-slack` session name, `pi` launch, and `/tmp/client-slack.log` output.
+- Add regression coverage for malicious-looking token values and argv redaction.
+
+## Non-Goals
+
+- Do not change the Slack Pi extension runtime semantics.
+- Do not change how users configure Slack tokens in `.devcontainer/.env`.
+- Do not touch sandbox application code.
+
+## User Stories
+
+### US-001 — Runtime env handoff
+
+As a sandbox operator, I want the `client-slack` restore path to pass Slack tokens through a permission-restricted runtime env file so secrets are inherited by `pi` without appearing in tmux argv.
+
+Acceptance criteria:
+- `.devcontainer/entrypoint.sh` no longer builds an `env SLACK_APP_TOKEN=...` command string.
+- The restore path writes only the required Slack keys to a temporary mode-600 runtime env file.
+- The tmux command string contains only the runtime env file path, sources and removes it inside the child shell, then runs `pi 2>&1 | tee /tmp/client-slack.log`.
+- Existing start conditions remain unchanged: `.devcontainer/.env` exists, both required Slack tokens are present, and sandbox-user `pi` is installed.
+
+### US-002 — Regression coverage and docs
+
+As a future maintainer, I want tests and durable docs to capture the secret-handling invariant.
+
+Acceptance criteria:
+- `scripts/__tests__/entrypoint.test.ts` executes the captured tmux command and proves fixture token values are absent from the command string.
+- The test still proves `pi` receives the original Slack values and malicious-looking fixture content is not evaluated.
+- `CHANGELOG.md` records the security fix.
+- `wiki/sandbox-auth-volumes.md` documents the Slack runtime env handoff and `wiki/README.md` stays indexed.
+
+## Wiki Alignment
+
+- **Impact**: REQUIRED
+- **Local entries**: `wiki/sandbox-auth-volumes.md`
+- **Spec alignment**: document that auth/secret handling now includes a Slack runtime env-file handoff that keeps token values out of tmux argv while preserving ownership and startup behavior.
+- **DeepWiki comparison**: no relevant public DeepWiki page was reachable from the local tooling during this run; local source-backed wiki entry is the authority.
+- **Acceptance criteria**: update the wiki entry with relevant source files and line-cited behavior; refresh `wiki/README.md`; verify with `bash evals/probes/wiki-readme-index.sh`.
+
+## Critique Synthesis
+
+Critics found no unmitigated high-severity findings. The main risk is accidentally changing Slack startup behavior; US-001 requires preserving start conditions, session name, and logging.

--- a/tasks/keep-slack-tokens-out-of/progress.txt
+++ b/tasks/keep-slack-tokens-out-of/progress.txt
@@ -1,0 +1,3 @@
+# progress
+
+STATUS: COMPLETE

--- a/tasks/keep-slack-tokens-out-of/prompt.md
+++ b/tasks/keep-slack-tokens-out-of/prompt.md
@@ -1,0 +1,14 @@
+# Ralph prompt — keep-slack-tokens-out-of
+
+Implement tasks/keep-slack-tokens-out-of/prd.json on branch feat/461-keep-slack-tokens-out-of for issue #461.
+
+Read:
+- tasks/keep-slack-tokens-out-of/prd.md
+- tasks/keep-slack-tokens-out-of/prd.json
+- tasks/keep-slack-tokens-out-of/critique.md
+- tasks/keep-slack-tokens-out-of/progress.txt
+
+Rules:
+- Harness-infra only.
+- Preserve client-slack behavior while keeping Slack token values out of tmux argv.
+- Run the entrypoint test and wiki index probe before completion.

--- a/wiki/README.md
+++ b/wiki/README.md
@@ -26,7 +26,7 @@ Schema rule, frontmatter spec, and all authoring conventions: `context/rules/wik
 
 | Slug | Title | Tags | Updated |
 | --- | --- | --- | --- |
+| sandbox-auth-volumes | Sandbox Auth Volume Ownership | [sandbox, devcontainer, auth, docker, ownership, secrets] | 2026-06-19 |
 | ci-build-gates | CI Build Gates | [ci, docs, build, eval, github-actions] | 2026-06-19 |
 | harness-audit | Harness Audit | [audit, skills, autopilot, memory, worktrees] | 2026-06-18 |
-| sandbox-auth-volumes | Sandbox Auth Volume Ownership | [sandbox, devcontainer, auth, docker, ownership] | 2026-06-16 |
 | cron-runtime | Cron Runtime | [cron, runtime, scheduler, drift-check, automation, open-harness] | 2026-06-16 |

--- a/wiki/raw/2026-06-19-slack-token-argv.md
+++ b/wiki/raw/2026-06-19-slack-token-argv.md
@@ -1,0 +1,7 @@
+# Slack token argv hardening snapshot — 2026-06-19
+
+Source: autopilot harness-audit finding and issue #461.
+
+Finding: `.devcontainer/entrypoint.sh` restored the `client-slack` tmux session by interpolating `SLACK_APP_TOKEN`, `SLACK_BOT_TOKEN`, and optional Slack allow-list values into the tmux shell command string. Those values can be exposed through process argv or tmux command inspection.
+
+Resolution model: keep `.devcontainer/.env` treated as data, write only the required Slack values into a temporary runtime env file with restrictive permissions, start `client-slack` with a command string that contains only the runtime env file path, source and remove that file inside the child shell, then launch `pi` with existing logging to `/tmp/client-slack.log`.

--- a/wiki/sandbox-auth-volumes.md
+++ b/wiki/sandbox-auth-volumes.md
@@ -1,12 +1,13 @@
 ---
 title: "Sandbox Auth Volume Ownership"
 slug: sandbox-auth-volumes
-tags: [sandbox, devcontainer, auth, docker, ownership]
+tags: [sandbox, devcontainer, auth, docker, ownership, secrets]
 created: 2026-06-16
-updated: 2026-06-16
+updated: 2026-06-19
 sources:
   - raw/2026-06-16-sandbox-auth-volumes.md
-related: [hermes-agent, inspectable-agent-harness]
+  - raw/2026-06-19-slack-token-argv.md
+related: [cron-runtime]
 confidence: provisional
 ---
 
@@ -16,7 +17,7 @@ confidence: provisional
 
 - `.devcontainer/docker-compose.yml` — mounts the repo plus persistent agent/GitHub auth named volumes.
 - `.devcontainer/entrypoint.sh` — reconciles the sandbox UID/GID and repairs ownership of auth/config mounts.
-- `scripts/__tests__/entrypoint.test.ts` — pins the ordering and numeric-owner invariant.
+- `scripts/__tests__/entrypoint.test.ts` — pins the ordering, numeric-owner invariant, and Slack token argv guard.
 
 ## Summary
 
@@ -27,6 +28,8 @@ Open Harness keeps agent and GitHub auth state in Docker named volumes under `/h
 Compose mounts `claude-auth`, `codex-auth`, `pi-auth`, `opencode-auth`, `grok-auth`, `deepagents-auth`, `cloudflared-auth`, and `gh-config` below `/home/sandbox` while mounting the checkout separately at `/home/sandbox/harness` (`.devcontainer/docker-compose.yml:31-40`). Docker can create those volume targets as root, so the entrypoint computes the sandbox user's current numeric owner with `id -u sandbox` and `id -g sandbox` before repair (`.devcontainer/entrypoint.sh:15-22`). Numeric ownership matters because UID/GID reconciliation can move `sandbox` to an existing host group whose name is not `sandbox`; `sandbox:sandbox` would then target the wrong group.
 
 The repair helper fixes existing auth/config mounts, preserves `.ssh` mode hardening, repairs root-created parents non-recursively, and handles legacy `/home/sandbox/.hermes` state without recursing into `$HERMES_HOME` when it lives inside the bind-mounted checkout (`.devcontainer/entrypoint.sh:24-56`). It runs once before the host UID block for default-host compatibility and again after UID/GID reconciliation so the final numeric identity owns persisted credentials (`.devcontainer/entrypoint.sh:59-95`). Tests assert both the numeric owner calculation and the pre/post UID-sync invocation order (`scripts/__tests__/entrypoint.test.ts:12-36`).
+
+Slack tokens are a separate secret-handling path in the same entrypoint. The `client-slack` restore block still reads only explicit Slack keys from `.devcontainer/.env`, but it now writes them into a temporary mode-600 runtime env file owned by the sandbox user, starts tmux with a command string containing only that file path, sources and removes the file inside the child shell, then launches `pi` with `/tmp/client-slack.log` logging (`.devcontainer/entrypoint.sh:394-427`). Tests execute the captured tmux command and assert fixture token values do not appear in argv while `pi` receives the original environment (`scripts/__tests__/entrypoint.test.ts:58-166`).
 
 Operator symptoms of ownership drift: `gh auth status` fails despite a populated `gh-config` volume, agent CLIs ask to re-authenticate after restart, or writes under `~/.claude`, `~/.codex`, `~/.pi`, `~/.grok`, `~/.deepagents`, `~/.cloudflared`, or `~/.config/gh` return EACCES. Verify with `stat -c '%u:%g %n' ~/.config/gh ~/.claude ~/.pi` inside the sandbox; expected owner is `$(id -u sandbox):$(id -g sandbox)`. If auth still fails, restart the sandbox to re-run the entrypoint, then manually chown only the affected auth volume path to that numeric owner; do not chown the whole bind-mounted checkout as a recovery shortcut.
 
@@ -42,5 +45,4 @@ flowchart TD
 
 ## See Also
 
-- [[hermes-agent]]
-- [[inspectable-agent-harness]]
+- [[cron-runtime]]


### PR DESCRIPTION
## Selection rationale

Research selection: queue had no non-duplicate actionable ticket; /harness-audit ranked Slack token exposure in the client-slack tmux launch as #1 by impact among harness-infra candidates. First-principles rationale: secrets must not appear in process argv or tmux command history, and the fix is small and testable. Filed as #461.

---

Closes #461.

**Status: READY — implementation, /eval, CI, and promotable checks passed.**

## Summary

Keeps Slack bridge token values out of the `client-slack` tmux command string by handing them to `pi` through a sandbox-owned temporary runtime env file that is sourced and removed inside the child shell.

## Stories

1. Runtime env handoff
2. Regression coverage and docs

## Verification

- `bash -n .devcontainer/entrypoint.sh`
- `pnpm test:scripts`
- `bash evals/probes/wiki-readme-index.sh`
- `bash .claude/skills/eval/run.sh` — 51 PASS, no new regressions

## Gates

- Critique: 0 high-severity findings; medium risks mitigated in PRD acceptance criteria.
- Wiki: `wiki/sandbox-auth-volumes.md` updated; README index probe passes.

🤖 Generated with Pi via /autopilot + /ship-spec-compatible flow.