### PR TITLE
FROM task/684-pi-enabled-models TO development

### DIFF
--- a/.pi/settings.json
+++ b/.pi/settings.json
@@ -2,6 +2,11 @@
   "defaultProvider": "openai-codex",
   "defaultModel": "gpt-5.6-sol",
   "defaultThinkingLevel": "medium",
+  "enabledModels": [
+    "openai-codex/gpt-5.6-sol",
+    "openai-codex/gpt-5.6-terra",
+    "openai-codex/gpt-5.6-luna"
+  ],
   "theme": "dark",
   "retry": {
     "enabled": true,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Update policy and release automation live in [`/git`](.claude/skills/git/SKILL.m
 
 ### Added
 ### Changed
+- Expose the supported GPT-5.6 variants in Pi's model selector ([#684](https://github.com/mifunedev/openharness/issues/684)).
 - Expand Advisor planning with a designer lens and make implementation/PR prompts explicitly finish with delegated audits and retrospectives ([#680](https://github.com/mifunedev/openharness/issues/680)).
 ### Fixed
 - Make Slack bridge admin commands discoverable and functional by declaring `/help`, `/trusted`, `/channels`, `/enable`, `/disable`, `/revoke`, and `/toggletools` in `.pi/install/slack-manifest.json`, pinning bridge-side Socket Mode command handlers, and separating Slack commands from Pi's `/msg-bridge` surface in docs ([#354](https://github.com/ryaneggz/openharness/issues/354)).


### PR DESCRIPTION
Closes #684

Adds the supported GPT-5.6 variants to Pi’s model selector.

Test: `jq empty .pi/settings.json`