### PR TITLE
FROM skill/647-stage-audit-protection TO development

### DIFF
--- a/.claude/protected-paths.txt
+++ b/.claude/protected-paths.txt
@@ -19,9 +19,7 @@ cloudflared-tunnel
 agent-browser
 prd
 ralph
-harness-audit
-skill-lint
-eval-lint
+audit
 delegate
 strategic-proposal
 ship-spec
@@ -32,7 +30,6 @@ spec-retro
 eval
 health-check
 retro
-drift-check
 
 # --- Orchestrator scripts (.oh/scripts/) ---
 .oh/scripts/ralph.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Update policy and release automation live in [`/git`](.claude/skills/git/SKILL.m
 
 ### Added
 ### Changed
+- Protect the consolidated `/audit` owner in place of the superseded `harness-audit`, `skill-lint`, `eval-lint`, and `drift-check` entry points, staging their removal in the separate audit-consolidation implementation ([#647](https://github.com/mifunedev/openharness/issues/647)).
 - **BREAKING:** Consolidate artifact authoring under `/builder <agent|skill|command|rule> <name-or-request>` with one authoritative reference per type ([#643](https://github.com/mifunedev/openharness/issues/643)).
 ### Fixed
 ### Removed


### PR DESCRIPTION
Closes #647

## Summary

- protect the consolidated `audit` owner
- remove only the superseded audit-family names from the protected-path policy
- record why implementation and legacy-file removal remain in the separate stacked consolidation PR #646

## Scope

Policy prerequisite only. No audit implementation or legacy entry point is changed here.

## Validation

- `audit` is present exactly once in `.claude/protected-paths.txt`
- superseded names are absent from the protected list
- `git diff --check`
