### PR TITLE
skill: add weakness-record (WH-xxx) cluster output to /prompt-miner (#580)

### DIFF
--- a/.oh/evals/probes/prompt-miner-weakness-record.sh
+++ b/.oh/evals/probes/prompt-miner-weakness-record.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# tier: A
+# source: issue #580 — prompt-miner weakness-record (WH-xxx) cluster output
+# desc: the prompt-miner engine must emit a metadata-only weaknesses[] array of
+#       WH-<NNN> harness-weakness records with all seven fields from the committed
+#       dual-schema (Claude + Pi) fixtures. Runs mine-traces.mjs --dry-run --no-git
+#       against the fixtures (no network, no git, no real data) and asserts >= 1 WH
+#       record whose first entry has all 7 non-empty fields (weakness_id matching
+#       /^WH-\d{3}$/, frequency matching /^\d+\/\d+$/) and carries NO promptText key.
+#       A regression that drops the array to empty, loses a field, or leaks prompt
+#       text flips REGRESSION.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+SKILL_DIR="$ROOT/.oh/skills/prompt-miner"
+ENGINE="$SKILL_DIR/scripts/mine-traces.mjs"
+FIXTURES="$SKILL_DIR/scripts/__tests__/fixtures"
+
+# --- SKIPPED: hard prerequisites genuinely absent --------------------------
+if [[ ! -d "$SKILL_DIR" ]]; then
+  echo "SKIPPED: prompt-miner skill dir absent: $SKILL_DIR" >&2
+  exit 2
+fi
+if [[ ! -f "$ENGINE" ]]; then
+  echo "SKIPPED: engine absent: $ENGINE" >&2
+  exit 2
+fi
+if [[ ! -d "$FIXTURES" ]]; then
+  echo "SKIPPED: fixtures dir absent: $FIXTURES" >&2
+  exit 2
+fi
+if ! command -v node >/dev/null 2>&1; then
+  echo "SKIPPED: node unavailable" >&2
+  exit 2
+fi
+
+# --- Run the engine hermetically (no git, no network, fixtures only) -------
+set +e
+out="$(node "$ENGINE" --dry-run --no-git --fixtures-dir "$FIXTURES" 2>/dev/null)"
+rc=$?
+set -e
+
+if [[ "$rc" -ne 0 || -z "$out" ]]; then
+  echo "REGRESSION: mine-traces.mjs --dry-run --no-git exited $rc with no parseable dataset" >&2
+  exit 1
+fi
+
+# --- Assert: >= 1 WH record with all 7 non-empty fields, no promptText ------
+# Parse the dry-run JSON with node (the dataset is printed to stdout).
+verdict="$(
+  printf '%s' "$out" | node -e '
+    let d = "";
+    process.stdin.on("data", c => d += c).on("end", () => {
+      try {
+        const j = JSON.parse(d);
+        const w = j.weaknesses;
+        if (!Array.isArray(w)) return void process.stdout.write("NO_WEAKNESSES_KEY");
+        if (w.length < 1) return void process.stdout.write("EMPTY");
+        // Privacy invariant: a weakness record NEVER carries prompt text, in any mode.
+        if (JSON.stringify(w).includes("promptText")) return void process.stdout.write("PROMPTTEXT_LEAK");
+        const REQUIRED = ["weakness_id","summary","frequency","affected_agents","likely_harness_layer","supporting_traces","recommended_repair_surface"];
+        const rec = w[0];
+        const isEmpty = (v) => v === undefined || v === null || v === "" || (Array.isArray(v) && v.length === 0);
+        const missing = REQUIRED.filter((k) => isEmpty(rec[k]));
+        if (missing.length) return void process.stdout.write("MISSING:" + missing.join(","));
+        if (!/^WH-\d{3}$/.test(rec.weakness_id)) return void process.stdout.write("BAD_ID:" + rec.weakness_id);
+        if (!/^\d+\/\d+$/.test(rec.frequency)) return void process.stdout.write("BAD_FREQ:" + rec.frequency);
+        process.stdout.write("OK " + w.length + " " + rec.weakness_id + " " + rec.frequency);
+      } catch (err) {
+        process.stdout.write("PARSE_FAIL");
+      }
+    });
+  '
+)" || true
+
+case "$verdict" in
+  OK\ *)
+    echo "PASS: prompt-miner weakness-record ($verdict; all 7 fields present, no promptText)" >&2
+    exit 0
+    ;;
+  PARSE_FAIL)
+    echo "REGRESSION: mine-traces.mjs --dry-run output was not valid JSON" >&2
+    exit 1
+    ;;
+  NO_WEAKNESSES_KEY)
+    echo "REGRESSION: dataset missing the additive weaknesses[] key" >&2
+    exit 1
+    ;;
+  EMPTY)
+    echo "REGRESSION: weaknesses[] is empty — no WH record clustered from fixtures (the tool_error signal should fire in 2/3)" >&2
+    exit 1
+    ;;
+  PROMPTTEXT_LEAK)
+    echo "REGRESSION: weakness record leaked a promptText key — privacy invariant broken" >&2
+    exit 1
+    ;;
+  MISSING:*)
+    echo "REGRESSION: WH record has missing/empty field(s): ${verdict#MISSING:}" >&2
+    exit 1
+    ;;
+  BAD_ID:*)
+    echo "REGRESSION: weakness_id not /^WH-\\d{3}\$/: ${verdict#BAD_ID:}" >&2
+    exit 1
+    ;;
+  BAD_FREQ:*)
+    echo "REGRESSION: frequency not n/total: ${verdict#BAD_FREQ:}" >&2
+    exit 1
+    ;;
+  *)
+    echo "REGRESSION: prompt-miner weakness-record probe: unexpected verdict '$verdict'" >&2
+    exit 1
+    ;;
+esac

--- a/.oh/skills/prompt-miner/SKILL.md
+++ b/.oh/skills/prompt-miner/SKILL.md
@@ -118,6 +118,10 @@ shape is documented in `references/report-schema.md`:
 - `sessions[]` — ranked (score desc), each with `score`, `scoreBreakdown`,
   `sessionType`, and a `features` vector (the 13 `markerFeatureKeys`).
 - `unranked[]` — `noHumanPrompt` / below-`minTurns` sessions (kept, not ranked).
+- `weaknesses[]` — metadata-only `WH-<NNN>` harness-weakness records clustering
+  repeated failure signals across the corpus; deterministic, and **never** carries
+  prompt text (`supporting_traces` = session-id metadata only). See
+  `references/report-schema.md`.
 
 Verify every score is reconstructable from its `scoreBreakdown` before trusting
 the ranking — the score is a **heuristic proxy**, not a verdict (see

--- a/.oh/skills/prompt-miner/references/report-schema.md
+++ b/.oh/skills/prompt-miner/references/report-schema.md
@@ -19,7 +19,8 @@ regardless; the flag documents that contract for the SKILL layer.
   "manifest": { ... },          // run metadata (below)
   "markerFeatureKeys": [ ... ], // the 13 feature keys (see markers.md)
   "sessions": [ ... ],          // ranked sessions (score desc), human-prompted, turns >= minTurns
-  "unranked": [ ... ]           // noHumanPrompt or below-minTurns sessions, same shape
+  "unranked": [ ... ],          // noHumanPrompt or below-minTurns sessions, same shape
+  "weaknesses": [ ... ]         // metadata-only WH-<NNN> harness-weakness records (below)
 }
 ```
 
@@ -73,6 +74,34 @@ regardless; the flag documents that contract for the SKILL layer.
   "promptText": "...redacted..."  // present only with --include-prompt-text
 }
 ```
+
+## `weaknesses[]`
+
+A deterministic, **metadata-only** clustering of repeated **harness-level** failure
+signals across the in-window corpus (both `sessions` and `unranked`). Each `WH-<NNN>`
+record has exactly seven fields and **never carries prompt text in any mode** — not
+even under `--include-prompt-text`; `supporting_traces` holds session-id metadata
+only. The array is purely additive — the four keys above are unchanged.
+
+```jsonc
+{
+  "weakness_id": "WH-001",                    // /^WH-\d{3}$/, stable across identical runs
+  "summary": "Repeated tool errors ...",      // fixed taxonomy phrase (no prompt text)
+  "frequency": "2/3",                         // n sessions matching / total in-window (/^\d+\/\d+$/)
+  "affected_agents": ["claude", "pi"],        // distinct harnesses, sorted
+  "likely_harness_layer": "terminal status",  // rfc-selfimprove item 4 vocab
+  "supporting_traces": [                       // session-id METADATA ONLY — never prompt text
+    { "sessionId": "...", "harness": "claude", "gitBranch": "feat/..." }
+  ],
+  "recommended_repair_surface": "verifier"     // rfc-selfimprove item 6 vocab
+}
+```
+
+Records are ordered by frequency desc, then a fixed taxonomy declaration order, so
+`WH-001` is stable across byte-identical inputs. A signal must recur across
+`>= WEAKNESS_MIN_FREQUENCY` (2) sessions to emit a record. Rendered into the markdown
+report as a `## Weakness records` table (metadata columns only — no `supporting_traces`
+prompt text). Guarded hermetically by `.oh/evals/probes/prompt-miner-weakness-record.sh`.
 
 ## See Also
 

--- a/.oh/skills/prompt-miner/scripts/__tests__/mine-traces.test.mjs
+++ b/.oh/skills/prompt-miner/scripts/__tests__/mine-traces.test.mjs
@@ -17,6 +17,7 @@ import {
   redact,
   validateWeights,
   resolveGroundTruth,
+  buildWeaknessRecords,
   DEFAULT_WEIGHTS,
   MARKER_FEATURE_KEYS,
 } from "../mine-traces.mjs";
@@ -324,4 +325,75 @@ test("CLI tolerates malformed lines without throwing", () => {
 
 test("CLI rejects an unknown flag with a non-zero exit", () => {
   assert.throws(() => execFileSync("node", [ENGINE, "--bogus"], { encoding: "utf8", stdio: "pipe" }));
+});
+
+// --- weakness records (WH-<NNN>): shape, determinism, privacy ---------------
+
+// Synthetic sessions: tool_error fires in 2 of 3 (>= WEAKNESS_MIN_FREQUENCY),
+// so exactly one WH-001 record is produced. Ordering is intentionally jumbled
+// (sessionId z before a, harness pi before claude) to exercise the sorts.
+const SYNTH_SESSIONS = [
+  { sessionId: "z-sess", harness: "pi", gitBranch: "feat/z", toolErrors: 1, incomplete: 0, abandoned: 0, scoreBreakdown: { signals: { correctionDensity: 0 } } },
+  { sessionId: "a-sess", harness: "claude", gitBranch: "feat/a", toolErrors: 2, incomplete: 0, abandoned: 0, scoreBreakdown: { signals: { correctionDensity: 0 } } },
+  { sessionId: "m-sess", harness: "claude", gitBranch: "feat/m", toolErrors: 0, incomplete: 0, abandoned: 0, scoreBreakdown: { signals: { correctionDensity: 0 } } },
+];
+
+test("buildWeaknessRecords returns exactly the 7 metadata fields, all non-empty, no promptText", () => {
+  const records = buildWeaknessRecords(SYNTH_SESSIONS);
+  assert.ok(records.length >= 1, "at least one WH record");
+  const rec = records[0];
+  assert.deepEqual(Object.keys(rec).sort(), [
+    "affected_agents",
+    "frequency",
+    "likely_harness_layer",
+    "recommended_repair_surface",
+    "summary",
+    "supporting_traces",
+    "weakness_id",
+  ]);
+  assert.match(rec.weakness_id, /^WH-\d{3}$/);
+  assert.match(rec.frequency, /^\d+\/\d+$/);
+  assert.ok(typeof rec.summary === "string" && rec.summary.length > 0);
+  assert.ok(typeof rec.likely_harness_layer === "string" && rec.likely_harness_layer.length > 0);
+  assert.ok(typeof rec.recommended_repair_surface === "string" && rec.recommended_repair_surface.length > 0);
+  assert.ok(Array.isArray(rec.affected_agents) && rec.affected_agents.length > 0);
+  assert.ok(Array.isArray(rec.supporting_traces) && rec.supporting_traces.length > 0);
+  // Privacy: no promptText key on the record OR on any supporting trace; traces
+  // are session-id metadata only.
+  assert.equal("promptText" in rec, false);
+  for (const t of rec.supporting_traces) {
+    assert.equal("promptText" in t, false);
+    assert.deepEqual(Object.keys(t).sort(), ["gitBranch", "harness", "sessionId"]);
+  }
+});
+
+test("buildWeaknessRecords is byte-identical across two calls and stable under input reordering", () => {
+  const a = JSON.stringify(buildWeaknessRecords(SYNTH_SESSIONS));
+  const b = JSON.stringify(buildWeaknessRecords(SYNTH_SESSIONS));
+  assert.equal(a, b, "two calls on the same input are byte-identical");
+  // WH-001 must not flip when the same sessions arrive in a different order.
+  const shuffled = [SYNTH_SESSIONS[2], SYNTH_SESSIONS[0], SYNTH_SESSIONS[1]];
+  assert.equal(JSON.stringify(buildWeaknessRecords(shuffled)), a, "stable under reorder");
+});
+
+test("weakness records serialize no raw human-prompt substring from the fixtures", () => {
+  const out = execFileSync(
+    "node",
+    [ENGINE, "--dry-run", "--no-git", "--harness", "all", "--fixtures-dir", FIXTURES, "--now", "2026-06-19T00:00:00.000Z"],
+    { encoding: "utf8" },
+  );
+  const data = JSON.parse(out);
+  assert.ok(Array.isArray(data.weaknesses) && data.weaknesses.length >= 1, ">= 1 WH record");
+  const serialized = JSON.stringify(data.weaknesses);
+  // Distinctive human-prompt substrings that live verbatim in the fixture .jsonl.
+  const humanPromptSubstrings = [
+    "Implement the foo widget",
+    "Add the bar feature",
+    "No, that's wrong",
+    "Create the baz module",
+  ];
+  for (const needle of humanPromptSubstrings) {
+    assert.ok(!serialized.includes(needle), `weakness records leaked prompt text: ${needle}`);
+  }
+  for (const w of data.weaknesses) assert.equal("promptText" in w, false);
 });

--- a/.oh/skills/prompt-miner/scripts/mine-traces.mjs
+++ b/.oh/skills/prompt-miner/scripts/mine-traces.mjs
@@ -487,6 +487,109 @@ export function detectSessionType(text) {
 }
 
 // ---------------------------------------------------------------------------
+// Weakness records (pure) — cluster repeated harness-level failure signals into
+// metadata-only WH-<NNN> records. A weakness record NEVER carries prompt text in
+// ANY mode (not even --include-prompt-text); supporting_traces holds session-id
+// metadata only. See references/report-schema.md and rfc-selfimprove-roadmap.md
+// items 4 + 6 (the likely_harness_layer / recommended_repair_surface vocab).
+// ---------------------------------------------------------------------------
+
+// A single occurrence is not a pattern: a signal must recur in at least this many
+// sessions before it earns a weakness record.
+export const WEAKNESS_MIN_FREQUENCY = 2;
+
+// Fixed failure-signal taxonomy. Declaration order is the deterministic tiebreak
+// when two clusters share a frequency, so WH-001 never flips across identical
+// runs. `likely_harness_layer` and `recommended_repair_surface` use the exact
+// RFC item 4 + 6 enum terms (harness layer: artifact contract | audit gate |
+// handoff | terminal status; repair surface: skill rule | probe | verifier).
+const WEAKNESS_SIGNALS = Object.freeze([
+  {
+    key: "tool_error",
+    match: (s) => Number(s?.toolErrors) > 0,
+    summary: "Recurring tool-call errors surfaced during execution",
+    likely_harness_layer: "terminal status",
+    recommended_repair_surface: "verifier",
+  },
+  {
+    key: "correction_churn",
+    match: (s) => Number(s?.scoreBreakdown?.signals?.correctionDensity) > 0,
+    summary: "Repeated user corrections point to an unclear task handoff",
+    likely_harness_layer: "handoff",
+    recommended_repair_surface: "skill rule",
+  },
+  {
+    key: "abandoned",
+    match: (s) => Number(s?.abandoned) > 0,
+    summary: "Sessions abandoned before a clean terminal status",
+    likely_harness_layer: "terminal status",
+    recommended_repair_surface: "probe",
+  },
+  {
+    key: "incomplete",
+    match: (s) => Number(s?.incomplete) > 0,
+    summary: "Sessions ended without a clean terminal status",
+    likely_harness_layer: "terminal status",
+    recommended_repair_surface: "probe",
+  },
+]);
+
+// buildWeaknessRecords clusters sessions by the fixed failure-signal taxonomy and
+// emits one metadata-only WH-<NNN> record per signal met by >= minFrequency
+// sessions. Pure + deterministic: clusters sort by frequency desc then taxonomy
+// order, so WH-001 is stable across byte-identical inputs.
+export function buildWeaknessRecords(sessions, opts = {}) {
+  const list = Array.isArray(sessions) ? sessions : [];
+  const total = list.length;
+  const minFrequency = Number.isInteger(opts.minFrequency)
+    ? opts.minFrequency
+    : WEAKNESS_MIN_FREQUENCY;
+
+  const clusters = [];
+  for (let order = 0; order < WEAKNESS_SIGNALS.length; order += 1) {
+    const signal = WEAKNESS_SIGNALS[order];
+    const matched = list.filter((s) => signal.match(s));
+    if (matched.length < minFrequency) continue;
+
+    // affected agents: distinct harness values, sorted (deterministic).
+    const affected_agents = [...new Set(matched.map((s) => s?.harness).filter(Boolean))].sort();
+
+    // supporting traces: session-id METADATA ONLY — never prompt text, in any mode.
+    const supporting_traces = matched
+      .map((s) => ({
+        sessionId: s?.sessionId ?? null,
+        harness: s?.harness ?? null,
+        gitBranch: s?.gitBranch ?? null,
+      }))
+      .sort((a, b) => String(a.sessionId).localeCompare(String(b.sessionId)));
+
+    clusters.push({
+      order,
+      count: matched.length,
+      summary: signal.summary,
+      frequency: `${matched.length}/${total}`,
+      affected_agents,
+      likely_harness_layer: signal.likely_harness_layer,
+      supporting_traces,
+      recommended_repair_surface: signal.recommended_repair_surface,
+    });
+  }
+
+  // Deterministic ordering: frequency desc, then taxonomy declaration order asc.
+  clusters.sort((a, b) => b.count - a.count || a.order - b.order);
+
+  return clusters.map((c, i) => ({
+    weakness_id: `WH-${String(i + 1).padStart(3, "0")}`,
+    summary: c.summary,
+    frequency: c.frequency,
+    affected_agents: c.affected_agents,
+    likely_harness_layer: c.likely_harness_layer,
+    supporting_traces: c.supporting_traces,
+    recommended_repair_surface: c.recommended_repair_surface,
+  }));
+}
+
+// ---------------------------------------------------------------------------
 // Redaction (pure)
 // ---------------------------------------------------------------------------
 
@@ -894,6 +997,10 @@ async function run(args) {
   const rankable = sessions.filter((s) => !s.noHumanPrompt && s.turns >= args.minTurns);
   rankable.sort((a, b) => b.score - a.score || String(a.sessionId).localeCompare(String(b.sessionId)));
 
+  // Weakness records cluster harness-level failure signals across ALL in-window
+  // sessions (ranked + unranked) — metadata only, never prompt text.
+  const weaknesses = buildWeaknessRecords(sessions);
+
   const manifest = {
     generatedAt,
     harnessFilter: args.harness,
@@ -917,6 +1024,7 @@ async function run(args) {
     markerFeatureKeys: MARKER_FEATURE_KEYS,
     sessions: rankable,
     unranked: sessions.filter((s) => s.noHumanPrompt || s.turns < args.minTurns),
+    weaknesses,
   };
 
   return { dataset, manifest, rankable, utcDate };

--- a/.oh/skills/prompt-miner/scripts/mine-traces.mjs
+++ b/.oh/skills/prompt-miner/scripts/mine-traces.mjs
@@ -1035,7 +1035,7 @@ async function run(args) {
 // ---------------------------------------------------------------------------
 
 function renderMarkdown(dataset, top) {
-  const { manifest, sessions } = dataset;
+  const { manifest, sessions, weaknesses = [] } = dataset;
   const lines = [];
   lines.push(`# prompt-miner report — ${manifest.generatedAt.slice(0, 10)}`);
   lines.push("");
@@ -1066,6 +1066,23 @@ function renderMarkdown(dataset, top) {
   lines.push(sep);
   for (const s of sessions.slice(-top).reverse()) lines.push(fmtRow(s));
   lines.push("");
+  // Weakness records: metadata-only WH-<NNN> clusters. No prompt text is
+  // rendered — only the fixed taxonomy summary + session-id counts.
+  lines.push("## Weakness records");
+  lines.push("");
+  if (!weaknesses.length) {
+    lines.push("_None — no failure signal recurred across enough sessions._");
+    lines.push("");
+  } else {
+    lines.push("| id | frequency | affected agents | likely harness layer | recommended repair surface | summary |");
+    lines.push("|---|---|---|---|---|---|");
+    for (const w of weaknesses) {
+      lines.push(
+        `| ${w.weakness_id} | ${w.frequency} | ${w.affected_agents.join(", ")} | ${w.likely_harness_layer} | ${w.recommended_repair_surface} | ${w.summary} |`,
+      );
+    }
+    lines.push("");
+  }
   return `${lines.join("\n")}\n`;
 }
 


### PR DESCRIPTION
Closes #580. Child of epic #525.

Extends the shipped, deterministic `/prompt-miner` engine (`mine-traces.mjs`) with a metadata-only `weaknesses[]` array of `WH-<NNN>` records — clustering repeated harness-level failure signals across sessions. Additive output-format change on proven machinery; no new scoring, capture, or LLM step.

## What shipped
- `buildWeaknessRecords(sessions, opts)` — pure, exported, deterministic (frequency-desc + stable taxonomy-order tiebreak, so `WH-001` never flips). Emits the 7 required fields: `weakness_id`, `summary`, `frequency` (n/total), `affected_agents`, `likely_harness_layer`, `supporting_traces`, `recommended_repair_surface` — using the `rfc-selfimprove-roadmap.md` (items 4+6) enum vocabulary.
- `weaknesses` wired into the dataset as a 5th top-level key (additive — `manifest/markerFeatureKeys/sessions/unranked` intact).
- `## Weakness records` section in the markdown report (metadata-only table).
- 3 new `node:test` cases (7-field shape, byte-identical determinism, no fixture prompt-text leak).
- New hermetic probe `.oh/evals/probes/prompt-miner-weakness-record.sh` (tier A, `--fixtures-dir`, no git/network).

## Privacy invariant
Weakness records carry **no** prompt text in any mode (not even `--include-prompt-text`); `supporting_traces` is session-id metadata only. No `MEMORY.md`/`IDENTITY.md` write path added.

## Verification (re-run by orchestrator)
- `node:test` suite: **19/19 pass**.
- `bash .oh/evals/probes/prompt-miner-weakness-record.sh` → exit 0 (WH-001, 2/3, all 7 fields).
- `bash .oh/evals/probes/prompt-miner-schema-compat.sh` → exit 0 (existing behavior intact).
- No `Math.random`/`Date.now`; two dry-runs byte-identical.

---
Built via an Advisor-briefed `ralph.sh` loop in an isolated worktree (`skill/580-prompt-miner-weakness-record`). The `.oh/tasks/` scaffolding is gitignored and not part of this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
