### PR TITLE
fix: seed .claude control-plane config into OH_IMAGE_ONLY no-bind volume

### DIFF
--- a/.devcontainer/entrypoint.sh
+++ b/.devcontainer/entrypoint.sh
@@ -66,6 +66,21 @@ seed_workspace_volume() {
   local marker="$dest/.oh/.image-seeded"
   local src="${OH_IMAGE_SEED_SRC:-/opt/oh-seed}"
   OH_IMAGE_SEEDED_THIS_BOOT=0
+  # Self-heal: backfill tracked .claude control-plane config that a prior
+  # (pre-fix) image failed to seed. Copy ONLY when the dest file is absent and
+  # the seed carries it, so operator edits are never clobbered. Runs before the
+  # marker early-return so an already-marked-but-incomplete volume heals in
+  # place — no volume wipe. Idempotent. protected-paths.txt is boot-critical
+  # (link-providers.sh --init hard-requires it); settings.json wires hooks.
+  if [ -n "$src" ] && [ -d "$src/.claude" ]; then
+    local _rel
+    for _rel in protected-paths.txt settings.json; do
+      if [ ! -e "$dest/.claude/$_rel" ] && [ -f "$src/.claude/$_rel" ]; then
+        mkdir -p "$dest/.claude"
+        cp -a "$src/.claude/$_rel" "$dest/.claude/$_rel" 2>/dev/null || true
+      fi
+    done
+  fi
   if [ -f "$marker" ]; then
     return 0
   fi

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,12 @@
 **/.env*
-.claude/
+# Exclude .claude/ CONTENTS (local plans, specs, screenshots, auth state) but
+# re-include the tracked control-plane config the OH_IMAGE_ONLY seed needs.
+# Without these in /opt/oh-seed, a no-bind volume boots without
+# .claude/protected-paths.txt and link-providers.sh --init crash-loops.
+.claude/*
+!.claude/protected-paths.txt
+!.claude/settings.json
+!.claude/.example.env.claude
 .oh/worktrees/*
 !.oh/worktrees/README.md
 # Defensive only: legacy root .worktrees/ is no longer canonical.

--- a/.oh/docs/deployment-prebuilt-image.md
+++ b/.oh/docs/deployment-prebuilt-image.md
@@ -232,6 +232,25 @@ A healthy boot ends with `Providers OK: …` and `SEED_OK`, and the logs show
 authoritative — later boots see the `.oh/.image-seeded` marker and skip
 re-seeding, so your in-container edits persist.
 
+```bash
+# ── 4. Attach an interactive shell (once the container is stable) ──
+# Optional: block until the healthcheck reports healthy (start_period ~300s).
+until [ "$(docker inspect -f '{{.State.Health.Status}}' "$NAME" 2>/dev/null)" = healthy ]; do
+  echo "waiting for $NAME to become healthy…"; sleep 5
+done
+
+docker exec -it -u sandbox "$NAME" zsh   # interactive shell (bash also available)
+# then, inside the container:
+#   claude        # start the coding agent (or: codex, pi)
+#   gh auth login && gh auth setup-git   # one-time, if GH_TOKEN was not passed
+```
+
+The image has no `HEALTHCHECK` of its own, so `docker run` won't populate
+`.State.Health` unless you add `--health-cmd`; on the plain `docker run` above,
+skip the wait loop and just exec once `docker ps` shows the container `Up`. The
+compose path (`docker-compose.image-only.yml`) defines the healthcheck, so there
+the wait loop works as written — or use `make shell` / `oh shell`.
+
 ### Single-arch caveat
 
 Same caveat as Flavor A above: the published image targets the CI runner's

--- a/.oh/docs/deployment-prebuilt-image.md
+++ b/.oh/docs/deployment-prebuilt-image.md
@@ -172,11 +172,65 @@ across image pulls and container recreation, not in the image itself. Later
 boots see the marker and skip re-seeding, so a populated volume is never
 clobbered.
 
-> ⚠️ **Flavor B requires an image built after the seed-bake change.** Baking
-> `/opt/oh-seed` into the image is a separate change on top of the Dockerfile;
-> only images published from that change onward contain it. The `latest` tag
-> at the time of writing does **not** yet contain `/opt/oh-seed` — pin a tag
-> from the next published release (or newer) before relying on Flavor B.
+> ⚠️ **Flavor B requires an image built after two changes:** (1) the seed-bake
+> that stages `/opt/oh-seed`, and (2) the `.claude` seed-config fix
+> ([#617](https://github.com/mifunedev/openharness/pull/617)) that stops
+> `.dockerignore` from starving `/opt/oh-seed` of `.claude/protected-paths.txt`.
+> An image missing (2) crash-loops on boot with
+> `ERROR: .claude/protected-paths.txt is missing`. Pin a tag published **after
+> #617 merges** (or a local build of that branch — see below) before relying on
+> Flavor B. Volumes already seeded by a pre-#617 image self-heal on the next
+> boot against a fixed image.
+
+### Clean slate + fresh run (explicit `docker run`)
+
+The [compose file](../../.devcontainer/docker-compose.image-only.yml) is the
+canonical one-liner (`docker compose -f … up -d`). If you drive Docker directly
+instead, this is the equivalent teardown → fresh run → verify sequence. It
+mirrors the compose file's env and volume set — note it reads `GIT_USER_NAME` /
+`GIT_USER_EMAIL` (the entrypoint ignores any `OH_GIT_*` variants).
+
+```bash
+# ── 0. Config ──────────────────────────────────────────────────────
+IMAGE=ghcr.io/mifunedev/openharness:latest   # a tag published after #617
+NAME=openharness
+
+# To test BEFORE #617 is published, build the fix branch locally and point
+# IMAGE at it (this is the "run it now" path):
+#   git fetch origin && git checkout feat/image-seed-claude-config
+#   docker build -t openharness:seedfix -f .devcontainer/Dockerfile .
+#   IMAGE=openharness:seedfix
+
+# ── 1. Clear previous state ── DESTRUCTIVE: wipes the seeded workspace ──
+docker rm -f "$NAME" 2>/dev/null || true
+docker volume rm oh_workspace 2>/dev/null || true   # the seeded .oh/ control plane
+
+# ── 2. Fresh run (no bind mount, no build) ─────────────────────────
+docker run -d --name "$NAME" --restart unless-stopped --init \
+  -e OH_IMAGE_ONLY=1 \
+  -e OH_PROJECT_ROOT=/home/sandbox/harness \
+  -e GIT_USER_NAME="ryaneggz" \
+  -e GIT_USER_EMAIL="kre8mymedia@gmail.com" \
+  -e GH_TOKEN="${GH_TOKEN:-}" \
+  -v oh_workspace:/home/sandbox/harness \
+  -v claude-auth:/home/sandbox/.claude \
+  -v gh-config:/home/sandbox/.config/gh \
+  -v oh_ssh:/home/sandbox/.ssh \
+  "$IMAGE" sleep infinity
+
+# ── 3. Verify the seed + provider wiring ───────────────────────────
+sleep 8
+docker logs "$NAME" 2>&1 | tail -30
+docker exec "$NAME" bash -lc '
+  ls -l /home/sandbox/harness/.claude/protected-paths.txt \
+  && bash /home/sandbox/harness/.oh/scripts/link-providers.sh --check \
+  && ls /home/sandbox/harness/.oh >/dev/null && echo SEED_OK'
+```
+
+A healthy boot ends with `Providers OK: …` and `SEED_OK`, and the logs show
+**no** `protected-paths.txt is missing`. The `oh_workspace` volume is now
+authoritative — later boots see the `.oh/.image-seeded` marker and skip
+re-seeding, so your in-container edits persist.
 
 ### Single-arch caveat
 

--- a/.oh/evals/probes/oh-image-only-deploy.sh
+++ b/.oh/evals/probes/oh-image-only-deploy.sh
@@ -152,6 +152,20 @@ else
   echo "[oh-image-only-deploy] Dockerfile not present — skipping /opt/oh-seed staging sub-check" >&2
 fi
 
+# (7) .claude control-plane seed contract. The no-bind seed must carry
+#     .claude/protected-paths.txt or link-providers.sh --init crash-loops. Guard
+#     BOTH halves: (a) .dockerignore re-includes it into the /opt/oh-seed build
+#     context (a bare `.claude/` exclusion starves the seed), and (b) the
+#     entrypoint seed fn backfills it so an already-seeded-but-incomplete volume
+#     self-heals without a wipe.
+DOCKERIGNORE="$ROOT/.dockerignore"
+if [[ -f "$DOCKERIGNORE" ]]; then
+  grep -Eq '^[[:space:]]*!\.claude/protected-paths\.txt[[:space:]]*$' "$DOCKERIGNORE" \
+    || fails+=(".dockerignore must re-include .claude/protected-paths.txt (!.claude/protected-paths.txt) so /opt/oh-seed carries it into the no-bind seed")
+fi
+grep -Fq 'protected-paths.txt' "$seed_fn_file" 2>/dev/null \
+  || fails+=("seed_workspace_volume must backfill .claude/protected-paths.txt so an already-seeded-but-incomplete volume self-heals")
+
 if (( ${#fails[@]} > 0 )); then
   echo "REGRESSION: Flavor B (image-only deploy) contract broken:" >&2
   printf '  - %s\n' "${fails[@]}" >&2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Update policy and release automation live in [`/git`](.claude/skills/git/SKILL.m
 ### Added
 ### Changed
 ### Fixed
+- Fix `OH_IMAGE_ONLY=1` (no-bind) boot crash-loop: `.dockerignore` excluded the whole `.claude/` directory, so `/opt/oh-seed` never carried `.claude/protected-paths.txt` and `link-providers.sh --init` failed on every boot. `.dockerignore` now re-includes the tracked `.claude/` control-plane config (`protected-paths.txt`, `settings.json`, `.example.env.claude`), and `entrypoint.sh`'s seed self-heals already-seeded-but-incomplete volumes by backfilling those files without clobbering operator edits (guarded by the `oh-image-only-deploy` probe).
 ### Removed
 - Remove the Railway hosted smoke deployment surface, including the root Railway config, deploy assets, documentation, README button, and eval guard.
 ### Deprecated


### PR DESCRIPTION
## Problem

Running the published image in no-bind mode (`OH_IMAGE_ONLY=1`, named `oh_workspace` volume, no repo checkout) crash-loops on boot:

```
ERROR: .claude/protected-paths.txt is missing
[entrypoint] failed to link provider skills; run: bash .oh/scripts/link-providers.sh --init
```

## Root cause

`.dockerignore` excluded the **entire** `.claude/` directory from the build context, so `Dockerfile`'s `COPY . /opt/oh-seed/` (its comment even admits it's "scoped by .dockerignore … .claude") never staged `.claude/protected-paths.txt`. In `OH_IMAGE_ONLY=1` mode the workspace volume seeds from `/opt/oh-seed`, so the file is absent and `link-providers.sh --init`'s `check_protected_paths()` fails → `exit 1` → crash loop.

Bind-mount mode (Flavor A) masks this entirely because the host's real `.claude/` is mounted in. Aggravator: the seed writes the `.oh/.image-seeded` marker after copying `.oh`, so subsequent boots skip re-seeding and stay broken permanently.

## Fix

- **`.dockerignore`** — exclude `.claude/*` contents (keeps local plans/specs/screenshots/auth out) but re-include the tracked control-plane config: `protected-paths.txt`, `settings.json`, `.example.env.claude`.
- **`entrypoint.sh`** — `seed_workspace_volume` now backfills those files (copy-if-absent, before the marker early-return) so an **already-seeded-but-incomplete** volume self-heals in place, without clobbering operator edits. Existing broken `oh_workspace` volumes recover on next boot — no wipe required.
- **`oh-image-only-deploy` probe** — new sub-check guards both halves of the seed contract.

## Validation

- Full `/eval` suite: 80 probes, no regressions.
- Isolated sim of the fenced seed fn against a stuck marked volume: `protected-paths.txt` backfilled, marker respected (`THIS_BOOT=0`, no full reseed), operator edit not clobbered.
- `.dockerignore` negation pattern verified to re-include only the whitelisted files on a live Docker build.

> Takes effect once a new image is published to `ghcr.io/mifunedev/openharness:latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
