### PR TITLE
docs: Start Here hub + live-docs discoverability (oh.mifune.dev)

### DIFF
--- a/.oh/docs/README.md
+++ b/.oh/docs/README.md
@@ -1,16 +1,38 @@
 # Open Harness docs
 
+📖 **Full rendered docs & search → https://oh.mifune.dev**
+
 GitHub-readable documentation for the core Open Harness repo. Prefer this index
 for repo-local docs and [DeepWiki](https://deepwiki.com/mifunedev/openharness)
 for generated codebase navigation. The rendered Docusaurus site and blog archive
 live in [`mifunedev/openharness-web`](https://github.com/mifunedev/openharness-web).
 
+## Start here
+
+Open Harness provides the sandbox; you choose the harness — a Docker workspace you
+clone-and-own, where `make sandbox` boots one long-lived container and the coding agent
+of your choice (Claude Code, Codex, Pi, Hermes, and more) works on its own branch and
+identity, running identically on your laptop or an unattended, lights-out remote VM.
+
+**Attach in 3 steps (VS Code):**
+
+```
+1. `make sandbox` — build the image and boot the container.
+2. VS Code → Command Palette (Ctrl/Cmd+Shift+P) → "Dev Containers: Attach to Running
+   Container" → select `openharness`. Ports auto-forward while attached.
+3. Open a terminal inside the container and run `claude` (or `codex` · `pi` · `hermes`).
+```
+
+Full terminal / Remote-SSH options: see [Connecting → Option B](connecting.md#option-b--vscode-attach-to-running-container-local-host).
+
+[Hermes](harnesses/hermes.md) — Nous Research's self-improving agent CLI — is an opt-in harness: set
+`install.hermes: true` in harness.yaml, rebuild, then run `hermes setup`.
 
 ## How the primitive pack ships
 
 Open Harness vendors the shared skills/agents/hooks primitive pack directly into the `.oh/` control plane (`.oh/skills/`, `.oh/agents/`, `.oh/hooks/`, `.oh/skills.lock`), tracked as ordinary files — the `oh` CLI lays them down during `oh init`/`oh update`, so a fresh checkout has them with no submodule or network step. Provider paths such as `.pi/skills`, `.claude/skills`, and `.codex/skills` are symlinks into `.oh/skills`; `.pi/` remains a provider surface for v1.
 
-## Start here
+## Setup & first steps
 
 - [Introduction](intro.md)
 - [Quickstart](quickstart.md)

--- a/.oh/docs/README.md
+++ b/.oh/docs/README.md
@@ -16,12 +16,10 @@ identity, running identically on your laptop or an unattended, lights-out remote
 
 **Attach in 3 steps (VS Code):**
 
-```
 1. `make sandbox` — build the image and boot the container.
 2. VS Code → Command Palette (Ctrl/Cmd+Shift+P) → "Dev Containers: Attach to Running
    Container" → select `openharness`. Ports auto-forward while attached.
 3. Open a terminal inside the container and run `claude` (or `codex` · `pi` · `hermes`).
-```
 
 Full terminal / Remote-SSH options: see [Connecting → Option B](connecting.md#option-b--vscode-attach-to-running-container-local-host).
 

--- a/README.md
+++ b/README.md
@@ -64,8 +64,9 @@ Run these **inside the sandbox** (`make shell`). Per-step depth + troubleshootin
 [quickstart → End-to-end setup walkthrough](.oh/docs/quickstart.md#end-to-end-setup-walkthrough).
 
 ```bash
-# GitHub auth over SSH — pick SSH, generate a key, paste a token:
-gh auth login && gh auth setup-git
+# GitHub auth over SSH — pick SSH, generate a key, paste a token
+# (SSH remotes use the key directly, so `gh auth setup-git` isn't needed):
+gh auth login
 
 # Create your own PRIVATE repo, point origin at it, add upstream — all over SSH:
 gh repo create <your-user>/openharness --private

--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@
 
 ---
 
+> 📖 **Read the docs → https://oh.mifune.dev**
+> Rendered, searchable docs, guides, and blog. New here? Start with the [Start Here hub](.oh/docs/README.md).
+
 ## 📦 Install
 
 Open Harness runs one project in one Docker sandbox. The recommended path is
@@ -247,10 +250,11 @@ make shell
 
 ## 📚 Where to go next
 
+- **[Read the docs → oh.mifune.dev](https://oh.mifune.dev)** — the rendered, searchable documentation site (start here)
 - [Docs index](.oh/docs/README.md) — GitHub-readable docs kept with the core repo
 - [Quickstart](.oh/docs/quickstart.md) — full step-by-step
 - [DeepWiki](https://deepwiki.com/mifunedev/openharness) — generated codebase map
-- [Docs site source](https://github.com/mifunedev/openharness-web) — migrated Docusaurus site and blog archive
+- [Docs site source](https://github.com/mifunedev/openharness-web) — Docusaurus source repo that builds oh.mifune.dev (contribute doc edits here)
 
 ## 🧹 Cleanup
 
@@ -268,4 +272,4 @@ MIT.
 
 ---
 
-[Docs index](.oh/docs/README.md) · [Docs site source](https://github.com/mifunedev/openharness-web)
+[Read the docs](https://oh.mifune.dev) · [Docs index](.oh/docs/README.md) · [Docs site source](https://github.com/mifunedev/openharness-web)


### PR DESCRIPTION
## What

Makes the rendered docs site **oh.mifune.dev** unmissable from the GitHub-first reader, and puts the value prop + VS Code attach + Hermes front-and-center.

- **`README.md`** — adds a compact "📖 Read the docs → https://oh.mifune.dev" callout band above `## 📦 Install`, and fixes the "Docs site source" mislabels so a reader can tell oh.mifune.dev is where you *read* the docs (vs. the openharness-web *source* repo).
- **`.oh/docs/README.md`** — leads with a **Start Here** hub: one-sentence value prop, a 3-step VS Code attach (linking Connecting → Option B), and a Hermes opt-in one-liner (linking `harnesses/hermes.md`).

## Why

The live site was only ever footer-linked and mislabeled as "source" — readers couldn't tell there was a searchable rendered docs site. The value prop, attach steps, and Hermes were scattered.

## Notes

- No rewrites of `connecting.md` / `hermes.md` — they're linked, not duplicated.
- Prose is kept word-identical to the mirrored **openharness-web** PR (Start Here block) so the two repos don't drift.

Companion PR (public site + blog): mifunedev/openharness-web `feat/docs-discoverability`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)