### PR TITLE
feat: image-only deployment mode — no repo checkout (#609)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -211,6 +211,14 @@ COPY --chown=sandbox:sandbox .oh/install/ /home/sandbox/install/
 RUN chmod +x /home/sandbox/install/*.sh
 COPY --chown=sandbox:sandbox workspace/ ${OH_PROJECT_ROOT}/workspace/
 
+# Flavor B (#609): bake a non-shadowed seed copy of the repo/control-plane so
+# the image-only path can populate an empty named workspace volume on first
+# boot (entrypoint OH_IMAGE_ONLY / seed_workspace_volume, OH_IMAGE_SEED_SRC).
+# Scoped by .dockerignore (.git, node_modules, .worktrees, .claude, .env* etc.).
+# Tradeoff: bakes the repo into the image (size cost) for the seeding path only;
+# the primary bind-mount build ignores /opt/oh-seed at runtime.
+COPY --chown=sandbox:sandbox . /opt/oh-seed/
+
 # ─── Entrypoint ────────────────────────────────────────────────────
 COPY .devcontainer/entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh

--- a/.devcontainer/docker-compose.image-only.yml
+++ b/.devcontainer/docker-compose.image-only.yml
@@ -1,0 +1,73 @@
+# Image-Only Sandbox Docker Compose Configuration (Flavor B, #609)
+# ===================================================================
+# Standalone recipe for running the PUBLISHED image with no repo checkout
+# and no local image build — there is no parent-directory bind mount and
+# no build stanza in this file. The workspace and control plane (.oh/,
+# agent state) live entirely in the named volume `oh_workspace`, seeded
+# from the image's baked /opt/oh-seed on first boot by entrypoint.sh (see
+# OH_IMAGE_ONLY handling). Edits made inside the running sandbox persist
+# in the volume across image pulls and container recreation, not in the
+# image itself.
+#
+# Usage:
+#   docker compose -f .devcontainer/docker-compose.image-only.yml up -d
+#
+# See .oh/docs/deployment-prebuilt-image.md for the full Flavor B writeup.
+
+name: ${SANDBOX_NAME:-openharness}
+
+services:
+  sandbox:
+    # Always runs the published image — never builds locally.
+    image: ${OH_SANDBOX_IMAGE:-ghcr.io/mifunedev/openharness:latest}
+    pull_policy: ${OH_PULL_POLICY:-always}
+    container_name: ${SANDBOX_NAME:-openharness}
+    volumes:
+      - oh_workspace:${OH_PROJECT_ROOT:-/home/sandbox/harness}
+      - claude-auth:/home/sandbox/.claude
+      - codex-auth:/home/sandbox/.codex
+      - pi-auth:/home/sandbox/.pi
+      - opencode-auth:/home/sandbox/.local/share/opencode
+      - grok-auth:/home/sandbox/.grok
+      - deepagents-auth:/home/sandbox/.deepagents
+      - cloudflared-auth:/home/sandbox/.cloudflared
+      - gh-config:/home/sandbox/.config/gh
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    environment:
+      - SANDBOX_NAME=${SANDBOX_NAME:-openharness}
+      - SANDBOX_PASSWORD=${SANDBOX_PASSWORD:-test1234}
+      - TZ=${TZ:-America/Los_Angeles}
+      - CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS=true
+      - GIT_USER_NAME=${GIT_USER_NAME:-}
+      - GIT_USER_EMAIL=${GIT_USER_EMAIL:-}
+      - GH_TOKEN=${GH_TOKEN:-}
+      - XAI_API_KEY=${XAI_API_KEY:-}
+      - OH_PROJECT_ROOT=${OH_PROJECT_ROOT:-/home/sandbox/harness}
+      - OH_IMAGE_ONLY=1
+      - CRONS_DIR=${CRONS_DIR:-.oh/crons}
+      - CRON_AGENT_BIN=${CRON_AGENT_BIN:-claude}
+      - MEMORY_DIR=${MEMORY_DIR:-.oh/memory}
+    stdin_open: true
+    tty: true
+    init: true
+    entrypoint: /usr/local/bin/entrypoint.sh
+    command: sleep infinity
+    healthcheck:
+      test: ["CMD", "bash", "${OH_PROJECT_ROOT:-/home/sandbox/harness}/.oh/scripts/sandbox-healthcheck.sh"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 300s
+    restart: unless-stopped
+
+volumes:
+  oh_workspace:
+  claude-auth:
+  codex-auth:
+  pi-auth:
+  opencode-auth:
+  grok-auth:
+  deepagents-auth:
+  cloudflared-auth:
+  gh-config:

--- a/.devcontainer/entrypoint.sh
+++ b/.devcontainer/entrypoint.sh
@@ -56,6 +56,31 @@ repair_home_mount_ownership() {
   fi
 }
 
+# >>> seed_workspace_volume >>>
+# First-boot seed for OH_IMAGE_ONLY (no-bind) mode: populate an empty named
+# workspace volume from the image's baked control plane (/opt/oh-seed by
+# default). Self-contained: uses only $1 (dest) + $OH_IMAGE_SEED_SRC so the
+# eval probe can source it in isolation. Sets OH_IMAGE_SEEDED_THIS_BOOT.
+seed_workspace_volume() {
+  local dest="$1"
+  local marker="$dest/.oh/.image-seeded"
+  local src="${OH_IMAGE_SEED_SRC:-/opt/oh-seed}"
+  OH_IMAGE_SEEDED_THIS_BOOT=0
+  if [ -f "$marker" ]; then
+    return 0
+  fi
+  # Clobber guard: only seed when the control plane is absent (marker AND emptiness).
+  if [ -n "$src" ] && [ -d "$src" ] && [ ! -d "$dest/.oh" ]; then
+    cp -a "$src/." "$dest/" 2>/dev/null || true
+  fi
+  if [ -d "$dest/.oh" ]; then
+    : > "$marker" 2>/dev/null || true
+    OH_IMAGE_SEEDED_THIS_BOOT=1
+  fi
+  return 0
+}
+# <<< seed_workspace_volume <<<
+
 repair_home_mount_ownership
 
 # ─── Host UID reconciliation ────────────────────────────────────────
@@ -82,7 +107,16 @@ uid_reconcile_step() {
 }
 
 HARNESS_DIR="$OH_PROJECT_ROOT"
-if [ -d "$HARNESS_DIR" ]; then
+if [ "${OH_IMAGE_ONLY:-}" = "1" ]; then
+  echo "[entrypoint] OH_IMAGE_ONLY=1 — no-bind mode; skipping host UID/GID sync"
+  seed_workspace_volume "$OH_PROJECT_ROOT"
+  if [ "${OH_IMAGE_SEEDED_THIS_BOOT:-0}" = "1" ]; then
+    echo "[entrypoint] seeded control plane into $OH_PROJECT_ROOT from ${OH_IMAGE_SEED_SRC:-/opt/oh-seed}"
+    chown -R "$(id -u sandbox):$(id -g sandbox)" "$OH_PROJECT_ROOT" 2>/dev/null || true
+  else
+    chown "$(id -u sandbox):$(id -g sandbox)" "$OH_PROJECT_ROOT" 2>/dev/null || true
+  fi
+elif [ -d "$HARNESS_DIR" ]; then
   HOST_UID=$(stat -c '%u' "$HARNESS_DIR")
   HOST_GID=$(stat -c '%g' "$HARNESS_DIR")
   SANDBOX_UID=$(id -u sandbox)

--- a/.oh/docs/deployment-prebuilt-image.md
+++ b/.oh/docs/deployment-prebuilt-image.md
@@ -125,14 +125,93 @@ container:
 }
 ```
 
-## Not yet: image-only, no checkout
+## Image-only deployment (no checkout) — Flavor B
 
-Running the image with **no** project bind-mounted (workspace in a named volume,
-control plane straight from the baked image) is a separate, deferred path — the
-entrypoint's bind-mount assumptions (UID sync, root `pnpm install`, provider
-symlinks) don't hold without a mounted repo. Prebuilt-image mode always keeps the
-bind mount. Tracked in
+Everything above (call it **Flavor A**) still keeps the bind mount: your
+checked-out repo shadows the image's toolchain. **Flavor B** drops the checkout
+entirely — there is no project directory on the host at all. The workspace and
+the `.oh/` control plane live in a named Docker volume, seeded once from the
+image itself. Tracked in
 [#609](https://github.com/mifunedev/openharness/issues/609).
+
+### The recipe
+
+[`.devcontainer/docker-compose.image-only.yml`](../../.devcontainer/docker-compose.image-only.yml)
+is a standalone compose file — no `..:` bind mount, no `build:` stanza:
+
+```bash
+docker compose -f .devcontainer/docker-compose.image-only.yml up -d
+```
+
+This pulls and runs the published image with **no clone and no build**. The
+workspace and control plane live entirely in the named `oh_workspace` volume
+declared in that file, mounted at `$OH_PROJECT_ROOT`.
+
+### `OH_IMAGE_ONLY=1`
+
+The compose file sets `OH_IMAGE_ONLY=1` in the container environment. This is
+the entrypoint flag that switches `entrypoint.sh` into **no-bind mode**:
+
+- the host UID/GID sync block is skipped (there is no host directory to read
+  ownership from)
+- the workspace mount is `chown`'d to the sandbox user instead
+- the first-boot seed (below) runs before `link-providers`, the root
+  `pnpm install`, and cron tmux setup, so those steps see a populated `.oh/`
+
+Prebuilt-image mode (Flavor A) never sets this flag — it always keeps the bind
+mount, so its host-UID-sync path is unchanged.
+
+### Seed-to-volume persistence
+
+On the **first boot** against an empty `oh_workspace` volume, the entrypoint
+seeds the baked control plane — from the image's `/opt/oh-seed` — into the
+volume, then writes the marker `.oh/.image-seeded`. From that point on, the
+**volume is authoritative**: it is the operator-editable copy of `.oh/` (and
+the rest of the repo), and edits made inside the running sandbox persist there
+across image pulls and container recreation, not in the image itself. Later
+boots see the marker and skip re-seeding, so a populated volume is never
+clobbered.
+
+> ⚠️ **Flavor B requires an image built after the seed-bake change.** Baking
+> `/opt/oh-seed` into the image is a separate change on top of the Dockerfile;
+> only images published from that change onward contain it. The `latest` tag
+> at the time of writing does **not** yet contain `/opt/oh-seed` — pin a tag
+> from the next published release (or newer) before relying on Flavor B.
+
+### Single-arch caveat
+
+Same caveat as Flavor A above: the published image targets the CI runner's
+architecture. If you run a different CPU arch, prefer a local build (or
+Flavor A, which builds locally by default) until multi-arch images land.
+
+### Relationship to the Railway smoke path
+
+Flavor B is a **supersede-candidate** for the existing (unvalidated) Railway
+smoke path under [`.oh/deploy/railway/`](../deploy/railway/) — once Flavor B
+itself has been host-validated (see the manual smoke checklist below), it may
+replace that path as the recommended no-checkout deployment target. This is a
+documentation note only; no file under `.oh/deploy/railway/` changes as part
+of this work.
+
+### Manual live-host smoke checklist (non-gating)
+
+The eval probe suite covers the static contract (env-var gating, compose
+shape, doc content) deterministically, without a Docker host. It cannot cover
+an actual live boot. Before relying on Flavor B in production, run this
+checklist by hand on a real host:
+
+- [ ] `docker pull ghcr.io/mifunedev/openharness:<tag built after the /opt/oh-seed change>`
+- [ ] `docker compose -f .devcontainer/docker-compose.image-only.yml up -d`
+- [ ] confirm **no build step ran** — the compose/Docker output shows a pull, not a build
+- [ ] confirm `.oh/` was seeded into the volume:
+      `docker compose -f .devcontainer/docker-compose.image-only.yml exec sandbox ls /home/sandbox/harness/.oh`
+- [ ] confirm an agent / the `oh` CLI is usable inside the container
+- [ ] edit a file under `.oh/` in the running container, then
+      `docker compose -f .devcontainer/docker-compose.image-only.yml restart`,
+      and confirm the edit is still there
+
+See also [the CLI path](#cli-path-recommended) above for the Flavor A
+equivalent of pulling a pinned tag.
 
 ## See also
 

--- a/.oh/evals/RESULTS.md
+++ b/.oh/evals/RESULTS.md
@@ -6,85 +6,86 @@ probe id; git history is the time series.** Schema and exit-code semantics are i
 
 | probe | tier | last-run (UTC) | status | source |
 |-------|------|----------------|--------|--------|
-| advisor-monitored-loop | A | 2026-07-05 21:25 | PASS | conversation 2026-06-19 (advisor-monitored ralph loop pattern, issue #257) |
-| agent-browser-cli | A | 2026-07-05 21:25 | PASS | .oh/memory/MEMORY.md 2026-06-07 (agent-browser 0.8.5 CLI) |
-| artifact-contract-audit | A | 2026-07-05 21:25 | PASS | issue #583 (repair-registry-artifact-contract) 2026-07-03 |
-| auditor-agent-contract | A | 2026-07-05 21:25 | PASS | auditor agent — the primary manager/dispatcher of the audit-skill family must preserve its frozen scope-boundary contract |
-| autopilot-executor-toggle | A | 2026-07-05 21:25 | PASS | conversation 2026-06-13 (autopilot executor); 2026-06-27 (ralph-default flip) |
-| autopilot-merged-pr-reference-dedupe | A | 2026-07-05 21:25 | PASS | issue #468 — autopilot must not rebuild open tickets whose development PRs already merged |
-| autopilot-no-pr-session-close | A | 2026-07-05 21:25 | PASS | issue #209 (autopilot no-PR tmux session closure) 2026-06-16 |
-| autopilot-open-pr-reference-dedupe | A | 2026-07-05 21:25 | PASS | issue #437 — autopilot must not start duplicate work when open PRs reference the same issue without linked-PR metadata |
-| autopilot-pi-agent | A | 2026-07-05 21:25 | PASS | issue #116 (autopilot Pi tmux alignment) 2026-06-14; issue #118 (attachable Pi TUI tmux) 2026-06-14; issue #126 (kept Pi overlap lock release) 2026-06-14; issue #142 (worktree-by-default, skip→worktree) 2026-06-14 |
-| autopilot-preflight-gate | A | 2026-07-05 21:25 | SKIPPED | issue #194 (deterministic autopilot caps preflight gate) 2026-06-15 |
-| autopilot-upstream-default | A | 2026-07-05 21:25 | PASS | issue #420 — future autopilots must target canonical repo, not personal fork |
-| autopilot-worktree-log-root | A | 2026-07-05 21:25 | PASS | issue #152 (persist autopilot worktree logs) 2026-06-15 |
-| boot-lint-glob | A | 2026-07-05 21:25 | PASS | issue #90, issue #120 |
-| capability-benchmark-schema | A | 2026-07-05 21:25 | PASS | issue #167 — capability benchmark instrument |
-| clean-restore | A | 2026-07-05 21:25 | PASS | issue #63 (autopilot-stray-wip-guard) 2026-06-12; issue #81 (owned-paths-zsh-split) 2026-06-13 |
-| cleanup-tasks-scoped-guard | A | 2026-07-05 21:25 | PASS | issue #85 |
-| cleanup-tasks-worktree-grooming | A | 2026-07-05 21:25 | PASS | issue #168; issue #327 |
-| codex-stale-response-retry | A | 2026-07-05 21:25 | PASS | issue #506 — Codex previous_response_not_found RCA |
-| cron-claude-codex-fallback | A | 2026-07-05 21:25 | PASS | conversation 2026-06-12 (default Codex fallback for crons) |
-| cron-watchdog | A | 2026-07-05 21:25 | PASS | issues #130/#453 (cron runtime watchdog + legacy system-cron reaping) 2026-06-19 |
-| curl-bash-safe-alternatives | A | 2026-07-05 21:25 | PASS | vet-run/vet integration — public curl|bash examples need review-first alternatives |
-| datasets-schema | A | 2026-07-05 21:25 | PASS | issue #196 — .oh/evals/datasets verifiable trajectory corpus (Repo2RLEnv-inspired) |
-| debugmcp-availability | A | 2026-07-05 21:25 | PASS | issue #297 — DebugMCP MCP debug-server availability |
-| devtcp-hook | A | 2026-07-05 21:25 | PASS | .oh/memory/MEMORY.md 2026-06-10 (zsh /dev/tcp) |
-| docs-build-fast-path | A | 2026-07-05 21:25 | PASS | #455 — docs builds must stay out of fast harness/eval/release gates; #536 — docs site externalized to openharness-web; docs markdown relocated to .oh/docs/ |
-| drift-check-cron-staleness-glob | A | 2026-07-05 21:25 | PASS | issue #98; issue #225 (restart-required cron frontmatter/config drift) |
-| entrypoint-pnpm-manifest-fingerprint | A | 2026-07-05 21:25 | PASS | issue #521 (manifest-aware sandbox installs) 2026-07-01 |
-| eval-ci-gate | A | 2026-07-05 21:25 | PASS | #103 — eval probe suite gated in CI |
-| eval-gate | A | 2026-07-05 21:25 | PASS | .oh/memory/MEMORY.md 2026-06-11 (eval-gate) |
-| eval-results-atomic | A | 2026-07-05 21:25 | PASS | issue #83 (eval-results-atomic-write) |
-| eval-runner-exit | A | 2026-07-05 21:25 | PASS | .oh/memory/MEMORY.md 2026-06-11 (eval-runner-exit) #29 |
-| get-oh-bootstrap | A | 2026-07-05 21:25 | PASS | get-oh.sh bootstrap — the Node-bootstrapping host-side path to the standalone `oh` CLI (also on npm as @mifune/openharness; see oh-npm-package.sh) |
-| git-skill | A | 2026-07-05 21:25 | PASS | conversation 2026-06-15 — rules are not always supported; git workflow must be the /git skill |
-| harness-audit-empty-output-gate | A | 2026-07-05 21:25 | PASS | issue #246 — /harness-audit must fail closed on empty auditor outputs |
-| harness-audit-memory-path | A | 2026-07-05 21:25 | PASS | issue #183 — /harness-audit must inspect the active worktree, not a hardcoded root |
-| harness-audit-shared-memory | A | 2026-07-05 21:25 | PASS | issue #432 — /harness-audit must load durable memory from shared log root in cron worktrees |
-| harness-ci-core-paths | A | 2026-07-05 21:25 | PASS | #165 — core sandbox config files must trigger harness CI |
-| harness-ci-hooks-paths | A | 2026-07-05 21:25 | PASS | issue #202 — credential/security hook changes must trigger harness CI |
-| health-check-docker-stats | A | 2026-07-05 21:25 | PASS | .oh/memory/MEMORY.md 2026-06-10 (docker stats vs ps Size) |
-| heartbeat-logging-contract | A | 2026-07-05 21:25 | PASS | issue #447 (heartbeat log append hardening) 2026-06-18 |
-| locked-append-critical-path | A | 2026-07-05 21:25 | PASS | issue #204 (lock shared runtime log appends) 2026-06-15 |
-| memory-gitignore-claim | A | 2026-07-05 21:25 | PASS | issue #101 |
-| memory-log-locked-append | A | 2026-07-05 21:25 | PASS | issue #476 — memory log writes in skill contracts must use .oh/scripts/locked-append.sh |
-| next-dev-prod | A | 2026-07-05 21:25 | SKIPPED | .oh/memory/MEMORY.md 2026-06-04 |
-| oh-devcontainer-restructure | A | 2026-07-05 21:25 | PASS | consolidate devcontainer — .oh/devcontainer/ folded back into .devcontainer/ |
-| oh-init-scaffold | A | 2026-07-05 21:25 | PASS | issue #531 Phase 2 |
-| oh-npm-package | A | 2026-07-05 21:25 | PASS | npm publish path for the standalone `oh` CLI (@mifune/openharness) — alternative to get-oh.sh |
-| oh-payload-manifest | A | 2026-07-05 21:25 | PASS | issue #531 follow-on (.oh payload manifest — oh update ships a declared allowlist) |
-| oh-sandbox-image-mode | A | 2026-07-05 21:25 | PASS | conversation 2026-07-05 (basic Docker deployment — prebuilt-image mode) |
-| oh-shipped-repo-overridable | A | 2026-07-05 21:25 | PASS | issue #531 follow-on (de-hardcode residual — shipped .oh shell scripts keep the upstream repo overridable) |
-| oh-standalone-lifecycle | A | 2026-07-05 21:25 | PASS | issue #564 |
-| oh-update | A | 2026-07-05 21:25 | PASS | issue #531 Phase 3 (oh update — upgrade only the .oh control plane) |
-| owned-surface-guard | A | 2026-07-05 21:25 | PASS | issue #63 (autopilot-stray-wip-guard) 2026-06-12; issue #81 (owned-paths-zsh-split) 2026-06-13 |
-| pnpm-audit-ci-gate | A | 2026-07-05 21:25 | PASS | issue #171 — pnpm security audits must run in CI |
-| post-bridge-publish-confirmation | A | 2026-07-05 21:25 | PASS | #523 — post-bridge live publishing requires an explicit final confirmation gate |
-| pr-audit-duplicate-issue-refs | A | 2026-07-05 21:25 | PASS | issue #439 — /pr-audit must flag duplicate open PRs that reference the same issue |
-| prd-output-path-contract | A | 2026-07-05 21:25 | PASS | .oh/memory/MEMORY.md 2026-06-19 |
-| project-root-seam | A | 2026-07-05 21:25 | PASS | issue #531 Phase 1 (OH_PROJECT_ROOT project-root seam) 2026-06-26 |
-| prompt-miner-schema-compat | A | 2026-07-05 21:25 | PASS | issue #253 — prompt-miner JSONL schema-drift guard |
-| prompt-miner-weakness-record | A | 2026-07-05 21:25 | PASS | issue #580 — prompt-miner weakness-record (WH-xxx) cluster output |
-| railway-one-click-deploy | A | 2026-07-05 21:25 | PASS | issue #553 — Railway one-click hosted deploy surface |
-| ralph-fallback-order | A | 2026-07-05 21:25 | PASS | conversation 2026-06-12 (Ralph default fallback order) |
-| repo-map-contract | A | 2026-07-05 21:25 | PASS | issue #464 — repo map must optimize orientation without adding a tree dependency or unmeasured performance claims |
-| retro-deterministic-contract | A | 2026-07-05 21:25 | PASS | issue #443 — /retro deterministic output and self-contained helper contract |
-| rl-delegation-write-worker | A | 2026-07-05 21:25 | PASS | .oh/memory/MEMORY.md 2026-06-10 (rl-delegation) #57 |
-| rlm-context-budget | A | 2026-07-05 21:25 | PASS | .oh/tasks/rlm-weighted-trajectories/prd.json US-006 |
-| sandbox-boot-guard-ci | A | 2026-07-05 21:25 | PASS | issue #449 (sandbox image build CI guard) 2026-06-19 |
-| ship-spec-ready-finalization | A | 2026-07-05 21:25 | PASS | issue #134 — /ship-spec must finalize ready PRs after gates, not stop at draft scaffold |
-| skill-paths | A | 2026-07-05 21:25 | PASS | issue #43 — stale path references; extended by issue #69 — apps/->packages/ rename guard |
-| skills-dir-clean | A | 2026-07-05 21:25 | PASS | conversation 2026-06-29 — Pi parses every top-level `.md` in the skills |
-| skills-vendored | A | 2026-07-05 21:25 | PASS | absorb .mifune submodule into .oh — the skills/agents/hooks pack is vendored |
-| spec-family-contract | A | 2026-07-05 21:25 | PASS | conversation 2026-06-19 (spec-* family split, issue #265); consolidated into /spec dispatcher 2026-06-23 (one skill, args) |
-| submitted-by-trailers | A | 2026-07-05 21:25 | PASS | conversation 2026-06-12 (commit attribution trailers) |
-| sync-skill-contract | A | 2026-07-05 21:25 | PASS | issue #331 — /sync dispatcher skill (bidirectional origin↔upstream sync) |
-| watchdog-completed-session-reap | A | 2026-07-05 21:25 | PASS | issue #235 (completed autopilot PR session reaping) |
-| watchdog-draft-prs | A | 2026-07-05 21:25 | PASS | conversation 2026-06-15 (generic watchdog + stale draft PR recovery) |
-| watchdog-stuck-sessions | A | 2026-07-05 21:25 | PASS | issue #240 (Codex zero-credit stuck autopilot sessions) 2026-06-17 |
-| weigh-scorer-contract | A | 2026-07-05 21:25 | PASS | .oh/tasks/rlm-weighted-trajectories/prd.json US-003 (2026-06-27) |
-| wiki-readme-index | A | 2026-07-05 21:25 | PASS | issue #132 — wiki README index drift guard |
-| workflow-boundaries | A | 2026-07-05 21:25 | PASS | conversation 2026-06-19 (workflow consolidation, issue #259) |
+| advisor-monitored-loop | A | 2026-07-05 22:41 | PASS | conversation 2026-06-19 (advisor-monitored ralph loop pattern, issue #257) |
+| agent-browser-cli | A | 2026-07-05 22:41 | PASS | .oh/memory/MEMORY.md 2026-06-07 (agent-browser 0.8.5 CLI) |
+| artifact-contract-audit | A | 2026-07-05 22:41 | PASS | issue #583 (repair-registry-artifact-contract) 2026-07-03 |
+| auditor-agent-contract | A | 2026-07-05 22:41 | PASS | auditor agent — the primary manager/dispatcher of the audit-skill family must preserve its frozen scope-boundary contract |
+| autopilot-executor-toggle | A | 2026-07-05 22:41 | PASS | conversation 2026-06-13 (autopilot executor); 2026-06-27 (ralph-default flip) |
+| autopilot-merged-pr-reference-dedupe | A | 2026-07-05 22:41 | PASS | issue #468 — autopilot must not rebuild open tickets whose development PRs already merged |
+| autopilot-no-pr-session-close | A | 2026-07-05 22:41 | PASS | issue #209 (autopilot no-PR tmux session closure) 2026-06-16 |
+| autopilot-open-pr-reference-dedupe | A | 2026-07-05 22:41 | PASS | issue #437 — autopilot must not start duplicate work when open PRs reference the same issue without linked-PR metadata |
+| autopilot-pi-agent | A | 2026-07-05 22:41 | PASS | issue #116 (autopilot Pi tmux alignment) 2026-06-14; issue #118 (attachable Pi TUI tmux) 2026-06-14; issue #126 (kept Pi overlap lock release) 2026-06-14; issue #142 (worktree-by-default, skip→worktree) 2026-06-14 |
+| autopilot-preflight-gate | A | 2026-07-05 22:41 | SKIPPED | issue #194 (deterministic autopilot caps preflight gate) 2026-06-15 |
+| autopilot-upstream-default | A | 2026-07-05 22:41 | PASS | issue #420 — future autopilots must target canonical repo, not personal fork |
+| autopilot-worktree-log-root | A | 2026-07-05 22:41 | PASS | issue #152 (persist autopilot worktree logs) 2026-06-15 |
+| boot-lint-glob | A | 2026-07-05 22:41 | PASS | issue #90, issue #120 |
+| capability-benchmark-schema | A | 2026-07-05 22:41 | PASS | issue #167 — capability benchmark instrument |
+| clean-restore | A | 2026-07-05 22:41 | PASS | issue #63 (autopilot-stray-wip-guard) 2026-06-12; issue #81 (owned-paths-zsh-split) 2026-06-13 |
+| cleanup-tasks-scoped-guard | A | 2026-07-05 22:41 | PASS | issue #85 |
+| cleanup-tasks-worktree-grooming | A | 2026-07-05 22:41 | PASS | issue #168; issue #327 |
+| codex-stale-response-retry | A | 2026-07-05 22:41 | PASS | issue #506 — Codex previous_response_not_found RCA |
+| cron-claude-codex-fallback | A | 2026-07-05 22:41 | PASS | conversation 2026-06-12 (default Codex fallback for crons) |
+| cron-watchdog | A | 2026-07-05 22:41 | PASS | issues #130/#453 (cron runtime watchdog + legacy system-cron reaping) 2026-06-19 |
+| curl-bash-safe-alternatives | A | 2026-07-05 22:41 | PASS | vet-run/vet integration — public curl|bash examples need review-first alternatives |
+| datasets-schema | A | 2026-07-05 22:41 | PASS | issue #196 — .oh/evals/datasets verifiable trajectory corpus (Repo2RLEnv-inspired) |
+| debugmcp-availability | A | 2026-07-05 22:41 | PASS | issue #297 — DebugMCP MCP debug-server availability |
+| devtcp-hook | A | 2026-07-05 22:41 | PASS | .oh/memory/MEMORY.md 2026-06-10 (zsh /dev/tcp) |
+| docs-build-fast-path | A | 2026-07-05 22:41 | PASS | #455 — docs builds must stay out of fast harness/eval/release gates; #536 — docs site externalized to openharness-web; docs markdown relocated to .oh/docs/ |
+| drift-check-cron-staleness-glob | A | 2026-07-05 22:41 | PASS | issue #98; issue #225 (restart-required cron frontmatter/config drift) |
+| entrypoint-pnpm-manifest-fingerprint | A | 2026-07-05 22:41 | PASS | issue #521 (manifest-aware sandbox installs) 2026-07-01 |
+| eval-ci-gate | A | 2026-07-05 22:41 | PASS | #103 — eval probe suite gated in CI |
+| eval-gate | A | 2026-07-05 22:41 | PASS | .oh/memory/MEMORY.md 2026-06-11 (eval-gate) |
+| eval-results-atomic | A | 2026-07-05 22:41 | PASS | issue #83 (eval-results-atomic-write) |
+| eval-runner-exit | A | 2026-07-05 22:41 | PASS | .oh/memory/MEMORY.md 2026-06-11 (eval-runner-exit) #29 |
+| get-oh-bootstrap | A | 2026-07-05 22:41 | PASS | get-oh.sh bootstrap — the Node-bootstrapping host-side path to the standalone `oh` CLI (also on npm as @mifune/openharness; see oh-npm-package.sh) |
+| git-skill | A | 2026-07-05 22:41 | PASS | conversation 2026-06-15 — rules are not always supported; git workflow must be the /git skill |
+| harness-audit-empty-output-gate | A | 2026-07-05 22:41 | PASS | issue #246 — /harness-audit must fail closed on empty auditor outputs |
+| harness-audit-memory-path | A | 2026-07-05 22:41 | PASS | issue #183 — /harness-audit must inspect the active worktree, not a hardcoded root |
+| harness-audit-shared-memory | A | 2026-07-05 22:41 | PASS | issue #432 — /harness-audit must load durable memory from shared log root in cron worktrees |
+| harness-ci-core-paths | A | 2026-07-05 22:41 | PASS | #165 — core sandbox config files must trigger harness CI |
+| harness-ci-hooks-paths | A | 2026-07-05 22:41 | PASS | issue #202 — credential/security hook changes must trigger harness CI |
+| health-check-docker-stats | A | 2026-07-05 22:41 | PASS | .oh/memory/MEMORY.md 2026-06-10 (docker stats vs ps Size) |
+| heartbeat-logging-contract | A | 2026-07-05 22:41 | PASS | issue #447 (heartbeat log append hardening) 2026-06-18 |
+| locked-append-critical-path | A | 2026-07-05 22:41 | PASS | issue #204 (lock shared runtime log appends) 2026-06-15 |
+| memory-gitignore-claim | A | 2026-07-05 22:41 | PASS | issue #101 |
+| memory-log-locked-append | A | 2026-07-05 22:41 | PASS | issue #476 — memory log writes in skill contracts must use .oh/scripts/locked-append.sh |
+| next-dev-prod | A | 2026-07-05 22:41 | SKIPPED | .oh/memory/MEMORY.md 2026-06-04 |
+| oh-devcontainer-restructure | A | 2026-07-05 22:41 | PASS | consolidate devcontainer — .oh/devcontainer/ folded back into .devcontainer/ |
+| oh-image-only-deploy | A | 2026-07-05 22:41 | PASS | .oh/tasks/image-only-deploy/prd.json US-004 (issue #609, Flavor B image-only deploy) |
+| oh-init-scaffold | A | 2026-07-05 22:41 | PASS | issue #531 Phase 2 |
+| oh-npm-package | A | 2026-07-05 22:41 | PASS | npm publish path for the standalone `oh` CLI (@mifune/openharness) — alternative to get-oh.sh |
+| oh-payload-manifest | A | 2026-07-05 22:41 | PASS | issue #531 follow-on (.oh payload manifest — oh update ships a declared allowlist) |
+| oh-sandbox-image-mode | A | 2026-07-05 22:41 | PASS | conversation 2026-07-05 (basic Docker deployment — prebuilt-image mode) |
+| oh-shipped-repo-overridable | A | 2026-07-05 22:41 | PASS | issue #531 follow-on (de-hardcode residual — shipped .oh shell scripts keep the upstream repo overridable) |
+| oh-standalone-lifecycle | A | 2026-07-05 22:41 | PASS | issue #564 |
+| oh-update | A | 2026-07-05 22:41 | PASS | issue #531 Phase 3 (oh update — upgrade only the .oh control plane) |
+| owned-surface-guard | A | 2026-07-05 22:41 | PASS | issue #63 (autopilot-stray-wip-guard) 2026-06-12; issue #81 (owned-paths-zsh-split) 2026-06-13 |
+| pnpm-audit-ci-gate | A | 2026-07-05 22:41 | PASS | issue #171 — pnpm security audits must run in CI |
+| post-bridge-publish-confirmation | A | 2026-07-05 22:41 | PASS | #523 — post-bridge live publishing requires an explicit final confirmation gate |
+| pr-audit-duplicate-issue-refs | A | 2026-07-05 22:41 | PASS | issue #439 — /pr-audit must flag duplicate open PRs that reference the same issue |
+| prd-output-path-contract | A | 2026-07-05 22:41 | PASS | .oh/memory/MEMORY.md 2026-06-19 |
+| project-root-seam | A | 2026-07-05 22:41 | PASS | issue #531 Phase 1 (OH_PROJECT_ROOT project-root seam) 2026-06-26 |
+| prompt-miner-schema-compat | A | 2026-07-05 22:41 | PASS | issue #253 — prompt-miner JSONL schema-drift guard |
+| prompt-miner-weakness-record | A | 2026-07-05 22:41 | PASS | issue #580 — prompt-miner weakness-record (WH-xxx) cluster output |
+| railway-one-click-deploy | A | 2026-07-05 22:41 | PASS | issue #553 — Railway one-click hosted deploy surface |
+| ralph-fallback-order | A | 2026-07-05 22:41 | PASS | conversation 2026-06-12 (Ralph default fallback order) |
+| repo-map-contract | A | 2026-07-05 22:41 | PASS | issue #464 — repo map must optimize orientation without adding a tree dependency or unmeasured performance claims |
+| retro-deterministic-contract | A | 2026-07-05 22:41 | PASS | issue #443 — /retro deterministic output and self-contained helper contract |
+| rl-delegation-write-worker | A | 2026-07-05 22:41 | PASS | .oh/memory/MEMORY.md 2026-06-10 (rl-delegation) #57 |
+| rlm-context-budget | A | 2026-07-05 22:41 | PASS | .oh/tasks/rlm-weighted-trajectories/prd.json US-006 |
+| sandbox-boot-guard-ci | A | 2026-07-05 22:41 | PASS | issue #449 (sandbox image build CI guard) 2026-06-19 |
+| ship-spec-ready-finalization | A | 2026-07-05 22:41 | PASS | issue #134 — /ship-spec must finalize ready PRs after gates, not stop at draft scaffold |
+| skill-paths | A | 2026-07-05 22:41 | PASS | issue #43 — stale path references; extended by issue #69 — apps/->packages/ rename guard |
+| skills-dir-clean | A | 2026-07-05 22:41 | PASS | conversation 2026-06-29 — Pi parses every top-level `.md` in the skills |
+| skills-vendored | A | 2026-07-05 22:41 | PASS | absorb .mifune submodule into .oh — the skills/agents/hooks pack is vendored |
+| spec-family-contract | A | 2026-07-05 22:41 | PASS | conversation 2026-06-19 (spec-* family split, issue #265); consolidated into /spec dispatcher 2026-06-23 (one skill, args) |
+| submitted-by-trailers | A | 2026-07-05 22:41 | PASS | conversation 2026-06-12 (commit attribution trailers) |
+| sync-skill-contract | A | 2026-07-05 22:41 | PASS | issue #331 — /sync dispatcher skill (bidirectional origin↔upstream sync) |
+| watchdog-completed-session-reap | A | 2026-07-05 22:41 | PASS | issue #235 (completed autopilot PR session reaping) |
+| watchdog-draft-prs | A | 2026-07-05 22:41 | PASS | conversation 2026-06-15 (generic watchdog + stale draft PR recovery) |
+| watchdog-stuck-sessions | A | 2026-07-05 22:41 | PASS | issue #240 (Codex zero-credit stuck autopilot sessions) 2026-06-17 |
+| weigh-scorer-contract | A | 2026-07-05 22:41 | PASS | .oh/tasks/rlm-weighted-trajectories/prd.json US-003 (2026-06-27) |
+| wiki-readme-index | A | 2026-07-05 22:41 | PASS | issue #132 — wiki README index drift guard |
+| workflow-boundaries | A | 2026-07-05 22:41 | PASS | conversation 2026-06-19 (workflow consolidation, issue #259) |
 
 <!-- benchmark: pass-rate = PASS / (PASS + REGRESSION + TIMEOUT); SKIPPED excluded -->

--- a/.oh/evals/probes/oh-image-only-deploy.sh
+++ b/.oh/evals/probes/oh-image-only-deploy.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# tier: A
+# source: .oh/tasks/image-only-deploy/prd.json US-004 (issue #609, Flavor B image-only deploy)
+# desc: guards the Flavor B (image-only, no-checkout) contract — entrypoint.sh
+#   gates its no-bind branch on OH_IMAGE_ONLY strictly BEFORE the host-UID-sync
+#   elif, and defines seed_workspace_volume/.image-seeded; a behavioral sim
+#   (fenced function extracted in isolation, no full entrypoint source) proves
+#   fresh-seed, idempotent-reseed, and no-clobber-of-existing-.oh/ behavior;
+#   docker-compose.image-only.yml mounts a named oh_workspace volume, sets
+#   OH_IMAGE_ONLY=1, parameterizes image:, sets pull_policy:, and has neither
+#   build: nor a `..:` bind mount; the primary docker-compose.yml still keeps
+#   its `..:` bind mount (regression floor); the deploy doc has dropped the
+#   "Not yet" placeholder and documents oh_workspace/OH_IMAGE_ONLY; the
+#   Dockerfile (if present) stages /opt/oh-seed for the entrypoint to seed from.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+ENTRYPOINT="$ROOT/.devcontainer/entrypoint.sh"
+COMPOSE_IO="$ROOT/.devcontainer/docker-compose.image-only.yml"
+COMPOSE_PRIMARY="$ROOT/.devcontainer/docker-compose.yml"
+DOCKERFILE="$ROOT/.devcontainer/Dockerfile"
+DOC="$ROOT/.oh/docs/deployment-prebuilt-image.md"
+
+# SKIPPED (exit 2): Flavor B (image-only) artifacts are not present on this
+# branch yet — do not REGRESSION on absence.
+if [[ ! -f "$COMPOSE_IO" ]] || [[ ! -f "$ENTRYPOINT" ]] || ! grep -q 'OH_IMAGE_ONLY' "$ENTRYPOINT"; then
+  echo "SKIPPED: Flavor B (image-only) artifacts not present (docker-compose.image-only.yml and/or entrypoint.sh OH_IMAGE_ONLY gate absent)" >&2
+  exit 2
+fi
+
+fails=()
+
+# (1) entrypoint.sh: the OH_IMAGE_ONLY gate must appear strictly BEFORE the
+#     host-UID-sync `elif [ -d "$HARNESS_DIR" ]` branch, and the seed helper
+#     + its marker must be present.
+# NOTE: each pipe is `|| true`-guarded at the statement level — under
+# `pipefail`, a no-match `grep -n` (exit 1) makes the WHOLE pipeline's exit
+# status non-zero even though `head`/`cut` succeed on empty input, which
+# would otherwise abort the script under `set -e` with no named failure.
+gate_line="$(grep -n 'if \[.*OH_IMAGE_ONLY' "$ENTRYPOINT" | head -1 | cut -d: -f1)" || true
+elif_line="$(grep -n 'elif \[ -d "\$HARNESS_DIR" \]' "$ENTRYPOINT" | head -1 | cut -d: -f1)" || true
+if [[ -z "$gate_line" ]] || [[ -z "$elif_line" ]] || (( gate_line >= elif_line )); then
+  fails+=("entrypoint.sh must gate the no-bind branch on OH_IMAGE_ONLY strictly BEFORE elif [ -d \"\$HARNESS_DIR\" ] (host UID sync path)")
+fi
+grep -Fq 'seed_workspace_volume' "$ENTRYPOINT" \
+  || fails+=("entrypoint.sh must define/call seed_workspace_volume")
+grep -Fq '.image-seeded' "$ENTRYPOINT" \
+  || fails+=("entrypoint.sh must reference the .image-seeded marker")
+
+# (2) BEHAVIORAL seed sim — extract ONLY the fenced seed_workspace_volume
+#     function (entrypoint.sh ends in `exec "$@"`, so we never source the
+#     whole file) and run it against real mktemp -d dirs.
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+seed_fn_file="$tmp/seed_workspace_volume.sh"
+awk '
+  /# >>> seed_workspace_volume >>>/ { flag=1; next }
+  /# <<< seed_workspace_volume <<</ { flag=0 }
+  flag
+' "$ENTRYPOINT" > "$seed_fn_file"
+
+if [[ ! -s "$seed_fn_file" ]] || ! grep -Fq 'seed_workspace_volume()' "$seed_fn_file"; then
+  fails+=("seed_workspace_volume fence markers missing — cannot run behavioral sim")
+else
+  # shellcheck disable=SC1090
+  source "$seed_fn_file"
+  if ! declare -F seed_workspace_volume >/dev/null 2>&1; then
+    fails+=("seed_workspace_volume fence markers missing — cannot run behavioral sim")
+  else
+    fixture="$tmp/fixture-src"
+    mkdir -p "$fixture/.oh"
+    echo "fixture-sentinel-$$" > "$fixture/.oh/SENTINEL_FIXTURE"
+    export OH_IMAGE_SEED_SRC="$fixture"
+
+    # (a) fresh empty dest: seeds .oh/, writes the marker, flags this-boot.
+    dest_a="$(mktemp -d "$tmp/dest-a.XXXXXX")"
+    if seed_workspace_volume "$dest_a"; then :; fi
+    if [[ ! -d "$dest_a/.oh" ]] || [[ ! -f "$dest_a/.oh/.image-seeded" ]] \
+       || [[ "${OH_IMAGE_SEEDED_THIS_BOOT:-}" != "1" ]]; then
+      fails+=("seed sim (a): fresh empty dest must seed .oh/, write the .image-seeded marker, and set OH_IMAGE_SEEDED_THIS_BOOT=1")
+    fi
+
+    # (b) second call on the same (now-seeded) dest: idempotent, no re-copy.
+    if seed_workspace_volume "$dest_a"; then :; fi
+    if [[ "${OH_IMAGE_SEEDED_THIS_BOOT:-}" != "0" ]]; then
+      fails+=("seed sim (b): a second call on an already-seeded dest must be idempotent (OH_IMAGE_SEEDED_THIS_BOOT=0, no re-copy)")
+    fi
+
+    # (c) fresh dest pre-populated with its OWN .oh/ (distinct sentinel, no
+    #     marker): existing content is preserved and the fixture is NOT
+    #     copied in (no clobber of a populated-but-unmarked volume).
+    dest_c="$(mktemp -d "$tmp/dest-c.XXXXXX")"
+    mkdir -p "$dest_c/.oh"
+    echo "own-sentinel-$$" > "$dest_c/.oh/OWN_SENTINEL"
+    if seed_workspace_volume "$dest_c"; then :; fi
+    if [[ ! -f "$dest_c/.oh/OWN_SENTINEL" ]]; then
+      fails+=("seed sim (c): pre-existing .oh/ content must be preserved (no-clobber guard)")
+    fi
+    if [[ -f "$dest_c/.oh/SENTINEL_FIXTURE" ]]; then
+      fails+=("seed sim (c): fixture sentinel must NOT be copied into a dest that already has its own .oh/ (no-clobber guard)")
+    fi
+  fi
+fi
+
+# (3) docker-compose.image-only.yml shape: named volume mount, OH_IMAGE_ONLY=1,
+#     parameterized image:, a pull_policy:, and NO build:/`..:` bind mount.
+grep -Eq '^[[:space:]]*-[[:space:]]*oh_workspace:\$\{OH_PROJECT_ROOT' "$COMPOSE_IO" \
+  || fails+=("docker-compose.image-only.yml must mount a named oh_workspace volume at \${OH_PROJECT_ROOT}")
+grep -Fq 'OH_IMAGE_ONLY=1' "$COMPOSE_IO" \
+  || fails+=("docker-compose.image-only.yml must set OH_IMAGE_ONLY=1 in the container environment")
+grep -Eq 'image:[[:space:]]*\$\{OH_SANDBOX_IMAGE' "$COMPOSE_IO" \
+  || fails+=("docker-compose.image-only.yml image: must interpolate \${OH_SANDBOX_IMAGE...}")
+grep -Eq '^[[:space:]]*pull_policy:' "$COMPOSE_IO" \
+  || fails+=("docker-compose.image-only.yml must set a pull_policy:")
+if grep -Eq '^[[:space:]]*build:' "$COMPOSE_IO"; then
+  fails+=("docker-compose.image-only.yml must NOT have a build: block (image-only, never builds locally)")
+fi
+if grep -Eq '^[[:space:]]*-[[:space:]]*\.\.:' "$COMPOSE_IO"; then
+  fails+=("docker-compose.image-only.yml must NOT have a '..:' bind mount (no checkout)")
+fi
+
+# (4) REGRESSION FLOOR: the primary docker-compose.yml must still keep its
+#     `..:` bind mount — Flavor B must not touch Flavor A's contract.
+if [[ ! -f "$COMPOSE_PRIMARY" ]]; then
+  fails+=("primary docker-compose.yml not found at $COMPOSE_PRIMARY")
+else
+  grep -Eq '^[[:space:]]*-[[:space:]]*\.\.:' "$COMPOSE_PRIMARY" \
+    || fails+=("docker-compose.yml lost its '..:' bind mount — regression floor broken")
+fi
+
+# (5) Deploy doc: placeholder gone, mentions oh_workspace + OH_IMAGE_ONLY.
+if [[ ! -f "$DOC" ]]; then
+  fails+=("deploy doc not found at $DOC")
+else
+  not_yet_count="$(grep -c "Not yet" "$DOC" || true)"
+  if [[ "${not_yet_count:-0}" -ne 0 ]]; then
+    fails+=("deployment-prebuilt-image.md still contains the 'Not yet' placeholder (${not_yet_count} occurrence(s))")
+  fi
+  grep -Fq 'oh_workspace' "$DOC" \
+    || fails+=("deployment-prebuilt-image.md must mention oh_workspace")
+  grep -Fq 'OH_IMAGE_ONLY' "$DOC" \
+    || fails+=("deployment-prebuilt-image.md must mention OH_IMAGE_ONLY")
+fi
+
+# (6) Dockerfile: if present, it must stage /opt/oh-seed for the entrypoint
+#     to seed from. SKIP just this sub-check if the Dockerfile is absent.
+if [[ -f "$DOCKERFILE" ]]; then
+  grep -Eq 'COPY.*/opt/oh-seed' "$DOCKERFILE" \
+    || fails+=("Dockerfile must stage the seed source (COPY ... /opt/oh-seed/)")
+else
+  echo "[oh-image-only-deploy] Dockerfile not present — skipping /opt/oh-seed staging sub-check" >&2
+fi
+
+if (( ${#fails[@]} > 0 )); then
+  echo "REGRESSION: Flavor B (image-only deploy) contract broken:" >&2
+  printf '  - %s\n' "${fails[@]}" >&2
+  exit 1
+fi
+
+echo "PASS: Flavor B (image-only) contract — entrypoint gates OH_IMAGE_ONLY before the host-UID-sync elif and defines seed_workspace_volume/.image-seeded; behavioral sim confirms fresh-seed, idempotent-reseed, and no-clobber-of-existing-.oh/; docker-compose.image-only.yml mounts oh_workspace, sets OH_IMAGE_ONLY=1, parameterizes image:/pull_policy:, and has no build:/'..:' bind mount; primary docker-compose.yml still binds '..:' (regression floor); deploy doc drops the 'Not yet' placeholder and documents oh_workspace/OH_IMAGE_ONLY; Dockerfile stages /opt/oh-seed" >&2
+exit 0

--- a/.oh/scripts/__tests__/entrypoint.test.ts
+++ b/.oh/scripts/__tests__/entrypoint.test.ts
@@ -52,9 +52,14 @@ describe("devcontainer entrypoint auth volume ownership", () => {
 
     expect(block).toContain("uid_reconcile_step()");
     expect(block).toContain("WARNING: failed to");
-    expect(block).not.toContain("2>/dev/null || true");
-    expect(block).not.toContain("groupmod -g \"$HOST_GID\" sandbox 2>/dev/null");
-    expect(block).not.toContain("usermod -u \"$HOST_UID\" sandbox 2>/dev/null");
+    // Scope the "no swallowed failures" guard to the host-reconciliation
+    // branch itself. The sibling `OH_IMAGE_ONLY` (no-bind) branch legitimately
+    // best-efforts a volume chown with `2>/dev/null || true`; it is not host
+    // UID reconciliation (it deliberately skips it), so it is excluded here.
+    const reconBranch = block.slice(block.indexOf('elif [ -d "$HARNESS_DIR" ]'));
+    expect(reconBranch).not.toContain("2>/dev/null || true");
+    expect(reconBranch).not.toContain("groupmod -g \"$HOST_GID\" sandbox 2>/dev/null");
+    expect(reconBranch).not.toContain("usermod -u \"$HOST_UID\" sandbox 2>/dev/null");
   });
 
   it("prints UID sync success only after reconciliation commands report success", () => {


### PR DESCRIPTION
Closes #609.

> **Stacked on #610 (Flavor A).** Base is `feat/prebuilt-image-mode`; review/merge #610 first. The diff here is the Flavor B delta only.

## What

**Flavor B** — image-only deployment, *no repo checkout*. Run the published image standalone; the workspace and `.oh/` control plane live in a **named volume** (`oh_workspace`), seeded once from the image. This is the "one command, no clone" path.

The blocker was `entrypoint.sh`, which assumes a bind-mounted repo. This PR adds a guarded **no-bind mode**.

## Changes

- **`entrypoint.sh` — `OH_IMAGE_ONLY` no-bind mode** (default unset = byte-for-byte today's behavior):
  - Skips host UID/GID sync — a named-volume mountpoint is root-owned (uid 0), so the normal `stat`-and-sync would mis-target. Instead chowns the volume to `sandbox`.
  - `seed_workspace_volume()` copies the baked control plane into an **empty** volume on **first boot** only (marker `.oh/.image-seeded`; idempotent + clobber-guarded). Runs before `link-providers`, root `pnpm install`, and cron tmux so they see a populated `.oh/`.
- **`Dockerfile`** — bake a non-shadowed seed source at `/opt/oh-seed`. The named volume shadows `$OH_PROJECT_ROOT`, so seeding needs an out-of-mount source. **Required for Flavor B to boot on a real host** (see caveat below).
- **`docker-compose.image-only.yml`** — standalone recipe: GHCR image, `pull_policy`, named `oh_workspace` volume, `OH_IMAGE_ONLY=1`, **no `build:`**, no bind mount.
- **`oh-image-only-deploy.sh`** (tier A probe) — env-gate ordering, a **behavioral seed simulation** (fresh-seed / idempotent / no-clobber against temp fixtures), compose shape, the **primary-compose bind-mount regression floor**, and doc/Dockerfile checks.
- **Docs** — replace the "Not yet" placeholder with the Flavor B section (recipe, seed-to-volume persistence, Railway supersede-candidate note, manual smoke checklist).
- **`entrypoint.test.ts`** — scope the "no swallowed failures" guard to the host-reconciliation branch (the new no-bind branch is a sibling that legitimately best-efforts a chown).

## Locked decisions

- **Control plane** = baked image, **seeded into a named volume on first boot**; volume authoritative + operator-editable afterward, persists across image pulls.
- **Railway** = docs-only supersede-candidate; `.oh/deploy/railway/` **untouched** (unvalidated path).
- **Build scope** = deterministically verifiable without a live Docker host; live boot smoke is the manual checklist below.

## Verification (no docker required)

- 447 CLI tests pass; 81 eval probes green (`oh-image-only-deploy.sh` PASS, no regressions; Flavor A probe still PASS).
- `bash -n entrypoint.sh` clean; behavioral seed sim: 9/9 assertions.
- Regression floor: primary `docker-compose.yml` bind mount intact; `OH_IMAGE_ONLY` unset → entrypoint behavior unchanged.

## ⚠️ Manual live-host smoke (NOT run here — required before relying on Flavor B)

Flavor B needs an image **built after the `/opt/oh-seed` bake** (i.e. a release newer than current `latest`). On a host:

- [ ] `docker pull ghcr.io/mifunedev/openharness:<tag built after this change>`
- [ ] `docker compose -f .devcontainer/docker-compose.image-only.yml up -d` → confirm a **pull, not a build**
- [ ] `.oh/` seeded into the volume (`… exec sandbox ls /home/sandbox/harness/.oh`)
- [ ] agent / `oh` CLI usable in the container
- [ ] edit a file under `.oh/`, `restart`, confirm it persists

## Provenance

PRD → `/ralph` prd.json → advisor-agent decomposition (which caught the missing seed-source bake, added as US-006) → specialized implementer agents in waves → consolidated verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
