### PR TITLE
FROM feat/651-herdr-default TO development

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -45,6 +45,14 @@ RUN curl -fsSL https://pkg.cloudflare.com/cloudflare-main.gpg \
 # ─── Bun ────────────────────────────────────────────────────────────
 RUN BUN_INSTALL=/usr/local curl -fsSL https://bun.sh/install | bash
 
+# ─── Herdr ──────────────────────────────────────────────────────────
+# Multi-agent terminal workspace. Install the stable release globally so every
+# sandbox user gets the command without a first-boot network dependency.
+RUN curl -fsSL https://herdr.dev/install.sh -o /tmp/herdr-install.sh \
+ && HERDR_INSTALL_DIR=/usr/local/bin sh /tmp/herdr-install.sh \
+ && rm /tmp/herdr-install.sh \
+ && herdr --version
+
 # ─── uv ─────────────────────────────────────────────────────────────
 RUN curl -LsSf https://astral.sh/uv/install.sh | env INSTALLER_NO_MODIFY_PATH=1 sh \
  && cp /root/.local/bin/uv /usr/local/bin/uv \

--- a/.devcontainer/docker-compose.image-only.yml
+++ b/.devcontainer/docker-compose.image-only.yml
@@ -30,8 +30,9 @@ services:
       - opencode-auth:/home/sandbox/.local/share/opencode
       - grok-auth:/home/sandbox/.grok
       - deepagents-auth:/home/sandbox/.deepagents
+      - herdr-data:/home/sandbox/.herdr
       - cloudflared-auth:/home/sandbox/.cloudflared
-      - gh-config:/home/sandbox/.config/gh
+      - config-dir:/home/sandbox/.config
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
@@ -70,5 +71,6 @@ volumes:
   opencode-auth:
   grok-auth:
   deepagents-auth:
+  herdr-data:
   cloudflared-auth:
-  gh-config:
+  config-dir:

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -3,8 +3,9 @@
 # Base sandbox compose. The base ships with zero in-tree overlays;
 # agent auth and tool state persist in named volumes managed by Docker
 # (claude-auth, codex-auth, pi-auth, opencode-auth, grok-auth,
-# deepagents-auth, cloudflared-auth, gh-config), and the bind-mounted
+# deepagents-auth, herdr-data, cloudflared-auth, config-dir), and the bind-mounted
 # repo's UID is synced into the sandbox user by entrypoint.sh on first boot.
+# config-dir persists all XDG config, including GitHub and Herdr settings.
 # Grok Build uses ~/.grok for user state/auth, persisted by grok-auth.
 # Hermes uses the project-local bind-mounted `.hermes/` directory as
 # HERMES_HOME for all runtime state, including auth.json (gitignored).
@@ -50,8 +51,9 @@ services:
       - opencode-auth:/home/sandbox/.local/share/opencode
       - grok-auth:/home/sandbox/.grok
       - deepagents-auth:/home/sandbox/.deepagents
+      - herdr-data:/home/sandbox/.herdr
       - cloudflared-auth:/home/sandbox/.cloudflared
-      - gh-config:/home/sandbox/.config/gh
+      - config-dir:/home/sandbox/.config
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
@@ -94,5 +96,6 @@ volumes:
   opencode-auth:
   grok-auth:
   deepagents-auth:
+  herdr-data:
   cloudflared-auth:
-  gh-config:
+  config-dir:

--- a/.devcontainer/entrypoint.sh
+++ b/.devcontainer/entrypoint.sh
@@ -25,7 +25,7 @@ repair_home_mount_ownership() {
   # sandbox user's numeric uid:gid so this remains correct after UID/GID sync,
   # even when the primary group is remapped to an existing host group whose
   # name is not `sandbox`.
-  for dir in .claude .codex .pi .grok .deepagents .cloudflared .config/gh .ssh; do
+  for dir in .claude .codex .pi .grok .deepagents .herdr .cloudflared .config .ssh; do
     if [ -d "/home/sandbox/$dir" ]; then
       chown -hR "$owner" "/home/sandbox/$dir" 2>/dev/null || true
       [ "$dir" = ".ssh" ] && chmod 700 "/home/sandbox/$dir" 2>/dev/null || true
@@ -352,7 +352,7 @@ fi
 
 # ─── GitHub CLI auth via PAT (optional) ─────────────────────────────
 # When GH_TOKEN is provided, persist it into ~/.config/gh/hosts.yml on
-# disk (via the gh-config volume) so auth survives env changes and
+# disk (via the config-dir volume) so auth survives env changes and
 # `gh auth setup-git` has proper host config to reference. gh refuses
 # `--with-token` while GH_TOKEN is in env, so unset it in the subprocess.
 # Disk-auth check uses `env -u GH_TOKEN` so we don't mistake the env var

--- a/.oh/docs/README.md
+++ b/.oh/docs/README.md
@@ -53,6 +53,7 @@ Open Harness vendors the shared skills/agents/hooks primitive pack directly into
 
 ## Integrations
 
+- [Herdr](integrations/herdr.md)
 - [GitHub](integrations/github.md)
 - [Slack](integrations/slack.md)
 - [Langfuse](integrations/langfuse.md)

--- a/.oh/docs/deployment-prebuilt-image.md
+++ b/.oh/docs/deployment-prebuilt-image.md
@@ -214,7 +214,7 @@ docker run -d --name "$NAME" --restart unless-stopped --init \
   -e GH_TOKEN="${GH_TOKEN:-}" \
   -v oh_workspace:/home/sandbox/harness \
   -v claude-auth:/home/sandbox/.claude \
-  -v gh-config:/home/sandbox/.config/gh \
+  -v config-dir:/home/sandbox/.config \
   -v oh_ssh:/home/sandbox/.ssh \
   "$IMAGE" sleep infinity
 

--- a/.oh/docs/installation.md
+++ b/.oh/docs/installation.md
@@ -292,6 +292,7 @@ Default CLIs are always present. Optional CLIs are excluded from the default ima
 
 | Tool | Purpose |
 |------|---------|
+| Herdr (`herdr`) | Default multi-agent terminal workspace; state persists across rebuilds in dedicated volumes |
 | Docker CLI + Compose | Container management from inside the sandbox (host docker socket bind-mounted by the base compose) |
 | GitHub CLI (`gh`) | PRs, issues, releases from the terminal |
 | tmux | Detachable terminal sessions for long-running agents |
@@ -330,7 +331,8 @@ Auth credentials survive container rebuilds via named Docker volumes:
 - `hermes-auth` → `~/.hermes` (Hermes auth only; non-auth runtime state defaults to project-local `~/harness/.hermes` when Hermes is enabled (`install.hermes: true` in `harness.yaml`))
 - `grok-auth` → `~/.grok` (all Grok Build user state: auth, config, sessions, memory, skills/plugins, logs; mounted alongside the other agent auth volumes and used by Grok Build when `install.grok_build: true` in `harness.yaml`). Cached OAuth/session state in `~/.grok/auth.json` takes precedence over `XAI_API_KEY`; if an API key seems ignored, run `grok logout` or reset the volume.
 - `cloudflared-auth` → `~/.cloudflared` (Cloudflare tunnel credentials, when used)
-- `gh-config` → `~/.config/gh` (GitHub CLI tokens)
+- `config-dir` → `~/.config` (shared XDG configuration, including GitHub CLI tokens and Herdr settings)
+- `herdr-data` → `~/.herdr` (Herdr session and worktree state)
 
 Hermes is split: when Hermes is enabled (`install.hermes: true` in `harness.yaml`), `HERMES_HOME` defaults to the project-local bind-mounted `~/harness/.hermes/` directory, while auth remains in the `~/.hermes` named volume and is linked into the project-local home as `auth.json`. The entrypoint links `.hermes/skills/openharness` to the tracked shared skill directory (`.oh/skills/`) so Hermes sees the same harness skills as Claude, Codex, and Pi without copying them into runtime state. Project-local runtime contents are gitignored except `.hermes/README.md`; `make destroy` removes the auth volume but not the bind-mounted project runtime directory.
 

--- a/.oh/docs/integrations/github.md
+++ b/.oh/docs/integrations/github.md
@@ -81,4 +81,4 @@ gh issue view 42
 
 ## Persisting credentials across restarts
 
-The `gh` token is stored inside the container at `~/.config/gh/`, backed by the named `gh-config` volume. The token survives `docker compose down` and `docker compose up` cycles. `docker compose down -v` removes the volume — re-run `gh auth login` after a `down -v`, or register your own compose overlay in `config.json` `composeOverrides[]` to bind-mount a host directory to `~/.config/gh/`.
+The `gh` token is stored inside the container at `~/.config/gh/`, backed by the named `config-dir` volume that persists all of `~/.config`. The token survives `docker compose down` and `docker compose up` cycles. `docker compose down -v` removes the volume — re-run `gh auth login` after a `down -v`, or register your own compose overlay in `config.json` `composeOverrides[]` to bind-mount a host directory to `~/.config/`.

--- a/.oh/docs/integrations/herdr.md
+++ b/.oh/docs/integrations/herdr.md
@@ -1,0 +1,19 @@
+# Herdr
+
+[Herdr](https://herdr.dev/) is installed in every Open Harness image. It provides a single terminal workspace for running and switching between multiple coding-agent sessions.
+
+From the project root inside the sandbox:
+
+```bash
+herdr
+```
+
+Herdr discovers supported agent CLIs already shipped by Open Harness. Its configuration (`~/.config/herdr`) persists in the shared `config-dir` volume, while session/worktree state (`~/.herdr`) uses `herdr-data`; both survive container rebuilds.
+
+Use Herdr's built-in updater for the direct install:
+
+```bash
+herdr update
+```
+
+See the upstream [quick start](https://herdr.dev/docs/quick-start/) and [configuration reference](https://herdr.dev/docs/configuration/) for keybindings and customization.

--- a/.oh/docs/security-considerations.md
+++ b/.oh/docs/security-considerations.md
@@ -40,7 +40,7 @@ templates are committed.
   - `/.oh/config.json` (`.gitignore:8`) — host-local harness config.
   - `**/auth.json` and `**/.credentials.json` (`.gitignore:63-64`) — provider auth blobs.
 - **Template allowlist:** the *tracked* files are templates that hold no real secrets — e.g. [`.devcontainer/.example.env`](../../.devcontainer/.example.env) and `.claude/.example.env.claude`. The operator copies the template to the real (gitignored) `.devcontainer/.env`; `install.sh` writes host defaults there. The `.example.env` header spells this out.
-- **In the sandbox:** auth/state persists in Docker **named volumes** (`claude-auth`, `codex-auth`, `pi-auth`, `gh-config`, …), not in the repo — see [`.devcontainer/docker-compose.yml:31-41`](../../.devcontainer/docker-compose.yml).
+- **In the sandbox:** auth/state persists in Docker **named volumes** (`claude-auth`, `codex-auth`, `pi-auth`, `config-dir`, …), not in the repo — see [`.devcontainer/docker-compose.yml:31-41`](../../.devcontainer/docker-compose.yml).
 
 **What this does not do:** it does not scan commit *contents* for
 secrets pasted into a tracked file by mistake. That is the job of the

--- a/.oh/scripts/__tests__/herdr-default.test.ts
+++ b/.oh/scripts/__tests__/herdr-default.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
+const readRepoFile = (file: string): string => readFileSync(path.join(repoRoot, file), "utf8");
+
+describe("default Herdr integration", () => {
+  it("installs and verifies Herdr in the default image", () => {
+    const dockerfile = readRepoFile(".devcontainer/Dockerfile");
+
+    expect(dockerfile).toContain("https://herdr.dev/install.sh");
+    expect(dockerfile).toContain("HERDR_INSTALL_DIR=/usr/local/bin");
+    expect(dockerfile).toContain("herdr --version");
+  });
+
+  it.each(["docker-compose.yml", "docker-compose.image-only.yml"])(
+    "persists Herdr state in %s",
+    (composeFile) => {
+      const compose = readRepoFile(`.devcontainer/${composeFile}`);
+
+      expect(compose).toContain("herdr-data:/home/sandbox/.herdr");
+      expect(compose).toContain("config-dir:/home/sandbox/.config");
+      expect(compose).not.toContain("/home/sandbox/.config/herdr");
+      expect(compose).not.toContain("/home/sandbox/.config/gh");
+      expect(compose).toMatch(/^  herdr-data:$/m);
+      expect(compose).toMatch(/^  config-dir:$/m);
+    },
+  );
+
+  it("repairs ownership for Herdr volumes after UID sync", () => {
+    const entrypoint = readRepoFile(".devcontainer/entrypoint.sh");
+
+    expect(entrypoint).toContain(".herdr");
+    expect(entrypoint).toMatch(/for dir in .* \.config /);
+  });
+});

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Update policy and release automation live in [`/git`](.claude/skills/git/SKILL.m
 ## [Unreleased]
 
 ### Added
+- Install Herdr by default as a persistent multi-agent terminal workspace ([#651](https://github.com/mifunedev/openharness/issues/651)).
 - Add bounded local PDF, DOCX, PPTX, and XLSX normalization to `/wiki ingest` through Microsoft MarkItDown's pinned upstream CLI, preserving immutable source provenance without a wrapper command ([#650](https://github.com/mifunedev/openharness/pull/650)).
 - Add the explicit nine-target `/audit` dispatcher, deterministic focused/queue PR classifier, correlated full campaigns, and shared locked ablation recovery ([#646](https://github.com/mifunedev/openharness/pull/646)).
 ### Changed

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 - **Host dependencies: Docker, Git, and make.** No Node, no Python, no toolchain rot on your laptop. (`make` runs the `make sandbox` / `make shell` wrappers — see [Prerequisites](.oh/docs/installation.md#prerequisites).)
 - **Composable infra.** Cherry-pick Cloudflare tunnels, SSH, Caddy gateway, or pack-supplied services via Compose overlays.
 - **Slack-ready.** The `pi-messenger-bridge` package bridges Slack (and other messengers) to a Pi agent — see [.oh/docs/integrations/slack.md](.oh/docs/integrations/slack.md).
-- **Multiple harnesses, one sandbox.** Claude, Codex, and Pi ship by default (Hermes, Grok, and more are opt-in); bridge them to Slack with [`pi-messenger-bridge`](.oh/docs/integrations/slack.md).
+- **Multiple harnesses, one sandbox.** Claude, Codex, and Pi ship by default (Hermes, Grok, and more are opt-in); coordinate sessions in the bundled [Herdr](.oh/docs/integrations/herdr.md) terminal or bridge Pi to Slack with [`pi-messenger-bridge`](.oh/docs/integrations/slack.md).
 
 ---
 
@@ -242,7 +242,7 @@ make shell
 |---|---|
 | **Core agents** | Defaults: Claude Code, Codex, Pi. Optional: OpenCode, DeepAgents, Hermes, Grok Build |
 | **Runtimes** | Node 22, pnpm, Bun, uv (Python) |
-| **DevOps** | Docker CLI + Compose, GitHub CLI, cloudflared, tmux, croner |
+| **DevOps** | Herdr, Docker CLI + Compose, GitHub CLI, cloudflared, tmux, croner |
 | **Browser** | agent-browser + Chromium (headless) |
 | **One project, one sandbox** | A single container scoped to a single repo and branch |
 | **Worktrees** | One sandbox → many isolated git worktrees: parallel branches, delegated sub-agents, satellite project clones under `.oh/worktrees/` |


### PR DESCRIPTION
## Summary
- install the stable Herdr CLI in every default sandbox image
- consolidate GitHub, Herdr, and other XDG settings into one persistent `~/.config` volume
- persist Herdr session/worktree state separately in `~/.herdr`
- document usage and guard the integration with regression tests

## Verification
- `pnpm run lint`
- `pnpm run format:check`
- `pnpm run typecheck`
- `pnpm test`
- Compose config validation for bind-mount and image-only modes
- `bash -n .devcontainer/entrypoint.sh`
- official installer smoke test: `herdr 0.7.4`

Closes #651