### PR TITLE
fix: move GitHub Actions pins off the deprecated Node 20 runtime (#670)

### DIFF
--- a/.github/workflows/ci-harness.yml
+++ b/.github/workflows/ci-harness.yml
@@ -62,7 +62,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 
@@ -70,15 +70,15 @@ jobs:
         run: bash .oh/scripts/link-providers.sh --init
 
       - name: Setup Node 22.x
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "22"
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Cache pnpm store
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.local/share/pnpm/store/v3
           key: pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
@@ -112,7 +112,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 
@@ -141,7 +141,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 
@@ -151,7 +151,7 @@ jobs:
       # Provision Node explicitly so the suite is runner-agnostic: GitHub-hosted
       # ships Node preinstalled, the self-hosted runner does not.
       - name: Setup Node 22.x
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "22"
 

--- a/.github/workflows/conciseness.yml
+++ b/.github/workflows/conciseness.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Eval filler-word density
         run: |

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -24,12 +24,12 @@ jobs:
       id-token: write # provenance attestation
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 
       - name: Setup Node 22.x
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "22"
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 
@@ -22,15 +22,15 @@ jobs:
         run: bash .oh/scripts/link-providers.sh --init
 
       - name: Setup Node 22.x
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "22"
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Cache pnpm store
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.local/share/pnpm/store/v3
           key: pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
@@ -69,7 +69,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 
@@ -97,7 +97,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 
@@ -117,7 +117,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 
@@ -147,18 +147,18 @@ jobs:
           echo "notes_file=$NOTES_FILE" >> "$GITHUB_OUTPUT"
 
       - name: Setup Node 22.x
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "22"
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -194,7 +194,7 @@ jobs:
           docker push "$LATEST"
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           name: v${{ steps.parse.outputs.version }}
           body_path: ${{ steps.notes.outputs.notes_file }}

--- a/.github/workflows/sandbox-boot-guard.yml
+++ b/.github/workflows/sandbox-boot-guard.yml
@@ -49,7 +49,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
           submodules: recursive
@@ -98,12 +98,12 @@ jobs:
       # readable/writable by the sandbox user. See
       # .claude/specs/boot-guard-cold-boot/spec.md (Option C).
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 10.33.0
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           # Match the devcontainer image (Dockerfile installs Node 22.x) so the
           # pre-seeded tree matches what the container runs — spec §9 parity.

--- a/.oh/evals/probes/pnpm-audit-ci-gate.sh
+++ b/.oh/evals/probes/pnpm-audit-ci-gate.sh
@@ -60,8 +60,11 @@ for (const file of process.argv.slice(2)) {
 process.exit(failed ? 1 : 0);
 NODE
 
-if ! grep -q 'pnpm/action-setup@v4' "$CI_WORKFLOW"; then
-  echo "REGRESSION: ci-harness workflow no longer installs pnpm via pnpm/action-setup@v4" >&2
+# Match any major: the guard is that pnpm is installed via the action at all,
+# not which version it is pinned to. Pinning the major here made routine
+# runtime bumps (Node 20 -> Node 24, #670) look like a regression.
+if ! grep -qE 'pnpm/action-setup@v[0-9]+' "$CI_WORKFLOW"; then
+  echo "REGRESSION: ci-harness workflow no longer installs pnpm via pnpm/action-setup" >&2
   exit 1
 fi
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Update policy and release automation live in [`/git`](.claude/skills/git/SKILL.m
 ### Security
 - Add a reproducible, audit-gated `pi-langfuse@1.5.7` installer that overrides its vulnerable OpenTelemetry SDK tree to patched `@opentelemetry/sdk-node@0.220.0` ([#664](https://github.com/mifunedev/openharness/issues/664)).
 - Pin the transitive `postcss` dependency (reached via `vitest > vite`) to the patched `^8.5.18` via `pnpm.overrides`, clearing GHSA-r28c-9q8g-f849 and unblocking `pnpm run security:audit` on every PR ([#668](https://github.com/mifunedev/openharness/issues/668)).
+- Move every pinned GitHub Action off the deprecated Node 20 runtime — `actions/checkout@v7`, `actions/setup-node@v7`, `pnpm/action-setup@v6`, `actions/cache@v6`, `softprops/action-gh-release@v3`, `docker/setup-buildx-action@v4`, `docker/login-action@v4` — and unpin the major in the `pnpm-audit-ci-gate` probe so future runtime bumps do not read as regressions ([#670](https://github.com/mifunedev/openharness/issues/670)).
 
 ## [2026.7.15] - 2026-07-15
 


### PR DESCRIPTION
Closes #670.

Every third-party action pinned in `.github/workflows/` declared
`runs.using: node20`. GitHub has
[deprecated Node 20 on Actions runners](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)
and currently force-runs them on Node 24 with a warning annotation on every run.
When the shim is withdrawn, they fail outright.

Surfaced as an annotation on the boot-guard run while unblocking #668.

## The bump

| Action | Was | Now | Verified `runs.using` at target tag |
|---|---|---|---|
| `actions/checkout` | `v4` | `v7` | `node24` |
| `actions/setup-node` | `v4` | `v7` | `node24` |
| `pnpm/action-setup` | `v4` | `v6` | `node24` |
| `actions/cache` | `v4` | `v6` | `node24` |
| `softprops/action-gh-release` | `v2` | `v3` | `node24` |
| `docker/setup-buildx-action` | `v3` | `v4` | `node24` |
| `docker/login-action` | `v3` | `v4` | `node24` |

Each `runs.using` was read out of `action.yml` at the target tag rather than
inferred from release notes. `hadolint/hadolint-action` is untouched — it is a
Docker action, not a Node one, and is already SHA-pinned.

## Why setup-node v6+ and not v5

`actions/setup-node@v5` auto-enables package-manager caching whenever a
`packageManager` field is present in `package.json`. Ours has one
(`pnpm@10.33.0`), and `ci-harness.yml` already runs its own `actions/cache` step
for the pnpm store — so v5 would have introduced two caches for the same thing.
`v6` narrowed that automatic caching to npm only, so landing on v6+ sidesteps
the interaction rather than inheriting it.

The explicit `cache: pnpm` input in `sandbox-boot-guard.yml` is unaffected;
that input has always been supported, and pnpm is already installed before
`setup-node` runs there.

## Probe fix included

`.oh/evals/probes/pnpm-audit-ci-gate.sh` asserted `pnpm/action-setup@v4`
literally, so this bump would have tripped it as a regression. Relaxed to
`pnpm/action-setup@v[0-9]+` — the guard's intent is that `ci-harness` installs
pnpm through the action at all, not which major it is pinned to. Future runtime
bumps will no longer read as regressions.

## Runner requirement

Node 24 actions require Actions Runner `>= 2.327.1`. No `CI_RUNNER` repo
variable is set, so every job runs on GitHub-hosted `ubuntu-latest`, which
satisfies it. A self-hosted fleet would need checking before adopting this —
several of these workflows are written to route to `${{ vars.CI_RUNNER }}`.

## What this PR's CI does and does not prove

`ci-harness.yml`, `conciseness.yml`, and `sandbox-boot-guard.yml` are exercised
by PR CI, so their bumps are proven by the checks on this PR.

`release.yml` (tag push) and `publish-cli.yml` (tag push / dispatch) are **not**
exercised — dispatching them would cut a real release or publish to npm. Their
bumps rest on the release-note review above: the docker `v4` majors and
`action-gh-release@v3` are runtime-only changes, and `setup-buildx-action@v4`
additionally removed deprecated inputs that this repo never passed. Worth a
human eye before the next `/release`.

## Verification

- Full probe suite: 92 probes, no regression attributable to this branch.
- `pnpm-audit-ci-gate` passes against the bumped workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
