### PR TITLE
feat: add pi-yaml-hooks support (YAML hooks for pi)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,9 @@ workspace/.slack/settings.json
 # Pi project config (generated symlinks)
 workspace/.pi/
 
+# pi-yaml-hooks audit output (see .pi/hook/hooks.yaml)
+.pi-hook-logs/
+
 # Startup script (contains runtime config, tokens sourced from env)
 workspace/startup.sh
 **/.pnpm-store

--- a/.pi/UPSTREAM.md
+++ b/.pi/UPSTREAM.md
@@ -44,3 +44,36 @@ On each review:
 1. Check whether `tintinweb/pi-messenger-bridge` has published a newer release.
 2. If so (or once the thread-reply PR is released), re-pin `.devcontainer/entrypoint.sh`'s `npm install` line from the fork branch to `pi-messenger-bridge@<release>` and validate.
 3. Verify the Slack transport still loads and bridges turns after the bump.
+
+---
+
+## Provenance — pi-yaml-hooks
+
+| Property | Value |
+|----------|-------|
+| **Capability** | Event-driven YAML hooks for pi (`tool.before.*`/`tool.after.*`/`file.changed`/`session.*` → `bash`/`tool`/`notify`/`confirm`/`setStatus`) |
+| **Package** | `pi-yaml-hooks` ([KristjanPikhof/Pi-YAML-Hooks](https://github.com/KristjanPikhof/Pi-YAML-Hooks)) |
+| **License** | MIT |
+| **Install / load** | Pinned in `.pi/settings.json` `packages[]` as `npm:pi-yaml-hooks@2026.6.14` (loads the engine in every pi session). Project hook config lives at `.pi/hook/hooks.yaml` and is **inert until trusted** via `/hooks-trust` or `PI_YAML_HOOKS_TRUST_PROJECT=1` — the harness does not auto-trust globally. See `.pi/hook/README.md`. |
+| **Vendored** | Engine: No — npm package pin. Examples: the small `pre-tool-developer-guards` pack is vendored under `.pi/hook/examples/` as reference-only (intentionally superseded by `.pi/extensions/path-guard.ts`); the repo-only `atomic-commit-snapshot-worker` pack is deliberately not vendored. |
+
+### Relationship Model
+
+The YAML-hooks capability is consumed as a **thin npm package pin** (same model
+as `pi-autoresearch`, `pi-subagents`, etc.), not a vendored port. The engine
+loads in every pi session, but the harness's project hook config (`.pi/hook/hooks.yaml`)
+is a conservative, observe-only demonstration that stays inert until an operator
+trusts the project. Blocking/guarding is intentionally left to the existing
+TypeScript extension `.pi/extensions/path-guard.ts` — the YAML layer does not
+duplicate it.
+
+### Review Cadence
+
+**Owner**: `@ryaneggz`
+**Schedule**: Quarterly (check for a newer `pi-yaml-hooks` release)
+**Last reviewed**: 2026-07-05
+
+On each review:
+1. Check whether `KristjanPikhof/Pi-YAML-Hooks` has published a newer release (`npm view pi-yaml-hooks version`).
+2. If so, re-pin `.pi/settings.json` `packages[]` **and** the matching entry in `.pi/extensions/__tests__/settings.test.ts` (asserted with `toEqual` — keep them in lockstep), then run `node_modules/.bin/vitest run`.
+3. Confirm the event/action/condition vocabulary in `.pi/hook/README.md` still matches upstream, and that `.pi/hook/hooks.yaml` still parses/loads under a trusted session.

--- a/.pi/extensions/__tests__/settings.test.ts
+++ b/.pi/extensions/__tests__/settings.test.ts
@@ -24,6 +24,7 @@ describe("project Pi settings", () => {
       "npm:@guwidoe/pi-prompt-suggester@0.3.10",
       "npm:pi-autoresearch@1.6.0",
       "npm:@ff-labs/pi-fff@0.9.5",
+      "npm:pi-yaml-hooks@2026.6.14",
       "git:github.com/Michaelliv/pi-dynamic-workflows@dbc6800d1f725f7439e51705e2664c59484afcd1",
     ]);
   });

--- a/.pi/hook/README.md
+++ b/.pi/hook/README.md
@@ -1,0 +1,94 @@
+# pi-yaml-hooks — harness config
+
+Event-driven **YAML hooks** for the pi coding agent. The engine is the
+[`pi-yaml-hooks`](https://github.com/KristjanPikhof/Pi-YAML-Hooks) npm package,
+pinned in [`.pi/settings.json`](../settings.json) `packages[]` as
+`npm:pi-yaml-hooks@2026.6.14`. This directory holds the harness's project-scoped
+hook config plus vendored upstream examples.
+
+Upstream tracking (package, license, review cadence) lives in
+[`.pi/UPSTREAM.md`](../UPSTREAM.md).
+
+## What loads
+
+| File | Status |
+|---|---|
+| [`hooks.yaml`](./hooks.yaml) | **Active** (when trusted) — observe-only demonstration hook |
+| [`post-tool-log.mjs`](./post-tool-log.mjs) | Helper for the active hook (NDJSON audit logger) |
+| [`examples/pre-tool-developer-guards/`](./examples/pre-tool-developer-guards/) | **Reference only** — intentionally NOT wired (see below) |
+
+Audit output is written to `.pi-hook-logs/tool-events.ndjson` at the repo root,
+which is **git-ignored** — logs are never committed.
+
+## Trust gate (required)
+
+Project hooks do **nothing** until the repo is explicitly trusted. This is a
+deliberate security boundary; the harness does **not** auto-trust globally.
+Enable per operator decision:
+
+```bash
+/hooks-trust                    # interactive, inside a pi session
+# or, per session:
+PI_YAML_HOOKS_TRUST_PROJECT=1 pi
+```
+
+Until then, `hooks.yaml` is inert even though the engine is installed.
+
+## The active hook (`hooks.yaml`)
+
+A conservative, **non-blocking** demonstration that YAML hooks work in the
+harness. It only:
+
+- **Logs** an NDJSON audit line on `tool.after.write`/`tool.after.edit` under
+  harness source areas (`.oh/**`, `.pi/**`, `.devcontainer/**`, `workspace/**`).
+- **Annotates** the pi status bar (`setStatus`) when dependency metadata
+  (`package.json`, lockfiles) changes.
+
+It intentionally does **not** block tools or inject follow-up prompts:
+
+- Pre-tool guarding (risky bash, protected-path writes) is already owned by the
+  TypeScript extension [`.pi/extensions/path-guard.ts`](../extensions/path-guard.ts).
+  A YAML pre-tool guard would double up and produce conflicting confirmations.
+- Prompt injection (`tool:` follow-ups) would interfere with unattended
+  autopilot/cron pi sessions.
+
+## Schema reference
+
+Config lives in `<project>/.pi/hook/hooks.yaml` (this file) or
+`<project>/.pi/hooks.yaml`; global hooks load from `~/.pi/agent/hook/hooks.yaml`.
+
+- **Events**: `tool.before.*`, `tool.after.*` (e.g. `tool.after.write`),
+  `file.changed`, `session.created`, `session.idle`, `session.deleted`.
+- **Actions**: `bash` (run a shell command; exit `2` blocks a `tool.before.*`
+  call), `tool` (inject a follow-up prompt), `notify` (UI notification),
+  `confirm` (confirmation dialog), `setStatus` (status-bar entry).
+  `command:` actions are **rejected by pi at load time** — always use `bash:`.
+- **Conditions**: `matchesCodeFiles`, `matchesAnyPath`, `matchesAllPaths`.
+- Context is injected as env vars (`PI_PROJECT_DIR`, `PI_SESSION_ID`, …) and the
+  tool payload is piped to the action on stdin (see `post-tool-log.mjs`).
+
+## Vendored examples (reference only)
+
+### `examples/pre-tool-developer-guards/` — NOT wired
+
+Verbatim upstream pack that blocks risky bash + protected-file writes/edits +
+package installs. **Intentionally kept as reference and not activated**: its
+behavior is already provided by `.pi/extensions/path-guard.ts`. Kept here to
+document the overlap and as a copy-paste starting point for downstream repos.
+Its `hooks.yaml` uses upstream repo-relative paths — adjust before any use.
+
+### `atomic-commit-snapshot-worker` — not vendored
+
+The upstream repo also ships a Python "snapshot worker" pack that auto-commits
+**every** `file.changed` event into a per-worktree SQLite queue. It is
+deliberately **not** included here:
+
+- It is **repo-only** (not in the npm tarball) and cannot be installed via the
+  package pin.
+- It auto-commits on every file change — destructive and unsuitable for the
+  harness's worktree/PR workflow.
+- ~3,400 lines of `fcntl`/POSIX-signal Python would be committed dead weight.
+
+If ever needed, clone it from
+<https://github.com/KristjanPikhof/Pi-YAML-Hooks/tree/main/examples/atomic-commit-snapshot-worker>
+and point a **project-local** `hooks.yaml` at the on-disk path.

--- a/.pi/hook/examples/pre-tool-developer-guards/README.md
+++ b/.pi/hook/examples/pre-tool-developer-guards/README.md
@@ -1,0 +1,45 @@
+# Pre-tool developer guards
+
+This is an opt-in example pack, not a built-in `pi-yaml-hooks` feature. Copy or adapt the snippets below into your own `hooks.yaml`.
+
+Use this pack when you want fast checks before PI runs tools that can mutate a project.
+
+## Good use cases
+
+| Hook | Use it when |
+|---|---|
+| `guard-risky-bash` | You want to block obviously dangerous shell commands before they run. |
+| `guard-protected-write` | You want to stop direct writes to secrets, certificates, keys, and local environment files. |
+| `guard-protected-edit` | You want the same protection for edit-based file changes. |
+| `guard-package-install` | You want package installs and dependency updates to be explicit human actions. |
+
+## Install
+
+Copy `hooks.yaml` into your global hook file or a trusted project hook file.
+
+If you keep the script in this repository, run PI from the repository root or update this path in `hooks.yaml`:
+
+```yaml
+bash: 'node ./examples/pre-tool-developer-guards/pre-tool-policy.mjs'
+```
+
+For another project, copy `pre-tool-policy.mjs` into that project and point the YAML at the copied path.
+
+## Behavior
+
+- Exit code `2` blocks the matching pre-tool call.
+- These hooks inspect the tool payload before execution; they do not run on `tool.after.*`.
+- The risky-bash regex matches commands following whitespace, start-of-string, or a shell separator (`;`, `&`, `|`, `` ` ``, `(`). It is a coarse heuristic, not a security boundary; quoting, env var indirection, `eval`, and aliasing can all defeat it. Use OS-level controls if you need real isolation.
+- `isProtectedPath` runs a path-segment check, so `config/.env`, `app/secrets/db.yml`, and `home/.ssh/id_rsa` are all protected.
+
+## Quick test
+
+1. Add the hooks.
+2. Ask PI to run `git reset --hard`.
+3. Confirm the bash tool call is blocked.
+4. Ask PI to write `.env`.
+5. Confirm the write tool call is blocked.
+6. Ask PI to run `npm install left-pad`.
+7. Confirm the package install is blocked.
+8. Ask PI to run a harmless command like `pwd`.
+9. Confirm it still runs.

--- a/.pi/hook/examples/pre-tool-developer-guards/hooks.yaml
+++ b/.pi/hook/examples/pre-tool-developer-guards/hooks.yaml
@@ -1,0 +1,21 @@
+# Example commands use repo-relative paths; copy this pack into your repo root or adjust paths.
+hooks:
+  - id: guard-risky-bash
+    event: tool.before.bash
+    actions:
+      - bash: 'node ./examples/pre-tool-developer-guards/pre-tool-policy.mjs'
+
+  - id: guard-protected-write
+    event: tool.before.write
+    actions:
+      - bash: 'node ./examples/pre-tool-developer-guards/pre-tool-policy.mjs'
+
+  - id: guard-protected-edit
+    event: tool.before.edit
+    actions:
+      - bash: 'node ./examples/pre-tool-developer-guards/pre-tool-policy.mjs'
+
+  - id: guard-package-install
+    event: tool.before.bash
+    actions:
+      - bash: 'node ./examples/pre-tool-developer-guards/pre-tool-policy.mjs --package-install-only'

--- a/.pi/hook/examples/pre-tool-developer-guards/pre-tool-policy.mjs
+++ b/.pi/hook/examples/pre-tool-developer-guards/pre-tool-policy.mjs
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+
+// Command-start prefix: beginning of string, whitespace, or a shell separator
+// (semicolon, ampersand, pipe, backtick, opening paren). This is intentionally
+// coarse — it catches obvious chained commands like `cd /tmp; rm -rf /` but is
+// not a security boundary. Determined attackers can defeat it with quoting,
+// env vars, eval, or aliasing. Use OS-level controls for real isolation.
+const CMD_START = String.raw`(?:^|[\s;&|\x60(])`
+
+const payload = JSON.parse(await readStdin())
+const packageInstallOnly = process.argv.includes("--package-install-only")
+const toolName = String(payload.tool_name ?? "")
+const toolArgs = isRecord(payload.tool_args) ? payload.tool_args : {}
+
+if (toolName === "bash") {
+  const command = String(toolArgs.command ?? "")
+  const reason = packageInstallOnly ? getPackageInstallReason(command) : getRiskyCommandReason(command)
+  if (reason) {
+    block(reason)
+  }
+}
+
+if (toolName === "write" || toolName === "edit") {
+  const filePath = String(toolArgs.path ?? toolArgs.filePath ?? toolArgs.file_path ?? toolArgs.file ?? "")
+  if (isProtectedPath(filePath)) {
+    block(`Blocked ${toolName} to protected path: ${filePath}`)
+  }
+}
+
+function getRiskyCommandReason(command) {
+  const compact = command.replace(/\s+/g, " ").trim()
+  const rules = [
+    [new RegExp(`${CMD_START}git\\s+reset\\s+--hard(\\s|$)`), "Blocked git reset --hard"],
+    [new RegExp(`${CMD_START}git\\s+clean\\s+-[^\\n;]*f[^\\n;]*d`), "Blocked destructive git clean"],
+    [new RegExp(`${CMD_START}rm\\s+-[^\\n;]*r[^\\n;]*f\\s+(\\/|\\$HOME|~)(\\s|$)`), "Blocked broad rm -rf target"],
+    [new RegExp(`${CMD_START}chmod\\s+-R\\s+777(\\s|$)`), "Blocked recursive chmod 777"],
+    [/(curl|wget)[^|;&]*\|\s*(sh|bash)(\s|$)/, "Blocked pipe-to-shell install command"],
+  ]
+
+  return rules.find(([pattern]) => pattern.test(compact))?.[1]
+}
+
+function getPackageInstallReason(command) {
+  const compact = command.replace(/\s+/g, " ").trim()
+  const rules = [
+    [new RegExp(`${CMD_START}(npm|pnpm|yarn)\\s+(install|add|update|upgrade)(\\s|$)`), "Blocked package install/update command"],
+    [new RegExp(`${CMD_START}bun\\s+(install|add|update)(\\s|$)`), "Blocked package install/update command"],
+    [new RegExp(`${CMD_START}pipx?\\s+install(\\s|$)`), "Blocked Python package install command"],
+    [new RegExp(`${CMD_START}uv\\s+(add|sync|pip\\s+install)(\\s|$)`), "Blocked Python dependency update command"],
+    [new RegExp(`${CMD_START}cargo\\s+(add|install|update)(\\s|$)`), "Blocked Rust dependency update command"],
+    [new RegExp(`${CMD_START}go\\s+get(\\s|$)`), "Blocked Go dependency update command"],
+  ]
+
+  return rules.find(([pattern]) => pattern.test(compact))?.[1]
+}
+
+function isProtectedPath(filePath) {
+  if (!filePath) return false
+  const normalized = filePath.replaceAll("\\", "/").replace(/^\.\//, "")
+  // Path-segment match: split on "/" and inspect every segment so that
+  // `config/.env`, `subdir/.env.local`, `app/secrets/db.yml`,
+  // and `home/.ssh/id_rsa` all match.
+  const segments = normalized.split("/").filter((s) => s.length > 0)
+  if (segments.length === 0) return false
+  const basename = segments[segments.length - 1]
+  const parents = segments.slice(0, -1)
+
+  const protectedBasenames = new Set([".env", "credentials.json", ".npmrc", "secrets.yaml", "secrets.yml"])
+  if (protectedBasenames.has(basename)) return true
+  if (basename.startsWith(".env.")) return true
+  if (basename.endsWith(".pem") || basename.endsWith(".key") || basename.endsWith(".p12")) return true
+
+  // Parent-segment match: any ancestor named `.ssh` or `secrets` makes the
+  // file protected. This catches both `/home/.ssh/id_rsa` and `app/secrets/db.yml`.
+  if (parents.includes(".ssh") || parents.includes("secrets")) return true
+
+  return false
+}
+
+function block(message) {
+  console.error(message)
+  process.exit(2)
+}
+
+function isRecord(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+async function readStdin() {
+  const chunks = []
+  for await (const chunk of process.stdin) {
+    chunks.push(chunk)
+  }
+  return Buffer.concat(chunks).toString("utf8")
+}

--- a/.pi/hook/hooks.yaml
+++ b/.pi/hook/hooks.yaml
@@ -1,0 +1,61 @@
+# Open Harness — active pi-yaml-hooks config
+#
+# Engine: pi-yaml-hooks (pinned in .pi/settings.json `packages[]`).
+# This file loads ONLY when the project is trusted:
+#   /hooks-trust        (interactive, per operator)
+#   PI_YAML_HOOKS_TRUST_PROJECT=1   (env, per session)
+# See README.md in this directory for the full schema + trust model.
+#
+# Scope note: this is a deliberately conservative, NON-blocking demonstration
+# of YAML hooks in the harness. It only observes (NDJSON audit log) and annotates
+# (status bar). It intentionally does NOT inject follow-up prompts or block tools
+# — pre-tool guarding is already owned by .pi/extensions/path-guard.ts, and prompt
+# injection would interfere with unattended autopilot/cron pi sessions.
+hooks:
+  # Append an NDJSON audit line whenever pi writes/edits a harness source file.
+  - id: log-harness-write
+    event: tool.after.write
+    conditions:
+      - matchesAnyPath:
+          - ".oh/**"
+          - ".pi/**"
+          - ".devcontainer/**"
+          - "workspace/**"
+    actions:
+      - bash: 'node ./.pi/hook/post-tool-log.mjs'
+
+  - id: log-harness-edit
+    event: tool.after.edit
+    conditions:
+      - matchesAnyPath:
+          - ".oh/**"
+          - ".pi/**"
+          - ".devcontainer/**"
+          - "workspace/**"
+    actions:
+      - bash: 'node ./.pi/hook/post-tool-log.mjs'
+
+  # Surface dependency-metadata changes in the pi status bar.
+  - id: mark-dependency-change-write
+    event: tool.after.write
+    conditions:
+      - matchesAnyPath:
+          - "package.json"
+          - "package-lock.json"
+          - "pnpm-lock.yaml"
+          - "yarn.lock"
+          - "bun.lock"
+    actions:
+      - setStatus: "Dependency metadata changed — consider `node_modules/.bin/vitest run`"
+
+  - id: mark-dependency-change-edit
+    event: tool.after.edit
+    conditions:
+      - matchesAnyPath:
+          - "package.json"
+          - "package-lock.json"
+          - "pnpm-lock.yaml"
+          - "yarn.lock"
+          - "bun.lock"
+    actions:
+      - setStatus: "Dependency metadata changed — consider `node_modules/.bin/vitest run`"

--- a/.pi/hook/post-tool-log.mjs
+++ b/.pi/hook/post-tool-log.mjs
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+import { mkdir, appendFile } from "node:fs/promises"
+import path from "node:path"
+
+const payload = JSON.parse(await readStdin())
+const cwd = typeof payload.cwd === "string" ? payload.cwd : process.cwd()
+const logDir = path.join(cwd, ".pi-hook-logs")
+const logPath = path.join(logDir, "tool-events.ndjson")
+
+const entry = {
+  timestamp: new Date().toISOString(),
+  event: payload.event,
+  tool: payload.tool_name,
+  files: Array.isArray(payload.files) ? payload.files : [],
+  changes: Array.isArray(payload.changes) ? payload.changes : [],
+}
+
+await mkdir(logDir, { recursive: true })
+await appendFile(logPath, `${JSON.stringify(entry)}\n`, "utf8")
+
+async function readStdin() {
+  const chunks = []
+  for await (const chunk of process.stdin) {
+    chunks.push(chunk)
+  }
+  return Buffer.concat(chunks).toString("utf8")
+}

--- a/.pi/settings.json
+++ b/.pi/settings.json
@@ -26,6 +26,7 @@
     "npm:@guwidoe/pi-prompt-suggester@0.3.10",
     "npm:pi-autoresearch@1.6.0",
     "npm:@ff-labs/pi-fff@0.9.5",
+    "npm:pi-yaml-hooks@2026.6.14",
     "git:github.com/Michaelliv/pi-dynamic-workflows@dbc6800d1f725f7439e51705e2664c59484afcd1"
   ]
 }


### PR DESCRIPTION
## What

Adds **pi-yaml-hooks** support to the harness — event-driven YAML hooks for the pi coding agent, adapted from [KristjanPikhof/Pi-YAML-Hooks `examples/`](https://github.com/KristjanPikhof/Pi-YAML-Hooks/tree/main/examples).

## Approach (scope decisions)

Advisor-guided. The three upstream example packs were triaged rather than dumped in wholesale:

| Pack | Decision | Why |
|---|---|---|
| **engine** (`pi-yaml-hooks` npm) | **Install** — pinned in `.pi/settings.json` `packages[]` | Idiomatic thin package pin (same model as sibling pi packages) |
| **post-tool-developer-feedback** | **Adapted → active hook** (`.pi/hook/hooks.yaml`) | Non-blocking, genuinely useful proof-of-usability |
| **pre-tool-developer-guards** | **Vendored reference-only, NOT wired** | Fully superseded by `.pi/extensions/path-guard.ts`; wiring it would double-fire confirmations |
| **atomic-commit-snapshot-worker** | **Not vendored** (pointer only) | Repo-only, destructive auto-commit, ~3.4k LOC of fcntl/signal Python |

## Changes

- `.pi/settings.json` — pin `npm:pi-yaml-hooks@2026.6.14`; **`settings.test.ts` updated in lockstep** (the array is asserted with `toEqual`).
- `.pi/hook/hooks.yaml` — active hook: NDJSON audit log (`tool.after.write|edit` under harness source areas) + `setStatus` on dependency-file changes. Deliberately **observe-only**: no `bash` blocking, no `tool:` prompt injection (would interfere with autopilot/cron pi sessions).
- `.pi/hook/post-tool-log.mjs` — audit-log helper (writes git-ignored `.pi-hook-logs/`).
- `.pi/hook/README.md` — provenance, event/action/condition schema, trust model, and why packs 1/3 aren't wired.
- `.pi/hook/examples/pre-tool-developer-guards/` — vendored reference pack.
- `.gitignore` — ignore `.pi-hook-logs/`.
- `.pi/UPSTREAM.md` — tracking entry (MIT, quarterly review, lockstep-bump note).

## ⚠️ Trust decision (operator-facing)

Project hooks are **inert until the repo is trusted** via `/hooks-trust` or `PI_YAML_HOOKS_TRUST_PROJECT=1`. This PR **does not** auto-trust globally — that would change behavior across every pi session (autopilot, cron, slack bridge) and is left as an explicit operator choice, documented in `.pi/hook/README.md`. The engine loads everywhere via the pin, but `hooks.yaml` does nothing until trusted.

## Verification

- `node_modules/.bin/vitest run .pi/extensions/__tests__/` → **57 passed** (incl. `settings.test.ts` with the new pin).
- `node --check` on both `.mjs` helpers; active `hooks.yaml` confirmed free of `command:` actions (rejected by pi at load).
- `npm view pi-yaml-hooks version` → `2026.6.14` (pin verified against registry, not guessed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)