### PR TITLE
task: harden gateway tmux sessions (health status, hermes restart floor, log cap)

### DIFF
--- a/.devcontainer/client-slack-supervise.sh
+++ b/.devcontainer/client-slack-supervise.sh
@@ -1,10 +1,15 @@
 #!/usr/bin/env bash
-# Self-healing supervisor for the dedicated Slack bridge (client-slack-pi tmux session).
+# Self-healing supervisor for the gateway client sessions (client-slack-<backend>
+# tmux sessions).
 #
-# Launched by .devcontainer/entrypoint.sh with the PI_SLACK_* tokens already in
-# the environment and HARNESS / BRIDGE_ENTRY / RECOVERY_ENTRY / LOG exported.
+# Launched by .devcontainer/entrypoint.sh (pi) or .oh/scripts/gateway.sh with
+# HARNESS / LOG exported, plus:
+#   pi (default):  PI_SLACK_* tokens, BRIDGE_ENTRY, RECOVERY_ENTRY.
+#   hermes:        GATEWAY_BACKEND=hermes and SUPERVISE_CMD=<the hermes launch
+#                  command> — a GENERIC crash-restart loop with NONE of the
+#                  pi-specific stale-ctx/lock/recovery logic below.
 #
-# Why this exists: pi-messenger-bridge binds its long-lived Slack socket to a
+# Why this exists (pi): pi-messenger-bridge binds its long-lived Slack socket to a
 # session-scoped pi ctx. When pi replaces the session (compaction, fork, switch,
 # reload) that ctx goes stale and every subsequent Slack message throws
 # "extension ctx is stale after session replacement or reload" — the package has
@@ -28,49 +33,131 @@
 # (.pi/bridge-recovery/index.ts), which re-injects a failed Slack-originated turn
 # once on `previous_response_not_found` — recovery the npm bridge lacks.
 #
-# A clean pi exit (rc=0) stops the loop; a crash or watchdog-kill (rc!=0)
-# restarts it.
+# Health/observability: each launch stamps a non-secret state file and a
+# background ticker refreshes a heartbeat (proving the session is actively
+# supervised, not merely "a tmux session exists") and caps $LOG in place so a
+# long-lived session cannot grow it without bound. `gateway status` reads these.
+#
+# A clean exit (rc=0) stops the loop; a crash or watchdog-kill (rc!=0) restarts it.
 #
 # NOTE: intentionally no `set -e` — pkill/kill return non-zero when there is
 # nothing to signal, which is normal control flow here, not an error.
 set -u
 
+BACKEND="${GATEWAY_BACKEND:-pi}"
+SUPERVISE_CMD="${SUPERVISE_CMD:-}"
 HARNESS="${HARNESS:-${OH_PROJECT_ROOT:-/home/sandbox/harness}}"
 BRIDGE_ENTRY="${BRIDGE_ENTRY:-$HARNESS/.pi/bridge/node_modules/pi-messenger-bridge/dist/index.js}"
 RECOVERY_ENTRY="${RECOVERY_ENTRY:-$HARNESS/.pi/bridge-recovery/index.ts}"
-LOG="${LOG:-/tmp/client-slack-pi.log}"
+LOG="${LOG:-/tmp/client-slack-$BACKEND.log}"
 LOCK="$HOME/.pi/msg-bridge.lock"
 
-cd "$HARNESS" 2>/dev/null || true
+# Non-secret runtime state consumed by `gateway status` (see gateway.sh).
+STATE_DIR="${GATEWAY_STATE_DIR:-$HOME/.pi/gateway}"
+STATE="$STATE_DIR/$BACKEND.state"
+HEARTBEAT_FILE="$STATE_DIR/$BACKEND.heartbeat"
+STALE_FILE="$STATE_DIR/$BACKEND.stale"
+HEARTBEAT_INTERVAL="${GATEWAY_HEARTBEAT_INTERVAL:-20}"
+LOG_MAX_BYTES="${GATEWAY_LOG_MAX_BYTES:-5242880}"  # 5 MiB
+mkdir -p "$STATE_DIR" 2>/dev/null || true
+rm -f "$STALE_FILE" 2>/dev/null || true
+
+if [ "$BACKEND" = pi ] && [ -n "${PI_SLACK_BOT_TOKEN:-}" ]; then TOKEN_STATE=present
+elif [ "$BACKEND" = pi ]; then TOKEN_STATE=absent
+else TOKEN_STATE="n/a"; fi
+
+STARTED_ISO="$(date -u +%FT%TZ)"
+LAUNCHES=0
+
+# Atomic single-line/kv writes (never carry secrets). Writers are disjoint per
+# file: the main loop owns $STATE, the ticker owns $HEARTBEAT_FILE, the watchdog
+# owns $STALE_FILE — so no locking is needed.
+write_state() {
+  local tmp
+  tmp=$(mktemp "$STATE_DIR/.state.XXXXXX" 2>/dev/null) || return 0
+  {
+    printf 'backend=%s\n'      "$BACKEND"
+    printf 'session=%s\n'      "client-slack-$BACKEND"
+    printf 'bridge_token=%s\n' "$TOKEN_STATE"
+    printf 'started=%s\n'      "$STARTED_ISO"
+    printf 'last_launch=%s\n'  "$(date -u +%FT%TZ)"
+    printf 'launches=%s\n'     "$LAUNCHES"
+  } >"$tmp" 2>/dev/null && mv -f "$tmp" "$STATE" 2>/dev/null || rm -f "$tmp" 2>/dev/null || true
+}
+
+write_heartbeat() {
+  local tmp
+  tmp=$(mktemp "$STATE_DIR/.hb.XXXXXX" 2>/dev/null) || return 0
+  date -u +%s >"$tmp" 2>/dev/null && mv -f "$tmp" "$HEARTBEAT_FILE" 2>/dev/null || rm -f "$tmp" 2>/dev/null || true
+}
+
+# Copytruncate cap: keep the last half, then rewrite the SAME inode in place so
+# the pipe-pane / pi-stderr append fds and the stale-ctx `tail -F` stay valid
+# (a rename/create would leave them writing to the rotated-away inode).
+cap_log() {
+  [ -f "$LOG" ] || return 0
+  local sz; sz=$(stat -c %s "$LOG" 2>/dev/null || echo 0)
+  case "$sz" in ''|*[!0-9]*) return 0 ;; esac
+  [ "$sz" -gt "$LOG_MAX_BYTES" ] || return 0
+  local keep=$((LOG_MAX_BYTES / 2)) tmp
+  tmp=$(mktemp "$STATE_DIR/.log.XXXXXX" 2>/dev/null) || return 0
+  tail -c "$keep" "$LOG" >"$tmp" 2>/dev/null && cat "$tmp" >"$LOG" 2>/dev/null
+  rm -f "$tmp" 2>/dev/null || true
+}
 
 while true; do
-  rm -f "$LOCK" 2>/dev/null || true
-  echo "[bridge-supervisor] launching pi bridge ($(date -u +%FT%TZ))" >>"$LOG"
+  LAUNCHES=$((LAUNCHES + 1))
+  [ "$BACKEND" = pi ] && { rm -f "$LOCK" 2>/dev/null || true; }
+  echo "[bridge-supervisor] launching $BACKEND bridge ($(date -u +%FT%TZ))" >>"$LOG"
+  write_state
 
-  # Watchdog: tail $LOG from end-of-file (old stale-ctx lines never re-trigger),
-  # strip ANSI/CR so a TUI-rendered error is still greppable, and kill the bridge
-  # pi — matched by its unique --extension path — on the first stale-ctx line so
-  # the loop relaunches a fresh, non-stale process. Fully redirected (incl. stdin
-  # from /dev/null) so it never reads the pane pty or holds a stdout pipe open.
-  ( tail -Fn0 "$LOG" 2>/dev/null \
-      | sed -u 's/\x1b\[[0-9;?]*[A-Za-z]//g; s/\r//g' \
-      | grep -m1 'ctx is stale' >/dev/null 2>&1 \
-      && { echo "[bridge-supervisor] stale-ctx detected — restarting pi ($(date -u +%FT%TZ))" >>"$LOG"; \
-           pkill -f 'pi-messenger-bridge/dist/index.js'; } ) </dev/null >/dev/null 2>&1 &
-  WD=$!
+  # Heartbeat + in-place log cap ticker: refreshes while the process runs, torn
+  # down when it exits. Fully redirected so it never touches the pane pty.
+  ( while true; do write_heartbeat; cap_log; sleep "$HEARTBEAT_INTERVAL"; done ) </dev/null >/dev/null 2>&1 &
+  HB=$!
 
-  # Interactive TTY launch: stdin+stdout = pane pty (-> interactive mode, no JSON
-  # flood, stays alive at idle), stderr -> $LOG. No pipe, no --mode rpc.
-  pi --extension "$BRIDGE_ENTRY" --extension "$RECOVERY_ENTRY" --approve 2>>"$LOG"
-  rc=$?
+  WD=""
+  if [ "$BACKEND" = pi ]; then
+    # Watchdog: tail $LOG from end-of-file (old stale-ctx lines never re-trigger),
+    # strip ANSI/CR so a TUI-rendered error is still greppable, record the recovery
+    # for `gateway status`, and kill the bridge pi — matched by its unique
+    # --extension path — on the first stale-ctx line so the loop relaunches a
+    # fresh, non-stale process. Fully redirected (incl. stdin from /dev/null) so it
+    # never reads the pane pty or holds a stdout pipe open.
+    ( tail -Fn0 "$LOG" 2>/dev/null \
+        | sed -u 's/\x1b\[[0-9;?]*[A-Za-z]//g; s/\r//g' \
+        | grep -m1 'ctx is stale' >/dev/null 2>&1 \
+        && { echo "[bridge-supervisor] stale-ctx detected — restarting pi ($(date -u +%FT%TZ))" >>"$LOG"; \
+             date -u +%s >"$STALE_FILE" 2>/dev/null; \
+             pkill -f 'pi-messenger-bridge/dist/index.js'; } ) </dev/null >/dev/null 2>&1 &
+    WD=$!
 
-  kill "$WD" 2>/dev/null || true
-  pkill -P "$WD" 2>/dev/null || true
+    # Interactive TTY launch: stdin+stdout = pane pty (-> interactive mode, no JSON
+    # flood, stays alive at idle), stderr -> $LOG. No pipe, no --mode rpc.
+    pi --extension "$BRIDGE_ENTRY" --extension "$RECOVERY_ENTRY" --approve 2>>"$LOG"
+    rc=$?
+  else
+    # Generic backend (hermes): crash-restart-with-backoff only. SUPERVISE_CMD
+    # ends in `exec <bin> gateway run`, so it replaces this subshell and returns
+    # the backend's own exit code. No stale-ctx/lock/recovery — those are
+    # pi-bridge-specific.
+    if [ -z "$SUPERVISE_CMD" ]; then
+      echo "[bridge-supervisor] no SUPERVISE_CMD for backend '$BACKEND' — exiting" >>"$LOG"
+      break
+    fi
+    bash -c "$SUPERVISE_CMD" 2>>"$LOG"
+    rc=$?
+  fi
+
+  kill "$HB" 2>/dev/null || true
+  pkill -P "$HB" 2>/dev/null || true
+  if [ -n "$WD" ]; then kill "$WD" 2>/dev/null || true; pkill -P "$WD" 2>/dev/null || true; fi
 
   if [ "$rc" -eq 0 ]; then
-    echo "[bridge-supervisor] pi exited cleanly (rc=0) — stopping ($(date -u +%FT%TZ))" >>"$LOG"
+    echo "[bridge-supervisor] $BACKEND exited cleanly (rc=0) — stopping ($(date -u +%FT%TZ))" >>"$LOG"
+    rm -f "$HEARTBEAT_FILE" 2>/dev/null || true
     break
   fi
-  echo "[bridge-supervisor] pi exited rc=$rc — restarting in 3s ($(date -u +%FT%TZ))" >>"$LOG"
+  echo "[bridge-supervisor] $BACKEND exited rc=$rc — restarting in 3s ($(date -u +%FT%TZ))" >>"$LOG"
   sleep 3
 done

--- a/.oh/docs/integrations/slack.md
+++ b/.oh/docs/integrations/slack.md
@@ -206,10 +206,16 @@ container (`.oh/scripts/gateway.sh` errors "run inside the sandbox" otherwise).
 
 ```bash
 gateway pi                 # start the client-slack-pi session (idempotent)
-gateway status             # both sessions + state, e.g.
-                           #   · client-slack-pi        stopped   (gateway pi)
-                           #   · client-slack-hermes    stopped   (gateway hermes)
+gateway status             # both sessions + HEALTH (not just existence), e.g.
+                           #   ✓ client-slack-pi  healthy   (tmux attach -t client-slack-pi)
+                           #   · client-slack-hermes  stopped   (gateway hermes)
 ```
+
+`status` reports the supervisor's live state, not merely "a tmux session exists":
+`healthy` (heartbeat fresh), `recovering` (in a restart/backoff — may add
+`· N restart(s)` / `· recovered <age> ago` after a stale-ctx heal), or
+`running · disconnected (no PI_SLACK token)` when the bridge loaded without tokens.
+A session with no state yet falls back to `running`.
 
 To **watch** a running gateway without any risk of killing it, attach **read-only** with
 `-r`, then detach with `Ctrl-b d` — never `Ctrl-C` or `exit` (those stop the pi process):

--- a/.oh/scripts/gateway.sh
+++ b/.oh/scripts/gateway.sh
@@ -59,12 +59,63 @@ session_live() { tmux ls -F '#{session_name}' 2>/dev/null | grep -Fxq "$1"; }
 
 ANSI_STRIP="sed -u 's/\\x1b\\[[0-9;?]*[A-Za-z]//g; s/\\r//g'"
 
+# Non-secret runtime state the supervisor writes (see client-slack-supervise.sh):
+# $STATE_DIR/<backend>.{state,heartbeat,stale}. Used to report health, not just
+# session existence, in `gateway status`.
+STATE_DIR="${GATEWAY_STATE_DIR:-$HOME/.pi/gateway}"
+STALE_AFTER="${GATEWAY_STALE_AFTER:-60}"   # seconds without a heartbeat => not healthy
+
+# Parse a key from a state file as DATA (grep/cut, never source/eval).
+_state_kv() {
+  [ -f "$1" ] || return 1
+  local line; line=$(grep -E "^$2=" "$1" 2>/dev/null | tail -1) || return 1
+  [ -n "$line" ] || return 1
+  printf '%s' "${line#*=}"
+}
+
+# Seconds since the epoch timestamp in $1, or non-zero if unreadable/non-numeric.
+_state_age() {
+  [ -f "$1" ] || return 1
+  local t; t=$(cat "$1" 2>/dev/null) || return 1
+  case "$t" in ''|*[!0-9]*) return 1 ;; esac
+  printf '%s' "$(( $(date -u +%s) - t ))"
+}
+
+# Human health phrase for a LIVE backend session, from its state files.
+backend_health() {
+  local b="$1"
+  local state="$STATE_DIR/$b.state" hb="$STATE_DIR/$b.heartbeat" stale="$STATE_DIR/$b.stale"
+  local token launches hbage staleage extra=""
+  launches=$(_state_kv "$state" launches) || launches=""
+  if [ -n "$launches" ] && [ "$launches" -gt 1 ] 2>/dev/null; then extra=" · $((launches - 1)) restart(s)"; fi
+  if staleage=$(_state_age "$stale"); then extra="$extra · recovered ${staleage}s ago"; fi
+  token=$(_state_kv "$state" bridge_token) || token=""
+  if [ "$token" = absent ]; then printf 'running · disconnected (no PI_SLACK token)%s' "$extra"; return 0; fi
+  if hbage=$(_state_age "$hb") && [ "$hbage" -le "$STALE_AFTER" ] 2>/dev/null; then
+    printf 'healthy%s' "$extra"
+  else
+    printf 'recovering%s' "$extra"
+  fi
+}
+
 show_status() {
-  local b s
+  local b s health
   for b in pi hermes; do
     s="client-slack-$b"
-    if session_live "$s"; then echo "  ✓ $s        running   (tmux attach -t $s)"
-    else                       echo "  · $s        stopped   (gateway $b)"; fi
+    if session_live "$s"; then
+      if [ -f "$STATE_DIR/$b.state" ]; then
+        health=$(backend_health "$b")
+        case "$health" in
+          healthy*)     echo "  ✓ $s  $health   (tmux attach -t $s)" ;;
+          *disconnect*) echo "  ⚠ $s  $health   (tmux attach -t $s)" ;;
+          *)            echo "  ⟳ $s  $health   (tmux attach -t $s)" ;;
+        esac
+      else
+        echo "  ✓ $s  running   (tmux attach -t $s)"
+      fi
+    else
+      echo "  · $s  stopped   (gateway $b)"
+    fi
   done
 }
 
@@ -306,13 +357,29 @@ start_hermes() {
   ensure_hermes_gateway_cwd "$hermes_home" "$gateway_cwd"
 
   # Hermes' gateway reads its own config (hermes gateway setup / hermes secrets),
-  # so no PI_SLACK_* plumbing here. Run in foreground inside the session.
-  local launch_cmd
-  printf -v launch_cmd 'cd %q && export HERMES_HOME=%q HERMES_GATEWAY_CWD=%q && exec %q gateway run' \
+  # so no PI_SLACK_* plumbing here. Run under the shared supervisor's GENERIC
+  # crash-restart mode (no pi-specific stale-ctx/lock/recovery) so a hermes crash
+  # self-heals with backoff, matching the pi backend's resilience floor.
+  local run_cmd
+  printf -v run_cmd 'cd %q && export HERMES_HOME=%q HERMES_GATEWAY_CWD=%q && exec %q gateway run' \
     "$gateway_cwd" "$hermes_home" "$gateway_cwd" "$hermes_bin"
-  if tmux new-session -d -s "$session" "$launch_cmd"; then
+
+  # No secrets in the hermes launch command, but use the same mode-600
+  # source-then-delete env-file pattern as pi for uniformity.
+  local envf; envf=$(mktemp /tmp/client-slack-hermes-env.XXXXXX) || return 1
+  chmod 600 "$envf"
+  {
+    printf 'export HARNESS=%q\n'         "$HARNESS"
+    printf 'export LOG=%q\n'             "$log"
+    printf 'export GATEWAY_BACKEND=%q\n' "hermes"
+    printf 'export SUPERVISE_CMD=%q\n'   "$run_cmd"
+  } >>"$envf"
+
+  if tmux new-session -d -s "$session" \
+       "bash -c '. \"$envf\"; rm -f \"$envf\"; exec bash \"$HARNESS/.devcontainer/client-slack-supervise.sh\"'"; then
     tmux pipe-pane -o -t "$session" "$ANSI_STRIP >> $log" 2>/dev/null || true
   else
+    rm -f "$envf"
     echo "[gateway] failed to start $session" >&2
     return 1
   fi

--- a/.oh/skills/t3/references/sandbox-processes.md
+++ b/.oh/skills/t3/references/sandbox-processes.md
@@ -63,6 +63,33 @@ sessions into one is not.
 - No need for `nohup`, `systemd-user`, or ad-hoc backgrounding inside the
   sandbox — tmux is the single convention.
 
+## Gateway client sessions (`client-slack-*`) — why tmux, not a service
+
+The Slack gateway (`.oh/scripts/gateway.sh`) is the load-bearing case for the
+tmux rule, and the reason it is **not** a separate Docker Compose service or an
+in-container `supervisord`/`systemd` unit:
+
+- **Interactive pty is required.** `pi` runs interactively on the pane's real TTY
+  so its UI extensions render in the TUI (off a TTY it floods stdout with
+  `extension_ui_request` JSON and exits at idle). `/msg-bridge`, `/trusted`,
+  `/channels` are typed **into** that pane, and challenge-code auth is **read off**
+  it (`tmux attach -r` / `capture-pane`). A detached service/supervisor process
+  has no attachable, driveable pane — the exact affordance tmux provides.
+- **The supervisor heals *live-but-bad* state, which `restart:` cannot see.**
+  `.devcontainer/client-slack-supervise.sh` restarts on the `ctx is stale`
+  signature (a process that keeps running while silently not serving), clears the
+  single-instance lock, and co-loads the retry-recovery extension. Docker/systemd
+  restart only reacts to process **exit**, so a service would still carry this
+  bash supervisor and gain nothing.
+
+The supervisor also stamps non-secret health state under
+`~/.pi/gateway/<backend>.{state,heartbeat,stale}`, which `gateway status` reads to
+report **healthy / recovering / disconnected** rather than mere session existence.
+The `hermes` backend runs under the same supervisor in a **generic** crash-restart
+mode (no pi-specific stale-ctx logic), giving it the same restart floor. See the
+decision analysis for the full trade-off; do not re-litigate tmux-vs-service
+without new constraints (e.g. a backend that needs inbound networking).
+
 ## Starting a Session
 
 Inside the sandbox:


### PR DESCRIPTION
## Context

Follow-up to an architecture analysis of whether the messaging gateway (Slack bridges for `pi`/`hermes`, `.oh/scripts/gateway.sh`) should become a Docker Compose service or in-container supervisor. **Verdict: keep tmux** — `pi` needs an interactive pty (TUI rendering, `/msg-bridge` config, challenge-code read) that neither offers, and the self-healing supervisor already handles *live-but-bad* failures (`ctx is stale`) that Docker/systemd `restart:` (exit-only) cannot see. This PR hardens the tmux design in place, closing the two real gaps that made a service tempting.

## Changes

**H1 — health-aware `gateway status`**
The supervisor stamps non-secret state (`~/.pi/gateway/<backend>.{state,heartbeat,stale}`, atomic writes, disjoint per-file writers, never carries tokens). `show_status` reads it and reports **healthy / recovering / disconnected** with restart count and recovery age — instead of the old `✓ running` that only meant "a tmux session exists". Falls back to `running` when no state file is present.

**H2 — hermes restart floor**
`hermes` previously ran bare (`exec hermes gateway run`) with no restart. It now runs under the *same* supervisor in a **generic** crash-restart-with-backoff mode (`GATEWAY_BACKEND=hermes` + `SUPERVISE_CMD`), with none of pi's stale-ctx/lock/recovery logic — restoring resilience parity behind the one uniform verb. Uses the same mode-600 source-then-delete env-file pattern as pi.

**H3 — log size cap**
A background ticker refreshes the heartbeat and caps the mirrored log at 5 MiB via in-place **copytruncate** (preserves the inode, so the `pipe-pane` / stale-ctx `tail -F` append fds stay valid). Kept on `/tmp` — no durable-volume move, so no widening of the secret/message-content exposure window.

**H4 — docs**
`sandbox-processes.md` records why the gateway stays tmux and what the supervisor does that `restart:` cannot; `slack.md` status example updated to the new health wording.

## Contracts preserved (tripwires)
- Token-as-data / no-injection (state file + logs never carry `PI_SLACK_*`)
- Exact `grep -Fxq` session-name match (no `client-slack` prefix collision)
- Supervisor scripts present (`client-slack-supervise.sh` + `seed-msg-bridge.sh`)
- Three-way `LOG` lockstep — rotation via copytruncate keeps the stale-ctx watchdog seeing new lines
- Verb / flag / exit-code surface unchanged (`oh gateway` / Makefile / boot symlink pass through untouched)

## Verification
- `bash -n` both scripts ✓
- `gateway.test.ts` — 8/8 pass ✓
- Eval probe floor — **78 pass, 2 pre-existing skips, 0 fail** ✓
- Functional: status rendering (healthy/recovering/disconnected/fallback/stopped), hermes generic restart-on-failure + missing-`SUPERVISE_CMD` guard, pi clean-stop lifecycle, copytruncate inode preservation ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)
