### PR TITLE
FROM feat/445-preserve-active-cron-worktrees TO development

### DIFF
--- a/evals/RESULTS.md
+++ b/evals/RESULTS.md
@@ -6,59 +6,59 @@ probe id; git history is the time series.** Schema and exit-code semantics are i
 
 | probe | tier | last-run (UTC) | status | source |
 |-------|------|----------------|--------|--------|
-| agent-browser-cli | A | 2026-06-19 08:13 | PASS | memory/MEMORY.md 2026-06-07 (agent-browser 0.8.5 CLI) |
-| autopilot-executor-toggle | A | 2026-06-19 08:13 | PASS | conversation 2026-06-13 (autopilot delegate-advisor executor) |
-| autopilot-no-pr-session-close | A | 2026-06-19 08:13 | PASS | issue #209 (autopilot no-PR tmux session closure) 2026-06-16 |
-| autopilot-open-pr-reference-dedupe | A | 2026-06-19 08:13 | PASS | issue #437 — autopilot must not start duplicate work when open PRs reference the same issue without linked-PR metadata |
-| autopilot-pi-agent | A | 2026-06-19 08:13 | PASS | issue #116 (autopilot Pi tmux alignment) 2026-06-14; issue #118 (attachable Pi TUI tmux) 2026-06-14; issue #126 (kept Pi overlap lock release) 2026-06-14; issue #142 (worktree-by-default, skip→worktree) 2026-06-14 |
-| autopilot-preflight-gate | A | 2026-06-19 08:13 | PASS | issue #194 (deterministic autopilot caps preflight gate) 2026-06-15 |
-| autopilot-upstream-default | A | 2026-06-19 08:13 | PASS | issue #420 — future autopilots must target canonical repo, not personal fork |
-| autopilot-worktree-log-root | A | 2026-06-19 08:13 | PASS | issue #152 (persist autopilot worktree logs) 2026-06-15 |
-| boot-lint-glob | A | 2026-06-19 08:13 | PASS | issue #90, issue #120 |
-| capability-benchmark-schema | A | 2026-06-19 08:13 | PASS | issue #167 — capability benchmark instrument |
-| clean-restore | A | 2026-06-19 08:13 | PASS | issue #63 (autopilot-stray-wip-guard) 2026-06-12; issue #81 (owned-paths-zsh-split) 2026-06-13 |
-| cleanup-tasks-scoped-guard | A | 2026-06-19 08:13 | PASS | issue #85 |
-| cleanup-tasks-worktree-grooming | A | 2026-06-19 08:13 | PASS | issue #168 |
-| cron-claude-codex-fallback | A | 2026-06-19 08:13 | PASS | conversation 2026-06-12 (default Codex fallback for crons) |
-| cron-watchdog | A | 2026-06-19 08:13 | PASS | issues #130/#453 (cron runtime watchdog + legacy system-cron reaping) 2026-06-19 |
-| curl-bash-safe-alternatives | A | 2026-06-19 08:13 | PASS | vet-run/vet integration — public curl|bash examples need review-first alternatives |
-| datasets-schema | A | 2026-06-19 08:13 | PASS | issue #196 — evals/datasets verifiable trajectory corpus (Repo2RLEnv-inspired) |
-| devtcp-hook | A | 2026-06-19 08:13 | PASS | memory/MEMORY.md 2026-06-10 (zsh /dev/tcp) |
-| docs-build-fast-path | A | 2026-06-19 08:13 | PASS | #455 — docs builds must stay out of fast harness/eval/release gates |
-| drift-check-cron-staleness-glob | A | 2026-06-19 08:13 | SKIPPED | issue #98; issue #225 (restart-required cron frontmatter/config drift) |
-| eval-ci-gate | A | 2026-06-19 08:13 | PASS | #103 — eval probe suite gated in CI |
-| eval-gate | A | 2026-06-19 08:13 | PASS | memory/MEMORY.md 2026-06-11 (eval-gate) |
-| eval-results-atomic | A | 2026-06-19 08:13 | PASS | issue #83 (eval-results-atomic-write) |
-| eval-runner-exit | A | 2026-06-19 08:13 | PASS | memory/MEMORY.md 2026-06-11 (eval-runner-exit) #29 |
-| git-skill | A | 2026-06-19 08:13 | PASS | conversation 2026-06-15 — rules are not always supported; git workflow must be the /git skill |
-| harness-audit-empty-output-gate | A | 2026-06-19 08:13 | PASS | issue #246 — /harness-audit must fail closed on empty auditor outputs |
-| harness-audit-memory-path | A | 2026-06-19 08:13 | PASS | issue #183 — /harness-audit must inspect the active worktree, not a hardcoded root |
-| harness-audit-shared-memory | A | 2026-06-19 08:13 | PASS | issue #432 — /harness-audit must load durable memory from shared log root in cron worktrees |
-| harness-ci-core-paths | A | 2026-06-19 08:13 | PASS | #165 — core sandbox config files must trigger harness CI |
-| harness-ci-hooks-paths | A | 2026-06-19 08:13 | PASS | issue #202 — credential/security hook changes must trigger harness CI |
-| health-check-docker-stats | A | 2026-06-19 08:13 | PASS | memory/MEMORY.md 2026-06-10 (docker stats vs ps Size) |
-| heartbeat-logging-contract | A | 2026-06-19 08:13 | PASS | issue #447 (heartbeat log append hardening) 2026-06-18 |
-| locked-append-critical-path | A | 2026-06-19 08:13 | PASS | issue #204 (lock shared runtime log appends) 2026-06-15 |
-| loop-benchmark-gate | A | 2026-06-19 08:13 | PASS | issue #179 — wire the executable-loop `benchmark` node (close the cycle) |
-| loop-handoff-consistency | A | 2026-06-19 08:13 | PASS | context/rules/loop.md § 4 (executable-loop Handoff convention) |
-| loop-repeat-gate | A | 2026-06-19 08:13 | PASS | issue #173 — wire the executable-loop `repeat` node (cycle-closing edge) |
-| memory-gitignore-claim | A | 2026-06-19 08:13 | PASS | issue #101 |
-| next-dev-prod | A | 2026-06-19 08:13 | PASS | memory/MEMORY.md 2026-06-04 |
-| orchestrate-contract | A | 2026-06-19 08:13 | PASS | issue #160 — /orchestrate contract; issue #175 — reserved /loop command rename |
-| owned-surface-guard | A | 2026-06-19 08:13 | PASS | issue #63 (autopilot-stray-wip-guard) 2026-06-12; issue #81 (owned-paths-zsh-split) 2026-06-13 |
-| pnpm-audit-ci-gate | A | 2026-06-19 08:13 | PASS | issue #171 — pnpm security audits must run in CI |
-| pr-audit-duplicate-issue-refs | A | 2026-06-19 08:13 | PASS | issue #439 — /pr-audit must flag duplicate open PRs that reference the same issue |
-| ralph-fallback-order | A | 2026-06-19 08:13 | PASS | conversation 2026-06-12 (Ralph default fallback order) |
-| repo-map-contract | A | 2026-06-19 08:13 | PASS | issue #464 — repo map must optimize orientation without adding a tree dependency or unmeasured performance claims |
-| retro-deterministic-contract | A | 2026-06-19 08:13 | PASS | issue #443 — /retro deterministic output and self-contained helper contract |
-| rl-delegation-write-worker | A | 2026-06-19 08:13 | PASS | memory/MEMORY.md 2026-06-10 (rl-delegation) #57 |
-| sandbox-boot-guard-ci | A | 2026-06-19 08:13 | PASS | issue #449 (sandbox image build CI guard) 2026-06-19 |
-| ship-spec-ready-finalization | A | 2026-06-19 08:13 | PASS | issue #134 — /ship-spec must finalize ready PRs after gates, not stop at draft scaffold |
-| skill-paths | A | 2026-06-19 08:13 | PASS | issue #43 — stale path references; extended by issue #69 — apps/->packages/ rename guard |
-| submitted-by-trailers | A | 2026-06-19 08:13 | PASS | conversation 2026-06-12 (commit attribution trailers) |
-| watchdog-completed-session-reap | A | 2026-06-19 08:13 | PASS | issue #235 (completed autopilot PR session reaping) |
-| watchdog-draft-prs | A | 2026-06-19 08:13 | PASS | conversation 2026-06-15 (generic watchdog + stale draft PR recovery) |
-| watchdog-stuck-sessions | A | 2026-06-19 08:13 | PASS | issue #240 (Codex zero-credit stuck autopilot sessions) 2026-06-17 |
-| wiki-readme-index | A | 2026-06-19 08:13 | PASS | issue #132 — wiki README index drift guard |
+| agent-browser-cli | A | 2026-06-20 05:57 | PASS | memory/MEMORY.md 2026-06-07 (agent-browser 0.8.5 CLI) |
+| autopilot-executor-toggle | A | 2026-06-20 05:57 | PASS | conversation 2026-06-13 (autopilot delegate-advisor executor) |
+| autopilot-no-pr-session-close | A | 2026-06-20 05:57 | PASS | issue #209 (autopilot no-PR tmux session closure) 2026-06-16 |
+| autopilot-open-pr-reference-dedupe | A | 2026-06-20 05:57 | PASS | issue #437 — autopilot must not start duplicate work when open PRs reference the same issue without linked-PR metadata |
+| autopilot-pi-agent | A | 2026-06-20 05:57 | PASS | issue #116 (autopilot Pi tmux alignment) 2026-06-14; issue #118 (attachable Pi TUI tmux) 2026-06-14; issue #126 (kept Pi overlap lock release) 2026-06-14; issue #142 (worktree-by-default, skip→worktree) 2026-06-14 |
+| autopilot-preflight-gate | A | 2026-06-20 05:57 | PASS | issue #194 (deterministic autopilot caps preflight gate) 2026-06-15 |
+| autopilot-upstream-default | A | 2026-06-20 05:57 | PASS | issue #420 — future autopilots must target canonical repo, not personal fork |
+| autopilot-worktree-log-root | A | 2026-06-20 05:57 | PASS | issue #152 (persist autopilot worktree logs) 2026-06-15 |
+| boot-lint-glob | A | 2026-06-20 05:57 | PASS | issue #90, issue #120 |
+| capability-benchmark-schema | A | 2026-06-20 05:57 | PASS | issue #167 — capability benchmark instrument |
+| clean-restore | A | 2026-06-20 05:57 | PASS | issue #63 (autopilot-stray-wip-guard) 2026-06-12; issue #81 (owned-paths-zsh-split) 2026-06-13 |
+| cleanup-tasks-scoped-guard | A | 2026-06-20 05:57 | PASS | issue #85 |
+| cleanup-tasks-worktree-grooming | A | 2026-06-20 05:57 | PASS | issue #168 |
+| cron-claude-codex-fallback | A | 2026-06-20 05:57 | PASS | conversation 2026-06-12 (default Codex fallback for crons) |
+| cron-watchdog | A | 2026-06-20 05:57 | PASS | issues #130/#453 (cron runtime watchdog + legacy system-cron reaping) 2026-06-19 |
+| curl-bash-safe-alternatives | A | 2026-06-20 05:57 | PASS | vet-run/vet integration — public curl|bash examples need review-first alternatives |
+| datasets-schema | A | 2026-06-20 05:57 | PASS | issue #196 — evals/datasets verifiable trajectory corpus (Repo2RLEnv-inspired) |
+| devtcp-hook | A | 2026-06-20 05:57 | PASS | memory/MEMORY.md 2026-06-10 (zsh /dev/tcp) |
+| docs-build-fast-path | A | 2026-06-20 05:57 | PASS | #455 — docs builds must stay out of fast harness/eval/release gates |
+| drift-check-cron-staleness-glob | A | 2026-06-20 05:57 | PASS | issue #98; issue #225 (restart-required cron frontmatter/config drift) |
+| eval-ci-gate | A | 2026-06-20 05:57 | PASS | #103 — eval probe suite gated in CI |
+| eval-gate | A | 2026-06-20 05:57 | PASS | memory/MEMORY.md 2026-06-11 (eval-gate) |
+| eval-results-atomic | A | 2026-06-20 05:57 | PASS | issue #83 (eval-results-atomic-write) |
+| eval-runner-exit | A | 2026-06-20 05:57 | PASS | memory/MEMORY.md 2026-06-11 (eval-runner-exit) #29 |
+| git-skill | A | 2026-06-20 05:57 | PASS | conversation 2026-06-15 — rules are not always supported; git workflow must be the /git skill |
+| harness-audit-empty-output-gate | A | 2026-06-20 05:57 | PASS | issue #246 — /harness-audit must fail closed on empty auditor outputs |
+| harness-audit-memory-path | A | 2026-06-20 05:57 | PASS | issue #183 — /harness-audit must inspect the active worktree, not a hardcoded root |
+| harness-audit-shared-memory | A | 2026-06-20 05:57 | PASS | issue #432 — /harness-audit must load durable memory from shared log root in cron worktrees |
+| harness-ci-core-paths | A | 2026-06-20 05:57 | PASS | #165 — core sandbox config files must trigger harness CI |
+| harness-ci-hooks-paths | A | 2026-06-20 05:57 | PASS | issue #202 — credential/security hook changes must trigger harness CI |
+| health-check-docker-stats | A | 2026-06-20 05:57 | PASS | memory/MEMORY.md 2026-06-10 (docker stats vs ps Size) |
+| heartbeat-logging-contract | A | 2026-06-20 05:57 | PASS | issue #447 (heartbeat log append hardening) 2026-06-18 |
+| locked-append-critical-path | A | 2026-06-20 05:57 | PASS | issue #204 (lock shared runtime log appends) 2026-06-15 |
+| loop-benchmark-gate | A | 2026-06-20 05:57 | PASS | issue #179 — wire the executable-loop `benchmark` node (close the cycle) |
+| loop-handoff-consistency | A | 2026-06-20 05:57 | PASS | context/rules/loop.md § 4 (executable-loop Handoff convention) |
+| loop-repeat-gate | A | 2026-06-20 05:57 | PASS | issue #173 — wire the executable-loop `repeat` node (cycle-closing edge) |
+| memory-gitignore-claim | A | 2026-06-20 05:57 | PASS | issue #101 |
+| next-dev-prod | A | 2026-06-20 05:57 | PASS | memory/MEMORY.md 2026-06-04 |
+| orchestrate-contract | A | 2026-06-20 05:57 | PASS | issue #160 — /orchestrate contract; issue #175 — reserved /loop command rename |
+| owned-surface-guard | A | 2026-06-20 05:57 | PASS | issue #63 (autopilot-stray-wip-guard) 2026-06-12; issue #81 (owned-paths-zsh-split) 2026-06-13 |
+| pnpm-audit-ci-gate | A | 2026-06-20 05:57 | PASS | issue #171 — pnpm security audits must run in CI |
+| pr-audit-duplicate-issue-refs | A | 2026-06-20 05:57 | PASS | issue #439 — /pr-audit must flag duplicate open PRs that reference the same issue |
+| ralph-fallback-order | A | 2026-06-20 05:57 | PASS | conversation 2026-06-12 (Ralph default fallback order) |
+| repo-map-contract | A | 2026-06-20 05:57 | PASS | issue #464 — repo map must optimize orientation without adding a tree dependency or unmeasured performance claims |
+| retro-deterministic-contract | A | 2026-06-20 05:57 | PASS | issue #443 — /retro deterministic output and self-contained helper contract |
+| rl-delegation-write-worker | A | 2026-06-20 05:57 | PASS | memory/MEMORY.md 2026-06-10 (rl-delegation) #57 |
+| sandbox-boot-guard-ci | A | 2026-06-20 05:57 | PASS | issue #449 (sandbox image build CI guard) 2026-06-19 |
+| ship-spec-ready-finalization | A | 2026-06-20 05:57 | PASS | issue #134 — /ship-spec must finalize ready PRs after gates, not stop at draft scaffold |
+| skill-paths | A | 2026-06-20 05:57 | PASS | issue #43 — stale path references; extended by issue #69 — apps/->packages/ rename guard |
+| submitted-by-trailers | A | 2026-06-20 05:57 | PASS | conversation 2026-06-12 (commit attribution trailers) |
+| watchdog-completed-session-reap | A | 2026-06-20 05:57 | PASS | issue #235 (completed autopilot PR session reaping) |
+| watchdog-draft-prs | A | 2026-06-20 05:57 | PASS | conversation 2026-06-15 (generic watchdog + stale draft PR recovery) |
+| watchdog-stuck-sessions | A | 2026-06-20 05:57 | PASS | issue #240 (Codex zero-credit stuck autopilot sessions) 2026-06-17 |
+| wiki-readme-index | A | 2026-06-20 05:57 | PASS | issue #132 — wiki README index drift guard |
 
 <!-- benchmark: pass-rate = PASS / (PASS + REGRESSION + TIMEOUT); SKIPPED excluded -->

--- a/scripts/__tests__/cron-runtime.test.ts
+++ b/scripts/__tests__/cron-runtime.test.ts
@@ -1114,6 +1114,39 @@ describe("fallback worktree pruning", () => {
     expect(worktreeInUse(wt, [path.join(tmp, "elsewhere")], ["autopilot-feat-445-example"])).toBe(false);
   });
 
+  it("does not prune a clean fallback worktree while a matching tmux session is live", () => {
+    const { repo, cleanWt } = initRepoWithFallbackWorktrees();
+    const priorCwd = process.cwd();
+    const priorPath = process.env.PATH;
+    const binDir = path.join(tmp, "bin");
+    const fakeTmux = path.join(binDir, "tmux");
+    mkdirSync(binDir, { recursive: true });
+    writeFileSync(
+      fakeTmux,
+      `#!/usr/bin/env bash
+set -euo pipefail
+case "$1" in
+  list-panes) printf '%s\\n' '${path.join(tmp, "elsewhere").replace(/'/g, "'\\''")}' ;;
+  ls) printf '%s\\n' 'cron-autopilot-clean' ;;
+  *) exit 1 ;;
+esac
+`,
+    );
+    chmodSync(fakeTmux, 0o755);
+
+    try {
+      process.chdir(repo);
+      process.env.PATH = `${binDir}:${priorPath ?? ""}`;
+
+      expect(pruneAndCountFallbackWorktrees("autopilot")).toBe(1);
+    } finally {
+      process.env.PATH = priorPath;
+      process.chdir(priorCwd);
+    }
+
+    expect(existsSync(cleanWt)).toBe(true);
+  });
+
   it("preserves dirty dead fallback worktrees but removes clean dead ones", () => {
     const { repo, dirtyWt, cleanWt } = initRepoWithFallbackWorktrees();
     const priorCwd = process.cwd();


### PR DESCRIPTION
## Selection rationale

Queue selection: implementing open autopilot issue #445 ("fix: preserve active cron worktrees") — the oldest actionable ticket (filed 2026-06-18T21:09:40Z) with no open PR reference after local PR dedupe. The runtime code for the basename-session fallback was already present on `development`; this run adds the missing pruning-level regression coverage and refreshes the eval benchmark.

---

Closes #445

## Summary

- Add a regression test proving `pruneAndCountFallbackWorktrees()` preserves a clean cron fallback worktree when a live tmux session still matches the worktree basename.
- Use a fake `tmux` executable in the test PATH so the coverage is deterministic and does not depend on the host tmux state.
- Refresh `evals/RESULTS.md` after running `/eval`.

## Verification

- `pnpm vitest run scripts/__tests__/cron-runtime.test.ts -t "fallback worktree pruning"`
- `pnpm test:scripts`
- `bash .claude/skills/eval/run.sh`
