### PR TITLE
FROM development TO main

### DIFF
--- a/.devcontainer/docker-compose.docker-sock.yml
+++ b/.devcontainer/docker-compose.docker-sock.yml
@@ -1,0 +1,16 @@
+# Docker-socket overlay (opt-in — see .oh/docs/security-considerations.md).
+#
+# Applied by .oh/scripts/docker-compose.sh only when DOCKER_SOCKET is truthy
+# (harness.yaml `sandbox.docker_socket` or .devcontainer/.env DOCKER_SOCKET).
+# Mounting the host Docker socket gives the sandboxed agent effectively host
+# root (it can start a privileged container that mounts the host filesystem),
+# so enable this ONLY when the agent must drive Docker. entrypoint.sh guards on
+# the socket's presence, so the sandbox boots fine whether or not this is applied.
+#
+# The VS Code "Reopen in Container" path reads docker-compose.yml directly and
+# bypasses the wrapper, so it never applies this overlay; add this file to
+# devcontainer.json's dockerComposeFile list to enable the socket there.
+services:
+  sandbox:
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -12,6 +12,14 @@
 # Downstream harness packs and Pi extensions can register additional
 # overlays by appending paths to composeOverrides[] in config.json;
 # `make sandbox` and `.oh/scripts/install.sh` pick those up via jq.
+#
+# The host Docker socket is NOT mounted here by default (socket access is
+# effectively host root). It is an opt-in overlay — docker-compose.docker-sock.yml
+# — applied by .oh/scripts/docker-compose.sh only when DOCKER_SOCKET is truthy
+# (harness.yaml `sandbox.docker_socket` or .devcontainer/.env). The VS Code
+# "Reopen in Container" path reads THIS file directly and bypasses that wrapper,
+# so it never gets the socket; add the overlay to devcontainer.json to enable it
+# there. See .oh/docs/security-considerations.md.
 
 name: ${SANDBOX_NAME:-openharness}
 
@@ -30,7 +38,6 @@ services:
         INSTALL_HERMES: ${INSTALL_HERMES:-false}
     volumes:
       - ..:${OH_PROJECT_ROOT:-/home/sandbox/harness}
-      - /var/run/docker.sock:/var/run/docker.sock
       - claude-auth:/home/sandbox/.claude
       - codex-auth:/home/sandbox/.codex
       - pi-auth:/home/sandbox/.pi

--- a/.oh/cli/src/__tests__/lifecycle.test.ts
+++ b/.oh/cli/src/__tests__/lifecycle.test.ts
@@ -102,14 +102,14 @@ function captureStdout(fn: () => void): string {
 // ---------------------------------------------------------------------------
 
 describe("runSandbox", () => {
-  it("delegates the EXACT vendored argv with inherited stdio and returns the child's exit code", () => {
+  it("delegates the EXACT vendored argv with inherited stdio and returns the child's exit code", async () => {
     const root = makeRepo();
     const script = addScript(root, "docker-compose.sh");
     writeFileSync(join(root, "harness.yaml"), "sandbox:\n  name: x\n");
     const { calls, run } = makeRunner([{ status: 0 }]);
     const { out, io } = makeIo();
 
-    expect(runSandbox({ cwd: root, run }, io)).toBe(0);
+    expect(await runSandbox({ cwd: root, run }, io)).toBe(0);
     expect(calls).toEqual([
       {
         cmd: "bash",
@@ -118,79 +118,163 @@ describe("runSandbox", () => {
       },
     ]);
     // harness.yaml already existed → no seed, no operation-log line.
+    // No io.ask injected + non-TTY → the Docker-socket prompt never fires.
     expect(out).toEqual([]);
   });
 
-  it("propagates a non-zero exit code from docker-compose.sh", () => {
+  it("propagates a non-zero exit code from docker-compose.sh", async () => {
     const root = makeRepo();
     addScript(root, "docker-compose.sh");
     const { run } = makeRunner([{ status: 17 }]);
-    expect(runSandbox({ cwd: root, run }, makeIo().io)).toBe(17);
+    expect(await runSandbox({ cwd: root, run }, makeIo().io)).toBe(17);
   });
 
-  it("seeds harness.yaml from harness.yaml.example with exactly one operation-log line", () => {
+  it("seeds harness.yaml from harness.yaml.example with exactly one operation-log line", async () => {
     const root = makeRepo();
     addScript(root, "docker-compose.sh");
     writeFileSync(join(root, "harness.yaml.example"), "sandbox:\n  name: seeded\n");
     const { run } = makeRunner();
     const { out, io } = makeIo();
 
-    expect(runSandbox({ cwd: root, run }, io)).toBe(0);
+    expect(await runSandbox({ cwd: root, run }, io)).toBe(0);
     expect(readFileSync(join(root, "harness.yaml"), "utf8")).toBe("sandbox:\n  name: seeded\n");
     expect(out).toEqual(["create harness.yaml (from harness.yaml.example)\n"]);
   });
 
-  it("seed is a no-op when harness.yaml already exists (never overwritten, no log line)", () => {
+  it("seed is a no-op when harness.yaml already exists (never overwritten, no log line)", async () => {
     const root = makeRepo();
     addScript(root, "docker-compose.sh");
     writeFileSync(join(root, "harness.yaml"), "sandbox:\n  name: mine\n");
     writeFileSync(join(root, "harness.yaml.example"), "sandbox:\n  name: template\n");
     const { out, io } = makeIo();
 
-    expect(runSandbox({ cwd: root, run: makeRunner().run }, io)).toBe(0);
+    expect(await runSandbox({ cwd: root, run: makeRunner().run }, io)).toBe(0);
     expect(readFileSync(join(root, "harness.yaml"), "utf8")).toBe("sandbox:\n  name: mine\n");
     expect(out).toEqual([]);
   });
 
-  it("seed is a no-op when no harness.yaml.example exists (oh init-equipped repos)", () => {
+  it("seed is a no-op when no harness.yaml.example exists (oh init-equipped repos)", async () => {
     const root = makeRepo();
     addScript(root, "docker-compose.sh");
     const { calls, run } = makeRunner();
     const { out, io } = makeIo();
 
-    expect(runSandbox({ cwd: root, run }, io)).toBe(0);
+    expect(await runSandbox({ cwd: root, run }, io)).toBe(0);
     expect(existsSync(join(root, "harness.yaml"))).toBe(false);
     expect(out).toEqual([]);
     expect(calls).toHaveLength(1); // compose still runs
   });
 
-  it("errors naming the missing docker-compose.sh path (no oh: prefix) without spawning", () => {
+  it("errors naming the missing docker-compose.sh path (no oh: prefix) without spawning", async () => {
     const root = makeRepo(); // .oh/scripts exists but the script does not
     const { calls, run } = makeRunner();
     const expected = join(root, ".oh", "scripts", "docker-compose.sh");
 
-    expect(() => runSandbox({ cwd: root, run }, makeIo().io)).toThrow(expected);
-    expect(() => runSandbox({ cwd: root, run }, makeIo().io)).not.toThrow(/oh:/);
+    // Now async → a thrown error surfaces as a rejected promise, not a sync throw.
+    await expect(runSandbox({ cwd: root, run }, makeIo().io)).rejects.toThrow(expected);
+    await expect(runSandbox({ cwd: root, run }, makeIo().io)).rejects.not.toThrow(/oh:/);
     expect(calls).toEqual([]);
   });
 
-  it("resolves the project root from a nested cwd", () => {
+  it("resolves the project root from a nested cwd", async () => {
     const root = makeRepo();
     const script = addScript(root, "docker-compose.sh");
     const nested = join(root, "src", "app", "deep");
     mkdirSync(nested, { recursive: true });
     const { calls, run } = makeRunner();
 
-    expect(runSandbox({ cwd: nested, run }, makeIo().io)).toBe(0);
+    expect(await runSandbox({ cwd: nested, run }, makeIo().io)).toBe(0);
     expect(calls[0].args).toEqual([script, "--repo-dir", root, "up", "-d", "--build"]);
   });
 
-  it("errors when not inside an equipped repo", () => {
+  it("errors when not inside an equipped repo", async () => {
     const bare = mkdtempSync(join(tmpdir(), "oh-lifecycle-bare-"));
     cleanups.push(bare);
-    expect(() => runSandbox({ cwd: bare, run: makeRunner().run }, makeIo().io)).toThrow(
+    await expect(runSandbox({ cwd: bare, run: makeRunner().run }, makeIo().io)).rejects.toThrow(
       "not an OpenHarness-equipped repo — run `oh init` first",
     );
+  });
+
+  // ── Docker-socket opt-in (default OFF; prompt only when interactive) ──────
+  it("prompts and writes DOCKER_SOCKET=true to .devcontainer/.env on yes", async () => {
+    const root = makeRepo();
+    addScript(root, "docker-compose.sh");
+    mkdirSync(join(root, ".devcontainer"), { recursive: true });
+    const { run } = makeRunner();
+    const asked: string[] = [];
+    const io: LifecycleIO = {
+      stdout: () => {},
+      stderr: () => {},
+      ask: async (q) => {
+        asked.push(q);
+        return "y";
+      },
+    };
+
+    expect(await runSandbox({ cwd: root, run }, io)).toBe(0);
+    expect(asked).toHaveLength(1);
+    expect(readFileSync(join(root, ".devcontainer", ".env"), "utf8")).toContain("DOCKER_SOCKET=true");
+  });
+
+  it("records DOCKER_SOCKET=false on no (sticks the choice; no re-prompt later)", async () => {
+    const root = makeRepo();
+    addScript(root, "docker-compose.sh");
+    mkdirSync(join(root, ".devcontainer"), { recursive: true });
+    const { run } = makeRunner();
+    const io: LifecycleIO = { stdout: () => {}, stderr: () => {}, ask: async () => "n" };
+
+    expect(await runSandbox({ cwd: root, run }, io)).toBe(0);
+    expect(readFileSync(join(root, ".devcontainer", ".env"), "utf8")).toContain("DOCKER_SOCKET=false");
+  });
+
+  it("does NOT re-prompt when DOCKER_SOCKET is already set in .devcontainer/.env", async () => {
+    const root = makeRepo();
+    addScript(root, "docker-compose.sh");
+    mkdirSync(join(root, ".devcontainer"), { recursive: true });
+    writeFileSync(join(root, ".devcontainer", ".env"), "DOCKER_SOCKET=false\n");
+    const { run } = makeRunner();
+    let asked = 0;
+    const io: LifecycleIO = {
+      stdout: () => {},
+      stderr: () => {},
+      ask: async () => {
+        asked++;
+        return "y";
+      },
+    };
+
+    expect(await runSandbox({ cwd: root, run }, io)).toBe(0);
+    expect(asked).toBe(0);
+    // Standing choice untouched.
+    expect(readFileSync(join(root, ".devcontainer", ".env"), "utf8")).toBe("DOCKER_SOCKET=false\n");
+  });
+
+  it("does NOT prompt when sandbox.docker_socket is set in harness.yaml", async () => {
+    const root = makeRepo();
+    const composeScript = addScript(root, "docker-compose.sh");
+    addScript(root, "harness-config.sh");
+    writeFileSync(join(root, "harness.yaml"), "sandbox:\n  docker_socket: true\n");
+    // call 0 = harness-config get (returns "true"); call 1 = compose up.
+    const { calls, run } = makeRunner([{ status: 0, stdout: "true\n" }, { status: 0 }]);
+    let asked = 0;
+    const io: LifecycleIO = {
+      stdout: () => {},
+      stderr: () => {},
+      ask: async () => {
+        asked++;
+        return "n";
+      },
+    };
+
+    expect(await runSandbox({ cwd: root, run }, io)).toBe(0);
+    expect(asked).toBe(0);
+    expect(calls[0].args).toEqual([
+      join(root, ".oh", "scripts", "harness-config.sh"),
+      "get",
+      "sandbox.docker_socket",
+      join(root, "harness.yaml"),
+    ]);
+    expect(calls[1].args).toEqual([composeScript, "--repo-dir", root, "up", "-d", "--build"]);
   });
 });
 

--- a/.oh/cli/src/cli.ts
+++ b/.oh/cli/src/cli.ts
@@ -724,7 +724,7 @@ async function main(argv: string[]): Promise<number> {
       printSandboxHelp();
       return 0;
     }
-    return runSandbox({}, lifecycleIo());
+    return await runSandbox({}, lifecycleIo());
   }
 
   if (first === "shell") {

--- a/.oh/cli/src/commands/lifecycle.ts
+++ b/.oh/cli/src/commands/lifecycle.ts
@@ -1,7 +1,8 @@
 import { spawnSync } from "node:child_process";
-import { copyFileSync, existsSync } from "node:fs";
+import { appendFileSync, copyFileSync, existsSync, readFileSync } from "node:fs";
 import { join, resolve, sep } from "node:path";
 import { resolveProjectRoot } from "../lib/project.js";
+import * as prompt from "../lib/prompt.js";
 
 /**
  * Lifecycle verbs for equipped repos (issue #564): `oh sandbox`, `oh shell`,
@@ -21,6 +22,13 @@ import { resolveProjectRoot } from "../lib/project.js";
 export interface LifecycleIO {
   stdout: (s: string) => void;
   stderr: (s: string) => void;
+  /**
+   * Reader for the one interactive prompt (`oh sandbox`'s Docker-socket
+   * opt-in). Defaults to `prompt.ask` (real stdin). Injecting it also FORCES
+   * the prompt on in tests regardless of isTTY — mirrors init.ts's `io.ask`
+   * gate. Production cli.ts never injects it → pure isTTY gate.
+   */
+  ask?: (q: string) => Promise<string>;
 }
 
 /**
@@ -123,15 +131,75 @@ function seedHarnessYaml(root: string, io: LifecycleIO): void {
 }
 
 /**
+ * Whether the DOCKER_SOCKET toggle already has an explicit value — set either
+ * in `<root>/harness.yaml` (`sandbox.docker_socket`, the source of truth
+ * docker-compose.sh reads first) or `.devcontainer/.env` (a `DOCKER_SOCKET=`
+ * line). When configured, `oh sandbox` respects the standing choice and does
+ * NOT re-prompt.
+ */
+function dockerSocketConfigured(root: string, run: LifecycleRunner): boolean {
+  const script = join(root, ".oh", "scripts", "harness-config.sh");
+  const harnessYaml = join(root, "harness.yaml");
+  if (existsSync(script) && existsSync(harnessYaml)) {
+    const r = run("sh", [script, "get", "sandbox.docker_socket", harnessYaml], { stdio: "capture" });
+    if (!r.error && r.status === 0 && (r.stdout ?? "").trim() !== "") return true;
+  }
+  const envFile = join(root, ".devcontainer", ".env");
+  if (existsSync(envFile)) {
+    try {
+      if (/^\s*DOCKER_SOCKET=/m.test(readFileSync(envFile, "utf8"))) return true;
+    } catch {
+      /* unreadable .env → treat as unconfigured */
+    }
+  }
+  return false;
+}
+
+/**
+ * The Docker-socket opt-in for `oh sandbox` (the get-oh.sh / CLI provisioning
+ * path). Mounting /var/run/docker.sock is effectively HOST ROOT, so it is OFF
+ * by default: we only prompt on a TTY (or when a test injects `io.ask`) and
+ * only when no standing choice exists. The answer is persisted to
+ * `.devcontainer/.env` (`DOCKER_SOCKET=true|false`) so the choice sticks and
+ * docker-compose.sh applies the docker-compose.docker-sock.yml overlay when true.
+ */
+async function maybePromptDockerSocket(root: string, io: LifecycleIO, run: LifecycleRunner): Promise<void> {
+  if (dockerSocketConfigured(root, run)) return;
+  const interactive = process.stdin.isTTY === true || io.ask !== undefined;
+  if (!interactive) return; // non-TTY → leave it OFF, don't persist
+  const envDir = join(root, ".devcontainer");
+  if (!existsSync(envDir)) return; // nowhere durable to record the choice
+  const askFn = io.ask ?? prompt.ask;
+  const answer = (
+    await askFn(
+      "Mount host Docker socket into the sandbox? (effectively host root — enable only if the agent must drive Docker) [y/N]",
+    )
+  )
+    .trim()
+    .toLowerCase();
+  const enabled = answer === "y" || answer === "yes";
+  const envFile = join(envDir, ".env");
+  assertInRoot(envFile, root);
+  appendFileSync(envFile, `DOCKER_SOCKET=${enabled ? "true" : "false"}\n`);
+  io.stdout(
+    enabled
+      ? "DOCKER_SOCKET=true — host Docker socket will be mounted\n"
+      : "DOCKER_SOCKET=false — host Docker socket stays unmounted\n",
+  );
+}
+
+/**
  * `oh sandbox` — provision and start the sandbox: seed harness.yaml if needed,
- * then delegate to the vendored compose wrapper (which owns ALL compose-argv
- * building): `bash .oh/scripts/docker-compose.sh --repo-dir <root> up -d --build`.
+ * prompt once for the (default-off) Docker-socket opt-in, then delegate to the
+ * vendored compose wrapper (which owns ALL compose-argv building):
+ * `bash .oh/scripts/docker-compose.sh --repo-dir <root> up -d --build`.
  * Runs with inherited stdio (live build output) and returns the child's exit code.
  */
-export function runSandbox(opts: LifecycleOptions, io: LifecycleIO): number {
+export async function runSandbox(opts: LifecycleOptions, io: LifecycleIO): Promise<number> {
   const run = opts.run ?? spawnRunner;
   const root = resolveProjectRoot(opts.cwd);
   seedHarnessYaml(root, io);
+  await maybePromptDockerSocket(root, io, run);
   const script = requireScript(root, "docker-compose.sh");
   const r = run("bash", [script, "--repo-dir", root, "up", "-d", "--build"], {
     stdio: "inherit",

--- a/.oh/docs/intro.md
+++ b/.oh/docs/intro.md
@@ -22,7 +22,7 @@ Key capabilities:
 
 The harness uses Docker Compose to build a sandbox image from `.devcontainer/`. You bring the sandbox up with `docker compose -f .devcontainer/docker-compose.yml up -d --build`, attach with `docker exec -it -u sandbox openharness zsh` (or VS Code), authenticate GitHub and your chosen LLM provider once, then launch the agent with `claude` inside the sandbox. When you're done, `docker compose -f .devcontainer/docker-compose.yml down -v` tears everything down.
 
-The agent session you attach to at the project root is your **orchestrator** — git, sandbox lifecycle, and most file edits all flow through a single attach. The orchestrator can drive other containers and edit files inside them over the Docker socket, so day-to-day work rarely needs anything else. Drop back to the host shell only when something can't be done from inside the container — typically adding a new bind-mounted volume, which requires a `.devcontainer/docker-compose.yml` change and restart.
+The agent session you attach to at the project root is your **orchestrator** — git, sandbox lifecycle, and most file edits all flow through a single attach. When the optional Docker socket is enabled (off by default — see [security-considerations.md](security-considerations.md#3-sandbox-isolation--the-docker-socket-caveat--enforced-with-a-caveat)), the orchestrator can also drive other containers and edit files inside them over that socket, so day-to-day work rarely needs anything else. Drop back to the host shell only when something can't be done from inside the container — typically adding a new bind-mounted volume, which requires a `.devcontainer/docker-compose.yml` change and restart.
 
 Stand up a **second sandbox** only when you want isolation — an independent identity, branch, or provider key running on its own. Most users won't need this.
 
@@ -38,7 +38,7 @@ flowchart TB
     subgraph sandbox["Sandbox container — default workspace"]
         Orch{{"<b>Orchestrator</b><br/>Claude @ project root<br/>git · lifecycle · file edits"}}
         Tmux["tmux sessions<br/>client-slack-pi · agent-t3code · cron-system"]
-        Sock(["docker.sock"])
+        Sock(["docker.sock<br/><i>opt-in</i>"])
     end
 
     Sb2["Second sandbox<br/><i>only if you need isolation</i>"]
@@ -49,7 +49,7 @@ flowchart TB
     Orch -->|launches & monitors| Tmux
     Orch <-->|git| GH
     Tmux <-->|API| LLM
-    Orch -->|docker socket| Sock
+    Orch -.->|docker socket · opt-in| Sock
     Sock -.->|provisions| Sb2
 ```
 

--- a/.oh/docs/security-considerations.md
+++ b/.oh/docs/security-considerations.md
@@ -80,13 +80,15 @@ guard message says as much.
 Agents run inside a container, not on the host.
 
 - **Mechanism:** [`.devcontainer/docker-compose.yml`](../../.devcontainer/docker-compose.yml) + [`.devcontainer/devcontainer.json`](../../.devcontainer/devcontainer.json) + [`.devcontainer/Dockerfile`](../../.devcontainer/Dockerfile). The repo is bind-mounted (`docker-compose.yml:32`); the agent runs as the non-root `sandbox` user (`devcontainer.json:6`); auth lives in named volumes, not on the host FS.
-- **Caveat 1 — the Docker socket (RECOMMENDED to harden).** `/var/run/docker.sock` is mounted into the sandbox (`docker-compose.yml:33`) so the agent can drive Docker. This is a deliberate capability trade-off: **socket access is effectively host root** (an agent can start a privileged container that mounts the host FS). The container is therefore *isolation for convenience and blast-radius reduction, not a hard security boundary* against a hostile agent. If your threat model needs a hard boundary, remove the socket mount or run a rootless/proxied Docker.
+- **Caveat 1 — the Docker socket (OFF by default; opt-in).** `/var/run/docker.sock` is **no longer mounted by default** — it is an explicit opt-in via the [`docker-compose.docker-sock.yml`](../../.devcontainer/docker-compose.docker-sock.yml) overlay, applied only when `DOCKER_SOCKET` is truthy (`harness.yaml` `sandbox.docker_socket: true`, or `DOCKER_SOCKET=true` in `.devcontainer/.env`). Both interactive installers prompt for it and **default to off**: `install.sh` (the `curl | bash` path) and `oh sandbox` (the `oh` CLI / `get-oh.sh` path). Enabling it is a deliberate capability trade-off: **socket access is effectively host root** (an agent can start a privileged container that mounts the host FS), so the container becomes *isolation for convenience and blast-radius reduction, not a hard security boundary* against a hostile agent. Leave it off unless the agent genuinely must drive Docker; if it must and you still need a hard boundary, run a rootless/proxied Docker. **VS Code "Reopen in Container"** reads `docker-compose.yml` directly and bypasses the wrapper, so it never mounts the socket; to enable it there, add `docker-compose.docker-sock.yml` to `dockerComposeFile` in [`devcontainer.json`](../../.devcontainer/devcontainer.json).
 - **Caveat 2 — permissions bypassed inside.** `CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS=true` (`docker-compose.yml:48`) turns off the interactive permission engine inside the sandbox. This is the *reason* the §2 guards are implemented as hooks (which still fire) rather than relying on deny-list prompts (which are skipped).
 
 **Bottom line:** the sandbox reliably keeps agent work off the host
-filesystem and out of host user state — a real, enforced boundary — but
-the socket mount means it is not an escape-proof jail. Run the harness on
-hosts and repos you are willing to expose to that trust level.
+filesystem and out of host user state — a real, enforced boundary. With the
+Docker socket left at its default (off) that boundary holds; opting the
+socket in trades it away for Docker access and makes the sandbox no longer
+an escape-proof jail. Run the harness on hosts and repos you are willing to
+expose to whichever trust level you choose.
 
 ## 4. Human merge gate / no auto-merge — **ENFORCED (process) · RECOMMENDED (hard gate)**
 

--- a/.oh/scripts/docker-compose.sh
+++ b/.oh/scripts/docker-compose.sh
@@ -122,6 +122,20 @@ if truthy "$hermes_value"; then
   args+=(-f "$(compose_path ".devcontainer/docker-compose.hermes-dashboard.yml")")
 fi
 
+# Host Docker socket is opt-in (effectively host root). Apply the overlay only
+# when DOCKER_SOCKET is truthy via harness.yaml `sandbox.docker_socket` or the
+# .devcontainer/.env DOCKER_SOCKET key. Mirrors the hermes-dashboard toggle above.
+docker_socket_value=""
+if [ -f "$HARNESS_YAML" ]; then
+  docker_socket_value=$(sh "$CONFIG_SCRIPT" get sandbox.docker_socket "$HARNESS_YAML")
+fi
+if [ -z "$docker_socket_value" ]; then
+  docker_socket_value=${DOCKER_SOCKET:-$(read_env_value DOCKER_SOCKET)}
+fi
+if truthy "$docker_socket_value"; then
+  args+=(-f "$(compose_path ".devcontainer/docker-compose.docker-sock.yml")")
+fi
+
 if [ -f "$HARNESS_YAML" ]; then
   while IFS= read -r override; do
     [ -n "$override" ] && args+=(-f "$(compose_path "$override")")

--- a/.oh/scripts/harness-config.sh
+++ b/.oh/scripts/harness-config.sh
@@ -60,6 +60,7 @@ awk -v mode="$_mode" -v filter_key="$_filter_key" -v sq="'" '
 BEGIN {
     envmap["sandbox.name"]          = "SANDBOX_NAME"
     envmap["sandbox.timezone"]      = "TZ"
+    envmap["sandbox.docker_socket"] = "DOCKER_SOCKET"
     envmap["git.user_name"]         = "GIT_USER_NAME"
     envmap["git.user_email"]        = "GIT_USER_EMAIL"
     envmap["install.opencode"]      = "INSTALL_OPENCODE"

--- a/.oh/scripts/install.sh
+++ b/.oh/scripts/install.sh
@@ -143,6 +143,10 @@ Env vars:
   INSTALL_HERMES=true  Enable an optional agent non-interactively. Also:
                        INSTALL_OPENCODE, INSTALL_DEEPAGENTS, INSTALL_GROK_BUILD,
                        INSTALL_AGENT_BROWSER
+  DOCKER_SOCKET=true   Mount the host Docker socket into the sandbox
+                       non-interactively. OFF by default (socket access is
+                       effectively host root). Otherwise you're prompted (TTY),
+                       and --yes/--no keep it off.
 
 Examples:
   curl -fsSL https://oh.mifune.dev/install.sh | bash
@@ -494,6 +498,29 @@ ENVEOF
   _opt_install DEEPAGENTS    "DeepAgents — LangChain multi-provider agent"
   _opt_install GROK_BUILD    "Grok Build — xAI terminal agent"
   _opt_install AGENT_BROWSER "agent-browser + Chromium (~1 GB)"
+
+  # ─── Host Docker socket (OFF by default — security-sensitive) ────────
+  # Mounting /var/run/docker.sock lets the agent drive Docker, but socket
+  # access is effectively HOST ROOT (an agent can start a privileged container
+  # that mounts the host filesystem). Off by default; a pre-set DOCKER_SOCKET
+  # env honors non-interactive installs; --yes/--no keep the socket OFF.
+  # docker-compose.sh reads this DOCKER_SOCKET key and applies the
+  # docker-compose.docker-sock.yml overlay when truthy.
+  banner "Host Docker socket (off by default)"
+  __want_sock=0
+  if [ "${DOCKER_SOCKET:-}" = "true" ]; then
+    __want_sock=1
+    ok "DOCKER_SOCKET=true (from environment)"
+  elif [ "$ASSUME_YES" = true ] || [ "$ASSUME_NO" = true ] || [ ! -r /dev/tty ]; then
+    :
+  elif prompt_yn "Mount host Docker socket into the sandbox? (effectively host root — enable only if the agent must drive Docker)" n; then
+    __want_sock=1
+  fi
+  if [ "$__want_sock" = "1" ]; then
+    printf 'DOCKER_SOCKET=true\n' >> "$REPO_DIR/.devcontainer/.env"
+    ok "DOCKER_SOCKET=true — host Docker socket will be mounted"
+  fi
+  unset __want_sock
 fi
 
 # ─── 5. Bring up the sandbox ─────────────────────────────────────────

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Update policy and release automation live in [`/git`](.claude/skills/git/SKILL.m
 
 ## [Unreleased]
 
+### Security
+- **The host Docker socket is no longer mounted by default — it is now an explicit, prompted opt-in.** `/var/run/docker.sock` was previously bind-mounted into every sandbox unconditionally (`docker-compose.yml:33`), which is effectively host root (an agent can start a privileged container that mounts the host FS). The mount now lives in an opt-in overlay, `.devcontainer/docker-compose.docker-sock.yml`, applied by `.oh/scripts/docker-compose.sh` only when `DOCKER_SOCKET` is truthy (`harness.yaml` `sandbox.docker_socket: true` or `DOCKER_SOCKET=true` in `.devcontainer/.env`) — mirroring the existing hermes-dashboard overlay toggle. Both interactive installers now prompt for it and **default to off**: `install.sh` (the `curl | bash` path, honoring a pre-set `DOCKER_SOCKET` env for non-interactive/CI installs) and `oh sandbox` (the `oh` CLI / `get-oh.sh` path, which persists the choice to `.devcontainer/.env` so it sticks). `entrypoint.sh` already guarded on the socket's presence, so the sandbox boots cleanly with or without it. The VS Code "Reopen in Container" path reads `docker-compose.yml` directly and never mounts the socket; enable it there by adding the overlay to `devcontainer.json`. Documented in `.oh/docs/security-considerations.md` and `.oh/docs/intro.md`.
+
 ### Fixed
 - **Equipped-project sandbox no longer crash-loops on boot.** `link-providers.sh` hard-required a git checkout (`git rev-parse --show-toplevel`), so an `oh init`-equipped project that wasn't a git repo failed the entrypoint's provider-linking step (`entrypoint.sh` `exit 1`) and the container restart-looped under `restart: unless-stopped`. It now falls back to `${OH_PROJECT_ROOT:-$PWD}` when not in a git checkout, guarded by a `.oh/skills` existence check; behavior inside a real git checkout is unchanged.
 

--- a/harness.yaml.example
+++ b/harness.yaml.example
@@ -18,6 +18,7 @@
 sandbox:
   # name: openharness          # SANDBOX_NAME — container + compose project name
   # timezone: America/Los_Angeles   # TZ — cron schedules, log timestamps
+  # docker_socket: false       # DOCKER_SOCKET — mount host /var/run/docker.sock (effectively host root; opt-in)
 
 git:
   # user_name: Your Name           # GIT_USER_NAME (spaces OK)


### PR DESCRIPTION
Release-promotion PR: promotes `development` into the `main` release line.

## What's being promoted

The only content delta between `development` and `main` is the Docker-socket opt-in feature (the other `main`-only commits are merge artifacts from prior promotion PRs):

- **[#607](https://github.com/mifunedev/openharness/pull/607) — make host Docker socket opt-in (off by default)** (closes #606). `/var/run/docker.sock` is no longer bind-mounted unconditionally; it's an opt-in overlay (`docker-compose.docker-sock.yml`) toggled by `DOCKER_SOCKET` through `docker-compose.sh`, with default-off prompts in `install.sh` and `oh sandbox`. CHANGELOG `### Security` entry included.

## Merge safety

- `git merge-tree --write-tree origin/main origin/development` → **clean, no conflicts**.
- Diff is exactly the 12 docker-sock files; CHANGELOG delta is purely additive (new `### Security` entry under `[Unreleased]`).
- `main` had diverged from `development` only via prior merge commits, so a fast-forward isn't possible — this merge PR is the correct promotion path.

## ⚠️ Behavior change for existing installs

This is a **security-hardening default flip**. Sandboxes that relied on the Docker socket being mounted must set `sandbox.docker_socket: true` (or `DOCKER_SOCKET=true`) and rebuild after pulling. Called out in the CHANGELOG.

> Note: this PR does not cut a version tag. Per `/git` § Releases, tagging/GHCR happens via `/release` after this promotion merges (which also promotes `[Unreleased]` → the versioned CHANGELOG section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)