### PR TITLE
fix: override postcss to patched ^8.5.18 to clear GHSA-r28c-9q8g-f849 (#668)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Update policy and release automation live in [`/git`](.claude/skills/git/SKILL.m
 ### Deprecated
 ### Security
 - Add a reproducible, audit-gated `pi-langfuse@1.5.7` installer that overrides its vulnerable OpenTelemetry SDK tree to patched `@opentelemetry/sdk-node@0.220.0` ([#664](https://github.com/mifunedev/openharness/issues/664)).
+- Pin the transitive `postcss` dependency (reached via `vitest > vite`) to the patched `^8.5.18` via `pnpm.overrides`, clearing GHSA-r28c-9q8g-f849 and unblocking `pnpm run security:audit` on every PR ([#668](https://github.com/mifunedev/openharness/issues/668)).
 
 ## [2026.7.15] - 2026-07-15
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
   },
   "pnpm": {
     "overrides": {
-      "esbuild": "^0.28.1"
+      "esbuild": "^0.28.1",
+      "postcss": "^8.5.18"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   esbuild: ^0.28.1
+  postcss: ^8.5.18
 
 importers:
 
@@ -806,8 +807,8 @@ packages:
     resolution: {integrity: sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
-  nanoid@3.3.12:
-    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+  nanoid@3.3.16:
+    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -834,8 +835,8 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
-  postcss@8.5.15:
-    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
+  postcss@8.5.23:
+    resolution: {integrity: sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==}
     engines: {node: ^10 || ^12 || >=14}
 
   punycode@2.3.1:
@@ -1787,7 +1788,7 @@ snapshots:
   mute-stream@3.0.0:
     optional: true
 
-  nanoid@3.3.12: {}
+  nanoid@3.3.16: {}
 
   outvariant@1.4.3:
     optional: true
@@ -1808,9 +1809,9 @@ snapshots:
 
   picomatch@4.0.4: {}
 
-  postcss@8.5.15:
+  postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.12
+      nanoid: 3.3.16
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -1999,7 +2000,7 @@ snapshots:
       esbuild: 0.28.1
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.15
+      postcss: 8.5.23
       rollup: 4.62.0
       tinyglobby: 0.2.17
     optionalDependencies:


### PR DESCRIPTION
Closes #668.

Two required checks fail on **every** PR into `development`. Both are the same
advisory, and neither is caused by any code change in the repo.

| Check | Where it fires |
|---|---|
| Lint, Typecheck, Build & Test | `.github/workflows/ci-harness.yml:89` — `pnpm run security:audit` |
| Validate sandbox compose and image build | `.github/workflows/sandbox-boot-guard.yml:114` — `pnpm install --frozen-lockfile` trips the `pnpm:devPreinstall` hook, which runs the same audit |

## Cause

`postcss <= 8.5.17` is vulnerable to path traversal via `sourceMappingURL`
auto-loading ([GHSA-r28c-9q8g-f849](https://github.com/advisories/GHSA-r28c-9q8g-f849)),
newly scored **high**. It is reached transitively through `.>vitest>vite>postcss`.
The gate runs at `--audit-level low`, so it fails.

## Fix

One line in `pnpm.overrides`, beside the existing `esbuild` entry:

```json
"postcss": "^8.5.18"
```

An override rather than a bare lockfile refresh, so the patched floor holds for
any future transitive consumer — not just the single path this advisory named.
Same shape as the OpenTelemetry override added in #664.

The lockfile moves `postcss 8.5.15 → 8.5.23` and its transitive
`nanoid 3.3.12 → 3.3.16`. **Nothing else resolves differently** — the full
lockfile diff is 17 lines.

## Not runtime-reachable, still worth patching

`vitest` is a devDependency and `postcss` ships in no published artifact, so
there is no exploit path for a consumer of Open Harness. The audit gate is
`--audit-level low` deliberately, though, so the correct answer is the patched
pin rather than an ignore entry that would also mask the next advisory on this
path.

## Verification

Run in a clean worktree cut from `upstream/development`:

```
pnpm run security:audit        → No known vulnerabilities found
pnpm install --frozen-lockfile → Done in 2.2s          (lockfile is consistent)
pnpm test                      → 37 files, 453 tests, all passed
pnpm run typecheck             → tsc --noEmit, clean
pnpm run build                 → dist/oh.js 72.6kb
```

## Relationship to #667

PR #667 (Apache-2.0 relicense) is red for this reason and this reason only —
its own `Eval Probe Regression Gate` and `Boot Path Lint` both pass. Merging
this first turns #667 green on rebase. The two PRs touch disjoint regions of
`package.json` and `CHANGELOG.md`, so they do not conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
