### PR TITLE
FROM task/633-deepswe-model-gauge TO development

### DIFF
--- a/.oh/agents/agent-builder.md
+++ b/.oh/agents/agent-builder.md
@@ -210,6 +210,7 @@ initialPrompt: "..."         # Optional: auto-submitted first user turn when run
    - **`sonnet`**: default executor — code generation, reasoning, architecture decisions
    - **`haiku`**: fast searches, simple analysis, quick lookups
    - Resolution order: `CLAUDE_CODE_SUBAGENT_MODEL` env var > per-invocation `model` arg > frontmatter > main conversation
+   - For newly released coding models, consult the [model-capability guidance](../docs/model-capability.md): DeepSWE is the current external gauge, but defaults still require availability, cost, latency/tool compatibility, and harness-specific evaluation.
 
    **Advisor Strategy (direct API consumers only)**:
    When building agents that make direct Anthropic API calls (e.g., Slack bot),

--- a/.oh/docs/README.md
+++ b/.oh/docs/README.md
@@ -62,6 +62,7 @@ Open Harness vendors the shared skills/agents/hooks primitive pack directly into
 
 ## Reference
 
+- [Gauging coding-model capability](model-capability.md)
 - [Security considerations](security-considerations.md)
 - [Repair-operator registry](repair-operator-registry.md)
 - [Artifact-contract schema](artifact-contract-schema.md)

--- a/.oh/docs/model-capability.md
+++ b/.oh/docs/model-capability.md
@@ -1,0 +1,37 @@
+# Gauging coding-model capability
+
+When a new coding model is released, Open Harness currently uses the public
+[DeepSWE leaderboard](https://deepswe.datacurve.ai/) as its external reference
+for an initial capability comparison. DeepSWE measures frontier coding agents on
+original, long-horizon software engineering tasks. Its leaderboard also exposes
+operational context such as cost, output tokens, and agent steps; its public
+[source and data](https://github.com/datacurve-ai/deep-swe) and the site's **Run
+DeepSWE** flow make the benchmark inspectable and reproducible outside Open
+Harness.
+
+DeepSWE is an independent DataCurve project. Open Harness does not own or operate
+it, and a leaderboard position is not, by itself, a release gate or sufficient
+reason to change a default model. Results are a point-in-time external signal:
+the task set, submissions, models, and rankings can change.
+
+For a model-default decision, combine the current DeepSWE signal with:
+
+- provider and region availability;
+- cost and observed latency;
+- tool-calling and coding-harness compatibility; and
+- harness-specific evaluation on the workflows the model will actually run.
+
+## Keep the evaluation layers separate
+
+DeepSWE answers an external question: how do released coding agents compare on
+its long-horizon software engineering workload? It complements, but does not
+replace, either repository-local instrument:
+
+- [The deterministic `/eval` probes](../evals/README.md) are the regression
+  **floor** for known Open Harness invariants.
+- [The local capability benchmark](../evals/capability/README.md) is the
+  progress **ceiling** for what this harness can deliver end to end.
+
+Use all three as evidence for their stated scopes. Do not interpret an external
+leaderboard result as proof that Open Harness remains regression-free or that a
+model performs best under local tools, prompts, budgets, and workflows.

--- a/.oh/evals/capability/README.md
+++ b/.oh/evals/capability/README.md
@@ -9,6 +9,9 @@ well the harness actually produced it. A rising suite score is evidence the loop
 The originating rationale is the **objective anchor**: harness capability is *what the
 harness can DO, not what it HAS*. This instrument is the *Capability benchmark* — the
 progress ceiling — consumed by the `/benchmark` verdict skill against the counterfactual.
+It is distinct from [DeepSWE, the current external reference used when gauging a
+newly released coding model](../../docs/model-capability.md); neither instrument
+substitutes for the other.
 
 ## Ceiling vs. floor
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Update policy and release automation live in [`/git`](.claude/skills/git/SKILL.m
 
 ### Added
 ### Changed
+- Document DeepSWE as the current external gauge for newly released coding-model capability and distinguish it from Open Harness's internal evaluation layers ([#633](https://github.com/mifunedev/openharness/issues/633)).
 ### Fixed
 ### Removed
 ### Deprecated


### PR DESCRIPTION
## Summary

- document DeepSWE as Open Harness’s current external gauge for newly released coding-model capability
- explain that DeepSWE is an independent, point-in-time signal rather than a model-default or release gate
- distinguish DeepSWE from the deterministic `/eval` floor and local capability benchmark ceiling
- link the canonical guidance from model-selection and capability surfaces

## Validation

- `git diff --check`
- `bash .oh/evals/probes/docs-build-fast-path.sh`
- `bash .oh/evals/probes/capability-benchmark-schema.sh`
- local Markdown target validation
- external URL checks for `https://deepswe.datacurve.ai/` and `https://github.com/datacurve-ai/deep-swe` (HTTP 200)
- full `/eval`: 78 PASS, 1 SKIPPED, 1 unrelated host-state regression (`next-dev-prod` detected an existing `next dev` process outside this change)

Closes #633