### PR TITLE
feat: require a sudo password (no NOPASSWD) for the sandbox user via SANDBOX_PASSWORD

### DIFF
--- a/.devcontainer/.example.env
+++ b/.devcontainer/.example.env
@@ -21,11 +21,17 @@
 # Default /home/sandbox/harness; leave unset unless relocating.
 # OH_PROJECT_ROOT=/home/sandbox/harness
 
-# ─── Sandbox User Login Password ──────────────────────────────────────
-# Remote login password for the `sandbox` user (SSH/shell access).
-# NOTE: This is the LOGIN password, not the sudo password — sudo remains
-# passwordless for the sandbox user. Default: `test1234` if unset.
-# SECURITY: This default is weak and known; override on any network-reachable
+# ─── Sandbox User Password (login + sudo) ─────────────────────────────
+# The `sandbox` user's password, used for BOTH remote login (SSH/`su sandbox`)
+# AND sudo. Sudo is NOT passwordless (/etc/sudoers.d/sandbox is
+# `sandbox ALL=(ALL) ALL`): an interactive operator who knows this password can
+# escalate, but a non-interactive internal agent hits the password prompt and
+# fails (`sudo -n` returns "a password is required"). Default: `test1234`.
+# NOTE: the sandbox user is also in the `docker` group with the socket mounted,
+# which remains an independent root-escalation path — this gates `sudo`, not all
+# escalation. Devcontainer reads this at runtime (entrypoint); the Railway image
+# bakes it at build time (--build-arg SANDBOX_PASSWORD=...).
+# SECURITY: this default is weak and known; override on any network-reachable
 # deployment. Set a strong value in the gitignored .devcontainer/.env or via
 # your platform's secret store (e.g. Railway variables).
 # SANDBOX_PASSWORD=test1234

--- a/.devcontainer/.example.env
+++ b/.devcontainer/.example.env
@@ -21,6 +21,15 @@
 # Default /home/sandbox/harness; leave unset unless relocating.
 # OH_PROJECT_ROOT=/home/sandbox/harness
 
+# ─── Sandbox User Login Password ──────────────────────────────────────
+# Remote login password for the `sandbox` user (SSH/shell access).
+# NOTE: This is the LOGIN password, not the sudo password — sudo remains
+# passwordless for the sandbox user. Default: `test1234` if unset.
+# SECURITY: This default is weak and known; override on any network-reachable
+# deployment. Set a strong value in the gitignored .devcontainer/.env or via
+# your platform's secret store (e.g. Railway variables).
+# SANDBOX_PASSWORD=test1234
+
 # ─── Migrated to harness.yaml ────────────────────────────────────────
 # The following vars were removed from this file. Set them in harness.yaml
 # using the keys shown. Values in an existing .env still take effect unless

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -143,7 +143,7 @@ RUN cd /opt/oh && npm install --no-audit --no-fund && npm run build \
 
 # ─── Sandbox user ──────────────────────────────────────────────────
 RUN useradd -m -s /bin/zsh sandbox \
- && echo "sandbox ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/sandbox \
+ && echo "sandbox ALL=(ALL) ALL" > /etc/sudoers.d/sandbox \
  && chmod 0440 /etc/sudoers.d/sandbox \
  && groupadd -f docker && usermod -aG docker sandbox
 

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -43,6 +43,7 @@ services:
       - "host.docker.internal:host-gateway"
     environment:
       - SANDBOX_NAME=${SANDBOX_NAME:-openharness}
+      - SANDBOX_PASSWORD=${SANDBOX_PASSWORD:-test1234}
       - TZ=${TZ:-America/Los_Angeles}
       - CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS=true
       - GIT_USER_NAME=${GIT_USER_NAME:-}

--- a/.devcontainer/entrypoint.sh
+++ b/.devcontainer/entrypoint.sh
@@ -109,15 +109,18 @@ if [ -d "$HARNESS_DIR" ]; then
   fi
 fi
 
-# Set the sandbox user's LOGIN password so an operator can authenticate on a
-# remote box (e.g. `su sandbox` or SSH password auth). This is unconditional
-# — independent of whether the UID/GID reconcile above succeeded — and is
-# distinct from sudo, which stays NOPASSWD:ALL via /etc/sudoers.d/sandbox.
+# Set the sandbox user's password. This is BOTH the remote login password
+# (e.g. `su sandbox` / SSH password auth) AND the sudo password: sudo now
+# requires it (/etc/sudoers.d/sandbox is `sandbox ALL=(ALL) ALL`, no NOPASSWD),
+# so an interactive operator who knows it can escalate, but a non-interactive
+# internal agent hits the password prompt and fails (`sudo -n` -> error). We
+# run as root here (before the gosu drop), so no sudo is needed to set it.
+# Unconditional — independent of whether the UID/GID reconcile above succeeded.
 # The trailing `|| echo ... >&2` (not a bare `|| true`) keeps a chpasswd
 # failure (e.g. read-only /etc on some hosts) from aborting boot under
 # `set -e`, while still surfacing it as a warning; never log $PW itself.
 PW="${SANDBOX_PASSWORD:-test1234}"
-echo "sandbox:${PW}" | chpasswd || echo "[entrypoint] WARNING: failed to set sandbox login password" >&2
+echo "sandbox:${PW}" | chpasswd || echo "[entrypoint] WARNING: failed to set sandbox password" >&2
 unset PW
 
 # UID/GID reconciliation can change the numeric identity behind the sandbox

--- a/.devcontainer/entrypoint.sh
+++ b/.devcontainer/entrypoint.sh
@@ -109,6 +109,17 @@ if [ -d "$HARNESS_DIR" ]; then
   fi
 fi
 
+# Set the sandbox user's LOGIN password so an operator can authenticate on a
+# remote box (e.g. `su sandbox` or SSH password auth). This is unconditional
+# — independent of whether the UID/GID reconcile above succeeded — and is
+# distinct from sudo, which stays NOPASSWD:ALL via /etc/sudoers.d/sandbox.
+# The trailing `|| echo ... >&2` (not a bare `|| true`) keeps a chpasswd
+# failure (e.g. read-only /etc on some hosts) from aborting boot under
+# `set -e`, while still surfacing it as a warning; never log $PW itself.
+PW="${SANDBOX_PASSWORD:-test1234}"
+echo "sandbox:${PW}" | chpasswd || echo "[entrypoint] WARNING: failed to set sandbox login password" >&2
+unset PW
+
 # UID/GID reconciliation can change the numeric identity behind the sandbox
 # user after Docker-created auth volumes were repaired above. Repeat the
 # idempotent repair with the final uid:gid so persisted credentials remain

--- a/.oh/deploy/railway/Dockerfile
+++ b/.oh/deploy/railway/Dockerfile
@@ -21,9 +21,16 @@ RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
  && corepack enable \
  && corepack prepare pnpm@10.33.0 --activate
 
+# Sudo requires a password (no NOPASSWD): an interactive operator who knows the
+# password can escalate, but a non-interactive internal agent hits the prompt
+# and fails. The password is set here at build time because start.sh runs as
+# the sandbox user and can no longer use passwordless sudo to set it. Override
+# at build with --build-arg SANDBOX_PASSWORD=... ; default is the weak `test1234`.
+ARG SANDBOX_PASSWORD=test1234
 RUN useradd -m -s /bin/zsh sandbox \
- && echo "sandbox ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/sandbox \
- && chmod 0440 /etc/sudoers.d/sandbox
+ && echo "sandbox ALL=(ALL) ALL" > /etc/sudoers.d/sandbox \
+ && chmod 0440 /etc/sudoers.d/sandbox \
+ && echo "sandbox:${SANDBOX_PASSWORD:-test1234}" | chpasswd
 
 WORKDIR ${OH_PROJECT_ROOT}
 COPY --chown=sandbox:sandbox . ${OH_PROJECT_ROOT}/

--- a/.oh/deploy/railway/start.sh
+++ b/.oh/deploy/railway/start.sh
@@ -6,6 +6,12 @@ export PORT
 export OPENHARNESS_HOSTED_MODE="${OPENHARNESS_HOSTED_MODE:-railway}"
 export OH_PROJECT_ROOT="${OH_PROJECT_ROOT:-/home/sandbox/harness}"
 
+# Give the sandbox user a real Unix login password (sudo itself stays
+# passwordless via the NOPASSWD:ALL sudoers entry set in the Dockerfile).
+# Do not echo ${PW} anywhere below.
+PW="${SANDBOX_PASSWORD:-test1234}"
+echo "sandbox:${PW}" | sudo chpasswd
+
 cd "$OH_PROJECT_ROOT"
 
 if ! command -v oh >/dev/null 2>&1; then

--- a/.oh/deploy/railway/start.sh
+++ b/.oh/deploy/railway/start.sh
@@ -6,11 +6,11 @@ export PORT
 export OPENHARNESS_HOSTED_MODE="${OPENHARNESS_HOSTED_MODE:-railway}"
 export OH_PROJECT_ROOT="${OH_PROJECT_ROOT:-/home/sandbox/harness}"
 
-# Give the sandbox user a real Unix login password (sudo itself stays
-# passwordless via the NOPASSWD:ALL sudoers entry set in the Dockerfile).
-# Do not echo ${PW} anywhere below.
-PW="${SANDBOX_PASSWORD:-test1234}"
-echo "sandbox:${PW}" | sudo chpasswd
+# The sandbox user's password (login + sudo) is set at image build time in the
+# Dockerfile — see `ARG SANDBOX_PASSWORD`. It is NOT set here: sudo now requires
+# a password (no NOPASSWD), so start.sh (which runs as the sandbox user) could
+# not use `sudo chpasswd` anyway. Rebuild with --build-arg SANDBOX_PASSWORD=...
+# to change it.
 
 cd "$OH_PROJECT_ROOT"
 

--- a/.oh/tasks/remote-sudo-password/prd.json
+++ b/.oh/tasks/remote-sudo-password/prd.json
@@ -2,52 +2,51 @@
     "schemaVersion": 1,
     "project": "Open Harness",
     "branchName": "feat/remote-sudo-password",
-    "description": "Set the sandbox user's Unix login password on remote/hosted deployments from a SANDBOX_PASSWORD variable with a fallback default of test1234, so an operator can authenticate as `sandbox` (SSH/console/su) on a remote box. The existing NOPASSWD:ALL passwordless sudo is preserved unchanged — this adds a *login* password only; it does NOT make sudo require a password. Both container images (.devcontainer and .oh/deploy/railway) and the local env surface are covered.",
+    "description": "Make sudo require a password for the `sandbox` user instead of NOPASSWD:ALL, and set that password from a SANDBOX_PASSWORD variable with a fallback default of test1234. Goal: a non-interactive internal agent (running as `sandbox`) can no longer escalate via sudo — it hits the password prompt and fails — while an interactive operator who knows the password still can. The same password doubles as the remote login password (SSH/su). NOTE (documented, not silently ignored): the sandbox user is in the `docker` group with the docker socket mounted, which remains a separate root-escalation path; this change gates `sudo` specifically, not every escalation vector.",
     "userStories": [
         {
             "id": "US-001",
-            "title": "Devcontainer: set sandbox login password from SANDBOX_PASSWORD (default test1234) at runtime, keep passwordless sudo",
-            "description": "As an operator of a remote devcontainer sandbox, I want the `sandbox` user to have a real Unix login password so I can authenticate as it, while sudo stays passwordless. The entrypoint already runs as root before it drops to `gosu sandbox`, so set the password there from the env var with the required fallback.",
+            "title": "Devcontainer: require a sudo password and set it from SANDBOX_PASSWORD (default test1234)",
+            "description": "As a harness operator, I want internal agents in the devcontainer to be unable to run sudo non-interactively, while I (interactively) still can. Change the sudoers policy to require a password and set the sandbox user's password from the env var at runtime.",
             "acceptanceCriteria": [
-                "In .devcontainer/docker-compose.yml, add `- SANDBOX_PASSWORD=${SANDBOX_PASSWORD:-test1234}` to the sandbox service `environment:` block (near the other identity vars) so the variable reaches the container with the fallback default.",
-                "In .devcontainer/entrypoint.sh, while still running as root (before any `gosu sandbox` handoff / near the existing usermod UID-reconcile ops), set the login password: resolve `PW=\"${SANDBOX_PASSWORD:-test1234}\"` and run `echo \"sandbox:${PW}\" | chpasswd`. Guard so an empty/unset value still falls back to test1234, and do not `set -x`/echo the password to logs.",
-                "Do NOT modify /etc/sudoers.d/sandbox — the `sandbox ALL=(ALL) NOPASSWD:ALL` line in .devcontainer/Dockerfile stays exactly as-is; sudo must remain passwordless.",
-                "`bash -n .devcontainer/entrypoint.sh` passes (script remains syntactically valid).",
-                "Verifiable behavior (documented in the story notes / progress.txt): after boot, `passwd -S sandbox` reports a set password (status `P`, not `L`/`NP`) and `sudo -n true` as sandbox still succeeds without a password prompt.",
-                "The password value is not printed to stdout/stderr or the entrypoint log."
+                "In .devcontainer/Dockerfile, /etc/sudoers.d/sandbox is `sandbox ALL=(ALL) ALL` (NOT NOPASSWD:ALL) — sudo access still exists but requires the password.",
+                "In .devcontainer/docker-compose.yml, `- SANDBOX_PASSWORD=${SANDBOX_PASSWORD:-test1234}` is passed into the sandbox service `environment:` block.",
+                "In .devcontainer/entrypoint.sh, while running as root (before any gosu drop), the sandbox password is set from `${SANDBOX_PASSWORD:-test1234}` via `chpasswd`, unconditionally, without logging the value. (Root sets it directly — no sudo needed.)",
+                "Behavioral check (documented in notes): as the sandbox user, `sudo -n true` FAILS with a 'password is required' error, while `echo \"$SANDBOX_PASSWORD\" | sudo -S -k true` (or an interactive sudo with the known password) SUCCEEDS.",
+                "Docker access is NOT via sudo — the sandbox user stays in the `docker` group — so removing NOPASSWD does not break `docker` for agents.",
+                "`bash -n .devcontainer/entrypoint.sh` passes."
             ],
             "priority": 1,
             "passes": false,
-            "notes": "Entrypoint root context confirmed at .devcontainer/entrypoint.sh (groupmod/chown/usermod run as root, then `gosu sandbox` drops privileges). Place the chpasswd near the usermod UID-reconcile block (~line 102) but unconditional (not gated on UID sync)."
+            "notes": "The password is the sudo credential and the login credential — one value. Setting it in entrypoint (runtime) means a compose/.env override applies without a rebuild."
         },
         {
             "id": "US-002",
-            "title": "Railway/hosted image: set sandbox login password from SANDBOX_PASSWORD (default test1234), keep passwordless sudo",
-            "description": "As an operator of the hosted (Railway) image, I want the same SANDBOX_PASSWORD-with-test1234-fallback login password behavior. That image runs `.oh/deploy/railway/start.sh` as the `sandbox` user (Dockerfile does `USER sandbox`), but `sandbox` has passwordless sudo, so the password can be set at container start via sudo.",
+            "title": "Railway image: require a sudo password and bake it at build time from SANDBOX_PASSWORD (default test1234)",
+            "description": "As an operator of the hosted Railway image, I want the same 'sudo requires a password' policy. Because start.sh runs as the sandbox user and can no longer use passwordless sudo, the password must be set at image build time.",
             "acceptanceCriteria": [
-                "In .oh/deploy/railway/start.sh, near the top (after `set -euo pipefail`, before `exec node ...`), resolve `PW=\"${SANDBOX_PASSWORD:-test1234}\"` and set the password using the available passwordless sudo: `echo \"sandbox:${PW}\" | sudo chpasswd`. It must tolerate a missing/empty SANDBOX_PASSWORD (fall back to test1234) and must not print the password.",
-                "Do NOT modify the `sandbox ALL=(ALL) NOPASSWD:ALL` sudoers line in .oh/deploy/railway/Dockerfile — passwordless sudo is preserved.",
-                "`bash -n .oh/deploy/railway/start.sh` passes.",
-                "start.sh keeps its `set -euo pipefail` discipline: the chpasswd step must not abort startup if it is a no-op environment, but a genuine failure to set the password should surface (do not blanket-`|| true` in a way that hides a real error — a short comment explaining the choice is acceptable).",
-                "Verifiable behavior (documented in notes): in a built railway image, `passwd -S sandbox` reports a set password after start.sh runs."
+                "In .oh/deploy/railway/Dockerfile, /etc/sudoers.d/sandbox is `sandbox ALL=(ALL) ALL` (NOT NOPASSWD:ALL).",
+                "The Dockerfile sets the sandbox password at build time from an `ARG SANDBOX_PASSWORD` (default test1234) via `chpasswd`, overridable with `--build-arg SANDBOX_PASSWORD=...`.",
+                ".oh/deploy/railway/start.sh no longer runs `sudo chpasswd` (that would now fail, since sudo requires a password); a comment records that the password is baked at build time.",
+                "`bash -n .oh/deploy/railway/start.sh` passes."
             ],
             "priority": 1,
             "passes": false,
-            "notes": "start.sh runs as `sandbox` (USER sandbox in .oh/deploy/railway/Dockerfile) and has NOPASSWD sudo, so `sudo chpasswd` works at runtime without a rebuild — a Railway-set SANDBOX_PASSWORD env var takes effect on next start."
+            "notes": "Runtime env override is intentionally not supported on the Railway image (no root at runtime); rebuild with --build-arg to change the password. This is a hosted-smoke image, so build-time is acceptable."
         },
         {
             "id": "US-003",
-            "title": "Document SANDBOX_PASSWORD in .example.env with the test1234 default and its security caveat",
-            "description": "As a new operator, I want to discover the SANDBOX_PASSWORD variable and understand that it defaults to a weak, publicly-known value that must be overridden on any exposed deployment.",
+            "title": "Document SANDBOX_PASSWORD as the login+sudo password with the test1234 default and caveats",
+            "description": "As a new operator, I want .example.env to explain that SANDBOX_PASSWORD gates sudo (not passwordless), doubles as the login password, defaults to test1234, and that the docker-group/socket path is a separate escalation vector.",
             "acceptanceCriteria": [
-                "Add a documented `SANDBOX_PASSWORD` entry to .devcontainer/.example.env (a commented example line plus a short explanation), describing it as the `sandbox` user's remote LOGIN password (not the sudo password — sudo stays passwordless) and stating the fallback default is `test1234`.",
-                "The comment includes a SECURITY warning: `test1234` is a known weak default intended for convenience/local use; set a strong value in the gitignored .devcontainer/.env (or the platform's secret store, e.g. Railway variables) for any network-reachable deployment.",
-                "Do NOT add SANDBOX_PASSWORD to tracked harness.yaml — it is a secret and belongs in the gitignored .env surface, consistent with the existing 'secrets in .env, non-secret defaults in harness.yaml' convention.",
-                "Wording matches the file's existing comment style/format in .devcontainer/.example.env."
+                "`.devcontainer/.example.env` documents SANDBOX_PASSWORD as the sandbox user's login AND sudo password, states sudo is NOT passwordless, and gives the test1234 default.",
+                "The doc notes the non-interactive-agent-can't-sudo behavior and the security caveat to override the weak default on exposed deployments.",
+                "The doc honestly notes the `docker` group + mounted socket as a separate root-escalation path (this change gates sudo, not all escalation).",
+                "SANDBOX_PASSWORD is NOT added to tracked harness.yaml (it is a secret; belongs in gitignored .env)."
             ],
             "priority": 2,
             "passes": false,
-            "notes": "harness.yaml keys map to env vars but harness.yaml is a tracked/non-secret surface; a password must not be committed there. Document only in .example.env."
+            "notes": "Truthful scoping: gating sudo is defense-in-depth, not full root containment while the docker socket is exposed."
         }
     ]
 }

--- a/.oh/tasks/remote-sudo-password/prd.json
+++ b/.oh/tasks/remote-sudo-password/prd.json
@@ -1,0 +1,53 @@
+{
+    "schemaVersion": 1,
+    "project": "Open Harness",
+    "branchName": "feat/remote-sudo-password",
+    "description": "Set the sandbox user's Unix login password on remote/hosted deployments from a SANDBOX_PASSWORD variable with a fallback default of test1234, so an operator can authenticate as `sandbox` (SSH/console/su) on a remote box. The existing NOPASSWD:ALL passwordless sudo is preserved unchanged — this adds a *login* password only; it does NOT make sudo require a password. Both container images (.devcontainer and .oh/deploy/railway) and the local env surface are covered.",
+    "userStories": [
+        {
+            "id": "US-001",
+            "title": "Devcontainer: set sandbox login password from SANDBOX_PASSWORD (default test1234) at runtime, keep passwordless sudo",
+            "description": "As an operator of a remote devcontainer sandbox, I want the `sandbox` user to have a real Unix login password so I can authenticate as it, while sudo stays passwordless. The entrypoint already runs as root before it drops to `gosu sandbox`, so set the password there from the env var with the required fallback.",
+            "acceptanceCriteria": [
+                "In .devcontainer/docker-compose.yml, add `- SANDBOX_PASSWORD=${SANDBOX_PASSWORD:-test1234}` to the sandbox service `environment:` block (near the other identity vars) so the variable reaches the container with the fallback default.",
+                "In .devcontainer/entrypoint.sh, while still running as root (before any `gosu sandbox` handoff / near the existing usermod UID-reconcile ops), set the login password: resolve `PW=\"${SANDBOX_PASSWORD:-test1234}\"` and run `echo \"sandbox:${PW}\" | chpasswd`. Guard so an empty/unset value still falls back to test1234, and do not `set -x`/echo the password to logs.",
+                "Do NOT modify /etc/sudoers.d/sandbox — the `sandbox ALL=(ALL) NOPASSWD:ALL` line in .devcontainer/Dockerfile stays exactly as-is; sudo must remain passwordless.",
+                "`bash -n .devcontainer/entrypoint.sh` passes (script remains syntactically valid).",
+                "Verifiable behavior (documented in the story notes / progress.txt): after boot, `passwd -S sandbox` reports a set password (status `P`, not `L`/`NP`) and `sudo -n true` as sandbox still succeeds without a password prompt.",
+                "The password value is not printed to stdout/stderr or the entrypoint log."
+            ],
+            "priority": 1,
+            "passes": false,
+            "notes": "Entrypoint root context confirmed at .devcontainer/entrypoint.sh (groupmod/chown/usermod run as root, then `gosu sandbox` drops privileges). Place the chpasswd near the usermod UID-reconcile block (~line 102) but unconditional (not gated on UID sync)."
+        },
+        {
+            "id": "US-002",
+            "title": "Railway/hosted image: set sandbox login password from SANDBOX_PASSWORD (default test1234), keep passwordless sudo",
+            "description": "As an operator of the hosted (Railway) image, I want the same SANDBOX_PASSWORD-with-test1234-fallback login password behavior. That image runs `.oh/deploy/railway/start.sh` as the `sandbox` user (Dockerfile does `USER sandbox`), but `sandbox` has passwordless sudo, so the password can be set at container start via sudo.",
+            "acceptanceCriteria": [
+                "In .oh/deploy/railway/start.sh, near the top (after `set -euo pipefail`, before `exec node ...`), resolve `PW=\"${SANDBOX_PASSWORD:-test1234}\"` and set the password using the available passwordless sudo: `echo \"sandbox:${PW}\" | sudo chpasswd`. It must tolerate a missing/empty SANDBOX_PASSWORD (fall back to test1234) and must not print the password.",
+                "Do NOT modify the `sandbox ALL=(ALL) NOPASSWD:ALL` sudoers line in .oh/deploy/railway/Dockerfile — passwordless sudo is preserved.",
+                "`bash -n .oh/deploy/railway/start.sh` passes.",
+                "start.sh keeps its `set -euo pipefail` discipline: the chpasswd step must not abort startup if it is a no-op environment, but a genuine failure to set the password should surface (do not blanket-`|| true` in a way that hides a real error — a short comment explaining the choice is acceptable).",
+                "Verifiable behavior (documented in notes): in a built railway image, `passwd -S sandbox` reports a set password after start.sh runs."
+            ],
+            "priority": 1,
+            "passes": false,
+            "notes": "start.sh runs as `sandbox` (USER sandbox in .oh/deploy/railway/Dockerfile) and has NOPASSWD sudo, so `sudo chpasswd` works at runtime without a rebuild — a Railway-set SANDBOX_PASSWORD env var takes effect on next start."
+        },
+        {
+            "id": "US-003",
+            "title": "Document SANDBOX_PASSWORD in .example.env with the test1234 default and its security caveat",
+            "description": "As a new operator, I want to discover the SANDBOX_PASSWORD variable and understand that it defaults to a weak, publicly-known value that must be overridden on any exposed deployment.",
+            "acceptanceCriteria": [
+                "Add a documented `SANDBOX_PASSWORD` entry to .devcontainer/.example.env (a commented example line plus a short explanation), describing it as the `sandbox` user's remote LOGIN password (not the sudo password — sudo stays passwordless) and stating the fallback default is `test1234`.",
+                "The comment includes a SECURITY warning: `test1234` is a known weak default intended for convenience/local use; set a strong value in the gitignored .devcontainer/.env (or the platform's secret store, e.g. Railway variables) for any network-reachable deployment.",
+                "Do NOT add SANDBOX_PASSWORD to tracked harness.yaml — it is a secret and belongs in the gitignored .env surface, consistent with the existing 'secrets in .env, non-secret defaults in harness.yaml' convention.",
+                "Wording matches the file's existing comment style/format in .devcontainer/.example.env."
+            ],
+            "priority": 2,
+            "passes": false,
+            "notes": "harness.yaml keys map to env vars but harness.yaml is a tracked/non-secret surface; a password must not be committed there. Document only in .example.env."
+        }
+    ]
+}


### PR DESCRIPTION
## What & why

The `sandbox` user had `NOPASSWD:ALL` sudo — any internal agent running as `sandbox` could silently escalate to root. This makes **sudo require a password**: an interactive operator who knows it can still escalate, but a **non-interactive internal agent hits the password prompt and fails** (`sudo -n` → "a password is required").

The password comes from `SANDBOX_PASSWORD` (fallback `test1234`) and doubles as the remote **login** password (SSH / `su sandbox`).

> **Note (v1 of this PR reversed):** an earlier revision set a login password while *keeping* `NOPASSWD:ALL` — which left sudo effectively passwordless. That was corrected in `fix:` — `NOPASSWD` is now removed and the password is the sudo gate.

## Changes

| File | Change |
|------|--------|
| `.devcontainer/Dockerfile` | `sandbox ALL=(ALL) ALL` (was `NOPASSWD:ALL`) — sudo requires the password |
| `.devcontainer/entrypoint.sh` | Set the password (login + sudo) via `chpasswd` at runtime as root from `${SANDBOX_PASSWORD:-test1234}` — env/`.env` override applies without a rebuild |
| `.devcontainer/docker-compose.yml` | Pass `SANDBOX_PASSWORD=${SANDBOX_PASSWORD:-test1234}` into the sandbox service env |
| `.oh/deploy/railway/Dockerfile` | `sandbox ALL=(ALL) ALL` + bake the password at build via `ARG SANDBOX_PASSWORD` (start.sh runs as `sandbox` and can no longer `sudo`) |
| `.oh/deploy/railway/start.sh` | Removed the now-broken runtime `sudo chpasswd`; password is baked at build |
| `.devcontainer/.example.env` | Document the login+sudo password, the agent-can't-sudo behavior, and the docker-socket caveat |
| `.oh/tasks/remote-sudo-password/prd.json` | The task spec |

## Security scope (honest)

- ✅ **Closes:** silent `sudo` escalation by non-interactive internal agents.
- ⚠️ **Does NOT close:** the `sandbox` user is in the `docker` group with `/var/run/docker.sock` mounted, so `docker run -v /:/host …` remains a root-escalation path. This PR gates `sudo` specifically; full root containment would also need to address Docker socket access (out of scope here).
- The `test1234` default is intentionally weak for local convenience — override it on any network-reachable deployment via the gitignored `.devcontainer/.env` (or a `--build-arg` for Railway).
- Docker still works for agents (via the `docker` group, not sudo), so removing `NOPASSWD` doesn't break tooling.

## Test plan

- [x] `bash -n` passes on `entrypoint.sh` and `start.sh`
- [x] No `NOPASSWD` grant remains (grep-verified; both sudoers files are `sandbox ALL=(ALL) ALL`)
- [ ] On a built devcontainer image: as `sandbox`, `sudo -n true` **fails** with "a password is required"; `echo "$SANDBOX_PASSWORD" | sudo -S -k true` **succeeds**; `docker ps` works without sudo
- [ ] On a built Railway image: `sudo -n true` fails; the baked password matches the build arg

🤖 Generated with [Claude Code](https://claude.com/claude-code)
