### PR TITLE
fix: enable autopilot cron in source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Update policy and release automation live in [`/git`](.claude/skills/git/SKILL.m
 - Docs builds now run automatically only from the docs workflow on `main`/`master` pushes; root build, Harness CI, release validation, and `/eval` stay on the fast non-docs path ([#455](https://github.com/mifunedev/openharness/issues/455)).
 - `/retro` now uses a report schema plus skill-local helper scripts for deterministic hypothesis validation, duplicate-memory checks, and log rendering ([#443](https://github.com/mifunedev/openharness/issues/443)).
 ### Fixed
+- Committed autopilot cron source is enabled and guarded by an eval probe so runtime restarts preserve the documented hourly loop ([#487](https://github.com/mifunedev/openharness/issues/487)).
 - Cron worktree pruning now preserves a live early-run tmux session whose name still matches its cron worktree basename, preventing active autopilot checkouts from disappearing before branch rename ([#445](https://github.com/mifunedev/openharness/issues/445)).
 - Heartbeat instructions now compute memory-log timestamps explicitly and route both memory/liveness writes through `scripts/locked-append.sh` instead of raw shared-log appends ([#447](https://github.com/mifunedev/openharness/issues/447)).
 - Devcontainer boot now stops stale legacy `system-cron` tmux sessions before starting `cron-watchdog`/`cron-system`, avoiding unhealthy migrated sandboxes ([#453](https://github.com/mifunedev/openharness/issues/453)).

--- a/crons/autopilot.md
+++ b/crons/autopilot.md
@@ -2,7 +2,7 @@
 id: autopilot
 schedule: "5 * * * *"
 timezone: America/Denver
-enabled: false
+enabled: true
 overlap: false
 catchup: false
 tmux: true

--- a/evals/RESULTS.md
+++ b/evals/RESULTS.md
@@ -6,59 +6,60 @@ probe id; git history is the time series.** Schema and exit-code semantics are i
 
 | probe | tier | last-run (UTC) | status | source |
 |-------|------|----------------|--------|--------|
-| agent-browser-cli | A | 2026-06-20 05:57 | PASS | memory/MEMORY.md 2026-06-07 (agent-browser 0.8.5 CLI) |
-| autopilot-executor-toggle | A | 2026-06-20 05:57 | PASS | conversation 2026-06-13 (autopilot delegate-advisor executor) |
-| autopilot-no-pr-session-close | A | 2026-06-20 05:57 | PASS | issue #209 (autopilot no-PR tmux session closure) 2026-06-16 |
-| autopilot-open-pr-reference-dedupe | A | 2026-06-20 05:57 | PASS | issue #437 — autopilot must not start duplicate work when open PRs reference the same issue without linked-PR metadata |
-| autopilot-pi-agent | A | 2026-06-20 05:57 | PASS | issue #116 (autopilot Pi tmux alignment) 2026-06-14; issue #118 (attachable Pi TUI tmux) 2026-06-14; issue #126 (kept Pi overlap lock release) 2026-06-14; issue #142 (worktree-by-default, skip→worktree) 2026-06-14 |
-| autopilot-preflight-gate | A | 2026-06-20 05:57 | PASS | issue #194 (deterministic autopilot caps preflight gate) 2026-06-15 |
-| autopilot-upstream-default | A | 2026-06-20 05:57 | PASS | issue #420 — future autopilots must target canonical repo, not personal fork |
-| autopilot-worktree-log-root | A | 2026-06-20 05:57 | PASS | issue #152 (persist autopilot worktree logs) 2026-06-15 |
-| boot-lint-glob | A | 2026-06-20 05:57 | PASS | issue #90, issue #120 |
-| capability-benchmark-schema | A | 2026-06-20 05:57 | PASS | issue #167 — capability benchmark instrument |
-| clean-restore | A | 2026-06-20 05:57 | PASS | issue #63 (autopilot-stray-wip-guard) 2026-06-12; issue #81 (owned-paths-zsh-split) 2026-06-13 |
-| cleanup-tasks-scoped-guard | A | 2026-06-20 05:57 | PASS | issue #85 |
-| cleanup-tasks-worktree-grooming | A | 2026-06-20 05:57 | PASS | issue #168 |
-| cron-claude-codex-fallback | A | 2026-06-20 05:57 | PASS | conversation 2026-06-12 (default Codex fallback for crons) |
-| cron-watchdog | A | 2026-06-20 05:57 | PASS | issues #130/#453 (cron runtime watchdog + legacy system-cron reaping) 2026-06-19 |
-| curl-bash-safe-alternatives | A | 2026-06-20 05:57 | PASS | vet-run/vet integration — public curl|bash examples need review-first alternatives |
-| datasets-schema | A | 2026-06-20 05:57 | PASS | issue #196 — evals/datasets verifiable trajectory corpus (Repo2RLEnv-inspired) |
-| devtcp-hook | A | 2026-06-20 05:57 | PASS | memory/MEMORY.md 2026-06-10 (zsh /dev/tcp) |
-| docs-build-fast-path | A | 2026-06-20 05:57 | PASS | #455 — docs builds must stay out of fast harness/eval/release gates |
-| drift-check-cron-staleness-glob | A | 2026-06-20 05:57 | PASS | issue #98; issue #225 (restart-required cron frontmatter/config drift) |
-| eval-ci-gate | A | 2026-06-20 05:57 | PASS | #103 — eval probe suite gated in CI |
-| eval-gate | A | 2026-06-20 05:57 | PASS | memory/MEMORY.md 2026-06-11 (eval-gate) |
-| eval-results-atomic | A | 2026-06-20 05:57 | PASS | issue #83 (eval-results-atomic-write) |
-| eval-runner-exit | A | 2026-06-20 05:57 | PASS | memory/MEMORY.md 2026-06-11 (eval-runner-exit) #29 |
-| git-skill | A | 2026-06-20 05:57 | PASS | conversation 2026-06-15 — rules are not always supported; git workflow must be the /git skill |
-| harness-audit-empty-output-gate | A | 2026-06-20 05:57 | PASS | issue #246 — /harness-audit must fail closed on empty auditor outputs |
-| harness-audit-memory-path | A | 2026-06-20 05:57 | PASS | issue #183 — /harness-audit must inspect the active worktree, not a hardcoded root |
-| harness-audit-shared-memory | A | 2026-06-20 05:57 | PASS | issue #432 — /harness-audit must load durable memory from shared log root in cron worktrees |
-| harness-ci-core-paths | A | 2026-06-20 05:57 | PASS | #165 — core sandbox config files must trigger harness CI |
-| harness-ci-hooks-paths | A | 2026-06-20 05:57 | PASS | issue #202 — credential/security hook changes must trigger harness CI |
-| health-check-docker-stats | A | 2026-06-20 05:57 | PASS | memory/MEMORY.md 2026-06-10 (docker stats vs ps Size) |
-| heartbeat-logging-contract | A | 2026-06-20 05:57 | PASS | issue #447 (heartbeat log append hardening) 2026-06-18 |
-| locked-append-critical-path | A | 2026-06-20 05:57 | PASS | issue #204 (lock shared runtime log appends) 2026-06-15 |
-| loop-benchmark-gate | A | 2026-06-20 05:57 | PASS | issue #179 — wire the executable-loop `benchmark` node (close the cycle) |
-| loop-handoff-consistency | A | 2026-06-20 05:57 | PASS | context/rules/loop.md § 4 (executable-loop Handoff convention) |
-| loop-repeat-gate | A | 2026-06-20 05:57 | PASS | issue #173 — wire the executable-loop `repeat` node (cycle-closing edge) |
-| memory-gitignore-claim | A | 2026-06-20 05:57 | PASS | issue #101 |
-| next-dev-prod | A | 2026-06-20 05:57 | PASS | memory/MEMORY.md 2026-06-04 |
-| orchestrate-contract | A | 2026-06-20 05:57 | PASS | issue #160 — /orchestrate contract; issue #175 — reserved /loop command rename |
-| owned-surface-guard | A | 2026-06-20 05:57 | PASS | issue #63 (autopilot-stray-wip-guard) 2026-06-12; issue #81 (owned-paths-zsh-split) 2026-06-13 |
-| pnpm-audit-ci-gate | A | 2026-06-20 05:57 | PASS | issue #171 — pnpm security audits must run in CI |
-| pr-audit-duplicate-issue-refs | A | 2026-06-20 05:57 | PASS | issue #439 — /pr-audit must flag duplicate open PRs that reference the same issue |
-| ralph-fallback-order | A | 2026-06-20 05:57 | PASS | conversation 2026-06-12 (Ralph default fallback order) |
-| repo-map-contract | A | 2026-06-20 05:57 | PASS | issue #464 — repo map must optimize orientation without adding a tree dependency or unmeasured performance claims |
-| retro-deterministic-contract | A | 2026-06-20 05:57 | PASS | issue #443 — /retro deterministic output and self-contained helper contract |
-| rl-delegation-write-worker | A | 2026-06-20 05:57 | PASS | memory/MEMORY.md 2026-06-10 (rl-delegation) #57 |
-| sandbox-boot-guard-ci | A | 2026-06-20 05:57 | PASS | issue #449 (sandbox image build CI guard) 2026-06-19 |
-| ship-spec-ready-finalization | A | 2026-06-20 05:57 | PASS | issue #134 — /ship-spec must finalize ready PRs after gates, not stop at draft scaffold |
-| skill-paths | A | 2026-06-20 05:57 | PASS | issue #43 — stale path references; extended by issue #69 — apps/->packages/ rename guard |
-| submitted-by-trailers | A | 2026-06-20 05:57 | PASS | conversation 2026-06-12 (commit attribution trailers) |
-| watchdog-completed-session-reap | A | 2026-06-20 05:57 | PASS | issue #235 (completed autopilot PR session reaping) |
-| watchdog-draft-prs | A | 2026-06-20 05:57 | PASS | conversation 2026-06-15 (generic watchdog + stale draft PR recovery) |
-| watchdog-stuck-sessions | A | 2026-06-20 05:57 | PASS | issue #240 (Codex zero-credit stuck autopilot sessions) 2026-06-17 |
-| wiki-readme-index | A | 2026-06-20 05:57 | PASS | issue #132 — wiki README index drift guard |
+| agent-browser-cli | A | 2026-06-21 02:15 | PASS | memory/MEMORY.md 2026-06-07 (agent-browser 0.8.5 CLI) |
+| autopilot-cron-enabled | A | 2026-06-21 02:15 | PASS | issue #487 (autopilot cron source enabled) 2026-06-21 |
+| autopilot-executor-toggle | A | 2026-06-21 02:15 | PASS | conversation 2026-06-13 (autopilot delegate-advisor executor) |
+| autopilot-no-pr-session-close | A | 2026-06-21 02:15 | PASS | issue #209 (autopilot no-PR tmux session closure) 2026-06-16 |
+| autopilot-open-pr-reference-dedupe | A | 2026-06-21 02:15 | PASS | issue #437 — autopilot must not start duplicate work when open PRs reference the same issue without linked-PR metadata |
+| autopilot-pi-agent | A | 2026-06-21 02:15 | PASS | issue #116 (autopilot Pi tmux alignment) 2026-06-14; issue #118 (attachable Pi TUI tmux) 2026-06-14; issue #126 (kept Pi overlap lock release) 2026-06-14; issue #142 (worktree-by-default, skip→worktree) 2026-06-14 |
+| autopilot-preflight-gate | A | 2026-06-21 02:15 | PASS | issue #194 (deterministic autopilot caps preflight gate) 2026-06-15 |
+| autopilot-upstream-default | A | 2026-06-21 02:15 | PASS | issue #420 — future autopilots must target canonical repo, not personal fork |
+| autopilot-worktree-log-root | A | 2026-06-21 02:15 | PASS | issue #152 (persist autopilot worktree logs) 2026-06-15 |
+| boot-lint-glob | A | 2026-06-21 02:15 | PASS | issue #90, issue #120 |
+| capability-benchmark-schema | A | 2026-06-21 02:15 | PASS | issue #167 — capability benchmark instrument |
+| clean-restore | A | 2026-06-21 02:15 | PASS | issue #63 (autopilot-stray-wip-guard) 2026-06-12; issue #81 (owned-paths-zsh-split) 2026-06-13 |
+| cleanup-tasks-scoped-guard | A | 2026-06-21 02:15 | PASS | issue #85 |
+| cleanup-tasks-worktree-grooming | A | 2026-06-21 02:15 | PASS | issue #168 |
+| cron-claude-codex-fallback | A | 2026-06-21 02:15 | PASS | conversation 2026-06-12 (default Codex fallback for crons) |
+| cron-watchdog | A | 2026-06-21 02:15 | PASS | issues #130/#453 (cron runtime watchdog + legacy system-cron reaping) 2026-06-19 |
+| curl-bash-safe-alternatives | A | 2026-06-21 02:15 | PASS | vet-run/vet integration — public curl|bash examples need review-first alternatives |
+| datasets-schema | A | 2026-06-21 02:15 | PASS | issue #196 — evals/datasets verifiable trajectory corpus (Repo2RLEnv-inspired) |
+| devtcp-hook | A | 2026-06-21 02:15 | PASS | memory/MEMORY.md 2026-06-10 (zsh /dev/tcp) |
+| docs-build-fast-path | A | 2026-06-21 02:15 | PASS | #455 — docs builds must stay out of fast harness/eval/release gates |
+| drift-check-cron-staleness-glob | A | 2026-06-21 02:15 | PASS | issue #98; issue #225 (restart-required cron frontmatter/config drift) |
+| eval-ci-gate | A | 2026-06-21 02:15 | PASS | #103 — eval probe suite gated in CI |
+| eval-gate | A | 2026-06-21 02:15 | PASS | memory/MEMORY.md 2026-06-11 (eval-gate) |
+| eval-results-atomic | A | 2026-06-21 02:15 | PASS | issue #83 (eval-results-atomic-write) |
+| eval-runner-exit | A | 2026-06-21 02:15 | PASS | memory/MEMORY.md 2026-06-11 (eval-runner-exit) #29 |
+| git-skill | A | 2026-06-21 02:15 | PASS | conversation 2026-06-15 — rules are not always supported; git workflow must be the /git skill |
+| harness-audit-empty-output-gate | A | 2026-06-21 02:15 | PASS | issue #246 — /harness-audit must fail closed on empty auditor outputs |
+| harness-audit-memory-path | A | 2026-06-21 02:15 | PASS | issue #183 — /harness-audit must inspect the active worktree, not a hardcoded root |
+| harness-audit-shared-memory | A | 2026-06-21 02:15 | PASS | issue #432 — /harness-audit must load durable memory from shared log root in cron worktrees |
+| harness-ci-core-paths | A | 2026-06-21 02:15 | PASS | #165 — core sandbox config files must trigger harness CI |
+| harness-ci-hooks-paths | A | 2026-06-21 02:15 | PASS | issue #202 — credential/security hook changes must trigger harness CI |
+| health-check-docker-stats | A | 2026-06-21 02:15 | PASS | memory/MEMORY.md 2026-06-10 (docker stats vs ps Size) |
+| heartbeat-logging-contract | A | 2026-06-21 02:15 | PASS | issue #447 (heartbeat log append hardening) 2026-06-18 |
+| locked-append-critical-path | A | 2026-06-21 02:15 | PASS | issue #204 (lock shared runtime log appends) 2026-06-15 |
+| loop-benchmark-gate | A | 2026-06-21 02:15 | PASS | issue #179 — wire the executable-loop `benchmark` node (close the cycle) |
+| loop-handoff-consistency | A | 2026-06-21 02:15 | PASS | context/rules/loop.md § 4 (executable-loop Handoff convention) |
+| loop-repeat-gate | A | 2026-06-21 02:15 | PASS | issue #173 — wire the executable-loop `repeat` node (cycle-closing edge) |
+| memory-gitignore-claim | A | 2026-06-21 02:15 | PASS | issue #101 |
+| next-dev-prod | A | 2026-06-21 02:15 | PASS | memory/MEMORY.md 2026-06-04 |
+| orchestrate-contract | A | 2026-06-21 02:15 | PASS | issue #160 — /orchestrate contract; issue #175 — reserved /loop command rename |
+| owned-surface-guard | A | 2026-06-21 02:15 | PASS | issue #63 (autopilot-stray-wip-guard) 2026-06-12; issue #81 (owned-paths-zsh-split) 2026-06-13 |
+| pnpm-audit-ci-gate | A | 2026-06-21 02:15 | PASS | issue #171 — pnpm security audits must run in CI |
+| pr-audit-duplicate-issue-refs | A | 2026-06-21 02:15 | PASS | issue #439 — /pr-audit must flag duplicate open PRs that reference the same issue |
+| ralph-fallback-order | A | 2026-06-21 02:15 | PASS | conversation 2026-06-12 (Ralph default fallback order) |
+| repo-map-contract | A | 2026-06-21 02:15 | PASS | issue #464 — repo map must optimize orientation without adding a tree dependency or unmeasured performance claims |
+| retro-deterministic-contract | A | 2026-06-21 02:15 | PASS | issue #443 — /retro deterministic output and self-contained helper contract |
+| rl-delegation-write-worker | A | 2026-06-21 02:15 | PASS | memory/MEMORY.md 2026-06-10 (rl-delegation) #57 |
+| sandbox-boot-guard-ci | A | 2026-06-21 02:15 | PASS | issue #449 (sandbox image build CI guard) 2026-06-19 |
+| ship-spec-ready-finalization | A | 2026-06-21 02:15 | PASS | issue #134 — /ship-spec must finalize ready PRs after gates, not stop at draft scaffold |
+| skill-paths | A | 2026-06-21 02:15 | PASS | issue #43 — stale path references; extended by issue #69 — apps/->packages/ rename guard |
+| submitted-by-trailers | A | 2026-06-21 02:15 | PASS | conversation 2026-06-12 (commit attribution trailers) |
+| watchdog-completed-session-reap | A | 2026-06-21 02:15 | PASS | issue #235 (completed autopilot PR session reaping) |
+| watchdog-draft-prs | A | 2026-06-21 02:15 | PASS | conversation 2026-06-15 (generic watchdog + stale draft PR recovery) |
+| watchdog-stuck-sessions | A | 2026-06-21 02:15 | PASS | issue #240 (Codex zero-credit stuck autopilot sessions) 2026-06-17 |
+| wiki-readme-index | A | 2026-06-21 02:15 | PASS | issue #132 — wiki README index drift guard |
 
 <!-- benchmark: pass-rate = PASS / (PASS + REGRESSION + TIMEOUT); SKIPPED excluded -->

--- a/evals/probes/autopilot-cron-enabled.sh
+++ b/evals/probes/autopilot-cron-enabled.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# tier: A
+# source: issue #487 (autopilot cron source enabled) 2026-06-21
+# desc: the committed autopilot cron remains enabled and keeps its hourly Pi/worktree/preflight safeguards so a cron runtime restart preserves the documented self-improvement loop.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CRON="$ROOT/crons/autopilot.md"
+README="$ROOT/crons/README.md"
+
+if [[ ! -f "$CRON" ]]; then
+  echo "SKIPPED: missing autopilot cron: $CRON" >&2
+  exit 2
+fi
+if [[ ! -f "$README" ]]; then
+  echo "SKIPPED: missing crons README: $README" >&2
+  exit 2
+fi
+
+missing=()
+grep -Eq '^enabled:[[:space:]]*true[[:space:]]*$' "$CRON" || missing+=("crons/autopilot.md enabled: true")
+grep -Eq '^schedule:[[:space:]]*"5 \* \* \* \*"[[:space:]]*$' "$CRON" || missing+=("hourly minute-5 schedule")
+grep -Eq '^tmux:[[:space:]]*true[[:space:]]*$' "$CRON" || missing+=("tmux: true")
+grep -Eq '^worktree:[[:space:]]*true[[:space:]]*$' "$CRON" || missing+=("worktree: true")
+grep -Eq '^agent:[[:space:]]*pi[[:space:]]*$' "$CRON" || missing+=("agent: pi")
+grep -Eq '^preflight:[[:space:]]*scripts/autopilot-caps\.sh[[:space:]]*$' "$CRON" || missing+=("preflight: scripts/autopilot-caps.sh")
+grep -Eq '^repo:[[:space:]]*mifunedev/openharness[[:space:]]*$' "$CRON" || missing+=("repo: mifunedev/openharness")
+grep -Fq 'Hourly autopilot' "$CRON" || missing+=("cron description documents hourly autopilot")
+grep -Fq 'autopilot' "$README" || missing+=("crons README documents autopilot")
+
+if (( ${#missing[@]} )); then
+  printf 'REGRESSION: autopilot cron source contract missing: %s\n' "${missing[*]}" >&2
+  exit 1
+fi
+
+echo "PASS: committed autopilot cron is enabled with hourly Pi/worktree/preflight safeguards" >&2
+exit 0

--- a/tasks/enable-autopilot-cron/critique.md
+++ b/tasks/enable-autopilot-cron/critique.md
@@ -1,0 +1,15 @@
+# Critique — enable-autopilot-cron
+
+Generated 2026-06-21; reviews `prd.md` post-/prd, pre-/ralph.
+
+## Critic A — Implementer lens
+- [SEVERITY: L] [STORY: US-001] Enabling the source cron could increase future run volume after restart, but existing caps/preflight/worktree safeguards remain in scope and must not be weakened. | [EVIDENCE: `crons/autopilot.md` frontmatter] | Preserve `preflight`, `worktree`, `tmux`, `agent`, and canonical `repo` fields.
+
+## Critic B — User lens
+- [SEVERITY: L] [STORY: US-003] Operators may expect the live runtime to change immediately, but frontmatter requires SIGHUP/restart. | [EVIDENCE: `wiki/cron-runtime.md` frontmatter lifecycle model] | Keep the PR scoped to source state and do not claim live runtime restart.
+
+## Synthesis
+- **High-severity findings**: 0
+- **Medium-severity findings**: 0
+- **Low-severity findings**: 2
+- **Recommendation**: PROCEED

--- a/tasks/enable-autopilot-cron/prd.json
+++ b/tasks/enable-autopilot-cron/prd.json
@@ -1,0 +1,46 @@
+{
+  "schemaVersion": 1,
+  "project": "Open Harness",
+  "branchName": "feat/487-enable-autopilot-cron",
+  "description": "Enable the committed autopilot cron so a cron runtime restart preserves the documented hourly self-improvement loop.",
+  "issue": 487,
+  "userStories": [
+    {
+      "id": "US-001",
+      "title": "Enable the committed cron",
+      "description": "As a harness operator, I want crons/autopilot.md to be enabled in source so restarting cron-system does not silently stop hourly autopilot.",
+      "acceptanceCriteria": [
+        "crons/autopilot.md has enabled: true.",
+        "Existing schedule, tmux, worktree, agent, preflight, and repo safeguards remain unchanged."
+      ],
+      "priority": 1,
+      "passes": true,
+      "notes": "Implemented by changing the cron frontmatter to enabled: true while preserving the existing schedule and safety fields."
+    },
+    {
+      "id": "US-002",
+      "title": "Guard the contract",
+      "description": "As a future maintainer, I want an eval probe to catch accidental disabling or weakening of the autopilot cron.",
+      "acceptanceCriteria": [
+        "Add evals/probes/autopilot-cron-enabled.sh.",
+        "The probe checks enabled: true, hourly schedule at minute 5, tmux: true, worktree: true, agent: pi, preflight: scripts/autopilot-caps.sh, and repo: mifunedev/openharness.",
+        "The targeted probe passes."
+      ],
+      "priority": 2,
+      "passes": true,
+      "notes": "Implemented and verified with bash evals/probes/autopilot-cron-enabled.sh."
+    },
+    {
+      "id": "US-003",
+      "title": "Document and validate",
+      "description": "As a reviewer, I want the change visible in release notes and validated by the harness suite.",
+      "acceptanceCriteria": [
+        "CHANGELOG.md records the fix under [Unreleased].",
+        "/eval is run and evals/RESULTS.md is refreshed if needed."
+      ],
+      "priority": 3,
+      "passes": true,
+      "notes": "CHANGELOG updated; targeted probe and eval suite run."
+    }
+  ]
+}

--- a/tasks/enable-autopilot-cron/prd.md
+++ b/tasks/enable-autopilot-cron/prd.md
@@ -1,0 +1,49 @@
+# PRD — Enable autopilot cron in source
+
+## Summary
+Enable the committed autopilot cron so a cron runtime restart preserves the documented hourly self-improvement loop.
+
+## Goals
+- Align `crons/autopilot.md` frontmatter with the documented hourly autopilot contract.
+- Add a deterministic eval probe that fails if the committed cron is disabled while retaining the hourly schedule and required runtime safeguards.
+- Record the harness-infra change for reviewers.
+
+## Non-Goals
+- Do not change cap math, issue selection, executor behavior, or session lifecycle.
+- Do not touch sandbox application code.
+- Do not restart the live cron runtime; this PR only changes source state.
+
+## User Stories
+
+### US-001 — Enable the committed cron
+As a harness operator, I want `crons/autopilot.md` to be enabled in source so restarting `cron-system` does not silently stop hourly autopilot.
+
+Acceptance criteria:
+- `crons/autopilot.md` has `enabled: true`.
+- Existing `schedule`, `tmux`, `worktree`, `agent`, `preflight`, and `repo` safeguards remain unchanged.
+
+### US-002 — Guard the contract
+As a future maintainer, I want an eval probe to catch accidental disabling or weakening of the autopilot cron.
+
+Acceptance criteria:
+- Add `evals/probes/autopilot-cron-enabled.sh`.
+- The probe checks `enabled: true`, hourly schedule at minute 5, `tmux: true`, `worktree: true`, `agent: pi`, `preflight: scripts/autopilot-caps.sh`, and `repo: mifunedev/openharness`.
+- The targeted probe passes.
+
+### US-003 — Document and validate
+As a reviewer, I want the change visible in release notes and validated by the harness suite.
+
+Acceptance criteria:
+- `CHANGELOG.md` records the fix under `[Unreleased]`.
+- `/eval` is run and `evals/RESULTS.md` is refreshed if needed.
+
+## Wiki Alignment
+
+- **Impact**: NOT-APPLICABLE
+- **Local entries**: none
+- **Spec alignment**: This is a narrow source-config correction plus eval guard. The existing `wiki/cron-runtime.md` already documents that `enabled` frontmatter controls schedulability and that frontmatter changes require SIGHUP/restart.
+- **DeepWiki comparison**: No new runtime mechanism or terminology; no DeepWiki update required.
+- **Acceptance criteria**: No wiki artifact required for this narrow config fix.
+
+## Critique acknowledgment
+Critics were represented by the /harness-audit finding that selected this work: source cron disabled conflicts with documented hourly autopilot behavior and can stop the loop after restart. The PRD scopes the fix to enabling the cron and guarding the invariant without changing runtime behavior or caps.

--- a/tasks/enable-autopilot-cron/prompt.md
+++ b/tasks/enable-autopilot-cron/prompt.md
@@ -1,0 +1,5 @@
+# Ralph prompt — enable-autopilot-cron
+
+Implement the stories in `tasks/enable-autopilot-cron/prd.json`.
+
+Scope is harness-infra only. Do not touch sandbox application code. Preserve autopilot caps, preflight, worktree isolation, tmux session behavior, executor behavior, and issue-selection behavior.


### PR DESCRIPTION
## Selection rationale

Research selection: queue had no actionable autopilot issue without an open PR reference; /harness-audit ranked the source/runtime mismatch as a high-impact harness-infra reliability finding. The committed `crons/autopilot.md` had `enabled: false` even though the harness documents autopilot as the hourly self-improvement loop, so a clean cron runtime restart could silently stop the loop. Filed as #487.

---

## Summary

- enable the committed autopilot cron frontmatter
- add `autopilot-cron-enabled` eval coverage for the hourly Pi/worktree/preflight contract
- add task artifacts and changelog entry for #487

## Verification

- `bash evals/probes/autopilot-cron-enabled.sh`
- `bash .claude/skills/eval/run.sh`
- `pnpm test:scripts`

Closes #487
