### PR TITLE
FROM feat/653-herdr-primary TO development

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -46,12 +46,19 @@ RUN curl -fsSL https://pkg.cloudflare.com/cloudflare-main.gpg \
 RUN BUN_INSTALL=/usr/local curl -fsSL https://bun.sh/install | bash
 
 # ─── Herdr ──────────────────────────────────────────────────────────
-# Multi-agent terminal workspace. Install the stable release globally so every
-# sandbox user gets the command without a first-boot network dependency.
-RUN curl -fsSL https://herdr.dev/install.sh -o /tmp/herdr-install.sh \
- && HERDR_INSTALL_DIR=/usr/local/bin sh /tmp/herdr-install.sh \
- && rm /tmp/herdr-install.sh \
- && herdr --version
+# Primary interactive workspace. Pin and verify both supported Linux artifacts
+# so every sandbox gets the same reviewed binary without a first-boot download.
+ARG HERDR_VERSION=0.7.4
+RUN case "$(dpkg --print-architecture)" in \
+      amd64) herdr_arch=x86_64; herdr_sha=bc0fc02d4ba500f9cac2353a43e67fe036785ecca6eb55378e050fac3c103059 ;; \
+      arm64) herdr_arch=aarch64; herdr_sha=544e0002de42806d1ab64ccdef3a7e7414f24717b0b6b022bc9e57d2eefd26a2 ;; \
+      *) echo "Unsupported Herdr architecture: $(dpkg --print-architecture)" >&2; exit 1 ;; \
+    esac \
+ && curl -fsSL "https://github.com/ogulcancelik/herdr/releases/download/v${HERDR_VERSION}/herdr-linux-${herdr_arch}" \
+      -o /usr/local/bin/herdr \
+ && echo "${herdr_sha}  /usr/local/bin/herdr" | sha256sum -c - \
+ && chmod 0755 /usr/local/bin/herdr \
+ && test "$(herdr --version)" = "herdr ${HERDR_VERSION}"
 
 # ─── uv ─────────────────────────────────────────────────────────────
 RUN curl -LsSf https://astral.sh/uv/install.sh | env INSTALLER_NO_MODIFY_PATH=1 sh \

--- a/.devcontainer/entrypoint.sh
+++ b/.devcontainer/entrypoint.sh
@@ -727,8 +727,8 @@ if [ ! -f "/home/sandbox/.claude/.onboarded" ]; then
   echo "  │  First boot detected.                           │"
   echo "  │  Optional Slack bridge setup:                   │"
   echo "  │    see .oh/docs/integrations/slack.md           │"
-  echo "  │  Start an agent from this shell:                │"
-  echo "  │    claude   # or: codex, pi                     │"
+  echo "  │  First command after attaching:                 │"
+  echo "  │    herdr   # then complete setup in its panes   │"
   echo "  └─────────────────────────────────────────────────┘"
   echo ""
 fi

--- a/.oh/docs/README.md
+++ b/.oh/docs/README.md
@@ -21,7 +21,7 @@ identity, running identically on your laptop or an unattended, lights-out remote
    Container" → select `openharness`. Ports auto-forward while attached.
 3. Open a terminal and run `herdr` first. Complete setup and launch `claude`, `codex`, `pi`, or `hermes` from Herdr panes.
 
-Full terminal / Remote-SSH options: see [Connecting → Option B](connecting.md#option-b--vscode-attach-to-running-container-local-host).
+Full terminal, VS Code, and Remote-SSH options: see [Connecting to the sandbox](connecting.md).
 
 [Hermes](harnesses/hermes.md) — Nous Research's self-improving agent CLI — is an opt-in harness: set
 `install.hermes: true` in harness.yaml, rebuild, then run `hermes setup`.

--- a/.oh/docs/README.md
+++ b/.oh/docs/README.md
@@ -19,7 +19,7 @@ identity, running identically on your laptop or an unattended, lights-out remote
 1. `make sandbox` — build the image and boot the container.
 2. VS Code → Command Palette (Ctrl/Cmd+Shift+P) → "Dev Containers: Attach to Running
    Container" → select `openharness`. Ports auto-forward while attached.
-3. Open a terminal inside the container and run `claude` (or `codex` · `pi` · `hermes`).
+3. Open a terminal and run `herdr` first. Complete setup and launch `claude`, `codex`, `pi`, or `hermes` from Herdr panes.
 
 Full terminal / Remote-SSH options: see [Connecting → Option B](connecting.md#option-b--vscode-attach-to-running-container-local-host).
 

--- a/.oh/docs/connecting.md
+++ b/.oh/docs/connecting.md
@@ -23,7 +23,7 @@ make shell
 ```
 Pass an optional container name to attach to a different running container, e.g. `make shell portfolio-advisor` (add `SHELL_USER=<user>` if the target has no `sandbox` user).
 
-You land inside the container as the `sandbox` user. This is enough to run CLI agents and configure Slack. Container ports are **not** forwarded to your laptop — you cannot open `localhost:3000` in your browser via this method alone.
+You land inside the container as the `sandbox` user. Run `herdr` first, then launch CLI agents and complete interactive setup from its panes. Container ports are **not** forwarded to your laptop — you cannot open `localhost:3000` in your browser via this method alone.
 
 ### Option B — VSCode Attach to Running Container (local host)
 
@@ -61,7 +61,7 @@ preflight, and the nginx multi-tenant recipe — is in
 
 Attaching via VSCode is the easiest way to reach container UIs on your laptop browser. The auto-forwarding is session-scoped: ports appear under the **Ports** panel while attached and disappear when you close or detach from the VSCode window.
 
-If you only need a terminal (no browser UI), Option A is fine.
+If you only need a terminal (no browser UI), Option A is fine. Whichever attach path you choose, make `herdr` the first command in the sandbox.
 
 ## What happens when you close VSCode
 

--- a/.oh/docs/contributing.md
+++ b/.oh/docs/contributing.md
@@ -40,13 +40,19 @@ A first-run helper is available at `.oh/scripts/install.sh` — it prompts for t
 
 ### Onboard inside the sandbox
 
-After `make shell`, complete one-time GitHub auth so `git push` and `gh` work from within the container:
+After `make shell`, start Herdr before any other inside-sandbox setup:
+
+```bash
+herdr
+```
+
+From the initial Herdr pane, complete one-time GitHub auth so `git push` and `gh` work from within the container:
 
 ```bash
 gh auth login && gh auth setup-git
 ```
 
-Then start an agent. The default is the `pi` CLI; `claude` and `codex` are also installed:
+Then start agents from Herdr panes. The default is the `pi` CLI; `claude` and `codex` are also installed:
 
 ```bash
 pi          # default agent CLI

--- a/.oh/docs/deployment-prebuilt-image.md
+++ b/.oh/docs/deployment-prebuilt-image.md
@@ -215,6 +215,7 @@ docker run -d --name "$NAME" --restart unless-stopped --init \
   -v oh_workspace:/home/sandbox/harness \
   -v claude-auth:/home/sandbox/.claude \
   -v config-dir:/home/sandbox/.config \
+  -v herdr-data:/home/sandbox/.herdr \
   -v oh_ssh:/home/sandbox/.ssh \
   "$IMAGE" sleep infinity
 
@@ -240,9 +241,9 @@ until [ "$(docker inspect -f '{{.State.Health.Status}}' "$NAME" 2>/dev/null)" = 
 done
 
 docker exec -it -u sandbox "$NAME" zsh   # interactive shell (bash also available)
-# then, inside the container:
-#   claude        # start the coding agent (or: codex, pi)
-#   gh auth login && gh auth setup-git   # one-time, if GH_TOKEN was not passed
+# first command inside the container:
+#   herdr
+# then complete gh/provider auth and launch agents from Herdr panes
 ```
 
 The image has no `HEALTHCHECK` of its own, so `docker run` won't populate

--- a/.oh/docs/harnesses/overview.md
+++ b/.oh/docs/harnesses/overview.md
@@ -4,7 +4,7 @@ title: "Harnesses Overview"
 
 # Harnesses Overview
 
-Open Harness ships with three agent CLIs in the default sandbox image: **Claude Code** (default), **Codex**, and **Pi**. **OpenCode**, **DeepAgents**, **Hermes**, and **Grok Build** are optional image-level installs controlled by `harness.yaml` `install:` keys (or `.devcontainer/.env` build flags). **T3 Code** runs on demand via the `/t3` skill (or directly with `npx t3`) as a browser UI on port 3773. Inside the sandbox, launch whichever you prefer — switch between them at any time, or keep long-running sessions in tmux.
+Open Harness ships with three agent CLIs in the default sandbox image: **Claude Code** (default), **Codex**, and **Pi**. **OpenCode**, **DeepAgents**, **Hermes**, and **Grok Build** are optional image-level installs controlled by `harness.yaml` `install:` keys (or `.devcontainer/.env` build flags). **T3 Code** runs on demand via the `/t3` skill (or directly with `npx t3`) as a browser UI on port 3773. Inside the sandbox, run `herdr` first, then launch whichever agent you prefer from its panes and switch between them at any time. Reserve tmux for Open Harness's managed/headless cron, gateway, and watchdog infrastructure.
 
 Open Harness is the harness; the **agent** is your call. To go beyond the preinstalled options, install via `npm` / `pip` / `cargo` inside the sandbox or edit the Dockerfile. For Pi+Slack specifically, the recommended path is the `pi-messenger-bridge` npm package — see [Slack integration](../integrations/slack.md). The product surface is one developer, one project, one agent — not racing or stacking multiple CLIs against each other.
 

--- a/.oh/docs/installation.md
+++ b/.oh/docs/installation.md
@@ -56,8 +56,9 @@ there is the one used for pushes.
                        # optional installs — see Quickstart → Configuration. Do this BEFORE building.
    make sandbox        # build + start the container (~10 min cold)
    make shell          # attach as the sandbox user
+   herdr              # first inside-sandbox command
    ```
-2. **Inside the sandbox**, authenticate GitHub over SSH — choose SSH as the protocol
+2. **Inside the initial Herdr pane**, authenticate GitHub over SSH — choose SSH as the protocol
    and let `gh` generate a key (details: [GitHub auth](./integrations/github.md)):
    ```bash
    gh auth login       # GitHub.com → SSH → generate a new SSH key → paste a token
@@ -321,7 +322,7 @@ codex   → codex --dangerously-bypass-approvals-and-sandbox
 
 ### Persistent volumes
 
-Auth credentials survive container rebuilds via named Docker volumes:
+Auth credentials and Herdr workspace state survive container rebuilds via named Docker volumes:
 
 - `claude-auth` → `~/.claude` (Claude Code OAuth)
 - `codex-auth` → `~/.codex` (Codex OAuth)
@@ -332,10 +333,10 @@ Auth credentials survive container rebuilds via named Docker volumes:
 - `grok-auth` → `~/.grok` (all Grok Build user state: auth, config, sessions, memory, skills/plugins, logs; mounted alongside the other agent auth volumes and used by Grok Build when `install.grok_build: true` in `harness.yaml`). Cached OAuth/session state in `~/.grok/auth.json` takes precedence over `XAI_API_KEY`; if an API key seems ignored, run `grok logout` or reset the volume.
 - `cloudflared-auth` → `~/.cloudflared` (Cloudflare tunnel credentials, when used)
 - `config-dir` → `~/.config` (shared XDG configuration, including GitHub CLI tokens and Herdr settings)
-- `herdr-data` → `~/.herdr` (Herdr session and worktree state)
+- `herdr-data` → `~/.herdr` (Herdr-created worktrees and related data; session metadata is under `~/.config/herdr`)
 
 Hermes is split: when Hermes is enabled (`install.hermes: true` in `harness.yaml`), `HERMES_HOME` defaults to the project-local bind-mounted `~/harness/.hermes/` directory, while auth remains in the `~/.hermes` named volume and is linked into the project-local home as `auth.json`. The entrypoint links `.hermes/skills/openharness` to the tracked shared skill directory (`.oh/skills/`) so Hermes sees the same harness skills as Claude, Codex, and Pi without copying them into runtime state. Project-local runtime contents are gitignored except `.hermes/README.md`; `make destroy` removes the auth volume but not the bind-mounted project runtime directory.
 
-`make destroy` and `docker compose down -v` remove named volumes, including `grok-auth`; use `make stop` when you want Grok Build credentials and state to survive.
+`make destroy` and `docker compose down -v` remove named volumes, including Herdr state and provider credentials; use `make stop` when you want them to survive.
 
 Downstream harness packs and Pi extensions can introduce additional volumes or bind-mount overlays by listing tracked compose files under `compose.overrides:` in `harness.yaml`, or by adding user-local files to `composeOverrides[]` in `config.json` (gitignored).

--- a/.oh/docs/integrations/herdr.md
+++ b/.oh/docs/integrations/herdr.md
@@ -53,7 +53,7 @@ herdr status
 herdr --help
 herdr server reload-config
 herdr server stop              # end a broken Herdr server
-herdr --no-session             # open an unmanaged recovery shell
+herdr --no-session             # run Herdr without its server/client session
 ```
 
 Herdr is pinned in the Open Harness image. Upgrade it by rebuilding against a reviewed Open Harness release rather than self-updating `/usr/local/bin/herdr`.

--- a/.oh/docs/integrations/herdr.md
+++ b/.oh/docs/integrations/herdr.md
@@ -33,7 +33,7 @@ herdr integration status
 ## Working model
 
 - Use Herdr workspaces, tabs, and panes for interactive setup, agents, tests, servers, and reviews.
-- Detach with `Ctrl-b q`; run `herdr` again to reattach.
+- Detach with `Ctrl-b q`; run `herdr` again to reattach while the container keeps running.
 - Open Harness automation worktrees stay under `.oh/worktrees`; open those paths in Herdr. Herdr-created worktrees default to `~/.herdr/worktrees`.
 - Cron, Slack gateway, watchdog, and other headless infrastructure remain in their existing tmux sessions. Do not run Herdr inside those managed sessions.
 - A raw shell or direct agent command remains a recovery path if Herdr is unavailable.
@@ -43,7 +43,7 @@ herdr integration status
 - `~/.config/herdr` (in the shared `config-dir` volume): configuration, logs, and session metadata.
 - `~/.herdr` (in `herdr-data`): Herdr-created worktrees and related data.
 
-`make stop` and normal rebuilds preserve these volumes. `make destroy` runs Compose with `-v` and removes them.
+`make stop` and normal rebuilds preserve metadata and layout in these volumes, but stopped containers do not preserve running agent, test, or server processes. `make destroy` runs Compose with `-v` and removes the volumes too.
 
 ## Troubleshooting
 
@@ -52,6 +52,8 @@ herdr --version
 herdr status
 herdr --help
 herdr server reload-config
+herdr server stop              # end a broken Herdr server
+herdr --no-session             # open an unmanaged recovery shell
 ```
 
 Herdr is pinned in the Open Harness image. Upgrade it by rebuilding against a reviewed Open Harness release rather than self-updating `/usr/local/bin/herdr`.

--- a/.oh/docs/integrations/herdr.md
+++ b/.oh/docs/integrations/herdr.md
@@ -1,19 +1,59 @@
 # Herdr
 
-[Herdr](https://herdr.dev/) is installed in every Open Harness image. It provides a single terminal workspace for running and switching between multiple coding-agent sessions.
+[Herdr](https://herdr.dev/) is Open Harness's primary interactive workspace. It is installed in every image.
 
-From the project root inside the sandbox:
+## Start here
+
+After entering the sandbox, make `herdr` your first command:
 
 ```bash
+# host
+make shell
+
+# first command inside the sandbox
 herdr
 ```
 
-Herdr discovers supported agent CLIs already shipped by Open Harness. Its configuration (`~/.config/herdr`) persists in the shared `config-dir` volume, while session/worktree state (`~/.herdr`) uses `herdr-data`; both survive container rebuilds.
-
-Use Herdr's built-in updater for the direct install:
+Bare Herdr works before GitHub or provider authentication. It creates or reattaches a workspace for the current repository. Complete GitHub setup, provider authentication, agent sessions, tests, development servers, and reviews from Herdr panes so interactive work stays together.
 
 ```bash
-herdr update
+# inside the initial Herdr pane
+gh auth login && gh auth setup-git
+claude auth login                 # or configure codex / pi
+claude                            # launch agents from Herdr panes
 ```
 
-See the upstream [quick start](https://herdr.dev/docs/quick-start/) and [configuration reference](https://herdr.dev/docs/configuration/) for keybindings and customization.
+Agent detection works without extra hooks. Optional integrations provide richer status and session restore, but modify provider configuration and are never installed automatically:
+
+```bash
+herdr integration install claude # or: codex, pi
+herdr integration status
+```
+
+## Working model
+
+- Use Herdr workspaces, tabs, and panes for interactive setup, agents, tests, servers, and reviews.
+- Detach with `Ctrl-b q`; run `herdr` again to reattach.
+- Open Harness automation worktrees stay under `.oh/worktrees`; open those paths in Herdr. Herdr-created worktrees default to `~/.herdr/worktrees`.
+- Cron, Slack gateway, watchdog, and other headless infrastructure remain in their existing tmux sessions. Do not run Herdr inside those managed sessions.
+- A raw shell or direct agent command remains a recovery path if Herdr is unavailable.
+
+## Persistence
+
+- `~/.config/herdr` (in the shared `config-dir` volume): configuration, logs, and session metadata.
+- `~/.herdr` (in `herdr-data`): Herdr-created worktrees and related data.
+
+`make stop` and normal rebuilds preserve these volumes. `make destroy` runs Compose with `-v` and removes them.
+
+## Troubleshooting
+
+```bash
+herdr --version
+herdr status
+herdr --help
+herdr server reload-config
+```
+
+Herdr is pinned in the Open Harness image. Upgrade it by rebuilding against a reviewed Open Harness release rather than self-updating `/usr/local/bin/herdr`.
+
+See the upstream [quick start](https://herdr.dev/docs/quick-start/), [agents guide](https://herdr.dev/docs/agents/), and [configuration reference](https://herdr.dev/docs/configuration/).

--- a/.oh/docs/intro.md
+++ b/.oh/docs/intro.md
@@ -20,9 +20,9 @@ Key capabilities:
 
 ## How it works
 
-The harness uses Docker Compose to build a sandbox image from `.devcontainer/`. You bring the sandbox up with `docker compose -f .devcontainer/docker-compose.yml up -d --build`, attach with `docker exec -it -u sandbox openharness zsh` (or VS Code), authenticate GitHub and your chosen LLM provider once, then launch the agent with `claude` inside the sandbox. When you're done, `docker compose -f .devcontainer/docker-compose.yml down -v` tears everything down.
+The harness uses Docker Compose to build a sandbox image from `.devcontainer/`. Bring it up with `docker compose -f .devcontainer/docker-compose.yml up -d --build`, attach with `docker exec -it -u sandbox openharness zsh` (or VS Code), then run `herdr` first. Authenticate GitHub and your chosen provider and launch agents from Herdr panes. `make stop` preserves state; `docker compose -f .devcontainer/docker-compose.yml down -v` is the destructive teardown.
 
-The agent session you attach to at the project root is your **orchestrator** — git, sandbox lifecycle, and most file edits all flow through a single attach. When the optional Docker socket is enabled (off by default — see [security-considerations.md](security-considerations.md#3-sandbox-isolation--the-docker-socket-caveat--enforced-with-a-caveat)), the orchestrator can also drive other containers and edit files inside them over that socket, so day-to-day work rarely needs anything else. Drop back to the host shell only when something can't be done from inside the container — typically adding a new bind-mounted volume, which requires a `.devcontainer/docker-compose.yml` change and restart.
+The primary agent pane at the project root inside Herdr is your **orchestrator** — git, sandbox lifecycle, and most file edits all flow through that organized workspace. When the optional Docker socket is enabled (off by default — see [security-considerations.md](security-considerations.md#3-sandbox-isolation--the-docker-socket-caveat--enforced-with-a-caveat)), the orchestrator can also drive other containers and edit files inside them over that socket, so day-to-day work rarely needs anything else. Drop back to the host shell only when something can't be done from inside the container — typically adding a new bind-mounted volume, which requires a `.devcontainer/docker-compose.yml` change and restart.
 
 Stand up a **second sandbox** only when you want isolation — an independent identity, branch, or provider key running on its own. Most users won't need this.
 
@@ -36,18 +36,20 @@ flowchart TB
     LLM["LLM provider"]
 
     subgraph sandbox["Sandbox container — default workspace"]
-        Orch{{"<b>Orchestrator</b><br/>Claude @ project root<br/>git · lifecycle · file edits"}}
-        Tmux["tmux sessions<br/>client-slack-pi · agent-t3code · cron-system"]
+        Herdr["<b>Herdr</b><br/>interactive workspaces · panes"]
+        Orch{{"<b>Orchestrator pane</b><br/>chosen agent @ project root<br/>git · lifecycle · file edits"}}
+        Tmux["managed tmux services<br/>client-slack-pi · cron-system · gateways"]
         Sock(["docker.sock<br/><i>opt-in</i>"])
     end
 
     Sb2["Second sandbox<br/><i>only if you need isolation</i>"]
 
-    You ==>|attach| Orch
+    You ==>|attach · run herdr| Herdr
+    Herdr --> Orch
     You -.->|browser · Slack| Tmux
     Repo <-.->|bind mount| Orch
-    Orch -->|launches & monitors| Tmux
     Orch <-->|git| GH
+    Orch <-->|API| LLM
     Tmux <-->|API| LLM
     Orch -.->|docker socket · opt-in| Sock
     Sock -.->|provisions| Sb2

--- a/.oh/docs/quickstart.md
+++ b/.oh/docs/quickstart.md
@@ -89,8 +89,9 @@ herdr
 
 Herdr creates or reattaches the persistent interactive workspace for this repository.
 Complete GitHub and provider authentication, launch agents, and run tests and servers
-inside its panes. Detach with `Ctrl-b q`; run `herdr` again to return. Raw shells and
-direct agent commands remain recovery paths. Cron, Slack, and gateway infrastructure
+inside its panes. Detach with `Ctrl-b q`; run `herdr` again to return while the container
+keeps running. A container stop/rebuild restores metadata and layout, not terminated
+agent or server processes. Raw shells and direct agent commands remain recovery paths. Cron, Slack, and gateway infrastructure
 continue to run independently under tmux.
 
 ## Set up agents inside Herdr
@@ -190,7 +191,7 @@ The full path from a bare Linux host to an authenticated multi-agent sandbox. Ea
 inlines the command to run; follow the link for depth/troubleshooting. Steps 5–14 run
 **inside the sandbox** (`make shell`); step 5 enters Herdr before setup. For agent-auth steps (9–12), the simplest
 cross-provider method is `/login` → **device mode** inside each agent's interactive session
-(see [Pick your harness](#pick-your-harness)); the explicit commands shown are equivalents.
+(see [Set up agents inside Herdr](#set-up-agents-inside-herdr)); the explicit commands shown are equivalents.
 
 1. **Install host prerequisites** — Docker (+ Compose), Git, and `make`
    ([details](./installation.md#prerequisites)):

--- a/.oh/docs/quickstart.md
+++ b/.oh/docs/quickstart.md
@@ -79,7 +79,21 @@ Pass an optional container name to attach to a different running container, e.g.
 Either way you're inside the isolated sandbox as the `sandbox` user. Working
 directory: `/home/sandbox/harness`.
 
-## Pick your harness
+## Start Herdr first
+
+Your first command inside a fresh sandbox should be:
+
+```bash
+herdr
+```
+
+Herdr creates or reattaches the persistent interactive workspace for this repository.
+Complete GitHub and provider authentication, launch agents, and run tests and servers
+inside its panes. Detach with `Ctrl-b q`; run `herdr` again to return. Raw shells and
+direct agent commands remain recovery paths. Cron, Slack, and gateway infrastructure
+continue to run independently under tmux.
+
+## Set up agents inside Herdr
 
 The default sandbox ships with Claude Code, Codex, and Pi. OpenCode,
 DeepAgents, Hermes, and Grok Build are optional image-level installs; T3 Code runs on
@@ -111,7 +125,7 @@ per-harness setup.
 
 If `GH_TOKEN` was set during install, the entrypoint already ran
 `gh auth login` and `gh auth setup-git` for you. Otherwise run them once
-inside the shell:
+inside a Herdr pane:
 
 ```bash
 gh auth login && gh auth setup-git
@@ -173,8 +187,8 @@ overlays to `composeOverrides[]` in `config.json` (gitignored, last wins).
 ## End-to-end setup walkthrough
 
 The full path from a bare Linux host to an authenticated multi-agent sandbox. Each step
-inlines the command to run; follow the link for depth/troubleshooting. Steps 5–13 run
-**inside the sandbox** (`make shell`). For the agent-auth steps (8–11), the simplest
+inlines the command to run; follow the link for depth/troubleshooting. Steps 5–14 run
+**inside the sandbox** (`make shell`); step 5 enters Herdr before setup. For agent-auth steps (9–12), the simplest
 cross-provider method is `/login` → **device mode** inside each agent's interactive session
 (see [Pick your harness](#pick-your-harness)); the explicit commands shown are equivalents.
 
@@ -196,43 +210,47 @@ cross-provider method is `/login` → **device mode** inside each agent's intera
    make sandbox        # build + start (~10 min cold)
    make shell          # attach as the sandbox user
    ```
-5. **Authenticate GitHub over SSH** — choose SSH, generate a key, paste a token
+5. **Start Herdr** — your first inside-sandbox command; all remaining setup runs in its panes:
+   ```bash
+   herdr
+   ```
+6. **Authenticate GitHub over SSH** — choose SSH, generate a key, paste a token
    ([GitHub auth](./integrations/github.md)):
    ```bash
    gh auth login && gh auth setup-git
    ```
-6. **Create your own private repo**:
+7. **Create your own private repo**:
    ```bash
    gh repo create <your-user>/openharness --private
    ```
-7. **Point remotes at your repo + upstream** (SSH, so the step-5 key is used;
+8. **Point remotes at your repo + upstream** (SSH, so the step-6 key is used;
    [clone-and-own](./installation.md#clone-and-own-private-origin-and-upstream-recommended)):
    ```bash
    git remote set-url origin git@github.com:<your-user>/openharness.git
    git remote add upstream git@github.com:mifunedev/openharness.git
    git push -u origin HEAD
    ```
-8. **Authenticate Claude Code** ([Claude Code](./harnesses/claude-code.md)):
+9. **Authenticate Claude Code** ([Claude Code](./harnesses/claude-code.md)):
    ```bash
    claude auth login && claude auth status
    ```
-9. **Authenticate Codex** ([Codex](./harnesses/codex.md)):
+10. **Authenticate Codex** ([Codex](./harnesses/codex.md)):
    ```bash
    codex login --device-auth
    ```
    > Optional: DebugMCP (cross-harness debugging over MCP) is available if you attached via
    > VS Code — see [Enter the sandbox](#enter-the-sandbox) above, not this step.
-10. **Authenticate Pi** — configure provider keys / OAuth ([Pi](./harnesses/pi.md)):
+11. **Authenticate Pi** — configure provider keys / OAuth ([Pi](./harnesses/pi.md)):
     ```bash
     pi        # first run walks provider auth
     ```
-11. **Authenticate Hermes** (optional; needs `install.hermes: true`) ([Hermes](./harnesses/hermes.md)):
+12. **Authenticate Hermes** (optional; needs `install.hermes: true`) ([Hermes](./harnesses/hermes.md)):
     ```bash
     hermes setup
     ```
-12. **Configure Slack** for Pi (and Hermes) — create the Slack app, add tokens, set trust
+13. **Configure Slack** for Pi (and Hermes) — create the Slack app, add tokens, set trust
     ([Slack](./integrations/slack.md); Hermes uses `hermes gateway setup`).
-13. **Run and verify the gateways** (sandbox-only; watch read-only so you can't kill them —
+14. **Run and verify the gateways** (sandbox-only; watch read-only so you can't kill them —
     [Slack § Run and verify](./integrations/slack.md), [Hermes § Run and verify](./harnesses/hermes.md#run-and-verify-read-only)):
     ```bash
     gateway pi && gateway hermes        # start the client-slack-* sessions

--- a/.oh/install/.zshrc
+++ b/.oh/install/.zshrc
@@ -44,3 +44,6 @@ alias claude='claude --dangerously-skip-permissions'
 alias codex='codex --dangerously-bypass-approvals-and-sandbox'
 
 cd ~/harness 2>/dev/null
+
+# One-shot onboarding status and canonical next action (shared with bash).
+source "${OH_PROJECT_ROOT:-$HOME/harness}/.oh/install/banner.sh" 2>/dev/null

--- a/.oh/install/banner.sh
+++ b/.oh/install/banner.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# banner.sh — sourced from .bashrc to print a one-shot onboarding banner
+# banner.sh — sourced from bash and zsh to print a one-shot onboarding banner
 # on interactive shell start. Never use `exit` here; always use `return`.
 
 # Only print in interactive shells
@@ -211,7 +211,10 @@ command -v opencode >/dev/null 2>&1 && shortcuts="$shortcuts · opencode"
 command -v grok >/dev/null 2>&1 && shortcuts="$shortcuts · grok"
 command -v deepagents >/dev/null 2>&1 && shortcuts="$shortcuts · deepagents"
 command -v hermes >/dev/null 2>&1 && shortcuts="$shortcuts · hermes"
-printf '  Shortcuts: %s · tmux attach -t cron-system\n' "$shortcuts"
+printf '  Recovery commands: %s · tmux attach -t cron-system\n' "$shortcuts"
+printf '\n'
+printf '  Next: run `herdr` to open your persistent Open Harness workspace.\n'
+printf '  Complete setup, authentication, agents, tests, and servers inside Herdr.\n'
 printf '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n'
 printf '\n'
 

--- a/.oh/scripts/__tests__/boot-banner.test.ts
+++ b/.oh/scripts/__tests__/boot-banner.test.ts
@@ -31,12 +31,21 @@ describe("boot banners", () => {
 
     expect(block).toContain(".oh/docs/integrations/slack.md");
     expect(block).toContain("Optional Slack bridge setup");
-    expect(block).toContain("Start an agent from this shell");
+    expect(block).toContain("First command after attaching");
+    expect(block).toContain("herdr");
+    expect(block).not.toContain("Start an agent from this shell");
     expect(block).not.toContain("openharness onboard");
     expect(block).not.toContain("Complete setup");
     // The `oh config slack` wizard was removed with the pi-messenger-bridge
     // swap (#481/#287); the banner must not advertise a command that errors.
     expect(block).not.toContain("oh config slack");
+  });
+
+  it("interactive shell banner makes Herdr the canonical next action", () => {
+    const banner = readRepoFile(".oh", "install", "banner.sh");
+
+    expect(banner).toContain("Next: run `herdr`");
+    expect(banner).toContain("Complete setup, authentication, agents, tests, and servers inside Herdr");
   });
 
   it("interactive shell banner checks and labels the installed oh CLI", () => {

--- a/.oh/scripts/__tests__/herdr-default.test.ts
+++ b/.oh/scripts/__tests__/herdr-default.test.ts
@@ -42,12 +42,14 @@ describe("default Herdr integration", () => {
     const readme = readRepoFile("README.md");
     const quickstart = readRepoFile(".oh/docs/quickstart.md");
     const agents = readRepoFile("AGENTS.md");
+    const contributing = readRepoFile(".oh/docs/contributing.md");
     const zshrc = readRepoFile(".oh/install/.zshrc");
 
     expect(readme.indexOf("\nherdr\n")).toBeGreaterThan(-1);
     expect(readme.indexOf("\nherdr\n")).toBeLessThan(readme.indexOf("gh auth login"));
     expect(quickstart.indexOf("## Start Herdr first")).toBeLessThan(quickstart.indexOf("gh auth login"));
     expect(agents.indexOf("Start the primary interactive workspace")).toBeLessThan(agents.indexOf("gh auth login"));
+    expect(contributing.indexOf("\nherdr\n")).toBeLessThan(contributing.indexOf("gh auth login"));
     expect(zshrc).toContain(".oh/install/banner.sh");
   });
 

--- a/.oh/scripts/__tests__/herdr-default.test.ts
+++ b/.oh/scripts/__tests__/herdr-default.test.ts
@@ -43,6 +43,7 @@ describe("default Herdr integration", () => {
     const quickstart = readRepoFile(".oh/docs/quickstart.md");
     const agents = readRepoFile("AGENTS.md");
     const contributing = readRepoFile(".oh/docs/contributing.md");
+    const harnessOverview = readRepoFile(".oh/docs/harnesses/overview.md");
     const zshrc = readRepoFile(".oh/install/.zshrc");
 
     expect(readme.indexOf("\nherdr\n")).toBeGreaterThan(-1);
@@ -50,6 +51,7 @@ describe("default Herdr integration", () => {
     expect(quickstart.indexOf("## Start Herdr first")).toBeLessThan(quickstart.indexOf("gh auth login"));
     expect(agents.indexOf("Start the primary interactive workspace")).toBeLessThan(agents.indexOf("gh auth login"));
     expect(contributing.indexOf("\nherdr\n")).toBeLessThan(contributing.indexOf("gh auth login"));
+    expect(harnessOverview).toContain("run `herdr` first");
     expect(zshrc).toContain(".oh/install/banner.sh");
   });
 

--- a/.oh/scripts/__tests__/herdr-default.test.ts
+++ b/.oh/scripts/__tests__/herdr-default.test.ts
@@ -7,12 +7,14 @@ const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../
 const readRepoFile = (file: string): string => readFileSync(path.join(repoRoot, file), "utf8");
 
 describe("default Herdr integration", () => {
-  it("installs and verifies Herdr in the default image", () => {
+  it("pins and verifies Herdr for both supported architectures", () => {
     const dockerfile = readRepoFile(".devcontainer/Dockerfile");
 
-    expect(dockerfile).toContain("https://herdr.dev/install.sh");
-    expect(dockerfile).toContain("HERDR_INSTALL_DIR=/usr/local/bin");
-    expect(dockerfile).toContain("herdr --version");
+    expect(dockerfile).toContain("HERDR_VERSION=0.7.4");
+    expect(dockerfile).toContain("bc0fc02d4ba500f9cac2353a43e67fe036785ecca6eb55378e050fac3c103059");
+    expect(dockerfile).toContain("544e0002de42806d1ab64ccdef3a7e7414f24717b0b6b022bc9e57d2eefd26a2");
+    expect(dockerfile).toContain("sha256sum -c -");
+    expect(dockerfile).toContain('test "$(herdr --version)" = "herdr ${HERDR_VERSION}"');
   });
 
   it.each(["docker-compose.yml", "docker-compose.image-only.yml"])(
@@ -34,5 +36,28 @@ describe("default Herdr integration", () => {
 
     expect(entrypoint).toContain(".herdr");
     expect(entrypoint).toMatch(/for dir in .* \.config /);
+  });
+
+  it("makes Herdr the first interactive action in canonical onboarding", () => {
+    const readme = readRepoFile("README.md");
+    const quickstart = readRepoFile(".oh/docs/quickstart.md");
+    const agents = readRepoFile("AGENTS.md");
+    const zshrc = readRepoFile(".oh/install/.zshrc");
+
+    expect(readme.indexOf("\nherdr\n")).toBeGreaterThan(-1);
+    expect(readme.indexOf("\nherdr\n")).toBeLessThan(readme.indexOf("gh auth login"));
+    expect(quickstart.indexOf("## Start Herdr first")).toBeLessThan(quickstart.indexOf("gh auth login"));
+    expect(agents.indexOf("Start the primary interactive workspace")).toBeLessThan(agents.indexOf("gh auth login"));
+    expect(zshrc).toContain(".oh/install/banner.sh");
+  });
+
+  it("documents correct state and direct-image persistence", () => {
+    const herdrDocs = readRepoFile(".oh/docs/integrations/herdr.md");
+    const imageDocs = readRepoFile(".oh/docs/deployment-prebuilt-image.md");
+
+    expect(herdrDocs).toContain("~/.config/herdr");
+    expect(herdrDocs).toContain("~/.herdr/worktrees");
+    expect(herdrDocs).not.toContain("herdr update");
+    expect(imageDocs).toContain("herdr-data:/home/sandbox/.herdr");
   });
 });

--- a/.oh/scripts/__tests__/herdr-default.test.ts
+++ b/.oh/scripts/__tests__/herdr-default.test.ts
@@ -43,6 +43,7 @@ describe("default Herdr integration", () => {
     const quickstart = readRepoFile(".oh/docs/quickstart.md");
     const agents = readRepoFile("AGENTS.md");
     const contributing = readRepoFile(".oh/docs/contributing.md");
+    const intro = readRepoFile(".oh/docs/intro.md");
     const harnessOverview = readRepoFile(".oh/docs/harnesses/overview.md");
     const zshrc = readRepoFile(".oh/install/.zshrc");
 
@@ -51,6 +52,7 @@ describe("default Herdr integration", () => {
     expect(quickstart.indexOf("## Start Herdr first")).toBeLessThan(quickstart.indexOf("gh auth login"));
     expect(agents.indexOf("Start the primary interactive workspace")).toBeLessThan(agents.indexOf("gh auth login"));
     expect(contributing.indexOf("\nherdr\n")).toBeLessThan(contributing.indexOf("gh auth login"));
+    expect(intro).toContain("then run `herdr` first");
     expect(harnessOverview).toContain("run `herdr` first");
     expect(zshrc).toContain(".oh/install/banner.sh");
   });

--- a/.oh/scripts/sandbox-boot-smoke.sh
+++ b/.oh/scripts/sandbox-boot-smoke.sh
@@ -51,7 +51,13 @@ while [ "$(date +%s)" -le "$end" ]; do
     # avoids waiting for Docker's start_period while still exercising the same check.
     # shellcheck disable=SC2086 # HEALTH_CMD intentionally splits into command argv.
     if docker exec "$cid" $HEALTH_CMD >/tmp/sandbox-boot-smoke-health.out 2>/tmp/sandbox-boot-smoke-health.err; then
-      echo "sandbox boot smoke ok: $SERVICE ($cid) passed $HEALTH_CMD"
+      if ! docker exec -u sandbox "$cid" sh -lc \
+        'test "$(herdr --version)" = "herdr 0.7.4" && test -w "$HOME/.config" && test -w "$HOME/.herdr"'; then
+        echo "sandbox boot smoke failed: Herdr runtime or writable state is unavailable" >&2
+        status_diagnostics "$cid"
+        exit 1
+      fi
+      echo "sandbox boot smoke ok: $SERVICE ($cid) passed $HEALTH_CMD and Herdr runtime checks"
       exit 0
     fi
     last_status=$(docker inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{else}}no-healthcheck{{end}}' "$cid" 2>/dev/null || echo "inspect-failed")

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,15 +60,24 @@ Provision the agent sandbox. The sandbox uses `.devcontainer/` as the base envir
    **Option C — VS Code Remote SSH + Attach (remote server):**
    SSH into the remote host first, then attach to the container
 
-4. Complete onboarding (one-time, inside the sandbox):
+4. Start the primary interactive workspace immediately after attaching:
+   ```bash
+   herdr
+   ```
+
+5. Complete onboarding once from the initial Herdr pane:
    ```bash
    gh auth login && gh auth setup-git
    ```
 
-5. Start the agent:
+6. Start agents, tests, and development servers from Herdr panes:
    ```bash
-   claude                           # terminal coding agent
+   claude                           # or: codex, pi
    ```
+
+   Detach with `Ctrl-b q`; run `herdr` again to reattach. Raw shells remain a
+   recovery path. Cron, Slack gateway, and other headless infrastructure stay
+   in their existing tmux sessions; do not migrate those services into Herdr.
 
    For multi-agent setups (e.g., Pi+Slack), the harness now ships Slack via
    the **pi-messenger-bridge** npm package — npm-installed into `.pi/bridge/`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -209,8 +209,9 @@ your own reverse proxy (nginx/Caddy/Traefik) or tunnel (cloudflared,
 ngrok, tailscale-funnel) in front of the sandbox — the base ships
 without any of these.
 
-Long-running apps inside the sandbox go in named tmux sessions, related
-apps as stacked panes — see `.oh/skills/t3/references/sandbox-processes.md`.
+Interactive apps and development servers belong in Herdr panes. Managed/headless
+services (cron, gateways, watchdogs) use named tmux sessions — see
+`.oh/skills/t3/references/sandbox-processes.md`.
 
 ## What You Do
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Update policy and release automation live in [`/git`](.claude/skills/git/SKILL.m
 - Add bounded local PDF, DOCX, PPTX, and XLSX normalization to `/wiki ingest` through Microsoft MarkItDown's pinned upstream CLI, preserving immutable source provenance without a wrapper command ([#650](https://github.com/mifunedev/openharness/pull/650)).
 - Add the explicit nine-target `/audit` dispatcher, deterministic focused/queue PR classifier, correlated full campaigns, and shared locked ablation recovery ([#646](https://github.com/mifunedev/openharness/pull/646)).
 ### Changed
+- Make Herdr the canonical first interactive workspace after sandbox entry, with setup and agents organized inside persistent panes and a pinned, checksum-verified CLI ([#653](https://github.com/mifunedev/openharness/issues/653)).
 - Protect the consolidated `/audit` owner in place of the superseded `harness-audit`, `skill-lint`, `eval-lint`, and `drift-check` entry points, staging their removal in the separate audit-consolidation implementation ([#647](https://github.com/mifunedev/openharness/issues/647)).
 - **BREAKING:** Consolidate artifact authoring under `/builder <agent|skill|command|rule> <name-or-request>` with one authoritative reference per type ([#643](https://github.com/mifunedev/openharness/issues/643)).
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 - **Host dependencies: Docker, Git, and make.** No Node, no Python, no toolchain rot on your laptop. (`make` runs the `make sandbox` / `make shell` wrappers — see [Prerequisites](.oh/docs/installation.md#prerequisites).)
 - **Composable infra.** Cherry-pick Cloudflare tunnels, SSH, Caddy gateway, or pack-supplied services via Compose overlays.
 - **Slack-ready.** The `pi-messenger-bridge` package bridges Slack (and other messengers) to a Pi agent — see [.oh/docs/integrations/slack.md](.oh/docs/integrations/slack.md).
-- **Multiple harnesses, one sandbox.** Claude, Codex, and Pi ship by default (Hermes, Grok, and more are opt-in); coordinate sessions in the bundled [Herdr](.oh/docs/integrations/herdr.md) terminal or bridge Pi to Slack with [`pi-messenger-bridge`](.oh/docs/integrations/slack.md).
+- **Herdr-first interactive work.** Claude, Codex, and Pi ship by default (Hermes, Grok, and more are opt-in). After entering the sandbox, run [Herdr](.oh/docs/integrations/herdr.md) first; keep setup, agents, tests, and servers organized in its persistent panes. Headless Slack and cron infrastructure remain independent.
 
 ---
 
@@ -51,16 +51,18 @@ git clone https://github.com/mifunedev/openharness.git ~/.openharness && cd ~/.o
 make harness-config
 nano harness.yaml
 
-# c. Build the image and open a shell inside the sandbox:
+# c. Build the image, enter the sandbox, then open its primary workspace:
 make sandbox && make shell
+herdr
 ```
 
-That is already a working sandbox. To make it **yours** (private `origin` + `upstream`) and
+`herdr` should be your first inside-sandbox command. Run the remaining setup,
+authentication, agents, tests, and servers from its panes. That is already a working sandbox. To make it **yours** (private `origin` + `upstream`) and
 authenticate the agents, continue with the optional full setup.
 
 ### 2. Full setup (optional) — private repo, remotes, agent auth
 
-Run these **inside the sandbox** (`make shell`). Per-step depth + troubleshooting:
+Run these **inside the initial Herdr pane** (`make shell`, then `herdr`). Per-step depth + troubleshooting:
 [quickstart → End-to-end setup walkthrough](.oh/docs/quickstart.md#end-to-end-setup-walkthrough).
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -199,7 +199,8 @@ Provider surfaces are symlinks into `.oh/`: `.pi/skills`, `.claude/skills`, and 
 ```bash
 cd ~/.openharness
 make shell       # enter the isolated sandbox
-# inside the sandbox, launch any core agent:
+herdr           # first command: open the primary interactive workspace
+# from Herdr panes, launch any core agent:
 #   claude     # Claude Code (default)
 #   codex      # OpenAI Codex CLI
 #   opencode   # OpenCode (optional: set install.opencode: true in harness.yaml and rebuild)
@@ -234,6 +235,7 @@ Full key reference: [Quickstart → Configuration](.oh/docs/quickstart.md#config
 git clone https://github.com/mifunedev/openharness.git && cd openharness
 make sandbox
 make shell
+herdr            # first inside-sandbox command
 ```
 
 </details>


### PR DESCRIPTION
## Summary
- make `herdr` the canonical first command after entering the sandbox
- keep setup, authentication, agents, tests, and servers organized in Herdr panes while preserving tmux-managed infrastructure
- surface the Herdr-first action in bash/zsh onboarding and all canonical setup paths
- pin Herdr 0.7.4 binaries with architecture-specific SHA-256 verification
- add documentation-order and built-image runtime regression coverage

## Verification
- `pnpm run lint`
- `pnpm run format:check`
- `pnpm run typecheck`
- `pnpm test`
- focused Herdr/banner tests: 9 passed
- Compose config validation for standard and image-only modes
- shell syntax validation for changed boot scripts
- official release artifact SHA-256 verification for amd64 and arm64

Closes #653