### PR TITLE
fix: verify Slack bridge health

### DIFF
--- a/docs/integrations/slack.md
+++ b/docs/integrations/slack.md
@@ -248,6 +248,18 @@ env (before attaching to tmux).
    `tmux attach -t client-slack` — you should see the inbound event logged
    and the agent's reply posted back to Slack.
 
+### 7.1 Container healthcheck behavior
+
+`scripts/sandbox-healthcheck.sh` skips Slack checks when no Slack tokens are
+configured. If either token is present, both `PI_SLACK_APP_TOKEN` and
+`PI_SLACK_BOT_TOKEN` are required. With both tokens configured, the Docker
+healthcheck now verifies the `pi` binary, `client-slack` tmux session, bridge
+entrypoint under `.pi/bridge/`, seeded `~/.pi/msg-bridge.json`, and
+`/tmp/client-slack.log` readiness. The log must include `[Slack] Bot user ID:`
+and must not include startup/auth/runtime failure signals such as
+`Cannot find module`, `invalid_auth`, `not_authed`, or supervisor restart-loop
+messages.
+
 ## 8. Troubleshooting
 
 | Symptom | Cause | Fix |

--- a/evals/RESULTS.md
+++ b/evals/RESULTS.md
@@ -6,63 +6,63 @@ probe id; git history is the time series.** Schema and exit-code semantics are i
 
 | probe | tier | last-run (UTC) | status | source |
 |-------|------|----------------|--------|--------|
-| advisor-monitored-loop | A | 2026-06-21 23:08 | PASS | conversation 2026-06-19 (advisor-monitored ralph loop pattern, issue #257) |
-| agent-browser-cli | A | 2026-06-21 23:08 | PASS | memory/MEMORY.md 2026-06-07 (agent-browser 0.8.5 CLI) |
-| autopilot-executor-toggle | A | 2026-06-21 23:08 | PASS | conversation 2026-06-13 (autopilot delegate-advisor executor) |
-| autopilot-merged-pr-reference-dedupe | A | 2026-06-21 23:08 | PASS | issue #468 — autopilot must not rebuild open tickets whose development PRs already merged |
-| autopilot-no-pr-session-close | A | 2026-06-21 23:08 | PASS | issue #209 (autopilot no-PR tmux session closure) 2026-06-16 |
-| autopilot-open-pr-reference-dedupe | A | 2026-06-21 23:08 | PASS | issue #437 — autopilot must not start duplicate work when open PRs reference the same issue without linked-PR metadata |
-| autopilot-pi-agent | A | 2026-06-21 23:08 | PASS | issue #116 (autopilot Pi tmux alignment) 2026-06-14; issue #118 (attachable Pi TUI tmux) 2026-06-14; issue #126 (kept Pi overlap lock release) 2026-06-14; issue #142 (worktree-by-default, skip→worktree) 2026-06-14 |
-| autopilot-preflight-gate | A | 2026-06-21 23:08 | PASS | issue #194 (deterministic autopilot caps preflight gate) 2026-06-15 |
-| autopilot-upstream-default | A | 2026-06-21 23:08 | PASS | issue #420 — future autopilots must target canonical repo, not personal fork |
-| autopilot-worktree-log-root | A | 2026-06-21 23:08 | PASS | issue #152 (persist autopilot worktree logs) 2026-06-15 |
-| boot-lint-glob | A | 2026-06-21 23:08 | PASS | issue #90, issue #120 |
-| capability-benchmark-schema | A | 2026-06-21 23:08 | PASS | issue #167 — capability benchmark instrument |
-| clean-restore | A | 2026-06-21 23:08 | PASS | issue #63 (autopilot-stray-wip-guard) 2026-06-12; issue #81 (owned-paths-zsh-split) 2026-06-13 |
-| cleanup-tasks-scoped-guard | A | 2026-06-21 23:08 | PASS | issue #85 |
-| cleanup-tasks-worktree-grooming | A | 2026-06-21 23:08 | PASS | issue #168; issue #478 |
-| codex-stale-response-retry | A | 2026-06-21 23:08 | PASS | issue #506 — Codex previous_response_not_found RCA |
-| cron-claude-codex-fallback | A | 2026-06-21 23:08 | PASS | conversation 2026-06-12 (default Codex fallback for crons) |
-| cron-watchdog | A | 2026-06-21 23:08 | PASS | issues #130/#453 (cron runtime watchdog + legacy system-cron reaping) 2026-06-19 |
-| curl-bash-safe-alternatives | A | 2026-06-21 23:08 | PASS | vet-run/vet integration — public curl|bash examples need review-first alternatives |
-| datasets-schema | A | 2026-06-21 23:08 | PASS | issue #196 — evals/datasets verifiable trajectory corpus (Repo2RLEnv-inspired) |
-| devtcp-hook | A | 2026-06-21 23:08 | PASS | memory/MEMORY.md 2026-06-10 (zsh /dev/tcp) |
-| docs-build-fast-path | A | 2026-06-21 23:08 | PASS | #455 — docs builds must stay out of fast harness/eval/release gates |
-| drift-check-cron-staleness-glob | A | 2026-06-21 23:08 | PASS | issue #98; issue #225 (restart-required cron frontmatter/config drift) |
-| eval-ci-gate | A | 2026-06-21 23:08 | PASS | #103 — eval probe suite gated in CI |
-| eval-gate | A | 2026-06-21 23:08 | PASS | memory/MEMORY.md 2026-06-11 (eval-gate) |
-| eval-results-atomic | A | 2026-06-21 23:08 | PASS | issue #83 (eval-results-atomic-write) |
-| eval-runner-exit | A | 2026-06-21 23:08 | PASS | memory/MEMORY.md 2026-06-11 (eval-runner-exit) #29 |
-| git-skill | A | 2026-06-21 23:08 | PASS | conversation 2026-06-15 — rules are not always supported; git workflow must be the /git skill |
-| harness-audit-empty-output-gate | A | 2026-06-21 23:08 | PASS | issue #246 — /harness-audit must fail closed on empty auditor outputs |
-| harness-audit-memory-path | A | 2026-06-21 23:08 | PASS | issue #183 — /harness-audit must inspect the active worktree, not a hardcoded root |
-| harness-audit-shared-memory | A | 2026-06-21 23:08 | PASS | issue #432 — /harness-audit must load durable memory from shared log root in cron worktrees |
-| harness-ci-core-paths | A | 2026-06-21 23:08 | PASS | #165 — core sandbox config files must trigger harness CI |
-| harness-ci-hooks-paths | A | 2026-06-21 23:08 | PASS | issue #202 — credential/security hook changes must trigger harness CI |
-| health-check-docker-stats | A | 2026-06-21 23:08 | PASS | memory/MEMORY.md 2026-06-10 (docker stats vs ps Size) |
-| heartbeat-logging-contract | A | 2026-06-21 23:08 | PASS | issue #447 (heartbeat log append hardening) 2026-06-18 |
-| locked-append-critical-path | A | 2026-06-21 23:08 | PASS | issue #204 (lock shared runtime log appends) 2026-06-15 |
-| memory-gitignore-claim | A | 2026-06-21 23:08 | PASS | issue #101 |
-| memory-log-locked-append | A | 2026-06-21 23:08 | PASS | issue #476 — memory log writes in skill contracts must use scripts/locked-append.sh |
-| next-dev-prod | A | 2026-06-21 23:08 | SKIPPED | memory/MEMORY.md 2026-06-04 |
-| owned-surface-guard | A | 2026-06-21 23:08 | PASS | issue #63 (autopilot-stray-wip-guard) 2026-06-12; issue #81 (owned-paths-zsh-split) 2026-06-13 |
-| pnpm-audit-ci-gate | A | 2026-06-21 23:08 | PASS | issue #171 — pnpm security audits must run in CI |
-| pr-audit-duplicate-issue-refs | A | 2026-06-21 23:08 | PASS | issue #439 — /pr-audit must flag duplicate open PRs that reference the same issue |
-| prd-output-path-contract | A | 2026-06-21 23:08 | PASS | memory/MEMORY.md 2026-06-19 |
-| prompt-miner-schema-compat | A | 2026-06-21 23:08 | PASS | issue #253 — prompt-miner JSONL schema-drift guard |
-| ralph-fallback-order | A | 2026-06-21 23:08 | PASS | conversation 2026-06-12 (Ralph default fallback order) |
-| repo-map-contract | A | 2026-06-21 23:08 | PASS | issue #464 — repo map must optimize orientation without adding a tree dependency or unmeasured performance claims |
-| retro-deterministic-contract | A | 2026-06-21 23:08 | PASS | issue #443 — /retro deterministic output and self-contained helper contract |
-| rl-delegation-write-worker | A | 2026-06-21 23:08 | PASS | memory/MEMORY.md 2026-06-10 (rl-delegation) #57 |
-| sandbox-boot-guard-ci | A | 2026-06-21 23:08 | PASS | issue #449 (sandbox image build CI guard) 2026-06-19 |
-| ship-spec-ready-finalization | A | 2026-06-21 23:08 | PASS | issue #134 — /ship-spec must finalize ready PRs after gates, not stop at draft scaffold |
-| skill-paths | A | 2026-06-21 23:08 | PASS | issue #43 — stale path references; extended by issue #69 — apps/->packages/ rename guard |
-| spec-family-contract | A | 2026-06-21 23:08 | PASS | conversation 2026-06-19 (spec-* family split, issue #265) |
-| submitted-by-trailers | A | 2026-06-21 23:08 | PASS | conversation 2026-06-12 (commit attribution trailers) |
-| watchdog-completed-session-reap | A | 2026-06-21 23:08 | PASS | issue #235 (completed autopilot PR session reaping) |
-| watchdog-draft-prs | A | 2026-06-21 23:08 | PASS | conversation 2026-06-15 (generic watchdog + stale draft PR recovery) |
-| watchdog-stuck-sessions | A | 2026-06-21 23:08 | PASS | issue #240 (Codex zero-credit stuck autopilot sessions) 2026-06-17 |
-| wiki-readme-index | A | 2026-06-21 23:08 | PASS | issue #132 — wiki README index drift guard |
-| workflow-boundaries | A | 2026-06-21 23:08 | PASS | conversation 2026-06-19 (workflow consolidation, issue #259) |
+| advisor-monitored-loop | A | 2026-06-22 01:16 | PASS | conversation 2026-06-19 (advisor-monitored ralph loop pattern, issue #257) |
+| agent-browser-cli | A | 2026-06-22 01:16 | PASS | memory/MEMORY.md 2026-06-07 (agent-browser 0.8.5 CLI) |
+| autopilot-executor-toggle | A | 2026-06-22 01:16 | PASS | conversation 2026-06-13 (autopilot delegate-advisor executor) |
+| autopilot-merged-pr-reference-dedupe | A | 2026-06-22 01:16 | PASS | issue #468 — autopilot must not rebuild open tickets whose development PRs already merged |
+| autopilot-no-pr-session-close | A | 2026-06-22 01:16 | PASS | issue #209 (autopilot no-PR tmux session closure) 2026-06-16 |
+| autopilot-open-pr-reference-dedupe | A | 2026-06-22 01:16 | PASS | issue #437 — autopilot must not start duplicate work when open PRs reference the same issue without linked-PR metadata |
+| autopilot-pi-agent | A | 2026-06-22 01:16 | PASS | issue #116 (autopilot Pi tmux alignment) 2026-06-14; issue #118 (attachable Pi TUI tmux) 2026-06-14; issue #126 (kept Pi overlap lock release) 2026-06-14; issue #142 (worktree-by-default, skip→worktree) 2026-06-14 |
+| autopilot-preflight-gate | A | 2026-06-22 01:16 | PASS | issue #194 (deterministic autopilot caps preflight gate) 2026-06-15 |
+| autopilot-upstream-default | A | 2026-06-22 01:16 | PASS | issue #420 — future autopilots must target canonical repo, not personal fork |
+| autopilot-worktree-log-root | A | 2026-06-22 01:16 | PASS | issue #152 (persist autopilot worktree logs) 2026-06-15 |
+| boot-lint-glob | A | 2026-06-22 01:16 | PASS | issue #90, issue #120 |
+| capability-benchmark-schema | A | 2026-06-22 01:16 | PASS | issue #167 — capability benchmark instrument |
+| clean-restore | A | 2026-06-22 01:16 | PASS | issue #63 (autopilot-stray-wip-guard) 2026-06-12; issue #81 (owned-paths-zsh-split) 2026-06-13 |
+| cleanup-tasks-scoped-guard | A | 2026-06-22 01:16 | PASS | issue #85 |
+| cleanup-tasks-worktree-grooming | A | 2026-06-22 01:16 | PASS | issue #168; issue #478 |
+| codex-stale-response-retry | A | 2026-06-22 01:16 | PASS | issue #506 — Codex previous_response_not_found RCA |
+| cron-claude-codex-fallback | A | 2026-06-22 01:16 | PASS | conversation 2026-06-12 (default Codex fallback for crons) |
+| cron-watchdog | A | 2026-06-22 01:16 | PASS | issues #130/#453 (cron runtime watchdog + legacy system-cron reaping) 2026-06-19 |
+| curl-bash-safe-alternatives | A | 2026-06-22 01:16 | PASS | vet-run/vet integration — public curl|bash examples need review-first alternatives |
+| datasets-schema | A | 2026-06-22 01:16 | PASS | issue #196 — evals/datasets verifiable trajectory corpus (Repo2RLEnv-inspired) |
+| devtcp-hook | A | 2026-06-22 01:16 | PASS | memory/MEMORY.md 2026-06-10 (zsh /dev/tcp) |
+| docs-build-fast-path | A | 2026-06-22 01:16 | PASS | #455 — docs builds must stay out of fast harness/eval/release gates |
+| drift-check-cron-staleness-glob | A | 2026-06-22 01:16 | PASS | issue #98; issue #225 (restart-required cron frontmatter/config drift) |
+| eval-ci-gate | A | 2026-06-22 01:16 | PASS | #103 — eval probe suite gated in CI |
+| eval-gate | A | 2026-06-22 01:16 | PASS | memory/MEMORY.md 2026-06-11 (eval-gate) |
+| eval-results-atomic | A | 2026-06-22 01:16 | PASS | issue #83 (eval-results-atomic-write) |
+| eval-runner-exit | A | 2026-06-22 01:16 | PASS | memory/MEMORY.md 2026-06-11 (eval-runner-exit) #29 |
+| git-skill | A | 2026-06-22 01:16 | PASS | conversation 2026-06-15 — rules are not always supported; git workflow must be the /git skill |
+| harness-audit-empty-output-gate | A | 2026-06-22 01:16 | PASS | issue #246 — /harness-audit must fail closed on empty auditor outputs |
+| harness-audit-memory-path | A | 2026-06-22 01:16 | PASS | issue #183 — /harness-audit must inspect the active worktree, not a hardcoded root |
+| harness-audit-shared-memory | A | 2026-06-22 01:16 | PASS | issue #432 — /harness-audit must load durable memory from shared log root in cron worktrees |
+| harness-ci-core-paths | A | 2026-06-22 01:16 | PASS | #165 — core sandbox config files must trigger harness CI |
+| harness-ci-hooks-paths | A | 2026-06-22 01:16 | PASS | issue #202 — credential/security hook changes must trigger harness CI |
+| health-check-docker-stats | A | 2026-06-22 01:16 | PASS | memory/MEMORY.md 2026-06-10 (docker stats vs ps Size) |
+| heartbeat-logging-contract | A | 2026-06-22 01:16 | PASS | issue #447 (heartbeat log append hardening) 2026-06-18 |
+| locked-append-critical-path | A | 2026-06-22 01:16 | PASS | issue #204 (lock shared runtime log appends) 2026-06-15 |
+| memory-gitignore-claim | A | 2026-06-22 01:16 | PASS | issue #101 |
+| memory-log-locked-append | A | 2026-06-22 01:16 | PASS | issue #476 — memory log writes in skill contracts must use scripts/locked-append.sh |
+| next-dev-prod | A | 2026-06-22 01:16 | SKIPPED | memory/MEMORY.md 2026-06-04 |
+| owned-surface-guard | A | 2026-06-22 01:16 | PASS | issue #63 (autopilot-stray-wip-guard) 2026-06-12; issue #81 (owned-paths-zsh-split) 2026-06-13 |
+| pnpm-audit-ci-gate | A | 2026-06-22 01:16 | PASS | issue #171 — pnpm security audits must run in CI |
+| pr-audit-duplicate-issue-refs | A | 2026-06-22 01:16 | PASS | issue #439 — /pr-audit must flag duplicate open PRs that reference the same issue |
+| prd-output-path-contract | A | 2026-06-22 01:16 | PASS | memory/MEMORY.md 2026-06-19 |
+| prompt-miner-schema-compat | A | 2026-06-22 01:16 | PASS | issue #253 — prompt-miner JSONL schema-drift guard |
+| ralph-fallback-order | A | 2026-06-22 01:16 | PASS | conversation 2026-06-12 (Ralph default fallback order) |
+| repo-map-contract | A | 2026-06-22 01:16 | PASS | issue #464 — repo map must optimize orientation without adding a tree dependency or unmeasured performance claims |
+| retro-deterministic-contract | A | 2026-06-22 01:16 | PASS | issue #443 — /retro deterministic output and self-contained helper contract |
+| rl-delegation-write-worker | A | 2026-06-22 01:16 | PASS | memory/MEMORY.md 2026-06-10 (rl-delegation) #57 |
+| sandbox-boot-guard-ci | A | 2026-06-22 01:16 | PASS | issue #449 (sandbox image build CI guard) 2026-06-19 |
+| ship-spec-ready-finalization | A | 2026-06-22 01:16 | PASS | issue #134 — /ship-spec must finalize ready PRs after gates, not stop at draft scaffold |
+| skill-paths | A | 2026-06-22 01:16 | PASS | issue #43 — stale path references; extended by issue #69 — apps/->packages/ rename guard |
+| spec-family-contract | A | 2026-06-22 01:16 | PASS | conversation 2026-06-19 (spec-* family split, issue #265) |
+| submitted-by-trailers | A | 2026-06-22 01:16 | PASS | conversation 2026-06-12 (commit attribution trailers) |
+| watchdog-completed-session-reap | A | 2026-06-22 01:16 | PASS | issue #235 (completed autopilot PR session reaping) |
+| watchdog-draft-prs | A | 2026-06-22 01:16 | PASS | conversation 2026-06-15 (generic watchdog + stale draft PR recovery) |
+| watchdog-stuck-sessions | A | 2026-06-22 01:16 | PASS | issue #240 (Codex zero-credit stuck autopilot sessions) 2026-06-17 |
+| wiki-readme-index | A | 2026-06-22 01:16 | PASS | issue #132 — wiki README index drift guard |
+| workflow-boundaries | A | 2026-06-22 01:16 | PASS | conversation 2026-06-19 (workflow consolidation, issue #259) |
 
 <!-- benchmark: pass-rate = PASS / (PASS + REGRESSION + TIMEOUT); SKIPPED excluded -->

--- a/scripts/__tests__/sandbox-healthcheck.test.ts
+++ b/scripts/__tests__/sandbox-healthcheck.test.ts
@@ -46,6 +46,18 @@ function runHealthcheck(env: Record<string, string>) {
   });
 }
 
+function addSlackReadyFixture(harness: string) {
+  const bridgeEntry = join(harness, ".pi", "bridge", "node_modules", "pi-messenger-bridge", "dist", "index.js");
+  const bridgeConfig = join(harness, ".pi", "msg-bridge.json");
+  const bridgeLog = join(harness, "client-slack.log");
+  mkdirSync(join(bridgeEntry, ".."), { recursive: true });
+  mkdirSync(join(bridgeConfig, ".."), { recursive: true });
+  writeFileSync(bridgeEntry, "// bridge fixture\n");
+  writeFileSync(bridgeConfig, "{}\n");
+  writeFileSync(bridgeLog, "[Slack] Bot user ID: U123\n");
+  return { bridgeEntry, bridgeConfig, bridgeLog };
+}
+
 describe("sandbox healthcheck", () => {
   it("passes when required cron tmux sessions are present", () => {
     const { harness, tmux } = fixture();
@@ -128,6 +140,91 @@ describe("sandbox healthcheck", () => {
 
     expect(result.status).toBe(1);
     expect(result.stderr).toContain("missing required tmux session: client-slack");
+  });
+
+  it("passes Slack readiness when configured bridge artifacts, session, and connect marker exist", () => {
+    const { bin, harness, tmux } = fixture();
+    const pi = join(bin, "pi");
+    writeFileSync(pi, "#!/usr/bin/env bash\nexit 0\n");
+    chmodSync(pi, 0o755);
+    const { bridgeEntry, bridgeConfig, bridgeLog } = addSlackReadyFixture(harness);
+
+    const result = runHealthcheck({
+      HARNESS: harness,
+      TMUX_BIN: tmux,
+      PI_BIN: pi,
+      PI_SLACK_APP_TOKEN: "xapp-test",
+      PI_SLACK_BOT_TOKEN: "xoxb-test",
+      SLACK_BRIDGE_ENTRY: bridgeEntry,
+      SLACK_BRIDGE_CONFIG: bridgeConfig,
+      SLACK_BRIDGE_LOG: bridgeLog,
+      HEALTHCHECK_TMUX_SESSIONS: "cron-watchdog,cron-system,client-slack",
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("sandbox healthcheck ok");
+  });
+
+  it("fails Slack readiness when the configured bridge entrypoint is missing", () => {
+    const { bin, harness, tmux } = fixture();
+    const pi = join(bin, "pi");
+    writeFileSync(pi, "#!/usr/bin/env bash\nexit 0\n");
+    chmodSync(pi, 0o755);
+    const { bridgeEntry, bridgeConfig, bridgeLog } = addSlackReadyFixture(harness);
+
+    const result = runHealthcheck({
+      HARNESS: harness,
+      TMUX_BIN: tmux,
+      PI_BIN: pi,
+      PI_SLACK_APP_TOKEN: "xapp-test",
+      PI_SLACK_BOT_TOKEN: "xoxb-test",
+      SLACK_BRIDGE_ENTRY: `${bridgeEntry}.missing`,
+      SLACK_BRIDGE_CONFIG: bridgeConfig,
+      SLACK_BRIDGE_LOG: bridgeLog,
+      HEALTHCHECK_TMUX_SESSIONS: "cron-watchdog,cron-system,client-slack",
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("missing Slack bridge entrypoint");
+  });
+
+  it("fails Slack readiness on configured bridge auth/runtime failure signals", () => {
+    const { bin, harness, tmux } = fixture();
+    const pi = join(bin, "pi");
+    writeFileSync(pi, "#!/usr/bin/env bash\nexit 0\n");
+    chmodSync(pi, 0o755);
+    const { bridgeEntry, bridgeConfig, bridgeLog } = addSlackReadyFixture(harness);
+    writeFileSync(bridgeLog, "[bridge-supervisor] pi exited rc=1 — restarting in 3s\ninvalid_auth\n");
+
+    const result = runHealthcheck({
+      HARNESS: harness,
+      TMUX_BIN: tmux,
+      PI_BIN: pi,
+      PI_SLACK_APP_TOKEN: "xapp-test",
+      PI_SLACK_BOT_TOKEN: "xoxb-test",
+      SLACK_BRIDGE_ENTRY: bridgeEntry,
+      SLACK_BRIDGE_CONFIG: bridgeConfig,
+      SLACK_BRIDGE_LOG: bridgeLog,
+      HEALTHCHECK_TMUX_SESSIONS: "cron-watchdog,cron-system,client-slack",
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("Slack bridge log contains startup/auth/runtime failure signal");
+    expect(result.stderr).toContain("bridge has not reported Socket Mode readiness");
+  });
+
+  it("fails clearly when Slack bridge credentials are only partially configured", () => {
+    const { harness, tmux } = fixture();
+
+    const result = runHealthcheck({
+      HARNESS: harness,
+      TMUX_BIN: tmux,
+      PI_SLACK_APP_TOKEN: "xapp-test",
+      HEALTHCHECK_TMUX_SESSIONS: "cron-watchdog,cron-system",
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("Slack bridge partially configured");
   });
 
   it("is wired into the devcontainer compose healthcheck", () => {

--- a/scripts/sandbox-healthcheck.sh
+++ b/scripts/sandbox-healthcheck.sh
@@ -53,6 +53,30 @@ has_value() {
   [ -n "$value" ] && [ "$value" != "''" ] && [ "$value" != '""' ]
 }
 
+require_file() {
+  local label="$1"
+  local file="$2"
+  if [ ! -f "$file" ]; then
+    record_failure "missing $label: $file"
+  fi
+}
+
+check_slack_bridge_log() {
+  local log_file="${SLACK_BRIDGE_LOG:-/tmp/client-slack.log}"
+  if [ ! -f "$log_file" ]; then
+    record_failure "Slack tokens configured but bridge log not found: $log_file"
+    return
+  fi
+
+  if grep -Eiq 'Cannot find module|ERR_MODULE_NOT_FOUND|invalid_auth|not_authed|account_inactive|Socket Mode.*(error|failed)|pi exited rc=|restarting in 3s' "$log_file"; then
+    record_failure "Slack bridge log contains startup/auth/runtime failure signal: $log_file"
+  fi
+
+  if ! grep -Fq '[Slack] Bot user ID:' "$log_file"; then
+    record_failure "Slack tokens configured but bridge has not reported Socket Mode readiness: $log_file"
+  fi
+}
+
 if ! command_exists "$TMUX_BIN"; then
   record_failure "tmux binary not found: $TMUX_BIN"
 else
@@ -71,9 +95,14 @@ else
 
   slack_app_token="${PI_SLACK_APP_TOKEN:-$(compose_env_value PI_SLACK_APP_TOKEN)}"
   slack_bot_token="${PI_SLACK_BOT_TOKEN:-$(compose_env_value PI_SLACK_BOT_TOKEN)}"
-  if has_value "$slack_app_token" && has_value "$slack_bot_token"; then
-    if command_exists "$PI_BIN"; then
+  if has_value "$slack_app_token" || has_value "$slack_bot_token"; then
+    if ! has_value "$slack_app_token" || ! has_value "$slack_bot_token"; then
+      record_failure "Slack bridge partially configured: both PI_SLACK_APP_TOKEN and PI_SLACK_BOT_TOKEN are required"
+    elif command_exists "$PI_BIN"; then
       require_session client-slack
+      require_file "Slack bridge entrypoint" "${SLACK_BRIDGE_ENTRY:-$HARNESS/.pi/bridge/node_modules/pi-messenger-bridge/dist/index.js}"
+      require_file "Slack bridge config" "${SLACK_BRIDGE_CONFIG:-/home/sandbox/.pi/msg-bridge.json}"
+      check_slack_bridge_log
     else
       record_failure "Slack tokens configured but Pi binary not found: $PI_BIN"
     fi


### PR DESCRIPTION
## Selection rationale

Research selection: queue was empty; /harness-audit ranked Slack bridge readiness verification #1 among non-duplicate harness-infra candidates. First-principles rationale: sandbox health must prove the configured Slack bridge is ready rather than merely that a tmux session exists, so operators and CI can catch silent install/runtime failures. Filed as #511.

---

## Summary

- require configured Slack sandboxes to prove bridge entrypoint, config, tmux session, and Socket Mode readiness in `scripts/sandbox-healthcheck.sh`
- fail clearly for partial Slack credentials and bridge install/auth/runtime failure log signatures
- document configured-vs-disabled Slack healthcheck behavior and refresh eval results

## Verification

- `pnpm run test:scripts -- scripts/__tests__/sandbox-healthcheck.test.ts` (vitest ran 25 files / 284 tests)
- `pnpm run format:check`
- `pnpm run lint`
- `bash .claude/skills/eval/run.sh` (58 probes; no regressions)
- `pnpm run build`
- `pnpm run typecheck`

Closes #511
