### PR TITLE
fix: keep cron-watchdog temp file root-owned so nodes survive restart (#640)

### DIFF
--- a/.devcontainer/entrypoint.sh
+++ b/.devcontainer/entrypoint.sh
@@ -627,7 +627,20 @@ if [ -f "$HARNESS/.oh/scripts/cron-runtime.ts" ] && command -v tmux &>/dev/null;
     gosu sandbox tmux kill-session -t system-cron 2>/dev/null || true
   fi
 
-  cat > /tmp/cron-watchdog.sh <<'CRON_WATCHDOG'
+  # This helper must be REWRITABLE on a container RESTART (`docker start`). The
+  # entrypoint runs as root; the previous version chowned this file to the
+  # sandbox user (1000:1000, mode 755). On the second boot /tmp still holds it
+  # (container writable-layer, not tmpfs), so the root entrypoint's `cat >` had
+  # to overwrite a file it no longer owned — which fails with EACCES on node
+  # runtimes that drop CAP_DAC_OVERRIDE, and the global `set -e` then promoted
+  # that one failed redirect into a fatal boot abort (container crash-loop on
+  # restart). Fix: keep the file root-owned (root can always rewrite a file it
+  # owns via the owner mode bits — no CAP_DAC_OVERRIDE needed); the sandbox only
+  # needs to READ it, since it is launched via `bash <path>`. rm any stale
+  # sandbox-owned copy left by an older image, and never let this OPTIONAL
+  # supervisor kill the sandbox boot.
+  rm -f /tmp/cron-watchdog.sh 2>/dev/null || true
+  if cat > /tmp/cron-watchdog.sh <<'CRON_WATCHDOG'
 #!/usr/bin/env bash
 set -u
 HARNESS="${HARNESS:-${OH_PROJECT_ROOT:-/home/sandbox/harness}}"
@@ -645,15 +658,18 @@ while true; do
   sleep "$INTERVAL"
 done
 CRON_WATCHDOG
-  chmod 755 /tmp/cron-watchdog.sh
-  chown -h "$(sandbox_ownership)" /tmp/cron-watchdog.sh 2>/dev/null || true
-
-  if gosu sandbox tmux has-session -t cron-watchdog 2>/dev/null; then
-    echo "[entrypoint] cron-watchdog tmux session already running — skipping"
+  then
+    chmod 755 /tmp/cron-watchdog.sh 2>/dev/null || true
+    if gosu sandbox tmux has-session -t cron-watchdog 2>/dev/null; then
+      echo "[entrypoint] cron-watchdog tmux session already running — skipping"
+    elif gosu sandbox tmux new-session -d -s cron-watchdog \
+      "OH_PROJECT_ROOT=$OH_PROJECT_ROOT HARNESS=$HARNESS CRON_WATCHDOG_INTERVAL=${CRON_WATCHDOG_INTERVAL:-60} bash /tmp/cron-watchdog.sh 2>&1 | tee /tmp/cron-watchdog.log"; then
+      echo "[entrypoint] cron-watchdog tmux session started (supervises cron-system)"
+    else
+      echo "[entrypoint] WARN: cron-watchdog tmux launch failed — skipping (sandbox boot continues)"
+    fi
   else
-    gosu sandbox tmux new-session -d -s cron-watchdog \
-      "OH_PROJECT_ROOT=$OH_PROJECT_ROOT HARNESS=$HARNESS CRON_WATCHDOG_INTERVAL=${CRON_WATCHDOG_INTERVAL:-60} bash /tmp/cron-watchdog.sh 2>&1 | tee /tmp/cron-watchdog.log"
-    echo "[entrypoint] cron-watchdog tmux session started (supervises cron-system)"
+    echo "[entrypoint] WARN: could not write /tmp/cron-watchdog.sh — skipping cron-watchdog (sandbox boot continues)"
   fi
 fi
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Update policy and release automation live in [`/git`](.claude/skills/git/SKILL.m
 ### Added
 ### Changed
 ### Fixed
+- Keep the cron-watchdog temp file (`/tmp/cron-watchdog.sh`) root-owned so a container **restart** (`docker start`) can rewrite it, and make the optional cron supervisor non-fatal under `set -e`; previously the root entrypoint could not overwrite the sandbox-chowned file on the second boot (EACCES on runtimes without `CAP_DAC_OVERRIDE`), which crash-looped the node ([#640](https://github.com/mifunedev/openharness/issues/640)).
 ### Removed
 ### Deprecated
 ### Security


### PR DESCRIPTION
Closes #640.

## Problem
A provisioned node boots clean on first start, then **crash-loops after a `docker stop` → `docker start`** (restart) with:

```
/usr/local/bin/entrypoint.sh: line 630: /tmp/cron-watchdog.sh: Permission denied
```

The UI "rebuild" button doesn't help because it restarts the *same* container (whose `/tmp` still holds the offending file); only recreating the container clears it.

## Root cause
`.devcontainer/entrypoint.sh` runs as **root** with `set -e`. The cron-watchdog block wrote `/tmp/cron-watchdog.sh` then `chown`ed it to the sandbox user (`1000:1000`, mode `755`). On restart `/tmp` persists in the container writable layer, so the root entrypoint's `cat >` must overwrite a file it no longer owns — which fails with **EACCES** on node runtimes that drop `CAP_DAC_OVERRIDE`. `set -e` then turns that one failed redirect into a **fatal boot abort**.

Evidence chain: boot-1 `chown` succeeded ⇒ `CAP_CHOWN` present; boot-2 root overwrite failed ⇒ `CAP_DAC_OVERRIDE` absent.

Two flaws: the file is chowned away from its writer, and an *optional* supervisor is allowed to kill the whole boot.

## Fix
- Keep `/tmp/cron-watchdog.sh` **root-owned** — root always rewrites a file it owns via the owner mode bits, no `CAP_DAC_OVERRIDE` needed. The sandbox only needs to READ it (launched via `bash <path>`).
- `rm -f` any stale sandbox-owned copy from an older image before writing.
- Wrap the write + `tmux` launch so a failure **warns and boot continues** instead of aborting under `set -e`.

## Verification
- `bash -n` clean on the edited entrypoint.
- Simulated the exact restart EACCES: the failed redirect no longer aborts under `set -e` (falls to warn branch, exit 0).
- Full eval probe suite: 78 PASS / 2 SKIP / 0 fix-related regressions — `cron-watchdog` and `entrypoint-pnpm-manifest-fingerprint` probes stay green.

Sibling to #639 (pnpm-audit 410 on *fresh* install); this closes the *restart* path so nodes survive stop/start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)