### PR TITLE
FROM fix/clarify-oh-website-copy TO main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,16 @@ Update policy and release automation live in [`/git`](.claude/skills/git/SKILL.m
 ## [Unreleased]
 
 ### Added
+
 ### Changed
+- Clarify oh.mifune.dev copy — "harness" now consistently means Open Harness (the repo); the CLI you pick is the "agent". The landing page, site tagline/meta, `docs/intro.md`, `docs/installation.md`, and `docs/harnesses/overview.md` now state one-repo-per-sandbox, that the repo tracks/versions state, and sandbox isolation (agents never run straight on your host) ([#268](https://github.com/ryaneggz/openharness/pull/268)).
+
 ### Fixed
+
 ### Removed
+
 ### Deprecated
+
 ### Security
 
 ## [2026.6.18] - 2026-06-18

--- a/docs/harnesses/overview.md
+++ b/docs/harnesses/overview.md
@@ -7,7 +7,7 @@ title: "Harnesses Overview"
 
 Open Harness ships with three agent CLIs in the default sandbox image: **Claude Code** (default), **Codex**, and **Pi**. **OpenCode**, **DeepAgents**, **Hermes**, and **Grok Build** are optional image-level installs controlled by `harness.yaml` `install:` keys (or `.devcontainer/.env` build flags). **T3 Code** runs on demand via `npx t3` as a browser UI on port 3773. Inside the sandbox, launch whichever you prefer — switch between them at any time, or keep long-running sessions in tmux.
 
-The sandbox is the product; the harness is your call. To go beyond the preinstalled options, install via `npm` / `pip` / `cargo` inside the sandbox, edit the Dockerfile, or layer in a harness pack such as [`@ryaneggz/mifune`](https://github.com/ryaneggz/mifune). For Pi+Slack specifically, the recommended path is the in-tree extension at [`.pi/extensions/slack/`](../integrations/slack.md). The product surface is one developer, one project, one harness — not racing or stacking multiple CLIs against each other.
+Open Harness is the harness; the **agent** is your call. To go beyond the preinstalled options, install via `npm` / `pip` / `cargo` inside the sandbox, edit the Dockerfile, or layer in a harness pack such as [`@ryaneggz/mifune`](https://github.com/ryaneggz/mifune). For Pi+Slack specifically, the recommended path is the in-tree extension at [`.pi/extensions/slack/`](../integrations/slack.md). The product surface is one developer, one project, one agent — not racing or stacking multiple CLIs against each other.
 
 ## Supported agents
 
@@ -16,7 +16,7 @@ The sandbox is the product; the harness is your call. To go beyond the preinstal
 | [Claude Code](./claude-code.md) | Anthropic's terminal coding agent (default) | `claude` | preinstalled |
 | [Codex](./codex.md) | OpenAI's CLI coding agent | `codex` | preinstalled |
 | [OpenCode](./opencode.md) | Terminal coding agent with OpenAI OAuth support | `opencode` | optional: `install.opencode: true` in `harness.yaml` |
-| [Pi](./pi.md) | Lightweight, customizable harness | `pi` | default |
+| [Pi](./pi.md) | Lightweight, customizable agent | `pi` | default |
 | [DeepAgents](./deepagents.md) | LangChain's multi-provider terminal agent | `deepagents` | optional: `install.deepagents: true` in `harness.yaml` |
 | [Hermes](./hermes.md) | Nous Research's self-improving terminal agent | `hermes` | optional: `install.hermes: true` in `harness.yaml` |
 | [Grok Build](./grok-build.md) | xAI's proprietary Grok Build terminal agent | `grok` | optional: `install.grok_build: true` in `harness.yaml` |

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -5,7 +5,7 @@ title: "Installation"
 
 # Installation
 
-Open Harness is a Docker-based sandbox image. Installation is `docker compose` against `.devcontainer/docker-compose.yml` — there is no host CLI, agent, or Node toolchain required on the host.
+Open Harness is a portable harness — a single repo that boots an isolated Docker sandbox for your project. Installation clones the repo and runs `docker compose` against `.devcontainer/docker-compose.yml` — there is no host CLI, agent, or Node toolchain required on the host.
 
 ## Prerequisites
 

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -6,15 +6,15 @@ title: "Introduction"
 
 # Open Harness
 
-Open Harness is a Docker-based agent harness for **one project**, agent-tended over time. A single sandbox container is scoped to a single repo, branch, and identity — the agent owns its workspace, runs against your code, and wakes itself on a schedule via a tiny croner runtime.
+Open Harness is your **portable harness** — one repo per sandbox — that wraps your project in an isolated Docker container and versions its state. The repo tracks the agent's identity, skills, crons, and memory in git; the sandbox keeps the agent (Claude Code, Codex, Pi, or another of your choice) off your host machine. The agent owns its workspace, runs against your code, and wakes itself on a schedule via a tiny croner runtime.
 
 ## What is Open Harness?
 
-Open Harness packages a single AI agent in a Docker container called a sandbox. You bring it up with `docker compose`, attach to it from your terminal or VS Code, and let the agent work the project over time. There is no per-agent fan-out and no host CLI; everything happens through standard `docker compose` commands and the croner runtime that ships in the image.
+Open Harness is a single repo that *is* your harness: it boots one Docker container — the sandbox — and wraps your project inside it. You bring the sandbox up with `docker compose`, attach to it from your terminal or VS Code, and let your chosen agent work the project over time. Because the harness is a git repo, its whole setup is tracked and versioned — reproducible and portable. There is no per-agent fan-out and no host CLI; everything happens through standard `docker compose` commands and the croner runtime that ships in the image.
 
 Key capabilities:
 
-- **One project, one sandbox.** A single container scoped to a single repo and branch. The agent owns its workspace; your laptop stays clean.
+- **One repo, one sandbox.** Your portable harness is one repo; it boots one container. The agent owns its workspace; your machine stays clean — you're not running agents straight on your host.
 - **Markdown-defined crons.** `crons/*.md` files declare schedules; an in-container croner runtime fires the bodies as agent prompts so the agent can work autonomously while you focus on other things.
 - **Host dependencies: Docker + Git.** No Node, no Python, and no toolchain maintenance required on your laptop.
 - **Composable infra.** Cloudflare tunnels, SSH, and pack-supplied services are opt-in Docker Compose overlays.

--- a/packages/docs/docusaurus.config.ts
+++ b/packages/docs/docusaurus.config.ts
@@ -9,7 +9,7 @@ import { terminalDark, terminalLight } from "./src/theme/prism-terminal";
 const config: Config = {
   title: "Open Harness",
   tagline:
-    "A Docker sandbox for Claude, Codex, OpenCode, or Pi.",
+    "A portable harness for running coding agents in an isolated Docker sandbox.",
   favicon: "img/favicon.svg",
 
   url: "https://oh.mifune.dev",

--- a/packages/docs/src/pages/index.tsx
+++ b/packages/docs/src/pages/index.tsx
@@ -48,7 +48,7 @@ const AGENTS: Array<{
   },
   {
     name: "Pi",
-    description: "A lightweight, customizable harness.",
+    description: "A lightweight, customizable agent.",
     href: "/docs/harnesses/pi",
     icon: <PiIcon />,
   },
@@ -112,7 +112,7 @@ export default function Home(): React.ReactElement {
   const starLabel = formatStars(stars);
 
   return (
-    <Layout description="We provide the sandbox; you choose the agent. Open Harness is a long-lived Docker sandbox dedicated to your project. Pick Claude Code, Codex, OpenCode, Pi, DeepAgents, Hermes, or Grok Build inside.">
+    <Layout description="Open Harness is a portable harness — one repo per sandbox — that wraps your project in an isolated Docker container and versions its state. Run coding agents like Claude Code, Codex, OpenCode, or Pi inside, never straight on your machine.">
       <main>
         <section className={styles.hero}>
           <div className={styles.heroBg} aria-hidden="true" />
@@ -120,13 +120,13 @@ export default function Home(): React.ReactElement {
             <div className={styles.heroCopy}>
               <p className={styles.heroEyebrow}>
                 <span className={styles.heroEyebrowDot} aria-hidden="true" />
-                Per-project agent sandbox
+                Portable agent harness
               </p>
               <h1 className={styles.heroTitle}>
-                We provide the sandbox. You choose the harness.
+                Run coding agents in a sandbox, not on your machine.
               </h1>
               <p className={styles.heroSubtitle}>
-                A long-lived Docker sandbox dedicated to your project. Pick Claude Code, Codex, OpenCode, Pi, DeepAgents, Hermes, or Grok Build inside, and let it work on demand or on a cron while you sleep.
+                Open Harness is a portable harness: one repo per sandbox that wraps your project in an isolated Docker container and versions its state. Bring your agent — Claude Code, Codex, OpenCode, Pi — and let it work while you sleep.
               </p>
               <div className={styles.heroButtons}>
                 <Link
@@ -233,10 +233,10 @@ export default function Home(): React.ReactElement {
 
         <section className={styles.section}>
           <div className={styles.container}>
-            <h2 className={styles.sectionTitle}>One project. One sandbox.</h2>
+            <h2 className={styles.sectionTitle}>One repo. One sandbox.</h2>
             <div className={styles.archCard}>
               <p>
-                Open Harness runs as a single long-lived Docker container dedicated to your project. The bind-mounted <code>workspace/</code> houses whatever your project needs — one repo, several, side-by-side branches, scratch dirs. The agent owns its workspace; your laptop stays clean.
+                Open Harness is one repo — your portable harness — that boots a single long-lived Docker sandbox. The repo tracks and versions the agent's whole setup in git: identity, skills, crons, memory. Your project lives in the bind-mounted <code>workspace/</code> — one repo or several, side-by-side branches, scratch dirs. The agent owns its workspace; your machine stays clean, never running agents straight on your host.
               </p>
               <p>
                 A markdown cron runtime reads <code>crons/*.md</code> and wakes the agent on a schedule — issue triage, PR review, background grooming, anything you want running while you sleep. Configure the sandbox via <code>.devcontainer/.env</code>; Postgres ships as an opt-in compose overlay, and additional infra (tunnels, reverse proxies) is registered via harness-pack overlays in <code>config.json</code>.


### PR DESCRIPTION
## What & why

Targeted copy correction to put the fix **live on oh.mifune.dev**. The site (built from this repo's `main` via `.github/workflows/docs.yml`) used the word **"harness"** in three contradictory ways and omitted a core claim:

1. **Inverted the relationship** — "Open Harness is a Docker-based **sandbox image**" (`installation.md`), "We provide the **sandbox**" (hero). The repo *is* the harness; the sandbox is the container it boots.
2. **Used "harness" to mean the agent CLI** — "You choose the **harness**", Pi = "a customizable **harness**", "the **harness** is your call".
3. **Never stated the repo tracks/versions state.**

This makes the model crystal clear: **one repo per sandbox**; the repo **is your portable harness** that wraps your project(s) and **tracks/versions state** (identity, skills, crons, memory); the **sandbox isolates** so agents never run straight on your host; and the thing you **choose** is the **agent**.

## Changes (docs/website only)

- `packages/docs/src/pages/index.tsx` — hero (isolation-led), `<Layout>` meta, Pi card `harness`→`agent`, `One project. One sandbox.`→`One repo. One sandbox.` + repo-versions-state.
- `packages/docs/docusaurus.config.ts` — tagline reframed; drops stale 4-agent list.
- `docs/intro.md`, `docs/installation.md`, `docs/harnesses/overview.md` — definitions reframed; "the harness is your call" → "the **agent** is your call".
- `CHANGELOG.md` — `### Changed` entry.

## Provenance & deploy
- Originated as fork PR ryaneggz/openharness#268 (merged to fork `development`); cherry-picked here onto `mifunedev/main` so it deploys without dragging the unrelated fork↔upstream divergence.
- Merging this to `main` triggers the Pages deploy (`docs.yml`, push→main, docs paths) → oh.mifune.dev redeploys.

## Verification
- All five docs/website files applied cleanly to `main` (only `CHANGELOG.md` needed a trivial structural merge — the inaccurate copy on `main` matched exactly what was fixed).
- Fork PR #268: full CI green (Build docs, Lint/Typecheck/Build&Test, Eval Probe Regression Gate, Boot Path Lint, GitGuardian); 55/55 eval probes pass locally.