### PR TITLE
docs: document Pi and Claude Langfuse observability

### DIFF
--- a/.devcontainer/.example.env
+++ b/.devcontainer/.example.env
@@ -85,6 +85,17 @@ GH_TOKEN=
 # this secret can be passed through for non-interactive use.
 # XAI_API_KEY=
 
+# ─── Optional Langfuse observability for Pi ───────────────────────────
+# pi-langfuse reads these only from the environment of the Pi process. This
+# `.env` file provides Docker Compose interpolation; it is not automatically
+# injected wholesale into Pi. If using these values, launch Pi from a shell with:
+#     set -a; source /home/sandbox/harness/.devcontainer/.env; set +a; pi
+# See .oh/docs/integrations/langfuse.md for precedence and privacy guidance.
+# LANGFUSE_PUBLIC_KEY=pk-lf-...
+# LANGFUSE_SECRET_KEY=sk-lf-...
+# LANGFUSE_BASE_URL=https://cloud.langfuse.com
+# LANGFUSE_PRIVACY_PRESET=metadata-only
+
 # ─── Slack bot (pi-messenger-bridge) ─────────────────────────────────
 # The pi-messenger-bridge package bridges Slack messages into a Pi agent
 # over Socket Mode. Read from process.env at session_start; no compose

--- a/.devcontainer/.example.env
+++ b/.devcontainer/.example.env
@@ -85,12 +85,14 @@ GH_TOKEN=
 # this secret can be passed through for non-interactive use.
 # XAI_API_KEY=
 
-# ─── Optional Langfuse observability for Pi ───────────────────────────
+# ─── Optional Langfuse observability for Pi only ──────────────────────
 # pi-langfuse reads these only from the environment of the Pi process. This
 # `.env` file provides Docker Compose interpolation; it is not automatically
-# injected wholesale into Pi. If using these values, launch Pi from a shell with:
+# injected wholesale into Pi. Claude Code uses its Langfuse marketplace plugin's
+# `/plugin configure` flow instead; do not add Claude plugin credentials here.
+# If using these Pi values, launch Pi from a shell with:
 #     set -a; source /home/sandbox/harness/.devcontainer/.env; set +a; pi
-# See .oh/docs/integrations/langfuse.md for precedence and privacy guidance.
+# See .oh/docs/integrations/langfuse.md for Pi precedence and privacy guidance.
 # LANGFUSE_PUBLIC_KEY=pk-lf-...
 # LANGFUSE_SECRET_KEY=sk-lf-...
 # LANGFUSE_BASE_URL=https://cloud.langfuse.com

--- a/.oh/docs/README.md
+++ b/.oh/docs/README.md
@@ -55,6 +55,7 @@ Open Harness vendors the shared skills/agents/hooks primitive pack directly into
 
 - [GitHub](integrations/github.md)
 - [Slack](integrations/slack.md)
+- [Langfuse](integrations/langfuse.md)
 - [DebugMCP](integrations/debugmcp.md)
 - [Pi autoresearch](integrations/pi-autoresearch.md)
 - [Pi dynamic workflows](integrations/pi-dynamic-workflows.md)

--- a/.oh/docs/harnesses/claude-code.md
+++ b/.oh/docs/harnesses/claude-code.md
@@ -40,6 +40,15 @@ the same OAuth flow, but `claude auth login` is the explicit, scriptable path.
 Credentials are stored in `~/.claude/.credentials.json` inside the sandbox (persisted via the
 `claude-auth` volume). The sandbox banner at login indicates whether credentials are present.
 
+## Optional Langfuse observability
+
+For optional Claude Code end-to-end traces, use Langfuse's official marketplace
+plugin and configure it at the Claude prompt; it is not a native OTEL or
+`.env` setup. The plugin is user-scoped and captures conversation and tool data,
+so disable it before sensitive sessions. See [Langfuse](../integrations/langfuse.md#claude-code)
+for the exact install/configure commands, endpoint choices, privacy boundary,
+and disable/uninstall steps.
+
 ## Common usage
 
 The sandbox alias pre-passes `--dangerously-skip-permissions` so Claude Code can read and write files without prompting on each operation:

--- a/.oh/docs/harnesses/pi.md
+++ b/.oh/docs/harnesses/pi.md
@@ -48,6 +48,13 @@ Open Harness loads these project-local Pi packages from `.pi/settings.json`:
 
 Pi installs missing project packages automatically on startup after the project is trusted. Open Harness also auto-loads project-local extensions from `.pi/extensions/`.
 
+## Optional Langfuse observability
+
+[Langfuse](../integrations/langfuse.md) is an opt-in Pi-only tracing package, not
+a default `.pi/settings.json` package. It can capture prompts, outputs, tool I/O,
+the system prompt, and cwd; review the package, choose a narrow privacy preset,
+and configure its external Langfuse deployment before installing it.
+
 ### Codex stale-response recovery
 
 The installed `@earendil-works/pi-ai` Codex Responses provider can reuse WebSocket cached continuation state by sending `previous_response_id`. If the upstream Codex backend forgets that response id, it returns `previous_response_not_found`; Pi clears the stale continuation but the failed user turn would otherwise be lost. Open Harness keeps a small auto-loaded `.pi/extensions/codex-stale-response-retry.ts` extension that re-injects non-Slack failed turns once via `sendUserMessage(..., { deliverAs: "followUp" })`, causing the next request to start from fresh/full context. Slack-prefixed turns remain owned by the dedicated `.pi/bridge-recovery/` extension that is co-loaded with `pi-messenger-bridge`.

--- a/.oh/docs/integrations/langfuse.md
+++ b/.oh/docs/integrations/langfuse.md
@@ -1,0 +1,151 @@
+---
+title: Langfuse
+---
+
+# Langfuse
+
+[Langfuse](https://langfuse.com) is optional observability for **Pi sessions**.
+Open Harness does not bundle or operate Langfuse: deploy it separately (Langfuse
+Cloud or your own installation) and follow the [official Docker Compose deployment
+guide](https://langfuse.com/self-hosting/deployment/docker-compose) if you
+self-host. Secure that external service with appropriate access controls and TLS;
+this integration does not add a proxy, exporter, credential pass-through, or
+tracing for other CLIs.
+
+[`pi-langfuse` v1.5.6](https://www.npmjs.com/package/pi-langfuse/v/1.5.6) is a
+Pi package. Its `v1.5.6` tag resolves to
+[commit `fa415f33458f010265a287251fd3e7d249e97b99`](https://github.com/gooyoung/pi-langfuse/commit/fa415f33458f010265a287251fd3e7d249e97b99).
+Pi packages can execute arbitrary code, so review that source before installing
+it. Choose the narrowest installation scope and pin the version:
+
+```bash
+# User installation: writes to ~/.pi/agent/settings.json
+pi install npm:pi-langfuse@1.5.6
+
+# Project installation: writes to .pi/settings.json (review before committing)
+pi install -l npm:pi-langfuse@1.5.6
+
+# One session only: does not change settings
+pi -e npm:pi-langfuse@1.5.6
+```
+
+This is deliberately **not** an Open Harness default package. It instruments Pi
+sessions only; it does not instrument standalone Claude Code, Codex CLI, or
+Gemini CLI sessions.
+
+## Configure
+
+### Interactive setup (recommended)
+
+Start Pi, then run its package command:
+
+```text
+/langfuse-setup
+```
+
+Enter the Langfuse public key (`pk-lf-...`), secret key (`sk-lf-...`), and
+external Langfuse URL. The package persists them in
+`~/.pi/agent/pi-langfuse/config.json`; in the sandbox, `~/.pi` is on the
+`pi-auth` named volume. When the package writes the file it creates a `0700`
+directory and a `0600` file where POSIX permissions are available. `make destroy`
+removes named volumes, including `pi-auth`, so configure again after destroying
+the sandbox.
+
+### Environment-only setup
+
+For a non-interactive shell, export credentials before starting Pi:
+
+```bash
+export LANGFUSE_PUBLIC_KEY='pk-lf-...'
+export LANGFUSE_SECRET_KEY='sk-lf-...'
+export LANGFUSE_BASE_URL='https://cloud.langfuse.com'
+export LANGFUSE_PRIVACY_PRESET='metadata-only'
+pi
+```
+
+`LANGFUSE_HOST` is supported as a fallback name. For an environment-only
+configuration, `LANGFUSE_BASE_URL` wins over `LANGFUSE_HOST`.
+
+`.devcontainer/.env` is Docker Compose interpolation, **not** a file that is
+automatically injected wholesale into Pi. If you keep Langfuse variables there,
+explicitly export them in the shell that launches Pi:
+
+```bash
+set -a
+source /home/sandbox/harness/.devcontainer/.env
+set +a
+pi
+```
+
+## Configuration and privacy precedence
+
+A valid saved `~/.pi/agent/pi-langfuse/config.json` (one with both keys) supplies
+credentials and host before environment configuration. Environment privacy
+settings still apply: `LANGFUSE_PRIVACY_PRESET` and the individual capture flags
+override saved privacy settings. If there is no complete saved config,
+environment credentials are used; then `LANGFUSE_BASE_URL` takes precedence over
+`LANGFUSE_HOST`.
+
+The upstream default is `full-debug`, which captures prompts, outputs, tool I/O,
+the system prompt, and cwd. Prefer a narrower preset unless that detail is
+explicitly approved:
+
+| Preset | Captures |
+| --- | --- |
+| `metadata-only` | metadata only; no inputs, outputs, tool I/O, system prompt, or cwd |
+| `prompts-only` | inputs/prompts only; no outputs, tool I/O, system prompt, or cwd |
+| `conversations` | inputs and assistant outputs; no tool I/O, system prompt, or cwd |
+| `full-debug` (default) | inputs, outputs, tool I/O, system prompt, and cwd |
+
+Fine-grained environment flags override a preset:
+
+```bash
+export LANGFUSE_CAPTURE_INPUTS=true
+export LANGFUSE_CAPTURE_OUTPUTS=true
+export LANGFUSE_CAPTURE_TOOL_IO=false
+export LANGFUSE_CAPTURE_SYSTEM_PROMPT=false
+export LANGFUSE_CAPTURE_CWD=false
+```
+
+The package redacts common secrets and local paths before upload, but redaction
+is defense in depth, not permission to upload sensitive prompts, tool results,
+or source context. Keep keys out of version control, use the least capture that
+meets the need, and treat the Langfuse deployment as an external data boundary.
+
+## Choose the URL from where Pi runs
+
+| Pi location | Langfuse location | URL to configure | Notes |
+| --- | --- | --- | --- |
+| Host shell | Langfuse on the same host | `http://localhost:3000` | Normal host-loopback case. |
+| Sandbox | Langfuse on the Docker host | `http://host.docker.internal:3000` | The sandbox already maps `host.docker.internal` to Docker's host gateway. `localhost` inside the sandbox is the sandbox itself. |
+| Sandbox | Another Compose service | that service's hostname, for example `http://langfuse-web:3000` | Works only after both services are explicitly attached to a shared Docker network. It is not automatic. |
+| Sandbox or host | Cloud or remote self-hosted Langfuse | its HTTPS public URL | Verify DNS, TLS, routing, and firewall access from the process running Pi. |
+
+## Verify with a real prompt
+
+1. Confirm Pi loaded the optional package:
+   ```bash
+   pi list
+   ```
+2. In Pi, run `/langfuse-status`. It shows the selected source, host, masked
+   public key, effective capture policy, config path, and last runtime error.
+3. Run `/langfuse-test`. It performs a timeout-bounded authenticated request and
+   sends a small test trace.
+4. Send a normal Pi prompt, then inspect the resulting trace in Langfuse. A
+   real prompt is the end-to-end check for the session trace, generations, and
+   any tool observations.
+
+## Troubleshooting
+
+| Symptom | Check and fix |
+| --- | --- |
+| Missing keys or no configuration | Run `/langfuse-setup`, or export both `LANGFUSE_PUBLIC_KEY` and `LANGFUSE_SECRET_KEY` before starting Pi. |
+| Old key or host still wins | A complete saved config takes precedence for credentials and host. Use `/langfuse-status` to see its source, then rerun `/langfuse-setup` to replace stale saved values. |
+| Wrong URL | With environment-only setup, use `LANGFUSE_BASE_URL`; it wins over `LANGFUSE_HOST`. A saved host still wins over either, so update or remove the stale saved config deliberately. |
+| Connection refused or timeout | Check the location table: sandbox `localhost` is not the Docker host; use `host.docker.internal` for the host, or explicitly share a Compose network for a service hostname. |
+| TLS or DNS error | Use the externally reachable HTTPS URL, verify the hostname resolves from the Pi process, and provide a certificate chain trusted by that process. |
+| Test works but no useful trace | Send a real Pi prompt after `/langfuse-test`, then use `/langfuse-status` and Pi output for the last runtime error and effective capture policy. |
+| Usage or cost is absent | These fields are conditional on provider events. Some providers do not expose them; inspect raw observations and do not treat their absence as a tracing failure. |
+
+For package installation scope, pins, and trust behavior, see the upstream
+[Pi packages documentation](https://github.com/earendil-works/pi-mono/blob/main/packages/coding-agent/docs/packages.md).

--- a/.oh/docs/integrations/langfuse.md
+++ b/.oh/docs/integrations/langfuse.md
@@ -33,6 +33,162 @@ This is deliberately **not** an Open Harness default package. It instruments Pi
 sessions only; it does not instrument standalone Claude Code, Codex CLI, or
 Gemini CLI sessions.
 
+## Local self-hosted setup walkthrough
+
+The following procedure mirrors a working local installation: clone Langfuse as
+an independent project under Open Harness's `.oh/worktrees/project/` namespace,
+start its Compose stack, attach the existing sandbox to Langfuse's Docker
+network, and configure Pi against the service hostname.
+
+Commands run from the normal host terminal unless marked **SANDBOX** or **PI**.
+
+### 1. Clone Langfuse under `.oh/worktrees`
+
+Start from the Open Harness checkout:
+
+```bash
+cd /path/to/openharness
+WORKTREES_ROOT="$(bash .oh/scripts/oh-path worktrees --no-create 2>/dev/null || printf '%s' "${WORKTREES_DIR:-.oh/worktrees}")"
+mkdir -p "$WORKTREES_ROOT/project/langfuse"
+git clone https://github.com/langfuse/langfuse.git \
+  "$WORKTREES_ROOT/project/langfuse/langfuse"
+cd "$WORKTREES_ROOT/project/langfuse/langfuse"
+```
+
+This is an independent repository with its own `.git`, not a harness branch or
+Git worktree. If it is already cloned, update it instead:
+
+```bash
+cd /path/to/openharness
+WORKTREES_ROOT="$(bash .oh/scripts/oh-path worktrees --no-create 2>/dev/null || printf '%s' "${WORKTREES_DIR:-.oh/worktrees}")"
+cd "$WORKTREES_ROOT/project/langfuse/langfuse"
+git pull --ff-only
+```
+
+### 2. Start and verify Langfuse
+
+```bash
+docker compose up -d --wait --wait-timeout 300
+docker compose ps
+curl -fsS http://localhost:3000/api/public/health
+```
+
+A failed health check can be investigated with:
+
+```bash
+docker compose logs --tail=200
+```
+
+### 3. Start the sandbox and discover Langfuse's network
+
+```bash
+docker start oh-sbx-local
+LANGFUSE_WEB_ID=$(docker compose ps -q langfuse-web)
+LANGFUSE_NETWORK=$(
+  docker inspect "$LANGFUSE_WEB_ID" \
+    --format '{{range $name, $_ := .NetworkSettings.Networks}}{{$name}}{{"\n"}}{{end}}' |
+  head -n 1
+)
+printf 'Langfuse container: %s\nLangfuse network: %s\n' \
+  "$LANGFUSE_WEB_ID" "$LANGFUSE_NETWORK"
+```
+
+Run these commands from the cloned Langfuse repository so `docker compose`
+selects its Compose project.
+
+### 4. Attach the sandbox to Langfuse
+
+The conditional network attachment is idempotent:
+
+```bash
+docker inspect oh-sbx-local \
+  --format '{{range $name, $_ := .NetworkSettings.Networks}}{{$name}}{{"\n"}}{{end}}' |
+  grep -Fxq "$LANGFUSE_NETWORK" ||
+  docker network connect "$LANGFUSE_NETWORK" oh-sbx-local
+```
+
+Confirm that both containers share the network, then verify DNS and HTTP from
+the sandbox:
+
+```bash
+docker network inspect "$LANGFUSE_NETWORK" \
+  --format '{{range .Containers}}{{println .Name}}{{end}}' |
+  sort
+
+docker exec -u sandbox oh-sbx-local getent hosts langfuse-web
+docker exec -u sandbox oh-sbx-local \
+  curl -fsS http://langfuse-web:3000/api/public/health
+```
+
+Compose may prefix the Langfuse container's displayed name. The service DNS
+name remains `langfuse-web`. Repeat the network attachment whenever the
+`oh-sbx-local` container is destroyed and recreated.
+
+### 5. Create the local user, project, and keys
+
+Open <http://localhost:3000> on the host and:
+
+1. Select **Sign up** and create the initial local user.
+2. Sign in and create an organization when prompted.
+3. Create a project, for example `openharness-local`.
+4. Open **Settings → API Keys** and select **Create new API keys**.
+5. Copy the public key (`pk-lf-...`) and secret key (`sk-lf-...`) while shown.
+
+Keep the secret key out of source files, shell history, screenshots, and chat.
+
+### 6. Install and configure Pi
+
+Enter the existing sandbox:
+
+```bash
+docker exec -it -u sandbox oh-sbx-local bash
+```
+
+Then run these commands in the **SANDBOX**:
+
+```bash
+pi --version
+pi install npm:pi-langfuse@1.5.6
+pi list
+export LANGFUSE_PRIVACY_PRESET=metadata-only
+pi
+```
+
+At the **PI** prompt, run `/langfuse-setup` and enter:
+
+```text
+Public key:  pk-lf-...
+Secret key:  sk-lf-...
+Langfuse URL: http://langfuse-web:3000
+```
+
+Do not use `localhost` here: inside the sandbox it refers to the sandbox, not
+the Langfuse container. The saved configuration lives at
+`~/.pi/agent/pi-langfuse/config.json` on Open Harness's persistent `pi-auth`
+volume.
+
+### 7. Verify tracing and permissions
+
+At the **PI** prompt:
+
+1. Run `/langfuse-status`; confirm the masked public key, host
+   `http://langfuse-web:3000`, `metadata-only` privacy, and no runtime error.
+2. Run `/langfuse-test`; confirm the test trace appears in the local project.
+3. Send a normal prompt and confirm its session trace appears as well.
+
+Exit Pi, then verify restrictive permissions from the **SANDBOX** without
+printing the credential file:
+
+```bash
+stat -c '%a %n' \
+  ~/.pi/agent/pi-langfuse \
+  ~/.pi/agent/pi-langfuse/config.json
+```
+
+Expected permissions are `700` for the directory and `600` for the file. Keep
+`LANGFUSE_PRIVACY_PRESET=metadata-only` set before future Pi launches unless a
+broader capture policy is deliberately approved.
+
 ## Configure
 
 ### Interactive setup (recommended)

--- a/.oh/docs/integrations/langfuse.md
+++ b/.oh/docs/integrations/langfuse.md
@@ -4,13 +4,19 @@ title: Langfuse
 
 # Langfuse
 
-[Langfuse](https://langfuse.com) is optional observability for **Pi sessions**.
-Open Harness does not bundle or operate Langfuse: deploy it separately (Langfuse
-Cloud or your own installation) and follow the [official Docker Compose deployment
-guide](https://langfuse.com/self-hosting/deployment/docker-compose) if you
-self-host. Secure that external service with appropriate access controls and TLS;
-this integration does not add a proxy, exporter, credential pass-through, or
-tracing for other CLIs.
+[Langfuse](https://langfuse.com) is optional, external observability for **Pi**
+and **Claude Code** sessions. Open Harness does not bundle or operate Langfuse:
+deploy it separately (Langfuse Cloud or your own installation) and follow the
+[official Docker Compose deployment guide](https://langfuse.com/self-hosting/deployment/docker-compose)
+if you self-host. Secure that external service with appropriate access controls
+and TLS.
+
+The two integrations provide end-to-end observability, **not identical event
+schemas or privacy controls**. In particular, Pi supports deliberate capture
+presets including `metadata-only`; the Claude Code plugin does not. Read the
+privacy sections for the CLI you use before enabling either integration.
+
+## Pi
 
 [`pi-langfuse` v1.5.6](https://www.npmjs.com/package/pi-langfuse/v/1.5.6) is a
 Pi package. Its `v1.5.6` tag resolves to
@@ -33,16 +39,18 @@ This is deliberately **not** an Open Harness default package. It instruments Pi
 sessions only; it does not instrument standalone Claude Code, Codex CLI, or
 Gemini CLI sessions.
 
-## Local self-hosted setup walkthrough
+### Local self-hosted setup walkthrough
 
 The following procedure mirrors a working local installation: clone Langfuse as
 an independent project under Open Harness's `.oh/worktrees/project/` namespace,
 start its Compose stack, attach the existing sandbox to Langfuse's Docker
-network, and configure Pi against the service hostname.
+network, and configure Pi against the service hostname. The same service can be
+used by Claude Code after completing steps 1–5; see [Claude Code](#claude-code)
+for its plugin configuration.
 
 Commands run from the normal host terminal unless marked **SANDBOX** or **PI**.
 
-### 1. Clone Langfuse under `.oh/worktrees`
+#### 1. Clone Langfuse under `.oh/worktrees`
 
 Start from the Open Harness checkout:
 
@@ -65,7 +73,7 @@ cd "$WORKTREES_ROOT/project/langfuse/langfuse"
 git pull --ff-only
 ```
 
-### 2. Start and verify Langfuse
+#### 2. Start and verify Langfuse
 
 ```bash
 docker compose up -d --wait --wait-timeout 300
@@ -79,7 +87,7 @@ A failed health check can be investigated with:
 docker compose logs --tail=200
 ```
 
-### 3. Start the sandbox and discover Langfuse's network
+#### 3. Start the sandbox and discover Langfuse's network
 
 ```bash
 docker start oh-sbx-local
@@ -96,7 +104,7 @@ printf 'Langfuse container: %s\nLangfuse network: %s\n' \
 Run these commands from the cloned Langfuse repository so `docker compose`
 selects its Compose project.
 
-### 4. Attach the sandbox to Langfuse
+#### 4. Attach the sandbox to Langfuse
 
 The conditional network attachment is idempotent:
 
@@ -124,7 +132,7 @@ Compose may prefix the Langfuse container's displayed name. The service DNS
 name remains `langfuse-web`. Repeat the network attachment whenever the
 `oh-sbx-local` container is destroyed and recreated.
 
-### 5. Create the local user, project, and keys
+#### 5. Create the local user, project, and keys
 
 Open <http://localhost:3000> on the host and:
 
@@ -136,7 +144,7 @@ Open <http://localhost:3000> on the host and:
 
 Keep the secret key out of source files, shell history, screenshots, and chat.
 
-### 6. Install and configure Pi
+#### 6. Install and configure Pi
 
 Enter the existing sandbox:
 
@@ -167,7 +175,7 @@ the Langfuse container. The saved configuration lives at
 `~/.pi/agent/pi-langfuse/config.json` on Open Harness's persistent `pi-auth`
 volume.
 
-### 7. Verify tracing and permissions
+#### 7. Verify Pi tracing and permissions
 
 At the **PI** prompt:
 
@@ -189,9 +197,9 @@ Expected permissions are `700` for the directory and `600` for the file. Keep
 `LANGFUSE_PRIVACY_PRESET=metadata-only` set before future Pi launches unless a
 broader capture policy is deliberately approved.
 
-## Configure
+### Configure Pi
 
-### Interactive setup (recommended)
+#### Interactive setup (recommended)
 
 Start Pi, then run its package command:
 
@@ -207,7 +215,7 @@ directory and a `0600` file where POSIX permissions are available. `make destroy
 removes named volumes, including `pi-auth`, so configure again after destroying
 the sandbox.
 
-### Environment-only setup
+#### Environment-only setup
 
 For a non-interactive shell, export credentials before starting Pi:
 
@@ -233,7 +241,7 @@ set +a
 pi
 ```
 
-## Configuration and privacy precedence
+### Pi configuration and privacy precedence
 
 A valid saved `~/.pi/agent/pi-langfuse/config.json` (one with both keys) supplies
 credentials and host before environment configuration. Environment privacy
@@ -268,7 +276,7 @@ is defense in depth, not permission to upload sensitive prompts, tool results,
 or source context. Keep keys out of version control, use the least capture that
 meets the need, and treat the Langfuse deployment as an external data boundary.
 
-## Choose the URL from where Pi runs
+### Choose the URL from where Pi runs
 
 | Pi location | Langfuse location | URL to configure | Notes |
 | --- | --- | --- | --- |
@@ -277,7 +285,7 @@ meets the need, and treat the Langfuse deployment as an external data boundary.
 | Sandbox | Another Compose service | that service's hostname, for example `http://langfuse-web:3000` | Works only after both services are explicitly attached to a shared Docker network. It is not automatic. |
 | Sandbox or host | Cloud or remote self-hosted Langfuse | its HTTPS public URL | Verify DNS, TLS, routing, and firewall access from the process running Pi. |
 
-## Verify with a real prompt
+### Verify Pi with a real prompt
 
 1. Confirm Pi loaded the optional package:
    ```bash
@@ -291,7 +299,7 @@ meets the need, and treat the Langfuse deployment as an external data boundary.
    real prompt is the end-to-end check for the session trace, generations, and
    any tool observations.
 
-## Troubleshooting
+### Troubleshoot Pi
 
 | Symptom | Check and fix |
 | --- | --- |
@@ -305,3 +313,124 @@ meets the need, and treat the Langfuse deployment as an external data boundary.
 
 For package installation scope, pins, and trust behavior, see the upstream
 [Pi packages documentation](https://github.com/earendil-works/pi-mono/blob/main/packages/coding-agent/docs/packages.md).
+
+## Claude Code
+
+The official, supported Claude Code path is Langfuse's marketplace plugin, not
+native Claude OpenTelemetry environment variables. The plugin repository is
+[Langfuse/Claude-Observability-Plugin](https://github.com/langfuse/Claude-Observability-Plugin),
+observed at commit
+[`9ad0076a7a24e8673ac6e7ac6f7b658b18826bb6`](https://github.com/langfuse/Claude-Observability-Plugin/commit/9ad0076a7a24e8673ac6e7ac6f7b658b18826bb6)
+(version 1.0.0). Review plugin source before installing it: marketplace plugins
+can execute code and add hooks to Claude Code.
+
+### Install and configure
+
+From a shell that runs Claude Code, install the marketplace and plugin exactly
+as follows:
+
+```bash
+claude plugin marketplace add langfuse/Claude-Observability-Plugin
+claude plugin install langfuse-observability@langfuse-observability
+```
+
+Restart Claude Code. Then, at the **Claude prompt** (not the shell), run:
+
+```text
+/plugin configure langfuse-observability@langfuse-observability
+```
+
+Enter the two required fields in the plugin configuration:
+
+- `LANGFUSE_PUBLIC_KEY`
+- `LANGFUSE_SECRET_KEY`
+
+`LANGFUSE_BASE_URL` is optional and defaults to the US region
+(`https://us.cloud.langfuse.com`); use `https://cloud.langfuse.com` for EU or
+your self-hosted URL. Other optional fields are `LANGFUSE_USER_ID`,
+`CC_LANGFUSE_DEBUG` (default `false`), `CC_LANGFUSE_MAX_CHARS` (default
+`20000`), `CC_LANGFUSE_SKILL_TAGS` (default `true`), and
+`CC_LANGFUSE_CAPTURE_SKILL_CONTENT` (default `false`). The plugin needs `uv`
+(already installed in Open Harness), or its Python 3.10+ fallback with
+`langfuse>=4.0,<5`. Do not add a separate `pip install` when `uv` is available.
+
+The plugin installs and is enabled at **user scope**. Configuration is stored by
+Claude's plugin configuration and OS-keychain mechanisms according to upstream.
+Open Harness persists `~/.claude` on the `claude-auth` volume, but OS-keychain
+availability and persistence are platform-dependent; verify the plugin remains
+configured after a sandbox rebuild. You can enter the same Langfuse key pair in
+Pi and Claude Code, but their saved configurations are independent. Do not put
+Claude plugin keys in `.devcontainer/.env`, source files, shell history,
+screenshots, or chat.
+
+### Choose the Claude plugin base URL
+
+Set `LANGFUSE_BASE_URL` according to where the Claude Code process runs:
+
+| Claude Code location | Langfuse location | `LANGFUSE_BASE_URL` |
+| --- | --- | --- |
+| Host shell | Same host | `http://localhost:3000` |
+| Sandbox | Docker host | `http://host.docker.internal:3000` |
+| Sandbox | Local Langfuse Compose service on an explicitly shared Docker network | `http://langfuse-web:3000` |
+| Host or sandbox | Cloud or remote self-hosted deployment | Its externally reachable HTTPS URL |
+
+`localhost` from the sandbox is the sandbox itself. The host-gateway mapping
+makes `host.docker.internal` the host route. The `langfuse-web` name works only
+after explicit shared-network attachment; Open Harness does not modify Compose
+or create that connection automatically. For a remote or Cloud endpoint, verify
+DNS, TLS, routing, and firewall access from the process running Claude Code.
+
+### Privacy and capture boundary
+
+The plugin uses Claude Code Stop and SessionEnd hooks plus transcript files. It
+captures user prompts, assistant text, tool invocations, tool inputs and
+results, session and timing data, and token usage when present.
+`CC_LANGFUSE_MAX_CHARS` defaults to 20,000 characters for relevant captured
+text and results; it is not a universal field-size cap, and structured tool
+inputs are not recursively truncated.
+
+This is not Pi's `metadata-only` model: the plugin offers no general redaction,
+no metadata-only mode, and no prompt-off control.
+`CC_LANGFUSE_CAPTURE_SKILL_CONTENT` defaults to `false`, but the conversation
+and tool data above are otherwise captured. The official integration page
+loosely mentions reasoning; do **not** rely on that as a capture claim—the
+examined plugin text extractor includes text blocks only and does not extract
+Claude thinking blocks.
+
+Treat every trace as data sent to the Langfuse deployment. Before a sensitive
+session, disable the plugin at user scope and restart Claude Code:
+
+```bash
+claude plugin disable langfuse-observability@langfuse-observability --scope user
+claude plugin list
+```
+
+Re-enable it when approved, then restart Claude Code:
+
+```bash
+claude plugin enable langfuse-observability@langfuse-observability --scope user
+claude plugin list
+```
+
+To remove it instead:
+
+```bash
+claude plugin uninstall langfuse-observability
+```
+
+### Verify and troubleshoot
+
+After configuration and restart, send a non-sensitive test prompt in Claude
+Code and confirm that its trace appears in the selected Langfuse project. For
+hook diagnostics, inspect `~/.claude/state/langfuse_hook.log` without exposing
+credentials. Restart Claude Code after installation or disable/enable changes.
+
+The plugin supports the Claude Code CLI and Claude Code GUI **Code** mode. It
+does not instrument Claude Desktop Chat. This guide intentionally adds no MCP
+server, custom launcher, adapter, native service, or native OTEL configuration.
+
+### Claude Code sources
+
+- [Langfuse: Claude Code integration](https://langfuse.com/integrations/developer-tools/claude-code) (verified 2026-07-11; page last edited 2026-06-22)
+- [Langfuse Claude Observability Plugin](https://github.com/langfuse/Claude-Observability-Plugin) at [observed commit `9ad0076a7a24e8673ac6e7ac6f7b658b18826bb6`](https://github.com/langfuse/Claude-Observability-Plugin/commit/9ad0076a7a24e8673ac6e7ac6f7b658b18826bb6)
+- Anthropic's [Claude Code plugins](https://code.claude.com/docs/en/plugins) and [hooks guide](https://code.claude.com/docs/en/hooks-guide)

--- a/.oh/plans/claude-code-langfuse.md
+++ b/.oh/plans/claude-code-langfuse.md
@@ -1,0 +1,84 @@
+# Claude Code Langfuse documentation plan
+
+## Purpose and discovery correction
+
+Extend issue #480 so Open Harness documents optional Langfuse end-to-end
+observability for both Pi and Claude Code. Initial discovery considered a native
+Claude OpenTelemetry/environment-variable recipe. Verification on 2026-07-11
+found that the supported, lowest-friction Claude Code integration is the
+**Langfuse Claude Code marketplace plugin**. It installs Stop and SessionEnd
+hooks; this change deliberately does not introduce an OTLP recipe, custom
+launcher, MCP server, adapter, native service, Compose change, or networking
+change.
+
+## Authoritative sources (verified 2026-07-11)
+
+- [Langfuse Claude Code integration](https://langfuse.com/integrations/developer-tools/claude-code), last edited 2026-06-22.
+- [Langfuse Claude Observability Plugin](https://github.com/langfuse/Claude-Observability-Plugin), observed at commit [`9ad0076a7a24e8673ac6e7ac6f7b658b18826bb6`](https://github.com/langfuse/Claude-Observability-Plugin/commit/9ad0076a7a24e8673ac6e7ac6f7b658b18826bb6), plugin version 1.0.0.
+- Anthropic's current [Claude Code plugins](https://code.claude.com/docs/en/plugins) and [hooks guide](https://code.claude.com/docs/en/hooks-guide), used to verify plugin scope, configuration, and hook lifecycle.
+- Existing pinned [Pi package documentation](https://www.npmjs.com/package/pi-langfuse/v/1.5.6) and its source commit, retained in the integration guide.
+
+## Scope and files
+
+1. Update `.oh/docs/integrations/langfuse.md` with separate Pi and Claude Code
+   paths while retaining Pi configuration, privacy precedence, and the local
+   self-hosted Langfuse walkthrough.
+2. Add the official Claude marketplace install and configuration commands,
+   endpoint-selection guidance for host, sandbox, shared Docker network, and
+   remote/Cloud deployments, lifecycle commands, verification, and
+   troubleshooting.
+3. Add a concise optional-observability cross-link to
+   `.oh/docs/harnesses/claude-code.md`.
+4. Clarify that `.devcontainer/.example.env`'s Langfuse block is Pi-only;
+   Claude plugin configuration owns Claude credentials, so no variables are
+   added and Compose is not changed.
+5. Record the user-visible documentation addition in `CHANGELOG.md` under
+   `Unreleased / Added`.
+
+## Security and privacy model
+
+- Langfuse is an external data boundary. Never put public or secret keys in
+  tracked files, shell history, screenshots, or chat.
+- Pi and Claude offer end-to-end observability, not identical schemas or
+  privacy semantics. Pi retains its explicit capture presets (including
+  `metadata-only`) and saved Pi configuration.
+- The Claude plugin has no Pi-style metadata-only or prompt-off control and no
+  general redaction. It captures conversation and tool data, so users must
+  disable it at user scope before sensitive sessions.
+- Claude plugin credentials are entered through Claude's plugin configuration
+  and stored according to upstream Claude plugin configuration/OS-keychain
+  behavior. Open Harness persists `~/.claude` on the `claude-auth` volume, but
+  OS-keychain availability and persistence are platform-dependent and must be
+  verified after a rebuild. Pi and Claude may use the same Langfuse key pair
+  but save independent settings.
+
+## Validation
+
+- Check the official command spelling, configuration field names/defaults,
+  plugin version/commit, data-capture claims, scopes, endpoint URLs, and
+  lifecycle commands against the verified findings and Claude Code CLI help.
+- Review the rendered Markdown hierarchy and ensure no unsupported native OTEL,
+  MCP, launcher, adapter, service, credential, or Compose instruction appears.
+- Run `git diff --check`, the core docs fast-path probe, core typecheck/script
+  tests, and the companion website typecheck/production build.
+- From a shared-network sandbox, verify Langfuse health and the prerequisites,
+  then use non-sensitive credentials entered by the operator to install and
+  configure the plugin, send one test turn, and confirm its turn trace,
+  generations, tool spans, session grouping, and token usage when available.
+- Disable the plugin at user scope, restart Claude Code, send a second uniquely
+  named test turn, and confirm no new trace is created. Re-enable only with
+  operator approval.
+- Do not test for a prompt-content-off mode: the official plugin has none.
+  Instead confirm injected skill instruction content is absent under its
+  default `CC_LANGFUSE_CAPTURE_SKILL_CONTENT=false` setting.
+- Scan the diff and test output for public keys, secret keys, encoded
+  authorization values, and generated credential files.
+
+## Explicit non-goals
+
+- Installing or configuring the plugin in a live Claude account.
+- Adding credentials, environment injection, Compose services, Docker networks,
+  custom hooks, MCP servers, OTLP exporters, launchers, or adapters.
+- Changing Pi saved configuration or its documented privacy semantics.
+- Claiming Claude captures hidden reasoning/thinking blocks; the examined
+  plugin text extractor includes text blocks only.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Update policy and release automation live in [`/git`](.claude/skills/git/SKILL.m
 ## [Unreleased]
 
 ### Added
+- Document optional Pi-to-Langfuse observability, configuration precedence, privacy controls, and sandbox network boundaries ([#480](https://github.com/mifunedev/openharness/issues/480)).
 ### Changed
 ### Fixed
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Update policy and release automation live in [`/git`](.claude/skills/git/SKILL.m
 
 ### Added
 - Document optional Pi-to-Langfuse observability, configuration precedence, privacy controls, and sandbox network boundaries ([#480](https://github.com/mifunedev/openharness/issues/480)).
+- Document optional Claude Code-to-Langfuse observability through the official marketplace plugin, including the user-scope privacy boundary and local sandbox endpoint setup ([#480](https://github.com/mifunedev/openharness/issues/480)).
 ### Changed
 ### Fixed
 ### Removed


### PR DESCRIPTION
Closes #480.

Companion rendered-docs PR: https://github.com/mifunedev/openharness-web/pull/18

## Summary

- adds **Integrations → Langfuse** as the primary Open Harness documentation surface for Pi and Claude Code
- keeps Langfuse external and optional; no runtime service, Docker networking, MCP server, custom launcher, or default telemetry is added
- documents the pinned `pi-langfuse` package, exact configuration precedence, privacy presets, and the tested local self-hosted walkthrough
- adds the official Claude Code marketplace-plugin path, shared-network endpoint, user-scope lifecycle, full-content capture warning, and troubleshooting
- records the source-backed implementation plan at `.oh/plans/claude-code-langfuse.md`
- adds concise Pi and Claude Code harness-page cross-links and keeps the `.devcontainer/.example.env` values explicitly Pi-only

## Presentation decision

An expert Advisor compared the internal wiki, core docs, and `openharness-web`. The selected surface is a dedicated integration guide mirrored between core GitHub-readable docs and the independently owned Docusaurus site. The internal wiki and promotional surfaces are intentionally excluded.

## Authoritative sources

- `pi-langfuse` v1.5.6, commit `fa415f33458f010265a287251fd3e7d249e97b99`
- Langfuse Claude Code integration, last edited 2026-06-22
- `langfuse/Claude-Observability-Plugin` v1.0.0, observed commit `9ad0076a7a24e8673ac6e7ac6f7b658b18826bb6`
- current Anthropic Claude Code plugin and hooks documentation
- official Langfuse self-hosted Docker Compose guide

## Verification

- `git diff --check`
- `bash .oh/evals/probes/docs-build-fast-path.sh`
- `pnpm run typecheck`
- `pnpm test:scripts` — 35 files, 456 tests
- companion web: `pnpm run typecheck`, `pnpm run build`
- Claude Code v2.1.206 plugin CLI, default user scope, `uv`/Python prerequisites, shared-network DNS, and Langfuse health endpoint verified in `oh-sbx-local`
- GPT-5.6 adversarial source review: PASS after correcting required/default fields and text-truncation scope
- credential-pattern scan: clean

Live Claude trace emission remains an operator verification step: installing the user-scoped plugin and entering the secret key would mutate persisted Claude state and enable full prompt/tool capture, so this PR does not perform that action automatically.
