### PR TITLE
skill: harden /worktrees trigger for "clone to worktrees" phrasing

### DIFF
--- a/.oh/skills/worktrees/SKILL.md
+++ b/.oh/skills/worktrees/SKILL.md
@@ -4,7 +4,10 @@ description: |
   Manage .worktrees/ lifecycle: create worktree, list worktrees, remove worktree,
   clean worktrees, stale worktrees audit, isolate work, project clone.
   TRIGGER when: any git worktree operation, branch isolation needed, stale worktrees
-  review, project clone under .worktrees/project/, worktree cleanup.
+  review, project clone under .worktrees/project/ (e.g. "clone <owner>/<repo> to
+  worktrees", "add <repo> to .worktrees", "clone this repo into worktrees"), worktree
+  cleanup. A leading-slash harness dir like "/worktrees" still means the repo-relative
+  .worktrees/ — never a literal filesystem-root path.
 allowed-tools: Bash
 ---
 


### PR DESCRIPTION
## What

Adds natural-language phrasings and a leading-slash caveat to the `/worktrees` skill frontmatter `TRIGGER`.

## Why

A "Clone `<repo>` to /worktrees" request failed to route to the skill's **PROJECT CLONE** op — it got hand-rolled as a raw `git clone` into a `sudo`-created **root-level** `/worktrees`. Naming the phrasings (`"clone <owner>/<repo> to worktrees"`, `"add <repo> to .worktrees"`) and clarifying that a leading-slash harness dir means the repo-relative `.worktrees/` makes dispatch unambiguous → PROJECT CLONE into `.worktrees/project/<owner>/<repo>`.

## Change

One-line frontmatter edit; the skill body is unchanged. No behavior change beyond routing/discoverability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
