### PR TITLE
FROM bug/664-pi-langfuse-remediation TO development

### DIFF
--- a/.oh/docs/integrations/langfuse.md
+++ b/.oh/docs/integrations/langfuse.md
@@ -18,22 +18,26 @@ privacy sections for the CLI you use before enabling either integration.
 
 ## Pi
 
-[`pi-langfuse` v1.5.6](https://www.npmjs.com/package/pi-langfuse/v/1.5.6) is a
-Pi package. Its `v1.5.6` tag resolves to
-[commit `fa415f33458f010265a287251fd3e7d249e97b99`](https://github.com/gooyoung/pi-langfuse/commit/fa415f33458f010265a287251fd3e7d249e97b99).
+[`pi-langfuse` v1.5.7](https://www.npmjs.com/package/pi-langfuse/v/1.5.7) is a
+Pi package. The published package resolves to
+[commit `131c1af13c24043890e820508ff1d7c1efc78ebe`](https://github.com/gooyoung/pi-langfuse/commit/131c1af13c24043890e820508ff1d7c1efc78ebe).
 Pi packages can execute arbitrary code, so review that source before installing
-it. Choose the narrowest installation scope and pin the version:
+it.
+
+Install the reviewed release through the repository-owned helper:
 
 ```bash
-# User installation: writes to ~/.pi/agent/settings.json
-pi install npm:pi-langfuse@1.5.6
-
-# Project installation: writes to .pi/settings.json (review before committing)
-pi install -l npm:pi-langfuse@1.5.6
-
-# One session only: does not change settings
-pi -e npm:pi-langfuse@1.5.6
+bash .pi/install/install-langfuse.sh
 ```
+
+The helper installs `pi-langfuse@1.5.7` in user scope, applies a scoped
+`@opentelemetry/sdk-node@0.220.0` override in Pi's managed npm manifest, and
+requires a clean `npm audit`. The override remediates the vulnerable
+OpenTelemetry tree selected by pi-langfuse's declared `^0.218.0` range without
+npm audit's unsafe recommendation to downgrade pi-langfuse to `1.0.0`. It is
+idempotent, preserves unrelated npm overrides, and remains in the persistent
+`~/.pi` volume across sandbox rebuilds. Rerun the helper if that volume is reset
+or if a future package operation reports an audit finding.
 
 This is deliberately **not** an Open Harness default package. It instruments Pi
 sessions only; it does not instrument standalone Claude Code, Codex CLI, or
@@ -156,7 +160,7 @@ Then run these commands in the **SANDBOX**:
 
 ```bash
 pi --version
-pi install npm:pi-langfuse@1.5.6
+bash .pi/install/install-langfuse.sh
 pi list
 export LANGFUSE_PRIVACY_PRESET=metadata-only
 pi
@@ -313,6 +317,8 @@ meets the need, and treat the Langfuse deployment as an external data boundary.
 
 For package installation scope, pins, and trust behavior, see the upstream
 [Pi packages documentation](https://github.com/earendil-works/pi-mono/blob/main/packages/coding-agent/docs/packages.md).
+The repository helper intentionally uses user scope so opting into observability
+does not modify the tracked project package list.
 
 ## Claude Code
 

--- a/.oh/scripts/__tests__/pi-langfuse-install.test.ts
+++ b/.oh/scripts/__tests__/pi-langfuse-install.test.ts
@@ -1,0 +1,89 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const ROOT = join(import.meta.dirname, "../../..");
+const INSTALLER = join(ROOT, ".pi/install/install-langfuse.sh");
+
+function fixture(auditExit = 0) {
+  const home = mkdtempSync(join(tmpdir(), "pi-langfuse-install-"));
+  const bin = join(home, "bin");
+  const npmRoot = join(home, ".pi/agent/npm");
+  const piLog = join(home, "pi.log");
+  const npmLog = join(home, "npm.log");
+  mkdirSync(bin, { recursive: true });
+  mkdirSync(npmRoot, { recursive: true });
+  writeFileSync(
+    join(npmRoot, "package.json"),
+    `${JSON.stringify({
+      name: "pi-extensions",
+      private: true,
+      dependencies: { "pi-langfuse": "^1.5.7" },
+      overrides: { existing: "1.0.0" },
+    }, null, 2)}\n`,
+  );
+  writeFileSync(join(bin, "pi"), '#!/usr/bin/env bash\nprintf "%s\\n" "$*" >> "$PI_LOG"\n');
+  writeFileSync(
+    join(bin, "npm"),
+    `#!/usr/bin/env bash\nprintf '%s\\n' "$*" >> "$NPM_LOG"\nif [ "$1" = audit ]; then exit "$AUDIT_EXIT"; fi\n`,
+  );
+  chmodSync(join(bin, "pi"), 0o755);
+  chmodSync(join(bin, "npm"), 0o755);
+
+  return {
+    home,
+    npmRoot,
+    piLog,
+    npmLog,
+    env: {
+      ...process.env,
+      HOME: home,
+      PATH: `${bin}:${process.env.PATH}`,
+      PI_LOG: piLog,
+      NPM_LOG: npmLog,
+      AUDIT_EXIT: String(auditExit),
+    },
+  };
+}
+
+describe("pi-langfuse installer", () => {
+  it("parses as valid bash", () => {
+    execFileSync("bash", ["-n", INSTALLER]);
+  });
+
+  it("pins the package, applies the scoped patched override, and audits idempotently", () => {
+    const test = fixture();
+
+    execFileSync("bash", [INSTALLER], { env: test.env });
+    execFileSync("bash", [INSTALLER], { env: test.env });
+
+    const manifest = JSON.parse(readFileSync(join(test.npmRoot, "package.json"), "utf8"));
+    expect(manifest.overrides).toEqual({
+      existing: "1.0.0",
+      "pi-langfuse": { "@opentelemetry/sdk-node": "0.220.0" },
+    });
+    expect(readFileSync(test.piLog, "utf8").trim().split("\n")).toEqual([
+      "install npm:pi-langfuse@1.5.7",
+      "install npm:pi-langfuse@1.5.7",
+    ]);
+    const npmCalls = readFileSync(test.npmLog, "utf8").trim().split("\n");
+    expect(npmCalls).toEqual([
+      `install --prefix ${test.npmRoot} --omit=dev --legacy-peer-deps`,
+      `audit --prefix ${test.npmRoot} --audit-level=low`,
+      `install --prefix ${test.npmRoot} --omit=dev --legacy-peer-deps`,
+      `audit --prefix ${test.npmRoot} --audit-level=low`,
+    ]);
+  });
+
+  it("fails when the final npm audit is not clean", () => {
+    const test = fixture(1);
+    const result = spawnSync("bash", [INSTALLER], { env: test.env, encoding: "utf8" });
+
+    expect(result.status).toBe(1);
+    expect(readFileSync(test.npmLog, "utf8")).toContain(
+      `audit --prefix ${test.npmRoot} --audit-level=low`,
+    );
+  });
+});

--- a/.pi/install/README.md
+++ b/.pi/install/README.md
@@ -1,0 +1,9 @@
+# Pi installation assets
+
+Repository-owned assets for optional Pi integrations live here. They are not
+auto-loaded as Pi extensions.
+
+| File | Purpose |
+| --- | --- |
+| `install-langfuse.sh` | Install the reviewed optional `pi-langfuse` release in user scope, apply the patched OpenTelemetry override, and require a clean npm audit. |
+| `slack-manifest.json` | Slack application manifest used by the Pi messenger bridge setup. |

--- a/.pi/install/install-langfuse.sh
+++ b/.pi/install/install-langfuse.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Install the reviewed pi-langfuse release with its patched OpenTelemetry dependency.
+set -euo pipefail
+
+PI_LANGFUSE_VERSION="1.5.7"
+OTEL_SDK_NODE_VERSION="0.220.0"
+PI_AGENT_DIR="${PI_AGENT_DIR:-$HOME/.pi/agent}"
+NPM_ROOT="$PI_AGENT_DIR/npm"
+PACKAGE_JSON="$NPM_ROOT/package.json"
+
+for command_name in pi npm node; do
+  if ! command -v "$command_name" >/dev/null 2>&1; then
+    echo "ERROR: required command not found: $command_name" >&2
+    exit 1
+  fi
+done
+
+mkdir -p "$NPM_ROOT"
+if [ ! -f "$PACKAGE_JSON" ]; then
+  printf '{\n  "name": "pi-extensions",\n  "private": true\n}\n' > "$PACKAGE_JSON"
+  chmod 600 "$PACKAGE_JSON"
+fi
+
+printf 'Preloading @opentelemetry/sdk-node@%s override...\n' "$OTEL_SDK_NODE_VERSION"
+node - "$PACKAGE_JSON" "$OTEL_SDK_NODE_VERSION" <<'NODE'
+const { readFileSync, renameSync, writeFileSync } = require("node:fs");
+
+const [packageJsonPath, otelVersion] = process.argv.slice(2);
+const manifest = JSON.parse(readFileSync(packageJsonPath, "utf8"));
+const overrides = manifest.overrides && typeof manifest.overrides === "object"
+  ? manifest.overrides
+  : {};
+const langfuseOverrides = overrides["pi-langfuse"] && typeof overrides["pi-langfuse"] === "object"
+  ? overrides["pi-langfuse"]
+  : {};
+
+manifest.overrides = {
+  ...overrides,
+  "pi-langfuse": {
+    ...langfuseOverrides,
+    "@opentelemetry/sdk-node": otelVersion,
+  },
+};
+
+const temporaryPath = `${packageJsonPath}.tmp`;
+writeFileSync(temporaryPath, `${JSON.stringify(manifest, null, 2)}\n`, { mode: 0o600 });
+renameSync(temporaryPath, packageJsonPath);
+NODE
+
+printf 'Installing pi-langfuse@%s in user scope...\n' "$PI_LANGFUSE_VERSION"
+pi install "npm:pi-langfuse@$PI_LANGFUSE_VERSION"
+
+npm install --prefix "$NPM_ROOT" --omit=dev --legacy-peer-deps
+npm audit --prefix "$NPM_ROOT" --audit-level=low
+
+printf 'pi-langfuse@%s installed with a clean npm audit.\n' "$PI_LANGFUSE_VERSION"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Update policy and release automation live in [`/git`](.claude/skills/git/SKILL.m
 - Retire the dead `RISKY_BASH` array and its bash branch from pi's `.pi/extensions/path-guard.ts` — it was a no-op in both headless and TUI modes, now superseded by cc-safety-net's fail-closed pi extension; `SENSITIVE_PATHS` and the `/guard` command are retained ([#654](https://github.com/mifunedev/openharness/issues/654)).
 ### Deprecated
 ### Security
+- Add a reproducible, audit-gated `pi-langfuse@1.5.7` installer that overrides its vulnerable OpenTelemetry SDK tree to patched `@opentelemetry/sdk-node@0.220.0` ([#664](https://github.com/mifunedev/openharness/issues/664)).
 
 ## [2026.7.15] - 2026-07-15
 


### PR DESCRIPTION
Closes #664

## Summary
- add an idempotent repository-owned installer for optional `pi-langfuse@1.5.7`
- preload a scoped `@opentelemetry/sdk-node@0.220.0` override before Pi installs dependencies, preventing the 25-finding audit output
- fail closed on the final npm audit and preserve unrelated overrides
- update the Langfuse guide and add regression tests

## Verification
- `pnpm test`
- `pnpm typecheck`
- `pnpm vitest run .oh/scripts/__tests__/pi-langfuse-install.test.ts`
- clean-HOME end-to-end run: initial and final installs report `found 0 vulnerabilities`
- existing configured sandbox run: `found 0 vulnerabilities`