### PR TITLE
FROM feat/625-cloud-cli TO development

### DIFF
--- a/.oh/cli/README.md
+++ b/.oh/cli/README.md
@@ -60,11 +60,30 @@ oh shell         # open a zsh shell in the running container
 | `oh sandbox` | Provision and start the sandbox (`docker compose up -d --build`). |
 | `oh shell [container]` | Open a `zsh` shell in the running sandbox container. |
 | `oh gateway <args…>` | Manage a messaging client session (Slack bridge for `pi`/`hermes`). |
+| `oh cloud <args…>` | Configure credentials and manage OpenHarness Cloud SSH keys and nodes. |
 | `oh --version` | Print the CLI version. |
 | `oh --help` | Show help; every subcommand also accepts `--help`. |
 
 `oh init` and `oh update` fetch their payload on demand — with no local source they shallow-clone
 the public OpenHarness repo into a temp dir and remove it after the run (`--from-remote`, `--ref <ref>`).
+
+## OpenHarness Cloud
+
+Configure the Cloud API once, then use `oh cloud` instead of hand-writing authenticated HTTP
+requests:
+
+```bash
+oh cloud config  # securely prompts for the current provisioner key
+oh cloud ssh-keys create --name laptop --public-key-file ~/.ssh/openharness_node.pub
+oh cloud nodes create --name demo --ssh-key-id <ssh-key-id>
+oh cloud nodes watch <node-id>
+```
+
+Until OpenHarness Cloud issues user API tokens, `oh cloud config` stores the user-provided
+provisioner key at `~/.config/openharness/cloud.json` with file mode `0600`. The key is never
+printed. `OH_CLOUD_CONFIG` overrides the file path; `OH_CLOUD_API_URL` and
+`OH_PROVISION_KEY` provide non-persistent overrides for automation. Run `oh cloud --help` for
+the complete SSH-key and node lifecycle command set.
 
 ## Documentation
 

--- a/.oh/cli/package-lock.json
+++ b/.oh/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mifune/openharness",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mifune/openharness",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "bin": {
         "oh": "dist/oh.js"
       },

--- a/.oh/cli/package.json
+++ b/.oh/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mifune/openharness",
-  "version": "0.1.1",
-  "description": "Open Harness CLI — in-sandbox configuration wizards.",
+  "version": "0.2.0",
+  "description": "Open Harness CLI — scaffold sandboxes and manage OpenHarness Cloud nodes.",
   "license": "MIT",
   "homepage": "https://github.com/mifunedev/openharness#readme",
   "repository": {

--- a/.oh/cli/src/__tests__/cloud.test.ts
+++ b/.oh/cli/src/__tests__/cloud.test.ts
@@ -1,0 +1,200 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { createCloudApiClient, runCloud, type CloudIO } from "../commands/cloud.js";
+import { cloudConfigPath, readCloudConfig } from "../lib/cloud-config.js";
+
+const cleanups: string[] = [];
+
+afterEach(() => {
+  while (cleanups.length > 0) rmSync(cleanups.pop()!, { recursive: true, force: true });
+});
+
+function tempConfig(): { dir: string; path: string; env: NodeJS.ProcessEnv } {
+  const dir = mkdtempSync(join(tmpdir(), "oh-cloud-"));
+  cleanups.push(dir);
+  const path = join(dir, "config", "cloud.json");
+  return { dir, path, env: { OH_CLOUD_CONFIG: path } };
+}
+
+function response(payload: unknown, status = 200): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function io(overrides: Partial<CloudIO> = {}): CloudIO & { out: string[]; err: string[] } {
+  const out: string[] = [];
+  const err: string[] = [];
+  return {
+    stdout: (text) => out.push(text),
+    stderr: (text) => err.push(text),
+    out,
+    err,
+    ...overrides,
+  };
+}
+
+describe("cloud config", () => {
+  it("stores a prompted provisioner key in a mode-0600 user config without echoing it", async () => {
+    const fixture = tempConfig();
+    const console = io({
+      env: fixture.env,
+      askSecret: async () => "temporary-provisioner-secret",
+    });
+
+    expect(await runCloud(["config"], console)).toBe(0);
+    expect(cloudConfigPath(fixture.env)).toBe(fixture.path);
+    expect(await readCloudConfig(fixture.path)).toEqual({
+      apiUrl: "http://127.0.0.1:3000",
+      provisionKey: "temporary-provisioner-secret",
+    });
+    expect(statSync(fixture.path).mode & 0o777).toBe(0o600);
+    expect(readFileSync(fixture.path, "utf8")).toContain('"version": 1');
+    expect(console.out.join("")).toContain("Provision credential: configured");
+    expect(console.out.join("")).not.toContain("temporary-provisioner-secret");
+  });
+
+  it("shows config state without revealing the stored credential", async () => {
+    const fixture = tempConfig();
+    const setup = io({ env: fixture.env, askSecret: async () => "secret" });
+    await runCloud(["config", "--api-url", "https://cloud.example.test"], setup);
+
+    const console = io({ env: fixture.env });
+    expect(await runCloud(["config", "show"], console)).toBe(0);
+    expect(console.out.join("")).toContain("API URL: https://cloud.example.test");
+    expect(console.out.join("")).toContain("Provision credential: configured");
+    expect(console.out.join("")).not.toContain("secret");
+  });
+});
+
+describe("cloud API commands", () => {
+  it("uses saved config to create a node and print one selected field", async () => {
+    const fixture = tempConfig();
+    await runCloud(
+      ["config", "--api-url", "https://cloud.example.test", "--provision-key", "saved-key"],
+      io({ env: fixture.env }),
+    );
+
+    const calls: Array<{ url: string; init: RequestInit }> = [];
+    const console = io({
+      env: fixture.env,
+      fetch: (async (url: string | URL | Request, init?: RequestInit) => {
+        calls.push({ url: String(url), init: init ?? {} });
+        return response({ id: "node-1", status: "queued" }, 202);
+      }) as typeof fetch,
+    });
+
+    expect(
+      await runCloud(
+        ["nodes", "create", "--name", "smoke-1", "--ssh-key-id", "key-1", "--output", "id"],
+        console,
+      ),
+    ).toBe(0);
+    expect(console.out.join("")).toBe("node-1\n");
+    expect(calls[0]?.url).toBe("https://cloud.example.test/api/nodes");
+    expect(calls[0]?.init.method).toBe("POST");
+    expect((calls[0]?.init.headers as Record<string, string>)["x-provision-key"]).toBe("saved-key");
+    expect(JSON.parse(String(calls[0]?.init.body))).toEqual({ name: "smoke-1", sshKeyId: "key-1" });
+  });
+
+  it("maps every SSH-key and node lifecycle command to its API endpoint", async () => {
+    const cases = [
+      { args: ["nodes", "list"], method: "GET", path: "/api/nodes" },
+      { args: ["nodes", "get", "node/1"], method: "GET", path: "/api/nodes/node%2F1" },
+      { args: ["nodes", "events", "node-1"], method: "GET", path: "/api/nodes/node-1/events" },
+      { args: ["nodes", "destroy", "node-1"], method: "DELETE", path: "/api/nodes/node-1" },
+      { args: ["nodes", "restart", "node-1"], method: "POST", path: "/api/nodes/node-1/restart" },
+      { args: ["nodes", "rebuild", "node-1"], method: "POST", path: "/api/nodes/node-1/rebuild" },
+      { args: ["ssh-keys", "list"], method: "GET", path: "/api/ssh-keys" },
+    ];
+
+    for (const item of cases) {
+      let call: { url: string; init: RequestInit } | undefined;
+      const console = io({
+        env: { OH_PROVISION_KEY: "env-key" },
+        fetch: (async (url: string | URL | Request, init?: RequestInit) => {
+          call = { url: String(url), init: init ?? {} };
+          return response({ ok: true });
+        }) as typeof fetch,
+      });
+      expect(await runCloud(item.args, console)).toBe(0);
+      expect(call?.url).toBe(`http://127.0.0.1:3000${item.path}`);
+      expect(call?.init.method).toBe(item.method);
+    }
+  });
+
+  it("reads and trims an SSH public key file", async () => {
+    let body: unknown;
+    const console = io({
+      env: { PROVISION_KEY: "key" },
+      readFile: async () => "ssh-ed25519 AAAA user@example\n",
+      fetch: (async (_url: string | URL | Request, init?: RequestInit) => {
+        body = JSON.parse(String(init?.body));
+        return response({ id: "key-1" }, 201);
+      }) as typeof fetch,
+    });
+
+    expect(
+      await runCloud(
+        ["ssh-keys", "create", "--name", "laptop", "--public-key-file", "/tmp/key.pub"],
+        console,
+      ),
+    ).toBe(0);
+    expect(body).toEqual({ name: "laptop", publicKey: "ssh-ed25519 AAAA user@example" });
+  });
+
+  it("watches status changes and stops at the requested terminal status", async () => {
+    const nodes = [
+      { id: "node-1", status: "queued" },
+      { id: "node-1", status: "queued" },
+      { id: "node-1", status: "creating_vm" },
+      { id: "node-1", status: "running" },
+    ];
+    const sleeps: number[] = [];
+    const console = io({
+      env: { OH_PROVISION_KEY: "key" },
+      sleep: async (milliseconds) => { sleeps.push(milliseconds); },
+      fetch: (async () => response(nodes.shift())) as typeof fetch,
+    });
+
+    expect(await runCloud(["nodes", "watch", "node-1", "--interval", "0.25"], console)).toBe(0);
+    expect(console.out.map((text) => JSON.parse(text).status)).toEqual([
+      "queued",
+      "creating_vm",
+      "running",
+    ]);
+    expect(sleeps).toEqual([250, 250, 250]);
+  });
+
+  it("reports structured API errors without throwing past the command boundary", async () => {
+    const request = createCloudApiClient({
+      apiUrl: "http://127.0.0.1:3000",
+      provisionKey: "wrong",
+      fetch: (async () => response({ error: "Unauthorized", code: "UNAUTHORIZED" }, 401)) as typeof fetch,
+    });
+    await expect(request("GET", "/api/nodes")).rejects.toMatchObject({
+      status: 401,
+      message: "API request failed with 401 (UNAUTHORIZED): Unauthorized",
+    });
+
+    const console = io({
+      env: { OH_PROVISION_KEY: "wrong" },
+      fetch: (async () => response({ error: "Unauthorized", code: "UNAUTHORIZED" }, 401)) as typeof fetch,
+    });
+    expect(await runCloud(["nodes", "list"], console)).toBe(1);
+    expect(console.err.join("")).toBe(
+      "oh cloud: API request failed with 401 (UNAUTHORIZED): Unauthorized\n",
+    );
+  });
+
+  it("prints help without requiring a stored credential", async () => {
+    const console = io({ env: {} });
+    expect(await runCloud(["--help"], console)).toBe(0);
+    expect(console.out.join("")).toContain("oh cloud config");
+    expect(console.out.join("")).toContain("nodes create");
+  });
+});

--- a/.oh/cli/src/__tests__/cloud.test.ts
+++ b/.oh/cli/src/__tests__/cloud.test.ts
@@ -195,6 +195,34 @@ describe("cloud API commands", () => {
     );
   });
 
+  it("summarizes HTML responses instead of dumping a full Next.js error page", async () => {
+    const html = `<!DOCTYPE html><html><body>${"server-details-".repeat(100)}</body></html>`;
+    const htmlResponse = (status: number): Response =>
+      new Response(html, { status, headers: { "content-type": "text/html; charset=utf-8" } });
+
+    const failedRequest = createCloudApiClient({
+      apiUrl: "http://127.0.0.1:3000",
+      provisionKey: "key",
+      fetch: (async () => htmlResponse(500)) as typeof fetch,
+    });
+    const failure = await failedRequest("GET", "/api/nodes").catch((error: unknown) => error);
+    expect(failure).toMatchObject({
+      status: 500,
+      message: expect.stringContaining("server returned text/html instead of JSON"),
+    });
+    expect((failure as Error).message.length).toBeLessThan(300);
+
+    const successfulHtmlRequest = createCloudApiClient({
+      apiUrl: "http://127.0.0.1:3000",
+      provisionKey: "key",
+      fetch: (async () => htmlResponse(200)) as typeof fetch,
+    });
+    await expect(successfulHtmlRequest("GET", "/api/nodes")).rejects.toMatchObject({
+      status: 200,
+      message: expect.stringContaining("expected JSON"),
+    });
+  });
+
   it("prints help without requiring a stored credential", async () => {
     const console = io({ env: {} });
     expect(await runCloud(["--help"], console)).toBe(0);

--- a/.oh/cli/src/__tests__/cloud.test.ts
+++ b/.oh/cli/src/__tests__/cloud.test.ts
@@ -113,9 +113,10 @@ describe("cloud API commands", () => {
     ];
 
     for (const item of cases) {
+      const fixture = tempConfig();
       let call: { url: string; init: RequestInit } | undefined;
       const console = io({
-        env: { OH_PROVISION_KEY: "env-key" },
+        env: { ...fixture.env, OH_PROVISION_KEY: "env-key" },
         fetch: (async (url: string | URL | Request, init?: RequestInit) => {
           call = { url: String(url), init: init ?? {} };
           return response({ ok: true });
@@ -128,9 +129,10 @@ describe("cloud API commands", () => {
   });
 
   it("reads and trims an SSH public key file", async () => {
+    const fixture = tempConfig();
     let body: unknown;
     const console = io({
-      env: { PROVISION_KEY: "key" },
+      env: { ...fixture.env, PROVISION_KEY: "key" },
       readFile: async () => "ssh-ed25519 AAAA user@example\n",
       fetch: (async (_url: string | URL | Request, init?: RequestInit) => {
         body = JSON.parse(String(init?.body));
@@ -148,6 +150,7 @@ describe("cloud API commands", () => {
   });
 
   it("watches status changes and stops at the requested terminal status", async () => {
+    const fixture = tempConfig();
     const nodes = [
       { id: "node-1", status: "queued" },
       { id: "node-1", status: "queued" },
@@ -156,7 +159,7 @@ describe("cloud API commands", () => {
     ];
     const sleeps: number[] = [];
     const console = io({
-      env: { OH_PROVISION_KEY: "key" },
+      env: { ...fixture.env, OH_PROVISION_KEY: "key" },
       sleep: async (milliseconds) => { sleeps.push(milliseconds); },
       fetch: (async () => response(nodes.shift())) as typeof fetch,
     });
@@ -181,8 +184,9 @@ describe("cloud API commands", () => {
       message: "API request failed with 401 (UNAUTHORIZED): Unauthorized",
     });
 
+    const fixture = tempConfig();
     const console = io({
-      env: { OH_PROVISION_KEY: "wrong" },
+      env: { ...fixture.env, OH_PROVISION_KEY: "wrong" },
       fetch: (async () => response({ error: "Unauthorized", code: "UNAUTHORIZED" }, 401)) as typeof fetch,
     });
     expect(await runCloud(["nodes", "list"], console)).toBe(1);

--- a/.oh/cli/src/__tests__/lifecycle.test.ts
+++ b/.oh/cli/src/__tests__/lifecycle.test.ts
@@ -612,6 +612,7 @@ describe("help surfaces", () => {
     expect(text).toContain("oh sandbox");
     expect(text).toContain("oh shell [container]");
     expect(text).toContain("oh gateway");
+    expect(text).toContain("oh cloud <args...>");
   });
 
   it("per-verb --help output documents each verb's contract", () => {

--- a/.oh/cli/src/cli.ts
+++ b/.oh/cli/src/cli.ts
@@ -4,6 +4,7 @@ import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { runInit, type InitIO, type InitOptions } from "./commands/init.js";
 import { runUpdate } from "./commands/update.js";
+import { runCloud } from "./commands/cloud.js";
 import {
   runGateway,
   runSandbox,
@@ -81,6 +82,7 @@ Usage:
   oh sandbox                Provision and start the sandbox (docker compose up)
   oh shell [container]      Open a zsh shell in the running sandbox container
   oh gateway <args...>      Manage a messaging client session (pi|hermes)
+  oh cloud <args...>        Manage OpenHarness Cloud nodes
   oh --version              Print version
   oh --help                 Show this help
 
@@ -777,6 +779,13 @@ async function main(argv: string[]): Promise<number> {
       return 0;
     }
     return runShell({ container: parsed.args.container }, lifecycleIo());
+  }
+
+  if (first === "cloud") {
+    return await runCloud(argv.slice(1), {
+      stdout: (s) => process.stdout.write(s),
+      stderr: (s) => process.stderr.write(s),
+    });
   }
 
   if (first === "gateway") {

--- a/.oh/cli/src/commands/cloud.ts
+++ b/.oh/cli/src/commands/cloud.ts
@@ -1,0 +1,434 @@
+import { readFile } from "node:fs/promises";
+import { askSecret } from "../lib/prompt.js";
+import {
+  cloudConfigPath,
+  readCloudConfig,
+  writeCloudConfig,
+  type CloudConfig,
+} from "../lib/cloud-config.js";
+
+const DEFAULT_API_URL = "http://127.0.0.1:3000";
+const DEFAULT_TERMINAL_STATUSES = ["running", "failed", "destroyed"];
+
+export const CLOUD_HELP = `oh cloud — Manage OpenHarness Cloud nodes
+
+Usage:
+  oh cloud config [--api-url <url>] [--provision-key <key>]
+  oh cloud config show
+  oh cloud [global options] nodes list
+  oh cloud [global options] nodes get <node-id>
+  oh cloud [global options] nodes create --ssh-key-id <id> [--name <name>]
+  oh cloud [global options] nodes events <node-id>
+  oh cloud [global options] nodes watch <node-id> [--interval <seconds>] [--until <statuses>]
+  oh cloud [global options] nodes destroy <node-id>
+  oh cloud [global options] nodes restart <node-id>
+  oh cloud [global options] nodes rebuild <node-id>
+  oh cloud [global options] ssh-keys list
+  oh cloud [global options] ssh-keys create --name <name> (--public-key <key> | --public-key-file <path>)
+
+Global options:
+  --api-url <url>          API base URL (default: OH_CLOUD_API_URL, OH_API_URL,
+                           or http://127.0.0.1:3000)
+  --provision-key <key>    Admin key (default: OH_PROVISION_KEY or PROVISION_KEY)
+  --output <field>         Print one top-level response field instead of JSON
+  -h, --help               Show this help
+
+Configuration:
+  oh cloud config securely prompts for the current provisioner key and stores
+  it in ~/.config/openharness/cloud.json with mode 0600. This is the temporary
+  credential model until OpenHarness Cloud issues user API tokens.
+
+Environment:
+  OH_CLOUD_CONFIG          Override the saved config file path
+  OH_CLOUD_API_URL         Override the OpenHarness Cloud API base URL
+  OH_PROVISION_KEY         Override the saved key (PROVISION_KEY is also accepted)
+
+Examples:
+  oh cloud config
+  oh cloud ssh-keys create --name laptop --public-key-file ~/.ssh/openharness_node.pub
+  oh cloud nodes create --name smoke-1 --ssh-key-id <ssh-key-id>
+  oh cloud nodes watch <node-id>
+`;
+
+export interface CloudIO {
+  stdout: (text: string) => void;
+  stderr: (text: string) => void;
+  env?: NodeJS.ProcessEnv;
+  fetch?: typeof globalThis.fetch;
+  readFile?: (path: string, encoding: BufferEncoding) => Promise<string>;
+  sleep?: (milliseconds: number) => Promise<void>;
+  askSecret?: (question: string) => Promise<string>;
+}
+
+export class CloudCliError extends Error {
+  readonly status?: number;
+  readonly payload?: unknown;
+
+  constructor(message: string, options: { status?: number; payload?: unknown } = {}) {
+    super(message);
+    this.name = "CloudCliError";
+    this.status = options.status;
+    this.payload = options.payload;
+  }
+}
+
+function takeOption(args: string[], name: string, alias?: string): string | undefined {
+  const names = alias ? [name, alias] : [name];
+  for (const candidate of names) {
+    const index = args.indexOf(candidate);
+    if (index === -1) continue;
+    const value = args[index + 1];
+    if (value === undefined || value.startsWith("-")) {
+      throw new CloudCliError(`${candidate} requires a value`);
+    }
+    args.splice(index, 2);
+    return value;
+  }
+  return undefined;
+}
+
+function requireOption(value: string | undefined, name: string): string {
+  if (!value) throw new CloudCliError(`${name} is required`);
+  return value;
+}
+
+function requirePositional(value: string | undefined, name: string): string {
+  if (!value || value.startsWith("-")) throw new CloudCliError(`${name} is required`);
+  return value;
+}
+
+function assertNoExtraArgs(args: string[]): void {
+  if (args.length > 0) {
+    throw new CloudCliError(
+      `unexpected argument${args.length === 1 ? "" : "s"}: ${args.join(" ")}`,
+    );
+  }
+}
+
+function normalizeApiUrl(value: string): string {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new CloudCliError(`invalid API URL: ${value}`);
+  }
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new CloudCliError(`API URL must use http or https: ${value}`);
+  }
+  return url.toString().replace(/\/$/, "");
+}
+
+function formatJson(value: unknown): string {
+  return `${JSON.stringify(value, null, 2)}\n`;
+}
+
+function formatApiFailure(status: number, payload: unknown): string {
+  if (payload && typeof payload === "object") {
+    const record = payload as Record<string, unknown>;
+    const message = record.error ?? record.message;
+    const code = typeof record.code === "string" ? ` (${record.code})` : "";
+    if (typeof message === "string") {
+      return `API request failed with ${status}${code}: ${message}`;
+    }
+  }
+  if (typeof payload === "string" && payload.length > 0) {
+    return `API request failed with ${status}: ${payload}`;
+  }
+  return `API request failed with ${status}`;
+}
+
+async function parseResponse(response: Response): Promise<unknown> {
+  const text = await response.text();
+  if (!text) return null;
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return text;
+  }
+}
+
+export type CloudRequest = (
+  method: string,
+  pathname: string,
+  body?: unknown,
+) => Promise<unknown>;
+
+export function createCloudApiClient(options: {
+  apiUrl: string;
+  provisionKey: string;
+  fetch?: typeof globalThis.fetch;
+}): CloudRequest {
+  const fetchImpl = options.fetch ?? globalThis.fetch;
+  if (typeof fetchImpl !== "function") {
+    throw new CloudCliError(
+      "the cloud CLI requires Node.js 20 or newer (global fetch is unavailable)",
+    );
+  }
+
+  return async (method: string, pathname: string, body?: unknown): Promise<unknown> => {
+    let response: Response;
+    try {
+      response = await fetchImpl(`${options.apiUrl}${pathname}`, {
+        method,
+        headers: {
+          "x-provision-key": options.provisionKey,
+          ...(body === undefined ? {} : { "content-type": "application/json" }),
+        },
+        ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+      });
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      throw new CloudCliError(`could not reach ${options.apiUrl}: ${detail}`);
+    }
+
+    const payload = await parseResponse(response);
+    if (!response.ok) {
+      throw new CloudCliError(formatApiFailure(response.status, payload), {
+        status: response.status,
+        payload,
+      });
+    }
+    return payload;
+  };
+}
+
+function nodePath(nodeId: string, suffix = ""): string {
+  return `/api/nodes/${encodeURIComponent(nodeId)}${suffix}`;
+}
+
+async function readPublicKey(
+  args: string[],
+  readFileImpl: (path: string, encoding: BufferEncoding) => Promise<string>,
+): Promise<string> {
+  const inline = takeOption(args, "--public-key");
+  const file = takeOption(args, "--public-key-file");
+  if (inline && file) {
+    throw new CloudCliError("use only one of --public-key or --public-key-file");
+  }
+  if (!inline && !file) {
+    throw new CloudCliError("--public-key or --public-key-file is required");
+  }
+
+  if (inline) return inline.trim();
+  try {
+    const value = (await readFileImpl(file as string, "utf8")).trim();
+    if (!value) throw new CloudCliError(`SSH public key file is empty: ${file}`);
+    return value;
+  } catch (error) {
+    if (error instanceof CloudCliError) throw error;
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new CloudCliError(`could not read SSH public key file ${file}: ${detail}`);
+  }
+}
+
+interface DispatchOptions {
+  request: CloudRequest;
+  readFile: (path: string, encoding: BufferEncoding) => Promise<string>;
+  sleep: (milliseconds: number) => Promise<void>;
+  write: (value: unknown) => void;
+}
+
+async function dispatch(args: string[], options: DispatchOptions): Promise<unknown> {
+  const resource = args.shift();
+  const action = args.shift();
+
+  if (!resource || !action) {
+    throw new CloudCliError("a resource and action are required. Run `oh cloud --help` for usage.");
+  }
+
+  if (resource === "ssh-keys") {
+    if (action === "list") {
+      assertNoExtraArgs(args);
+      return options.request("GET", "/api/ssh-keys");
+    }
+    if (action === "create") {
+      const name = requireOption(takeOption(args, "--name"), "--name");
+      const publicKey = await readPublicKey(args, options.readFile);
+      assertNoExtraArgs(args);
+      return options.request("POST", "/api/ssh-keys", { name, publicKey });
+    }
+    throw new CloudCliError(`unknown ssh-keys action: ${action}`);
+  }
+
+  if (resource !== "nodes") throw new CloudCliError(`unknown resource: ${resource}`);
+
+  if (action === "list") {
+    assertNoExtraArgs(args);
+    return options.request("GET", "/api/nodes");
+  }
+
+  if (action === "create") {
+    const name = takeOption(args, "--name");
+    const sshKeyId = requireOption(takeOption(args, "--ssh-key-id"), "--ssh-key-id");
+    assertNoExtraArgs(args);
+    return options.request("POST", "/api/nodes", {
+      ...(name ? { name } : {}),
+      sshKeyId,
+    });
+  }
+
+  const nodeIdActions = ["get", "events", "destroy", "restart", "rebuild", "watch"];
+  if (!nodeIdActions.includes(action)) {
+    throw new CloudCliError(`unknown nodes action: ${action}`);
+  }
+  const nodeId = requirePositional(args.shift(), "<node-id>");
+  if (action === "get") {
+    assertNoExtraArgs(args);
+    return options.request("GET", nodePath(nodeId));
+  }
+  if (action === "events") {
+    assertNoExtraArgs(args);
+    return options.request("GET", nodePath(nodeId, "/events"));
+  }
+  if (action === "destroy") {
+    assertNoExtraArgs(args);
+    return options.request("DELETE", nodePath(nodeId));
+  }
+  if (action === "restart" || action === "rebuild") {
+    assertNoExtraArgs(args);
+    return options.request("POST", nodePath(nodeId, `/${action}`));
+  }
+  if (action === "watch") {
+    const intervalValue = takeOption(args, "--interval") ?? "5";
+    const intervalSeconds = Number(intervalValue);
+    if (!Number.isFinite(intervalSeconds) || intervalSeconds < 0) {
+      throw new CloudCliError(`--interval must be a non-negative number: ${intervalValue}`);
+    }
+    const untilValue = takeOption(args, "--until");
+    const terminalStatuses = new Set(
+      (untilValue ? untilValue.split(",") : DEFAULT_TERMINAL_STATUSES)
+        .map((status) => status.trim())
+        .filter(Boolean),
+    );
+    if (terminalStatuses.size === 0) {
+      throw new CloudCliError("--until must contain at least one status");
+    }
+    assertNoExtraArgs(args);
+
+    let lastStatus: string | undefined;
+    while (true) {
+      const node = await options.request("GET", nodePath(nodeId));
+      if (
+        !node ||
+        typeof node !== "object" ||
+        typeof (node as Record<string, unknown>).status !== "string"
+      ) {
+        throw new CloudCliError("node response did not include a status");
+      }
+      const status = (node as Record<string, unknown>).status as string;
+      if (status !== lastStatus) {
+        options.write(node);
+        lastStatus = status;
+      }
+      if (terminalStatuses.has(status)) return undefined;
+      await options.sleep(intervalSeconds * 1_000);
+    }
+  }
+
+  throw new CloudCliError(`unknown nodes action: ${action}`);
+}
+
+async function configureCloud(args: string[], io: CloudIO, env: NodeJS.ProcessEnv): Promise<void> {
+  const path = cloudConfigPath(env);
+  const current = await readCloudConfig(path);
+  if (args[0] === "show") {
+    args.shift();
+    assertNoExtraArgs(args);
+    io.stdout(`Cloud config: ${path}\n`);
+    io.stdout(`API URL: ${current.apiUrl ?? DEFAULT_API_URL}\n`);
+    io.stdout(`Provision credential: ${current.provisionKey ? "configured" : "not configured"}\n`);
+    return;
+  }
+
+  const apiUrl = normalizeApiUrl(
+    takeOption(args, "--api-url") ??
+      current.apiUrl ??
+      env.OH_CLOUD_API_URL ??
+      env.OH_API_URL ??
+      DEFAULT_API_URL,
+  );
+  const providedKey = takeOption(args, "--provision-key");
+  assertNoExtraArgs(args);
+  const provisionKey = (
+    providedKey ??
+    (await (io.askSecret ?? askSecret)("OpenHarness Cloud provisioner key:"))
+  ).trim();
+  if (!provisionKey) throw new CloudCliError("provisioner key cannot be empty");
+
+  const config: CloudConfig = { apiUrl, provisionKey };
+  await writeCloudConfig(path, config);
+  io.stdout(`Saved OpenHarness Cloud config to ${path}\n`);
+  io.stdout("Provision credential: configured\n");
+}
+
+async function executeCloud(argv: string[], io: CloudIO): Promise<void> {
+  const args = [...argv];
+  const env = io.env ?? process.env;
+
+  if (args.includes("--help") || args.includes("-h") || args[0] === "help") {
+    io.stdout(CLOUD_HELP);
+    return;
+  }
+  if (args[0] === "config") {
+    args.shift();
+    await configureCloud(args, io, env);
+    return;
+  }
+
+  const saved = await readCloudConfig(cloudConfigPath(env));
+  const apiUrl = normalizeApiUrl(
+    takeOption(args, "--api-url") ??
+      env.OH_CLOUD_API_URL ??
+      env.OH_API_URL ??
+      saved.apiUrl ??
+      DEFAULT_API_URL,
+  );
+  const provisionKey =
+    takeOption(args, "--provision-key") ??
+    env.OH_PROVISION_KEY ??
+    env.PROVISION_KEY ??
+    saved.provisionKey;
+  if (!provisionKey) {
+    throw new CloudCliError(
+      "no provision credential found. Run `oh cloud config` or set OH_PROVISION_KEY.",
+    );
+  }
+
+  const outputField = takeOption(args, "--output");
+  const request = createCloudApiClient({
+    apiUrl,
+    provisionKey,
+    fetch: io.fetch,
+  });
+  const write = (value: unknown): void => io.stdout(formatJson(value));
+  const result = await dispatch(args, {
+    request,
+    readFile: io.readFile ?? readFile,
+    sleep:
+      io.sleep ??
+      ((milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds))),
+    write,
+  });
+  if (result === undefined) return;
+
+  if (outputField) {
+    if (!result || typeof result !== "object" || !(outputField in result)) {
+      throw new CloudCliError(`response does not contain top-level field: ${outputField}`);
+    }
+    const value = (result as Record<string, unknown>)[outputField];
+    io.stdout(typeof value === "object" ? formatJson(value) : `${String(value)}\n`);
+    return;
+  }
+  write(result);
+}
+
+export async function runCloud(argv: string[], io: CloudIO): Promise<number> {
+  try {
+    await executeCloud(argv, io);
+    return 0;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    io.stderr(`oh cloud: ${message}\n`);
+    return 1;
+  }
+}

--- a/.oh/cli/src/commands/cloud.ts
+++ b/.oh/cli/src/commands/cloud.ts
@@ -122,7 +122,20 @@ function formatJson(value: unknown): string {
   return `${JSON.stringify(value, null, 2)}\n`;
 }
 
-function formatApiFailure(status: number, payload: unknown): string {
+function bodyPreview(body: string): string {
+  const compact = body.replace(/\s+/g, " ").trim();
+  return compact.length > 180 ? `${compact.slice(0, 177)}...` : compact;
+}
+
+function responseKind(contentType: string | null): string {
+  return contentType?.split(";", 1)[0]?.trim() || "non-JSON content";
+}
+
+function formatApiFailure(
+  status: number,
+  payload: unknown,
+  contentType: string | null,
+): string {
   if (payload && typeof payload === "object") {
     const record = payload as Record<string, unknown>;
     const message = record.error ?? record.message;
@@ -132,18 +145,25 @@ function formatApiFailure(status: number, payload: unknown): string {
     }
   }
   if (typeof payload === "string" && payload.length > 0) {
-    return `API request failed with ${status}: ${payload}`;
+    return `API request failed with ${status}: server returned ${responseKind(contentType)} instead of JSON (${bodyPreview(payload)})`;
   }
   return `API request failed with ${status}`;
 }
 
-async function parseResponse(response: Response): Promise<unknown> {
+interface ParsedResponse {
+  payload: unknown;
+  isJson: boolean;
+  contentType: string | null;
+}
+
+async function parseResponse(response: Response): Promise<ParsedResponse> {
   const text = await response.text();
-  if (!text) return null;
+  const contentType = response.headers.get("content-type");
+  if (!text) return { payload: null, isJson: true, contentType };
   try {
-    return JSON.parse(text) as unknown;
+    return { payload: JSON.parse(text) as unknown, isJson: true, contentType };
   } catch {
-    return text;
+    return { payload: text, isJson: false, contentType };
   }
 }
 
@@ -181,14 +201,23 @@ export function createCloudApiClient(options: {
       throw new CloudCliError(`could not reach ${options.apiUrl}: ${detail}`);
     }
 
-    const payload = await parseResponse(response);
+    const parsed = await parseResponse(response);
     if (!response.ok) {
-      throw new CloudCliError(formatApiFailure(response.status, payload), {
-        status: response.status,
-        payload,
-      });
+      throw new CloudCliError(
+        formatApiFailure(response.status, parsed.payload, parsed.contentType),
+        {
+          status: response.status,
+          payload: parsed.payload,
+        },
+      );
     }
-    return payload;
+    if (!parsed.isJson) {
+      throw new CloudCliError(
+        `API returned ${response.status} ${responseKind(parsed.contentType)}; expected JSON (${bodyPreview(parsed.payload as string)})`,
+        { status: response.status, payload: parsed.payload },
+      );
+    }
+    return parsed.payload;
   };
 }
 

--- a/.oh/cli/src/lib/cloud-config.ts
+++ b/.oh/cli/src/lib/cloud-config.ts
@@ -1,0 +1,68 @@
+import { chmod, mkdir, readFile, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+
+export interface CloudConfig {
+  apiUrl?: string;
+  provisionKey?: string;
+}
+
+interface StoredCloudConfig extends CloudConfig {
+  version: 1;
+}
+
+export function cloudConfigPath(env: NodeJS.ProcessEnv = process.env): string {
+  if (env.OH_CLOUD_CONFIG) return env.OH_CLOUD_CONFIG;
+  const configRoot = env.OH_CONFIG_DIR
+    ? env.OH_CONFIG_DIR
+    : join(env.XDG_CONFIG_HOME ?? join(homedir(), ".config"), "openharness");
+  return join(configRoot, "cloud.json");
+}
+
+export async function readCloudConfig(path: string): Promise<CloudConfig> {
+  let raw: string;
+  try {
+    raw = await readFile(path, "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return {};
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(`could not read cloud config ${path}: ${detail}`);
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw) as unknown;
+  } catch {
+    throw new Error(`cloud config is not valid JSON: ${path}`);
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(`cloud config must contain a JSON object: ${path}`);
+  }
+
+  const record = parsed as Record<string, unknown>;
+  if (record.apiUrl !== undefined && typeof record.apiUrl !== "string") {
+    throw new Error(`cloud config apiUrl must be a string: ${path}`);
+  }
+  if (record.provisionKey !== undefined && typeof record.provisionKey !== "string") {
+    throw new Error(`cloud config provisionKey must be a string: ${path}`);
+  }
+
+  return {
+    ...(typeof record.apiUrl === "string" ? { apiUrl: record.apiUrl } : {}),
+    ...(typeof record.provisionKey === "string" ? { provisionKey: record.provisionKey } : {}),
+  };
+}
+
+export async function writeCloudConfig(path: string, config: CloudConfig): Promise<void> {
+  const parent = dirname(path);
+  await mkdir(parent, { recursive: true, mode: 0o700 });
+  const stored: StoredCloudConfig = {
+    version: 1,
+    ...(config.apiUrl ? { apiUrl: config.apiUrl } : {}),
+    ...(config.provisionKey ? { provisionKey: config.provisionKey } : {}),
+  };
+  await writeFile(path, `${JSON.stringify(stored, null, 2)}\n`, { mode: 0o600 });
+  // writeFile preserves an existing file's mode, so enforce the secret-file
+  // contract after every update as well as on first creation.
+  await chmod(path, 0o600);
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Update policy and release automation live in [`/git`](.claude/skills/git/SKILL.m
 ## [Unreleased]
 
 ### Added
+- Add `oh cloud` commands for securely storing the current provisioner credential and managing OpenHarness Cloud SSH keys and node lifecycles without hand-written API requests ([#625](https://github.com/mifunedev/openharness/issues/625)).
 - Add an opt-in sshd compose overlay with loopback binding, public-key-first auth, host-port collision checks, and direct-SSH/nginx multi-tenant docs ([#599](https://github.com/mifunedev/openharness/pull/599)).
 ### Changed
 ### Fixed


### PR DESCRIPTION
Closes #625

## Summary
- add `oh cloud config` with a hidden prompt and user-local mode-`0600` credential storage
- add `oh cloud ssh-keys` and complete node lifecycle commands (`list`, `get`, `create`, `watch`, `events`, `destroy`, `restart`, `rebuild`)
- preserve flag/environment overrides for automation while preferring saved config for interactive use
- document the temporary provisioner-key model and future migration to official user API tokens
- bump `@mifune/openharness` to `0.2.0`

## Security
- the stored provisioner credential is never printed
- the credential file is forced to mode `0600` after every write
- `OH_CLOUD_CONFIG`, `OH_CLOUD_API_URL`, and `OH_PROVISION_KEY` remain non-persistent override seams

## Verification
- `pnpm typecheck`
- `pnpm build`
- `pnpm test`
- built CLI config smoke (mode `0600`, no secret echo)
- `npm pack --dry-run` (`@mifune/openharness@0.2.0`, dist + README + LICENSE)
- `.oh/evals/probes/oh-npm-package.sh`
- `.oh/evals/probes/oh-standalone-lifecycle.sh`
