### PR TITLE
task: lightweight RFC/ADR index (#567)

### DIFF
--- a/.oh/docs/README.md
+++ b/.oh/docs/README.md
@@ -42,6 +42,7 @@ Open Harness vendors the shared skills/agents/hooks primitive pack directly into
 
 ## Reference
 
+- [RFC / ADR index](rfcs/README.md)
 - [Property testing](property-testing.md)
 - [Resources](resources.md)
 - [Roadmap](roadmap.md)

--- a/.oh/docs/rfcs/README.md
+++ b/.oh/docs/rfcs/README.md
@@ -1,0 +1,39 @@
+# RFC / ADR index
+
+A lightweight convention for proposing and recording notable changes to Open
+Harness. This is a **convention, not a standards organization** — there is no
+formal document-type taxonomy, no registries, and no conformance profiles. It
+formalizes the RFC-style issues the project already writes, nothing more.
+
+## Convention
+
+A proposal is a **GitHub issue** whose title starts with `RFC:` (a change we want
+to discuss and adopt) or `ADR:` (an architecture decision we want to record on the
+record). Discussion happens on the issue; its outcome is captured by the issue's
+state and the index below. Every proposal moves through the same minimal
+lifecycle:
+
+- **Draft** — open issue, under discussion.
+- **Accepted** — agreed, and being (or already) implemented.
+- **Superseded** — replaced by a later proposal (link to the replacement).
+
+That is the whole lifecycle — three states by design (kept to ≤4 deliberately).
+No stage gates, no editors, no numbering scheme beyond the GitHub issue number.
+
+## Index
+
+| Proposal | Status | Summary |
+|---|---|---|
+| [#531](https://github.com/mifunedev/openharness/issues/531) | Accepted | Portable `.oh/` control plane — `oh init` / `oh update`, the project-root seam, and the machinery-namespace relocation. |
+| [#525](https://github.com/mifunedev/openharness/issues/525) | Draft | Self-improving-harness roadmap epic. |
+| [#532](https://github.com/mifunedev/openharness/issues/532) | Draft | Standards process — the full RFC/ADR taxonomy, registries, and conformance profiles (deferred scope; see below). |
+
+## Deferred scope
+
+The full IETF-style standards body — the `OH-RFC` / `STD` / `BCP` / `EXP` / `INF`
+/ `ADR` document taxonomy, formal registries, an IANA-style allocation authority,
+conformance profiles, and a multi-stage lifecycle — is **out of scope for this
+index** and tracked in
+[#532](https://github.com/mifunedev/openharness/issues/532). This page stays
+deliberately proportionate to what the project already produces; reach for the
+heavier process only if #532 concludes we need it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Update policy and release automation live in [`/git`](.claude/skills/git/SKILL.m
 ## [Unreleased]
 
 ### Added
+- Add a lightweight RFC/ADR index and convention at [`.oh/docs/rfcs/README.md`](.oh/docs/rfcs/README.md), linked from the docs index: a proposal is a `RFC:`/`ADR:`-titled GitHub issue moving through a minimal Draft → Accepted → Superseded lifecycle, seeded with #531/#525/#532 as first entries. Framed as a convention, not a standards body; the full taxonomy/registries/conformance scope stays deferred to [#532](https://github.com/mifunedev/openharness/issues/532) ([#567](https://github.com/mifunedev/openharness/issues/567)).
 - Add an agent-browser X.com login snippet for dashboard-observed human login, persistent profiles, 2FA/CAPTCHA handling, Google OAuth fallback, and credential safety.
 - Add a Railway one-click hosted smoke deploy path from the README, with config-as-code, deploy assets, docs, and an eval drift guard ([#553](https://github.com/mifunedev/openharness/issues/553)).
 - **`OH_PROJECT_ROOT` project-root seam** (RFC #531 Phase 1) — single source of truth for the container workspace path (default `/home/sandbox/harness`); `HARNESS` is kept as a back-compat alias. `evals/probes/project-root-seam.sh` guards the seam contract against regression ([#531](https://github.com/mifunedev/openharness/issues/531)).


### PR DESCRIPTION
Closes #567. Part of the #532 docs-first Phase-1 slice (carved from the signal-vs-noise triage of epic #532).

## What
Adds `.oh/docs/rfcs/README.md` — a lightweight RFC/ADR index + convention (a proposal is a `RFC:`/`ADR:`-titled GitHub issue moving through a minimal Draft → Accepted → Superseded lifecycle), seeded with #531/#525/#532 as first entries and linked from the docs index. The full IETF-style standards body stays deferred to #532.

## How it was built
Advisor-monitored `ralph.sh` loop (tmux session `oh-rfc-adr-index`) in an isolated worktree — single story US-001, one iteration (commit e1d008d).

## Scope
Docs only: `.oh/docs/rfcs/README.md` (new), `.oh/docs/README.md` (+1 link), `CHANGELOG.md` (+1 entry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
