### PR TITLE
FROM fix/527-dependabot-security TO development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Update policy and release automation live in [`/git`](.claude/skills/git/SKILL.m
 ### Removed
 ### Deprecated
 ### Security
+- Patch Dependabot security alerts for `dompurify`, `http-proxy-middleware`, `undici`, and `webpack-dev-server` via pnpm overrides and lockfile refresh ([#527](https://github.com/mifunedev/openharness/issues/527)).
 
 ## [2026.6.25-2] - 2026-06-25
 

--- a/package.json
+++ b/package.json
@@ -49,12 +49,15 @@
       "form-data": "^4.0.6",
       "launch-editor": "^2.14.1",
       "@babel/core": "^7.29.7",
-      "dompurify": "^3.4.10",
+      "dompurify": "^3.4.11",
       "mermaid": "^11.15.0",
       "postcss": "^8.5.10",
       "joi": "^18.2.1",
       "esbuild": "^0.28.1",
-      "js-yaml": "^4.2.0"
+      "js-yaml": "^4.2.0",
+      "undici": "^7.28.0",
+      "webpack-dev-server": "^5.2.5",
+      "http-proxy-middleware": "^2.0.10"
     },
     "auditConfig": {
       "ignoreCves": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,17 +14,20 @@ overrides:
   serialize-javascript: ^7.0.3
   qs: ^6.15.2
   uuid: ^11.1.1
+  ws@>=7.0.0 <7.5.11: ^7.5.11
   ws@>=8.0.0 <9.0.0: ^8.20.1
+  form-data: ^4.0.6
+  launch-editor: ^2.14.1
+  '@babel/core': ^7.29.7
+  dompurify: ^3.4.11
   mermaid: ^11.15.0
   postcss: ^8.5.10
   joi: ^18.2.1
   esbuild: ^0.28.1
-  ws@>=7.0.0 <7.5.11: ^7.5.11
-  form-data: ^4.0.6
-  launch-editor: ^2.14.1
   js-yaml: ^4.2.0
-  dompurify: ^3.4.10
-  '@babel/core': ^7.29.7
+  undici: ^7.28.0
+  webpack-dev-server: ^5.2.5
+  http-proxy-middleware: ^2.0.10
 
 patchedDependencies:
   gray-matter@4.0.3:
@@ -3452,8 +3455,8 @@ packages:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
-  dompurify@3.4.10:
-    resolution: {integrity: sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w==}
+  dompurify@3.4.11:
+    resolution: {integrity: sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==}
 
   domutils@2.8.0:
     resolution: {integrity: sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==}
@@ -3996,8 +3999,8 @@ packages:
   http-parser-js@0.5.10:
     resolution: {integrity: sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==}
 
-  http-proxy-middleware@2.0.9:
-    resolution: {integrity: sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==}
+  http-proxy-middleware@2.0.10:
+    resolution: {integrity: sha512-RKzRWNPxUZqbuk3BC5mGVJbBnWgr+diEnjJexIOytFbBzDy88Fbh/YvBr3DsNrl1jYAfjWfpATEv0NO35FDuPQ==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
       '@types/express': ^4.17.13
@@ -6177,8 +6180,8 @@ packages:
   undici-types@7.19.2:
     resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
 
-  undici@7.27.2:
-    resolution: {integrity: sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==}
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
   unicode-canonical-property-names-ecmascript@2.0.1:
@@ -6399,8 +6402,8 @@ packages:
       webpack:
         optional: true
 
-  webpack-dev-server@5.2.4:
-    resolution: {integrity: sha512-GqDPGZN9bRqKBTkp4aWkobDDHMsrXKoGSdOH56smIri8qR0JG8gfL8/v/f/OZR3/OKXjG8uwJbFVhKm/FNU/UA==}
+  webpack-dev-server@5.2.5:
+    resolution: {integrity: sha512-4wZtCquSuv9CKX8oybo+mqxtxZqWz47uM1Ch94lxowBztOhWCbhqvRbfC/mODOwxgV2brY+JGZpHq58/SuVFYg==}
     engines: {node: '>= 18.12.0'}
     hasBin: true
     peerDependencies:
@@ -7965,7 +7968,7 @@ snapshots:
       update-notifier: 6.0.2
       webpack: 5.107.2
       webpack-bundle-analyzer: 4.10.2
-      webpack-dev-server: 5.2.4(debug@4.4.3)(tslib@2.8.1)(webpack@5.107.2)
+      webpack-dev-server: 5.2.5(debug@4.4.3)(tslib@2.8.1)(webpack@5.107.2)
       webpack-merge: 6.0.1
     transitivePeerDependencies:
       - '@parcel/css'
@@ -10296,7 +10299,7 @@ snapshots:
       parse5: 7.3.0
       parse5-htmlparser2-tree-adapter: 7.1.0
       parse5-parser-stream: 7.1.2
-      undici: 7.27.2
+      undici: 7.28.0
       whatwg-mimetype: 4.0.0
 
   chokidar@3.6.0:
@@ -10925,7 +10928,7 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
-  dompurify@3.4.10:
+  dompurify@3.4.11:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -11631,7 +11634,7 @@ snapshots:
 
   http-parser-js@0.5.10: {}
 
-  http-proxy-middleware@2.0.9(@types/express@4.17.25)(debug@4.4.3):
+  http-proxy-middleware@2.0.10(@types/express@4.17.25)(debug@4.4.3):
     dependencies:
       '@types/http-proxy': 1.17.17
       http-proxy: 1.18.1(debug@4.4.3)
@@ -11869,7 +11872,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.1
-      undici: 7.27.2
+      undici: 7.28.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -12279,7 +12282,7 @@ snapshots:
       d3-sankey: 0.12.3
       dagre-d3-es: 7.0.14
       dayjs: 1.11.20
-      dompurify: 3.4.10
+      dompurify: 3.4.11
       es-toolkit: 1.47.0
       katex: 0.16.45
       khroma: 2.1.0
@@ -14209,7 +14212,7 @@ snapshots:
 
   undici-types@7.19.2: {}
 
-  undici@7.27.2: {}
+  undici@7.28.0: {}
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 
@@ -14467,7 +14470,7 @@ snapshots:
     transitivePeerDependencies:
       - tslib
 
-  webpack-dev-server@5.2.4(debug@4.4.3)(tslib@2.8.1)(webpack@5.107.2):
+  webpack-dev-server@5.2.5(debug@4.4.3)(tslib@2.8.1)(webpack@5.107.2):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4
@@ -14485,7 +14488,7 @@ snapshots:
       connect-history-api-fallback: 2.0.0
       express: 4.22.1
       graceful-fs: 4.2.11
-      http-proxy-middleware: 2.0.9(@types/express@4.17.25)(debug@4.4.3)
+      http-proxy-middleware: 2.0.10(@types/express@4.17.25)(debug@4.4.3)
       ipaddr.js: 2.3.0
       launch-editor: 2.14.1
       open: 10.2.0


### PR DESCRIPTION
Closes #527

## Summary
- Patch all open Dependabot security notifications by lifting pnpm overrides for `dompurify`, `undici`, `webpack-dev-server`, and `http-proxy-middleware` to fixed versions.
- Refresh/dedupe `pnpm-lock.yaml` so vulnerable lockfile entries are removed.
- Add an Unreleased security changelog entry.

## Alerts addressed
- `dompurify` <= 3.4.10 -> 3.4.11
- `undici` < 7.28.0 -> 7.28.0
- `webpack-dev-server` < 5.2.5 -> 5.2.5
- `http-proxy-middleware` < 2.0.10 -> 2.0.10

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm security:audit`
- lockfile grep confirms vulnerable versions are absent
- `pnpm docs:build`
- `pnpm typecheck`
- `pnpm test:scripts`
- `bash .mifune/skills/eval/run.sh` (61 probes; no regressions)
