### PR TITLE
task: make README description representative of the actual harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,11 @@
   <img src=".github/assets/mifune-banner.jpg" alt="Open Harness" width="100%">
 </p>
 
-**Open Harness** is a Docker-based agent harness for **one project**, agent-tended over time. One `docker compose up` gives you a long-lived sandbox where Claude (or another agent of your choice) runs against a single repo, branch, and identity — not a multi-tenant comparison rig.
+**Open Harness provides the sandbox; you choose the harness.** It's a Docker-based workspace, agent-tended over time: clone-and-own the repo, set one `harness.yaml`, and `make sandbox` boots a long-lived container where the coding agent of your choice — Claude Code, Codex, Pi (Hermes, Grok, and more opt-in) — works on its own branch and identity. Because it's just Docker, it runs **identically on your laptop or a remote VM** — and remote is the default: deployed on a VM, Open Harness becomes a **lights-out software factory**, where the agent works unattended, on a schedule and reachable over Slack, fanning out across isolated **git worktrees** — parallel branches, delegated sub-agents, even other cloned repos — while you're away and your laptop stays clean.
 
 - **One project, one sandbox.** A single container scoped to a single repo. The agent owns its branch and its workspace; you keep your laptop clean.
+- **Parallel by design.** The worktrees skill fans one sandbox into isolated git worktrees — parallel branches, delegated sub-agents, even other cloned repos.
+- **Remote-first, lights-out.** Runs the same on your laptop or a cloud VM; on a VM it's an unattended software factory — agents build on a schedule, reachable over Slack.
 - **Agents that work while you sleep.** A tiny croner runtime reads `.oh/crons/*.md` markdown and wakes the agent on a schedule.
 - **Host dependencies: Docker, Git, and make.** No Node, no Python, no toolchain rot on your laptop. (`make` runs the `make sandbox` / `make shell` wrappers — see [Prerequisites](.oh/docs/installation.md#prerequisites).)
 - **Composable infra.** Cherry-pick Cloudflare tunnels, SSH, Caddy gateway, or pack-supplied services via Compose overlays.
@@ -201,6 +203,7 @@ make shell
 | **DevOps** | Docker CLI + Compose, GitHub CLI, cloudflared, tmux, croner |
 | **Browser** | agent-browser + Chromium (headless) |
 | **One project, one sandbox** | A single container scoped to a single repo and branch |
+| **Worktrees** | One sandbox → many isolated git worktrees: parallel branches, delegated sub-agents, satellite project clones under `.worktrees/` |
 | **Crons** | Markdown-defined schedules in `.oh/crons/*.md` driven by the in-container croner runtime |
 | **Multi-agent** | Claude, Codex, Pi by default (Hermes/Grok opt-in); Slack bridging via [pi-messenger-bridge](.oh/docs/integrations/slack.md) |
 


### PR DESCRIPTION
## What

Makes the README **description** representative of how Open Harness actually works. The old lead paragraph stopped at "one `docker compose up`" and capped the framing at one project / one codebase; this surfaces the real model.

## Changes (README.md only)

- **Lead paragraph** — leads with the positioning tagline ("provides the sandbox; you choose the harness"), walks the real flow (clone-and-own → `harness.yaml` → `make sandbox` → pick your agent), and frames **local/remote parity with remote-VM-by-default as a lights-out software factory** (unattended, on a schedule, reachable over Slack), fanning out across **git worktrees**.
- **Two feature bullets** — "Parallel by design" (worktrees) and "Remote-first, lights-out".
- **"What you get" table** — new **Worktrees** row.

## Why

The description under-represented two things the harness leans on: the **worktrees** fan-out (one sandbox → many parallel branches, delegated sub-agents, even other cloned repos) and the **remote-first / lights-out** deployment model. Both were essentially absent from the README before; now they lead the description and appear in the bullets + capability table.

## Scope

`README.md` only — no code, docs, or config touched. `harness.yaml` left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
