### PR TITLE
fix: installer refuses to clobber a running sandbox + prompts optional installs

### DIFF
--- a/.oh/scripts/__tests__/install-prereqs.test.ts
+++ b/.oh/scripts/__tests__/install-prereqs.test.ts
@@ -45,14 +45,14 @@ describe("installer host prerequisite docs", () => {
     expect(install).toContain("make not found");
   });
 
-  it("refuses to overwrite a sandbox already running under the same name", () => {
+  it("refuses to overwrite a sandbox that already exists under the same name", () => {
     const install = readRepoFile(".oh", "scripts", "install.sh");
 
-    // Checks running containers by name before bringing the sandbox up...
-    expect(install).toContain("docker ps --format");
+    // Checks existing containers (running OR stopped) by name before up...
+    expect(install).toContain("docker ps -a --format");
     // ...and hard-errors (die) rather than silently recreating it,
     expect(install).toContain('die "A sandbox named');
-    expect(install).toContain("already running");
+    expect(install).toContain("already exists");
     // with an explicit opt-in to replace in place.
     expect(install).toContain("OH_REPLACE");
   });

--- a/.oh/scripts/__tests__/install-prereqs.test.ts
+++ b/.oh/scripts/__tests__/install-prereqs.test.ts
@@ -44,4 +44,26 @@ describe("installer host prerequisite docs", () => {
     // ...and warns rather than dies when it's absent.
     expect(install).toContain("make not found");
   });
+
+  it("refuses to overwrite a sandbox already running under the same name", () => {
+    const install = readRepoFile(".oh", "scripts", "install.sh");
+
+    // Checks running containers by name before bringing the sandbox up...
+    expect(install).toContain("docker ps --format");
+    // ...and hard-errors (die) rather than silently recreating it,
+    expect(install).toContain('die "A sandbox named');
+    expect(install).toContain("already running");
+    // with an explicit opt-in to replace in place.
+    expect(install).toContain("OH_REPLACE");
+  });
+
+  it("offers optional agent installs (Hermes etc.) as INSTALL_* toggles", () => {
+    const install = readRepoFile(".oh", "scripts", "install.sh");
+
+    expect(install).toContain("_opt_install HERMES");
+    expect(install).toContain("_opt_install AGENT_BROWSER");
+    // interactive prompt that writes the toggle the compose build args read
+    expect(install).toContain('prompt_yn "Install ');
+    expect(install).toContain("INSTALL_");
+  });
 });

--- a/.oh/scripts/install.sh
+++ b/.oh/scripts/install.sh
@@ -137,6 +137,12 @@ Env vars:
   SANDBOX_NAME         Skip the "Container name" prompt
   OH_GITHUB_REPO       GitHub repo to clone (default: mifunedev/openharness)
   OH_GITHUB_REF        Git ref to clone (alias: OH_INSTALL_REF)
+  OH_REPLACE           Set to 1 to rebuild in place even when a sandbox of the
+                       same name is already running (default: refuse, so a live
+                       sandbox is never overwritten)
+  INSTALL_HERMES=true  Enable an optional agent non-interactively. Also:
+                       INSTALL_OPENCODE, INSTALL_DEEPAGENTS, INSTALL_GROK_BUILD,
+                       INSTALL_AGENT_BROWSER
 
 Examples:
   curl -fsSL https://oh.mifune.dev/install.sh | bash
@@ -352,6 +358,16 @@ DEFAULT_NAME=$(basename "$REPO_DIR"); DEFAULT_NAME="${DEFAULT_NAME#.}"
 prompt_input SANDBOX_NAME "Container name" "$DEFAULT_NAME"
 ok "Name: $SANDBOX_NAME"
 
+# ─── Guard: don't clobber a sandbox already running under this name ──────
+# The compose service uses container_name=$SANDBOX_NAME and image
+# sandbox-$SANDBOX_NAME (.devcontainer/docker-compose.yml), so bringing the
+# sandbox up while a container of the same name is already running would
+# recreate it and kill that live session. Names must be unique — refuse unless
+# the operator explicitly opts into replacing it with OH_REPLACE=1.
+if [ "${OH_REPLACE:-}" != "1" ] && docker ps --format '{{.Names}}' 2>/dev/null | grep -Fxq "$SANDBOX_NAME"; then
+  die "A sandbox named '$SANDBOX_NAME' is already running — refusing to overwrite it. Choose a unique name (re-run with SANDBOX_NAME=<name>), or pass OH_REPLACE=1 to rebuild this one in place."
+fi
+
 mkdir -p "$REPO_DIR/.devcontainer"
 
 if [ -f "$REPO_DIR/.devcontainer/.env" ]; then
@@ -446,6 +462,34 @@ ENVEOF
       unset __GH_TOKEN_RAW
     fi
   fi
+
+  # ─── Optional installs (extra agents/features — OFF by default) ──────
+  # Each maps to an INSTALL_* build arg/env in .devcontainer/docker-compose.yml.
+  # Enabling one rebuilds the image with that CLI; agent_browser also pulls
+  # ~1 GB of Chromium. A pre-set INSTALL_* env var is honored (non-interactive
+  # installs); otherwise we prompt — but only with a TTY, and --yes/--no keep
+  # the lean default (nothing extra) rather than auto-enabling everything.
+  banner "Optional installs (off by default)"
+  _opt_install() {   # $1 = INSTALL_ suffix, $2 = human label
+    local __k="INSTALL_$1"
+    if [ "${!__k:-}" = "true" ]; then
+      printf '%s=true\n' "$__k" >> "$REPO_DIR/.devcontainer/.env"
+      ok "$__k=true (from environment)"
+      return 0
+    fi
+    if [ "$ASSUME_YES" = true ] || [ "$ASSUME_NO" = true ] || [ ! -r /dev/tty ]; then
+      return 0
+    fi
+    if prompt_yn "Install $2?" n; then
+      printf '%s=true\n' "$__k" >> "$REPO_DIR/.devcontainer/.env"
+      ok "$__k=true"
+    fi
+  }
+  _opt_install HERMES        "Hermes — Nous self-improving agent CLI"
+  _opt_install OPENCODE      "OpenCode — OpenAI-OAuth terminal agent"
+  _opt_install DEEPAGENTS    "DeepAgents — LangChain multi-provider agent"
+  _opt_install GROK_BUILD    "Grok Build — xAI terminal agent"
+  _opt_install AGENT_BROWSER "agent-browser + Chromium (~1 GB)"
 fi
 
 # ─── 5. Bring up the sandbox ─────────────────────────────────────────

--- a/.oh/scripts/install.sh
+++ b/.oh/scripts/install.sh
@@ -358,14 +358,18 @@ DEFAULT_NAME=$(basename "$REPO_DIR"); DEFAULT_NAME="${DEFAULT_NAME#.}"
 prompt_input SANDBOX_NAME "Container name" "$DEFAULT_NAME"
 ok "Name: $SANDBOX_NAME"
 
-# ─── Guard: don't clobber a sandbox already running under this name ──────
+# ─── Guard: don't clobber a sandbox that already exists under this name ──
 # The compose service uses container_name=$SANDBOX_NAME and image
-# sandbox-$SANDBOX_NAME (.devcontainer/docker-compose.yml), so bringing the
-# sandbox up while a container of the same name is already running would
-# recreate it and kill that live session. Names must be unique — refuse unless
-# the operator explicitly opts into replacing it with OH_REPLACE=1.
-if [ "${OH_REPLACE:-}" != "1" ] && docker ps --format '{{.Names}}' 2>/dev/null | grep -Fxq "$SANDBOX_NAME"; then
-  die "A sandbox named '$SANDBOX_NAME' is already running — refusing to overwrite it. Choose a unique name (re-run with SANDBOX_NAME=<name>), or pass OH_REPLACE=1 to rebuild this one in place."
+# sandbox-$SANDBOX_NAME (.devcontainer/docker-compose.yml). Bringing the
+# sandbox up while a container of the same name exists — running OR stopped —
+# would recreate it and can lose its bind-mounted .devcontainer/.env and
+# .hermes state. Names must be unique; refuse unless the operator explicitly
+# opts into replacing it with OH_REPLACE=1. `docker ps -a` covers stopped
+# containers too, so an idle prior install isn't silently overwritten. (A
+# leftover clone with NO container is safe: its .env/.hermes are reused, not
+# lost, so we don't block on the directory alone.)
+if [ "${OH_REPLACE:-}" != "1" ] && docker ps -a --format '{{.Names}}' 2>/dev/null | grep -Fxq "$SANDBOX_NAME"; then
+  die "A sandbox named '$SANDBOX_NAME' already exists (a container with that name is present — running or stopped) — refusing to overwrite it and risk losing its .devcontainer/.env or .hermes state. Choose a unique name (re-run with SANDBOX_NAME=<name>), or pass OH_REPLACE=1 to rebuild this one in place."
 fi
 
 mkdir -p "$REPO_DIR/.devcontainer"


### PR DESCRIPTION
## Context

Real install feedback surfaced problems with `.oh/scripts/install.sh`:
- A fresh `curl … | bash` **overwrote a running `openharness` sandbox**, losing its `.devcontainer/.env` and Hermes (`.hermes`) state.
- There was **no prompt to enable Hermes** (or the other optional agents) during install.

## Changes

**1. Refuse to clobber an existing same-name sandbox**
- Before `docker compose up`, checks `docker ps -a` for a container named `$SANDBOX_NAME` — **running OR stopped** (compose sets `container_name`/`image` from it).
- If found → `die`: pick a unique name (`SANDBOX_NAME=…`) or pass `OH_REPLACE=1` to rebuild in place.
- Runs **before any build/up**, so the existing container and its bind-mounted `.env`/`.hermes` stay untouched. (A leftover clone with *no* container is safe — its state is reused, not lost — so we don't block on the directory alone.)

**2. Optional-install prompts**
- Interactively offer Hermes / OpenCode / DeepAgents / Grok Build / agent-browser, all **off by default**, writing `INSTALL_*=true` into `.devcontainer/.env` (the compose build args).
- Pre-set `INSTALL_*` env vars are honored (non-interactive); `--yes`/`--no` keep the lean default (no surprise ~1 GB Chromium).

`--help` documents `OH_REPLACE` and the `INSTALL_*` toggles.

### Why not just volume-mount `.hermes` / `.env`?
- **`.hermes`** intentionally stays project-local, **not** a named volume: the home-scoped-volume design was reverted because hermes' atomic auth writes (`write-temp-then-os.replace`) fail with `EXDEV` across the volume boundary (`.devcontainer/entrypoint.sh:144-150`).
- **`.env`** can't be a volume: compose reads it as the `--env-file` *before* any container/volume exists, and `.devcontainer/` holds tracked build files a volume would shadow.
- So the correct protection is a **non-destructive installer** (this PR), not new volumes.

## QA — how to test (against this branch)

```bash
RAW=https://raw.githubusercontent.com/mifunedev/openharness/refs/heads/feat/install-qa-guards/.oh/scripts/install.sh

curl -fsSL "$RAW" | bash -s -- --help          # shows OH_REPLACE + INSTALL_* vars

# collision guard — with a sandbox named "openharness" present (running OR stopped):
curl -fsSL "$RAW" | bash                        # → "already exists — refusing to overwrite"; untouched
curl -fsSL "$RAW" | OH_REPLACE=1 bash           # → rebuild in place
curl -fsSL "$RAW" | SANDBOX_NAME=myharness bash # → unique-name path

curl -fsSL "$RAW" | INSTALL_HERMES=true bash    # → Hermes enabled non-interactively
```

## Verification
- `bash -n` clean; `install.sh --help` renders the new vars.
- `vitest` install-prereqs + compose-args: **17/17 pass** (2 new).
- `/eval` probes `oh-shipped-repo-overridable` + `curl-bash-safe-alternatives`: PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
