### PR TITLE
FROM task/686-rfcs-decision-route TO development

### DIFF
--- a/.oh/agents/critic.md
+++ b/.oh/agents/critic.md
@@ -29,7 +29,7 @@ You see the issue through the lens of **what could go wrong**. You care about:
 Before analyzing, read these files for context:
 - `CLAUDE.md` — project instructions, stack, conventions
 - `README.md` — project overview and structure
-- `.claude/rules/` — coding standards that might be violated
+- `.oh/context/IDENTITY.md` — operating principles a proposal might violate
 - `.claude/protected-paths.txt` — load-bearing skills, scripts, and configs
 
 ## Protected paths — deletion gate

--- a/.oh/agents/implementer.md
+++ b/.oh/agents/implementer.md
@@ -28,7 +28,7 @@ You see the issue through the lens of **how to build it**. You care about:
 Before analyzing, read these files for context:
 - `CLAUDE.md` — project instructions, stack, conventions
 - `README.md` — project overview and structure
-- `.claude/rules/` — coding standards that apply to the relevant files
+- `.oh/context/IDENTITY.md` — operating principles that apply to the relevant files
 
 ## Output Format
 

--- a/.oh/docs/README.md
+++ b/.oh/docs/README.md
@@ -73,6 +73,7 @@ Open Harness vendors the shared skills/agents/hooks primitive pack directly into
 - [Glossary](glossary.md)
 - [RFC / ADR index](rfcs/README.md)
 - [ADR-0001: #532 standards scope](rfcs/adr-0001-standards-scope.md)
+- [Runtime support — axes taxonomy & the "supported runtime" contract (#592)](rfcs/rfc-runtime-support.md)
 - [Self-improving harness roadmap curation (#525)](rfcs/rfc-selfimprove-roadmap.md)
 - [Trace/event ledger RFC (#525 foundation)](rfcs/rfc-trace-ledger.md)
 - [Property testing](property-testing.md)

--- a/.oh/tasks/rfcs-decision-route/council.md
+++ b/.oh/tasks/rfcs-decision-route/council.md
@@ -1,0 +1,272 @@
+# Council — decision-record route and index guard (#686)
+
+First Mate council per `.oh/prompts/advisor/plan.yml`. Wave 1: `architect`, `pm`, `designer` in
+parallel, each given the same brief preamble (ADR-0001 deferral, evidence ledger, six-surface table,
+hard constraints, B-state M4 precedent). Wave 2: this synthesis. Wave 3: two adversarial critics.
+
+---
+
+## Wave 1 — analyses
+
+### architect — five binary calls
+
+| # | Call | Verdict | Killing fact |
+|---|---|---|---|
+| 1 | YAML frontmatter vs plain `Status:`/`Date:`/`Related:` | **plain headers** | Zero YAML delimiters exist in the corpus; nothing parses rfcs frontmatter today. Contrast the wiki, where frontmatter is load-bearing because `.oh/evals/probes/wiki-readme-index.sh:40` actually invokes the canonical extraction. Converting 4 tracked files is churn for zero consumers. |
+| 2 | `0000-adr-index.json` vs markdown table | **markdown** | `.oh/docs/rfcs/README.md:23-37` is already the single source of truth. No JSON-for-knowledge precedent exists under `.oh/docs/`; `prd.json` is JSON-for-*work*. A second index is two sources of truth with no writer/reader pair to sync them. |
+| 3 | `> Agent Directive:` blockquotes | **reject** | Repo-wide grep returns zero hits. `.oh/manifest.json` `include` has no `docs/**`, so `.oh/docs/` is not vendored downstream and nothing loads it at session start — a normative marker there has no runtime force. The existing carrier of "always do X" is `.oh/context/IDENTITY.md`; the existing greppable local marker is `## Constraints` (`.oh/tasks/first-mate-charter/plan.md:15`). |
+| 4 | Subsumes / duplicates | subsumes the hand-rolled task-local decision docs; risks duplicating wiki and MEMORY | **Discriminating test: does the record name a rejected alternative and why it lost?** Yes → decision record. No → wiki fact or MEMORY observation. |
+| 5 | Probe | one executable | Modeled on `wiki-readme-index.sh` (git-tracked enumeration, diff) + `first-mate-charter.sh` (accumulator, honest SKIP). |
+
+Architect additionally proposed negative-space assertions banning YAML frontmatter, `*.json` in the
+rfcs dir, `> Agent Directive:` lines, and `.github/workflows/rfc-to-adr.yml`. **Overruled in
+synthesis — see Ruling 1.**
+
+### pm — cut list, decomposition, honesty
+
+Cut, each mapped to ADR-0001's "concrete evidence" bar with the evidence that *would* have justified
+it and the finding that it does not exist: repo-root `docs/adr/`; `0000-adr-index.json` (this *is*
+"formal registries"); `> Agent Directive:` (conformance machinery, #532 AC 5/8 disposition
+`DEFERRED`); `rfc-to-adr.yml`; YAML frontmatter (no consumer once the JSON index is cut); a new
+`NNNN` numbering authority separate from GitHub issue numbers ("IANA-style allocation authority");
+any 4th lifecycle stage (`.oh/docs/rfcs/README.md:20` — "three states by design (kept to ≤4
+deliberately)").
+
+PM independently verified pain point (d) against `git ls-files .oh/tasks` (35 tracked files) and
+`.gitignore:12-13`, and reported: the decision docs **are** git-tracked, force-added per the pattern
+`.oh/tasks/slack-admin-command-surface/critique.md:24` itself documents. **Nothing is lost.** The
+defect is the same class as the live `rfc-runtime-support.md` index rot — unindexed, not unrouted.
+
+PM's conclusion, adopted verbatim into the PRD: *none of the four pain points is solved by a document
+format; all four reduce to a promotion/index step.*
+
+### designer — measured ergonomics
+
+**The cold-start question splits, and the split is the difference between a strong and a weak
+argument.** Measured:
+
+| Sub-question | Answered at | Files opened | Delta if adopted |
+|---|---|---|---|
+| Q1 — what does declaring it in the manifest buy? | `.oh/docs/integrations/slack.md:66-67` | **2** | **0 — unchanged** |
+| Q2 — why isn't documenting them enough? | `.oh/tasks/slack-admin-command-surface/critique.md:53` | **7** | **3 (−57%)** |
+
+Three properties of the Q2 path, each verified: natural-language greps in `.oh/docs/` hit **0/4**
+(`why.*manifest`, `instead of.*document`, `not.*enough.*doc` all return zero); the terminal hop is
+**not linked from `.oh/docs/README.md`**, and `.oh/context/REPO_MAP.md:96` actively routes readers
+*away* from `.oh/tasks/`; and the terminal artifact sits on a **weekly GC path**
+(`.oh/crons/cleanup-tasks.md`, `schedule: "0 23 * * 0"`, `enabled: true`, no exclusion for
+referenced artifacts).
+
+**Corroborating scale — 7 hand-rolled decision records across 4 surfaces**, three of which were not
+in the brief's ledger and were found by the designer:
+
+| # | Location | Shape |
+|---|---|---|
+| 1 | `.oh/tasks/cc-safety-net/decision.md:9-16` | ADOPT/KEEP/RETIRE/DOCUMENT GAP verdict table + `## Accepted risk` |
+| 2 | `.oh/tasks/cc-safety-net/install-decision.md` | provider × mechanism decision table |
+| 3 | `.oh/tasks/slack-admin-command-surface/critique.md:51-64` | operator ruling reversing a shipped approach |
+| 4 | `.oh/tasks/first-mate-charter/plan.md:8` | *"the lighter alternative … was rejected because…"* |
+| 5 | `.oh/docs/integrations/debugmcp.md:258-278` | `## Maintainer Decision Gate`, 3-option table, `**Decision (2026-06-23).**` |
+| 6 | `.oh/docs/open-core.md:39-45` | `## Why not the alternatives` (AGPL/SSPL/BSL, Apache+dual) |
+| 7 | `CHANGELOG.md:642` | an ADR compressed into a changelog line |
+
+**Two independent bugs found, both verified by the orchestrator:**
+
+- `.oh/evals/probes/slack-admin-command-surface.sh:12` hard-codes
+  `$ROOT/.oh/tasks/slack-admin-command-surface/root-package-audit.md` and asserts three literals
+  against it. The weekly cleanup cron relocates that path into `.oh/tasks/archive/$TODAY/`, which
+  **turns a tier-A probe red**. Latent today, independent of #686 — and direct evidence that
+  decision-grade content currently lives on a garbage-collection path.
+- `.oh/agents/critic.md:32` references `.claude/rules/`, which does not exist.
+
+**Read-path baseline:** `git grep -n 'docs/rfcs\|adr-0001'` returns references only from
+`.oh/docs/*` and `CHANGELOG.md` — **zero from any of the 40 skills, 6 agents, 5 context files, or
+`AGENTS.md`.** An agent's probability of encountering an ADR today is effectively zero.
+
+**Budget arithmetic, measured:** 40 skill frontmatters = 25,992 chars ≈ 6,498 tok, always-injected;
+6 agent frontmatters = 3,109 chars ≈ 777 tok, also always-injected. No proposed insertion touches any
+`description:` field. `.oh/evals/probes/repo-map-contract.sh:13` pins `MAX_BYTES=12288` against a
+12,217-byte `REPO_MAP.md` — **71 bytes of headroom**, and a useful routing row costs 147.
+
+**Designer's honest risk finding (§6), adopted:** the step most likely to be skipped is not the ADR
+but `Impact: NOT-APPLICABLE` at plan time — because *the highest-value decision class is the plan
+being overturned mid-flight*. `critique.md:51` is literally headed `## Operator correction`. A
+plan-time gate structurally cannot catch it. The designer explicitly declined to propose a
+truthfulness probe ("a judgment call wearing a PASS/REGRESSION costume") and declined to import
+eye-tracking claims it had no local evidence for.
+
+---
+
+## Wave 2 — First Mate rulings
+
+Four points where the crew disagreed or over-reached. These are HOW-decisions; none redefines WHAT
+was asked.
+
+**Ruling 1 — the probe ships, but without the negative-space assertions.** Architect wanted the probe
+to ban YAML frontmatter, `*.json` in the rfcs dir, `> Agent Directive:` lines, and the CI workflow
+file. Rejected. Those assertions encode *this council's preference* as a permanent guard, which is
+precisely the over-constraint ADR-0001 warns against — a future issue with concrete evidence must
+remain able to adopt frontmatter without deleting a probe. They would also flag `/audit eval-quality`
+mode 6 (too-narrow/special-cased). The probe asserts **index freshness and the header contract** —
+things that rot silently — not the council's taste. PM proposed no probe at all; overruled, because
+criterion C2 requires a named instrument to move and the index rot is real and currently undetected.
+
+**Ruling 2 — `Why:` beats `Decision:`.** Designer's measured evidence wins: the repo has independently
+converged on a one-line rationale three times, with observed lengths of 86–202 chars in the closest
+analogue (`cc-safety-net/decision.md` "One-line rationale" column). 240 chars accommodates the
+observed max plus the "rather than Y" clause the existing fields omit. The same string serves as the
+file header *and* the index-row cell — one authoring act, no drift.
+
+**Ruling 3 — the contract lives in `rfcs/README.md`, not a separate template file.** PM proposed
+`.oh/docs/rfcs/decision-record-template.md`. Rejected: a second file is a second place to drift from
+the index that governs it. A fenced skeleton inside `rfcs/README.md` § "Writing a decision record" is
+equally copy-pasteable and cannot desync from the lifecycle rules beside it.
+
+**Ruling 4 — the `REPO_MAP.md` insertion is deferred to an optional story.** Designer's paid-for swap
+(delete the duplicate line 26, insert a routing row, net +47 bytes, verified against all 20 pinned
+literals) is careful work and the analysis is sound. But it edits the single most budget-constrained
+always-loaded file in the repo, and it makes the always-loaded delta positive rather than zero.
+Designer's own Insertion 2 — one bullet in `.oh/agents/critic.md`'s body, which runs twice per
+`/spec critique`, exactly where re-litigation happens — buys the read path at **zero** cost. The
+core slice takes the zero-cost path; the `REPO_MAP.md` row becomes an optional story with the
+paid-for-swap requirement recorded.
+
+**Correction carried into the PRD.** The task brief and the orchestrator's own plan claimed
+`grep -rl 'slack-manifest' .oh/docs/` returns nothing. It returns **three files**. The mechanics are
+well documented; what is absent from `.oh/docs/` is the *rejected alternative* — verified by
+`grep -rniE 'docs-only|rejected|instead of.*document'` across those three files returning **zero**.
+The corrected claim is narrower and stronger, and it is exactly the architect's discriminating test:
+docs state what *is*; an ADR states what *lost*.
+
+---
+
+## Wave 2 — scored verdict
+
+Criteria fixed before the council ran. Veto rows: C1, C2, C3, C6.
+
+### The source proposal, as written
+
+| # | Criterion | Score | Basis |
+|---|---|:--:|---|
+| C1 | Always-loaded delta | 2 | Adds no always-loaded content — but only because nothing reads it. |
+| C2 | Moves a named instrument | **0** | A CI Action moves no probe and no capability benchmark. **VETO** |
+| C3 | Arbitration rows | **0** | None proposed; a 7th surface with no boundary rule. **VETO** |
+| C4 | Evidence vs ADR-0001 | 0 | Cites no repo artifact. |
+| C5 | Net machinery | 0 | New CI job, new vendor, new repo secret. |
+| C6 | Pain-point honesty | 0 | Implicitly claims the format solves all four. |
+| C7 | Reversibility | 0 | Converts 4 tracked docs to YAML; creates a competing root directory. |
+
+**2 / 14 — two veto zeros — NO-GO.**
+
+### The residual design
+
+| # | Criterion | Score | Basis |
+|---|---|:--:|---|
+| C1 | Always-loaded delta | 2 | Core insertions are skill/agent **bodies** and `references/` only. No `description:` frontmatter touched; `AGENTS.md`, `.oh/context/`, `.oh/memory/` untouched. Delta **0**. |
+| C2 | Moves a named instrument | **1** | One probe, red today on the `rfc-runtime-support.md` rot, green after the fix. **Not scored 2**: no capability-benchmark A/B is claimed, because the designer showed the real skip is unmeasurable and a rate-check proxy would be a false-positive generator. Honest 1. |
+| C3 | Arbitration rows | 2 | Both written verbatim with mechanical, judgment-free discriminating tests — including an ordered first-match-wins test for the MEMORY/ADR/IDENTITY three-way. |
+| C4 | Evidence vs ADR-0001 | 2 | 7 hand-rolled records across 4 surfaces, ≥1 operator ruling (`critique.md:51-64`), ≥1 live rot instance (`.oh/docs/README.md` missing `rfc-runtime-support.md`), plus a latent tier-A probe break caused by storing decision content on a GC path. |
+| C5 | Net machinery | 2 | Exactly one new executable. Zero new skills, zero CI jobs, zero vendors. |
+| C6 | Pain-point honesty | 2 | (a) partial — the route solves it, not the format; (b) split Q1 delta 0 / Q2 delta 7→3; (c) *worse* unless arbitrated; (d) not lost, unindexed. Plus the structural plan-time-gate admission. |
+| C7 | Reversibility | 2 | Purely additive; `git rm` the new files and revert three reference paragraphs. The one subtractive edit (`REPO_MAP.md`) is deferred to an optional story. |
+
+**13 / 14 — no veto zeros — GO on the residual.**
+
+### Verdict
+
+**PARTIAL-GO.** Adopt the destination, the route, the index guard, and the arbitration rows. Reject
+YAML frontmatter, the JSON index, `> Agent Directive:`, and `rfc-to-adr.yml`. The destination the
+source proposal identified is right; every mechanism it proposed to get there is wrong for this repo.
+
+---
+
+## Wave 3 — critics
+
+Two adversarial critics, run after synthesis. **Critic A: HALT. Critic B: REVISE-PRD.**
+
+### Critic A — implementer lens (HALT)
+
+Six HIGH findings. Four survive orchestrator verification intact and are decisive:
+
+`[SEVERITY: H] [STORY: *] Revealed preference argues "unused", not "underspecified" — 4 of the 7 ad hoc decision records were authored AFTER the formal .oh/docs/rfcs/ destination already existed | [EVIDENCE: adr-0001 created 2026-07-03 (e19dcb62); cc-safety-net/decision.md 2026-07-19, first-mate-charter/plan.md 2026-07-21, open-core.md 2026-07-24, slack-admin-command-surface/critique.md 2026-07-31 — 16 to 28 days later] | [RECOMMENDATION: discount C4; require evidence of an author ATTEMPTING .oh/docs/rfcs/ and hitting friction, not merely skipping it]`
+
+`[SEVERITY: H] [STORY: *] The residual ships nothing that answers its own diagnosis — PM concluded all four pain points reduce to a promotion/index step, but Why:, the contract section, arbitration rows, the probe, and two backfills are all format, guidance, or one-time backfill; none moves a future critique.md ruling into the index without an author remembering by hand | [EVIDENCE: council.md PM conclusion vs the residual scorecard's own C6 "(a) partial — the route solves it, not the format"] | [RECOMMENDATION: scope a real promotion mechanism, or shrink to the two orthogonal bugs]`
+
+`[SEVERITY: H] [STORY: *] C2=1 is circular self-justification — the probe's whole value is guarding index freshness on a surface with no demonstrated write traffic, which is /audit eval-quality Check 7 (probe count grows, capability ceiling flat) | [EVIDENCE: .oh/skills/audit/references/eval-quality.md Check 7; council.md's own "no capability-benchmark A/B is claimed"] | [RECOMMENDATION: score C2 as 0; defer the probe]`
+
+`[SEVERITY: H] [STORY: *] Undercounted blast radius — a ## Decision Record block in .oh/skills/prd/SKILL.md edits a PROTECTED, universally-reused skill invoked by every /prd, /spec plan, /ship-spec and /autopilot run harness-wide, turning a norm needed a few times a month into a permanent section every future PRD author reads or skips | [EVIDENCE: .claude/protected-paths.txt lists `prd`; .oh/skills/prd/SKILL.md:58-132] | [RECOMMENDATION: gate behind a trigger test, or do not ship]`
+
+`[SEVERITY: H] [STORY: *] B-state M4 violated in spirit — 6+ scattered edit points enforcing one norm reproduces exactly the proliferation shape M4 just collapsed, even though the token delta is zero | [EVIDENCE: AGENTS.md:31 vs the Rulings 1-4 touch list] | [RECOMMENDATION: consolidate into one on-demand artifact]`
+
+`[SEVERITY: H] [STORY: *] FALSE AS SPECIFIED — the "verified" claim that the slack-admin probe will break when cleanup-tasks runs does not hold on the cited instance | [EVIDENCE: .oh/crons/cleanup-tasks.md:76-77 requires progress.txt to END with a line matching exactly STATUS: COMPLETE; in slack-admin-command-surface/progress.txt that line is 19 of 40 and the last line is unrelated prose] | [RECOMMENDATION: downgrade to "a plausible failure class, unconfirmed on the cited instance"]`
+
+Material M findings: the 7→3 delta conflates "files a keyword grep returns" with "hops to find the why" and should be reported as two facts; "one ADR in four months" is wrong — `.oh/docs/rfcs/` was created 2026-07-02, ~1 month ago; the arbitration rows sit outside what `/audit context` Dimension D scans, so the "mechanical test" is unenforced prose; `.claude/agents/critic.md` is a materialized copy, not a symlink, so editing `.oh/agents/critic.md` alone never reaches the Claude-facing agent without `.oh/scripts/link-providers.sh`.
+
+### Critic B — maintainer lens (REVISE-PRD)
+
+`[SEVERITY: H] [STORY: *] The isomorphic precedent is omitted 87.5% of the time — ## Wiki Alignment, a mandatory Stage 2.5 step, appears in 1 of 8 prd.md files | [EVIDENCE: orchestrator re-verified: PRESENT only in archive/2026-07-27/markitdown-wiki-pilot/prd.md; ABSENT in the other 7] | [RECOMMENDATION: do not assume ## Decision Record fares better; wire a structural check or accept silent decay]`
+
+`[SEVERITY: H] [STORY: *] No blocking gate — Wiki Alignment's Impact: REQUIRED is wired into the audit that must PASS; the proposed promotion sits in improve/compound, which is the advisory tail | [EVIDENCE: execute.md:78-81 "before the audit can PASS" vs :89-94 compound and :102-103 "report-only... do not block the merge"] | [RECOMMENDATION: wire it into the AUDIT-PASS gate or state plainly it is advisory and will be skipped under merge pressure]`
+
+`[SEVERITY: H] [STORY: *] Probe blind spot — an index-freshness probe can only diff ADRs that exist; it structurally cannot detect a REQUIRED decision never written, so a green probe reads as "the convention works" while the real failure is invisible | [EVIDENCE: wiki-readme-index.sh has nothing to diff against if the file was never created; designer §6 concedes the same for plan time] | [RECOMMENDATION: do not claim the probe guards the actual risk]`
+
+M findings: the 240-char cap leaves only 38 chars over the observed 202-char max, too little for the rejected-alternative clause that defines an ADR; `CONTRIBUTING.md` has zero mention of the convention (verified: 0 matches); backfilled ADRs need a `Source:` line citing the `file:line` they reconstruct from; the expected `REQUIRED` base rate is ~2–3% of tasks.
+
+---
+
+## Wave 4 — approve gate and revised verdict
+
+Both critics were verified independently by the orchestrator rather than taken at face value. **Every
+factual challenge they raised was upheld**, including one against a claim this document asserted as
+verified.
+
+### Corrections to the record
+
+1. **The GC/probe-break claim was wrong.** The orchestrator confirmed the probe hard-codes
+   `.oh/tasks/slack-admin-command-surface/root-package-audit.md` and that the cleanup cron archives
+   completed tasks — then asserted the break. It never checked whether the cron's predicate *fires on
+   this file*. It does not. Checking a proxy instead of the behaviour is exactly
+   `.oh/context/IDENTITY.md:8`, committed inside a document that cites it. The hazard remains real
+   for any task whose `progress.txt` genuinely ends with `STATUS: COMPLETE`; it is not evidence here.
+2. **"One ADR in four months" is wrong.** `.oh/docs/rfcs/README.md` was created 2026-07-02 and
+   ADR-0001 on 2026-07-03 — roughly one month ago. This was stated in issue #686 and must be
+   corrected there.
+3. **The 7→3 delta conflates two metrics** and is restated as two separate facts.
+
+### Rescored — residual design, post-critique
+
+| # | Criterion | Was | Now | Why it moved |
+|---|---|:--:|:--:|---|
+| C1 | Always-loaded delta | 2 | **2** | Holds — token delta is genuinely 0. Blast radius is a separate concern, recorded under C5. |
+| C2 | Moves a named instrument | 1 | **0** | Circular: the probe guards index freshness on a surface with no demonstrated write traffic, and structurally cannot detect the dominant failure (never written). **VETO** |
+| C3 | Arbitration rows | 2 | **1** | The rows are real and well-drafted, but sit outside `/audit context` Dimension D's scanned set — an unenforced convention, not a mechanical boundary. |
+| C4 | Evidence vs ADR-0001 | 2 | **1** | Inverted by dating: 4 of 7 records post-date the formal destination by 16–28 days. That is evidence authors *avoid* the surface, not that it is underspecified. One cited instance also refuted. |
+| C5 | Net machinery | 2 | **1** | One executable, but 6+ scattered edit points enforcing one norm — the proliferation shape B-state M4 collapsed — plus an edit to the protected, harness-wide `prd` skill. |
+| C6 | Pain-point honesty | 2 | **1** | The analysis was honest, but shipped one false "verified" claim and one wrong dormancy stat. |
+| C7 | Reversibility | 2 | **2** | Holds — purely additive. |
+
+**8 / 14 — one veto zero (C2) — NO-GO.**
+
+### Verdict
+
+**NO-GO on the machinery. Carve out and ship the two orthogonal bugs.**
+
+The source proposal scored 2/14 with two vetoes and is rejected outright. The residual survived wave
+2 at 13/14 and then failed under adversarial review at 8/14 with a veto — because the decisive
+question was never "what should an ADR look like" but "is this surface unused or underspecified,"
+and the dating evidence answers *unused*. Building route, contract, and probe machinery on a surface
+authors demonstrably route around is machinery-growth-without-capability-movement, which is the exact
+pattern `/audit eval-quality` Check 7 names and which ADR-0001 pre-emptively deferred.
+
+**What ships instead** — two real defects, found by this council, orthogonal to the machinery and
+independently valuable:
+
+1. `.oh/docs/README.md` does not link `rfc-runtime-support.md` (25% of the corpus invisible from the
+   index a human enters through).
+2. `.oh/agents/critic.md:32` references `.claude/rules/`, which does not exist.
+
+**Re-entry bar**, per ADR-0001's own discipline: a future issue should show an author or agent
+**attempting** to use `.oh/docs/rfcs/` and hitting concrete friction — not merely bypassing it. Until
+then the lightweight convention stands, exactly as ADR-0001 decided.
+
+`STATUS: SPEC-DENIED`

--- a/.oh/tasks/rfcs-decision-route/prd.json
+++ b/.oh/tasks/rfcs-decision-route/prd.json
@@ -1,0 +1,101 @@
+{
+  "schemaVersion": 1,
+  "project": "Open Harness",
+  "branchName": "task/686-rfcs-decision-route",
+  "description": "Council assessment of an externally-proposed ADR/RFC pipeline for .oh/docs/rfcs/. Verdict: NO-GO on the machinery (source proposal 2/14 with two vetoes; residual design 8/14 with a C2 veto after adversarial review). Decisive finding: 4 of 7 hand-rolled decision records were authored 16-28 days AFTER the formal .oh/docs/rfcs/ destination already existed, so the surface is routed around rather than underspecified. Ships the two orthogonal defects the council found and an explicit re-entry bar.",
+  "artifact_contract": {
+    "required_artifacts": [
+      ".oh/tasks/rfcs-decision-route/prd.md",
+      ".oh/tasks/rfcs-decision-route/prd.json",
+      ".oh/tasks/rfcs-decision-route/council.md",
+      ".oh/tasks/rfcs-decision-route/prompt.md",
+      ".oh/tasks/rfcs-decision-route/progress.txt"
+    ],
+    "allowed_locations": [
+      ".oh/tasks/rfcs-decision-route/",
+      ".oh/docs/README.md",
+      ".oh/agents/critic.md",
+      ".claude/agents/critic.md",
+      "CHANGELOG.md"
+    ],
+    "forbidden_destructive_edits": [
+      "AGENTS.md",
+      ".oh/context/",
+      ".oh/memory/",
+      ".oh/skills/prd/SKILL.md",
+      ".oh/skills/wiki/references/schema.md",
+      ".oh/skills/retro/references/memory-protocol.md",
+      ".oh/docs/rfcs/adr-0001-standards-scope.md"
+    ],
+    "verification_commands": [
+      "git diff upstream/development...HEAD --stat -- AGENTS.md .oh/context/ .oh/memory/",
+      "grep -c 'rfc-runtime-support' .oh/docs/README.md",
+      "grep -c 'claude/rules' .oh/agents/critic.md",
+      "diff .oh/agents/critic.md .claude/agents/critic.md",
+      "bash .oh/skills/eval/run.sh"
+    ],
+    "acceptance_criteria": [
+      "Both scorecards present with C1-C7 scored 0/1/2 and a total out of 14",
+      "Residual scorecard shows C2 = 0 and the verdict reads NO-GO",
+      "Always-loaded diff is empty",
+      "Zero new executables, zero new skills, zero new CI jobs"
+    ],
+    "rollback_conditions": [
+      "Any green->red probe regression in .oh/evals/RESULTS.md beyond the two already red on development",
+      "Any change to a file in the always-loaded set",
+      "Any SKILL.md or agent description: frontmatter change"
+    ],
+    "final_handoff_requirements": [
+      "bash .oh/skills/eval/run.sh green with no new regression",
+      "CI green via /ci-status",
+      "PR marked ready only after /audit implementation PASSes"
+    ]
+  },
+  "userStories": [
+    {
+      "id": "US-001",
+      "title": "Record the council verdict and correct the issue",
+      "description": "As the operator, I want the go/no-go assessment committed alongside its evidence so the decision is auditable without rerunning the council.",
+      "acceptanceCriteria": [
+        "prd.md contains a ## Council Verdict section with both scorecards, each scoring C1-C7 as 0/1/2 with a total out of 14",
+        "The residual scorecard shows C2 = 0 and the verdict reads NO-GO",
+        "council.md contains the three wave-1 analyses, four First Mate rulings, both critics' findings in [SEVERITY] [STORY] [FINDING] | [EVIDENCE] | [RECOMMENDATION] format, and ends with STATUS: SPEC-DENIED",
+        "A ## Rejected from the source proposal section names all four elements with one repo fact each",
+        "A ## Corrections section records the two false claims this council made and caught",
+        "Issue #686 body no longer claims four months dormancy: gh issue view 686 --json body --jq .body | grep -c 'four months' returns 0",
+        "git ls-files .oh/tasks/rfcs-decision-route lists all five files"
+      ],
+      "priority": 1,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-002",
+      "title": "Fix the live RFC index rot",
+      "description": "As a maintainer, I want every file in .oh/docs/rfcs/ reachable from the index a human enters through, so a quarter of the corpus is not invisible.",
+      "acceptanceCriteria": [
+        ".oh/docs/README.md section Reference gains a link to rfcs/rfc-runtime-support.md",
+        "grep -c 'rfc-runtime-support' .oh/docs/README.md returns 1 or more (returns 0 on development)",
+        "Every file matching .oh/docs/rfcs/*.md except README.md is linked from .oh/docs/README.md; the set difference is empty",
+        "CHANGELOG ## [Unreleased] gains a ### Fixed entry referencing #686"
+      ],
+      "priority": 2,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-003",
+      "title": "Fix the dangling .claude/rules/ reference in the critic agent",
+      "description": "As an agent author, I want critic.md to reference only paths that exist, so its instructions stay internally consistent.",
+      "acceptanceCriteria": [
+        ".oh/agents/critic.md line 32 .claude/rules/ bullet is removed or repointed to a path that exists",
+        "grep -c 'claude/rules' .oh/agents/critic.md returns 0",
+        "bash .oh/scripts/link-providers.sh is run and diff .oh/agents/critic.md .claude/agents/critic.md shows the change propagated, because .claude/agents/critic.md is a materialized copy not a symlink",
+        "bash .oh/skills/eval/run.sh shows no probe transitioning green to red"
+      ],
+      "priority": 3,
+      "passes": false,
+      "notes": ""
+    }
+  ]
+}

--- a/.oh/tasks/rfcs-decision-route/prd.json
+++ b/.oh/tasks/rfcs-decision-route/prd.json
@@ -15,9 +15,10 @@
       ".oh/tasks/rfcs-decision-route/",
       ".oh/docs/README.md",
       ".oh/agents/critic.md",
-      ".claude/agents/critic.md",
+      ".oh/agents/implementer.md",
       "CHANGELOG.md"
     ],
+    "allowed_locations_amendment": "Added .oh/agents/implementer.md after discovering it carries the identical dangling .claude/rules/ bullet at :31 (same grep, same one-line fix, same zero risk); half-fixing a two-instance defect would guarantee a duplicate follow-up. Removed .claude/agents/critic.md: it is not a separate file — .claude/agents is tracked at mode 120000 as a directory symlink to ../.oh/agents, so it shares an inode with the .oh/ original.",
     "forbidden_destructive_edits": [
       "AGENTS.md",
       ".oh/context/",
@@ -30,8 +31,8 @@
     "verification_commands": [
       "git diff upstream/development...HEAD --stat -- AGENTS.md .oh/context/ .oh/memory/",
       "grep -c 'rfc-runtime-support' .oh/docs/README.md",
-      "grep -c 'claude/rules' .oh/agents/critic.md",
-      "diff .oh/agents/critic.md .claude/agents/critic.md",
+      "grep -c 'claude/rules' .oh/agents/critic.md .oh/agents/implementer.md",
+      "git ls-files -s .claude | grep '120000 .* .claude/agents$'",
       "bash .oh/skills/eval/run.sh"
     ],
     "acceptance_criteria": [
@@ -66,8 +67,8 @@
         "git ls-files .oh/tasks/rfcs-decision-route lists all five files"
       ],
       "priority": 1,
-      "passes": false,
-      "notes": ""
+      "passes": true,
+      "notes": "The issue-body AC was corrected mid-build: gh issue view 686 showed the body never carried the 'four months' stat, so no issue edit was required."
     },
     {
       "id": "US-002",
@@ -80,22 +81,23 @@
         "CHANGELOG ## [Unreleased] gains a ### Fixed entry referencing #686"
       ],
       "priority": 2,
-      "passes": false,
-      "notes": ""
+      "passes": true,
+      "notes": "rfc-runtime-support.md was the only unlinked record; the set difference over .oh/docs/rfcs/*.md minus README.md is now empty."
     },
     {
       "id": "US-003",
-      "title": "Fix the dangling .claude/rules/ reference in the critic agent",
-      "description": "As an agent author, I want critic.md to reference only paths that exist, so its instructions stay internally consistent.",
+      "title": "Fix the dangling .claude/rules/ reference in the crew agents",
+      "description": "As an agent author, I want the crew agents to reference only paths that exist, so their instructions stay internally consistent.",
       "acceptanceCriteria": [
-        ".oh/agents/critic.md line 32 .claude/rules/ bullet is removed or repointed to a path that exists",
+        ".oh/agents/critic.md line 32 .claude/rules/ bullet is removed or repointed to a path that exists (repointed to .oh/context/IDENTITY.md)",
         "grep -c 'claude/rules' .oh/agents/critic.md returns 0",
-        "bash .oh/scripts/link-providers.sh is run and diff .oh/agents/critic.md .claude/agents/critic.md shows the change propagated, because .claude/agents/critic.md is a materialized copy not a symlink",
+        "CORRECTED AC: diff .oh/agents/critic.md .claude/agents/critic.md is clean with no link-providers.sh run, because .claude/agents is tracked at mode 120000 as a directory symlink to ../.oh/agents (link-providers.sh:44) and the two paths share inode 4263547. The original AC asserted a materialized copy requiring a sync step; that was false and is recorded in prd.md Corrections #3.",
+        "SCOPE AMENDMENT: .oh/agents/implementer.md line 31 carries the identical dangling bullet and is fixed the same way; grep -c 'claude/rules' .oh/agents/implementer.md returns 0",
         "bash .oh/skills/eval/run.sh shows no probe transitioning green to red"
       ],
       "priority": 3,
-      "passes": false,
-      "notes": ""
+      "passes": true,
+      "notes": "Out of scope, reported not fixed: .oh/docs/harnesses/deepagents.md:113 references .claude/rules/sandbox-processes.md (moved to .oh/skills/t3/references/) and .oh/docs/roadmap.md:17 describes .claude/rules as auto-loading. Both are docs prose on a different surface. .oh/skills/builder/references/rule.md deliberately documents .claude/rules/<name>.md as a Claude-specific exception and is asserted by .oh/evals/probes/builder-skill-consolidation.sh:85 — it must NOT be changed."
     }
   ]
 }

--- a/.oh/tasks/rfcs-decision-route/prd.md
+++ b/.oh/tasks/rfcs-decision-route/prd.md
@@ -36,24 +36,24 @@ the decision is auditable without rerunning the council.
 
 **Acceptance Criteria:**
 
-- [ ] `.oh/tasks/rfcs-decision-route/prd.md` contains a `## Council Verdict` section with both
+- [x] `.oh/tasks/rfcs-decision-route/prd.md` contains a `## Council Verdict` section with both
       scorecards (source proposal and residual), each scoring C1–C7 as 0/1/2 with a total out of 14.
-- [ ] The residual scorecard shows `C2 = 0` and the verdict reads `NO-GO`.
-- [ ] `.oh/tasks/rfcs-decision-route/council.md` contains the three wave-1 analyses, four First Mate
+- [x] The residual scorecard shows `C2 = 0` and the verdict reads `NO-GO`.
+- [x] `.oh/tasks/rfcs-decision-route/council.md` contains the three wave-1 analyses, four First Mate
       rulings, both critics' findings in
       `[SEVERITY] [STORY] [FINDING] | [EVIDENCE] | [RECOMMENDATION]` format, and ends with
       `STATUS: SPEC-DENIED`.
-- [ ] A `## Rejected from the source proposal` section names all four elements with one repo fact each.
-- [ ] A `## Corrections` section records the two false claims this council made and caught.
-- [ ] No shipped artifact claims `.oh/docs/rfcs/` is four months dormant. Verified in both places:
+- [x] A `## Rejected from the source proposal` section names all four elements with one repo fact each.
+- [x] A `## Corrections` section records the false claims this council made and caught.
+- [x] No shipped artifact claims `.oh/docs/rfcs/` is four months dormant. Verified in both places:
       `gh issue view 686 --repo mifunedev/openharness --json body --jq .body | grep -ciE "four months|one ADR"` → `0`,
       and the same grep over `.oh/tasks/rfcs-decision-route/*.md` → `0` outside the `## Corrections`
       section that records the error. *(Checked: the issue body never carried the stat — it appeared
       only in council drafts, so no issue edit was required. The AC originally assumed otherwise and
       is corrected here rather than reported as satisfied on a false premise.)*
-- [ ] Issue #686 carries a comment stating the verdict and linking the PR, so a reader of the issue
+- [x] Issue #686 carries a comment stating the verdict and linking the PR, so a reader of the issue
       does not have to open the PR to learn the outcome.
-- [ ] `git ls-files .oh/tasks/rfcs-decision-route` lists all five files.
+- [x] `git ls-files .oh/tasks/rfcs-decision-route` lists all five files.
 
 ### US-002: Fix the live RFC index rot
 
@@ -62,26 +62,33 @@ human enters through, so a quarter of the corpus is not invisible.
 
 **Acceptance Criteria:**
 
-- [ ] `.oh/docs/README.md` § Reference gains a link to `rfcs/rfc-runtime-support.md`.
-- [ ] `grep -c "rfc-runtime-support" .oh/docs/README.md` returns `≥1` (returns `0` on `development`).
-- [ ] Every file matching `.oh/docs/rfcs/*.md` except `README.md` is linked from `.oh/docs/README.md`;
-      verify the set difference is empty.
-- [ ] CHANGELOG `## [Unreleased]` gains a `### Fixed` entry referencing #686.
+- [x] `.oh/docs/README.md` § Reference gains a link to `rfcs/rfc-runtime-support.md`.
+- [x] `grep -c "rfc-runtime-support" .oh/docs/README.md` returns `≥1` (returns `0` on `development`).
+      *Result: `1`.*
+- [x] Every file matching `.oh/docs/rfcs/*.md` except `README.md` is linked from `.oh/docs/README.md`;
+      verify the set difference is empty. *Result: empty across all four tracked records.*
+- [x] CHANGELOG `## [Unreleased]` gains a `### Fixed` entry referencing #686.
 
-### US-003: Fix the dangling `.claude/rules/` reference in the critic agent
+### US-003: Fix the dangling `.claude/rules/` reference in the crew agents
 
-**Description:** As an agent author, I want `critic.md` to reference only paths that exist, so its
-instructions stay internally consistent.
+**Description:** As an agent author, I want the crew agents to reference only paths that exist, so
+their instructions stay internally consistent.
 
 **Acceptance Criteria:**
 
-- [ ] `.oh/agents/critic.md:32`'s `.claude/rules/` bullet is removed or repointed to a path that
-      exists; `ls -d .claude/rules` currently fails.
-- [ ] `grep -c 'claude/rules' .oh/agents/critic.md` returns `0`.
-- [ ] `bash .oh/scripts/link-providers.sh` is run and `diff .oh/agents/critic.md .claude/agents/critic.md`
-      shows the change propagated — `.claude/agents/critic.md` is a **materialized copy, not a
-      symlink**, so editing the `.oh/` original alone does not reach the Claude-facing agent.
-- [ ] `bash .oh/skills/eval/run.sh` shows no probe transitioning green→red.
+- [x] `.oh/agents/critic.md:32`'s `.claude/rules/` bullet is removed or repointed to a path that
+      exists; `ls -d .claude/rules` currently fails. *Repointed to `.oh/context/IDENTITY.md`.*
+- [x] `grep -c 'claude/rules' .oh/agents/critic.md` returns `0`.
+- [x] `diff .oh/agents/critic.md .claude/agents/critic.md` is clean. **AC corrected:** the original
+      criterion asserted `.claude/agents/critic.md` is a materialized copy requiring a
+      `link-providers.sh` run. It is not. `.claude/agents` is tracked in git as a **directory
+      symlink** (mode `120000` → `../.oh/agents`, `link-providers.sh:44`), so the two paths share an
+      inode (`4263547`) and propagation is automatic. No sync step exists or is needed. See
+      `### Corrections` #3.
+- [x] **Scope amendment:** `.oh/agents/implementer.md:31` carries the identical dangling bullet,
+      found by the same grep. Fixed in the same way and `allowed_locations` amended to match, rather
+      than half-fixing a two-instance defect. Recorded, not silent.
+- [x] `bash .oh/skills/eval/run.sh` shows no probe transitioning green→red.
 
 ## 4. Functional Requirements
 
@@ -277,7 +284,7 @@ ADR-0001 pre-emptively deferred.
 
 ### Corrections
 
-This council made two errors and caught both. Recorded rather than quietly fixed.
+This council made three errors and caught all three. Recorded rather than quietly fixed.
 
 1. **A "verified" claim that was not verified.** The council asserted that
    `.oh/evals/probes/slack-admin-command-surface.sh` would break when the cleanup cron archived its
@@ -290,6 +297,14 @@ This council made two errors and caught both. Recorded rather than quietly fixed
    drafts. `.oh/docs/rfcs/README.md` was created 2026-07-02 and ADR-0001 on 2026-07-03 — about one
    month. The corrected framing (4 of 7 records post-date the formal option) is both accurate and a
    stronger argument, in the opposite direction.
+3. **A false claim about provider wiring, carried into an acceptance criterion.** US-003 AC3
+   originally required running `.oh/scripts/link-providers.sh` because `.claude/agents/*.md` are
+   "materialized copies, not symlinks." They are not copies. `git ls-files -s .claude` shows
+   `.claude/agents` at mode `120000` → `../.oh/agents`, and `.oh/agents/critic.md` and
+   `.claude/agents/critic.md` share inode `4263547`. The belief was carried in from a prior session's
+   notes and restated in `progress.txt` § Codebase Patterns without being checked against this repo.
+   Both are corrected. Same failure mode as #1 — a remembered proxy asserted in place of the
+   behaviour — which is the second instance in one task and the reason the pattern is worth naming.
 
 ### Re-entry bar
 

--- a/.oh/tasks/rfcs-decision-route/prd.md
+++ b/.oh/tasks/rfcs-decision-route/prd.md
@@ -45,8 +45,14 @@ the decision is auditable without rerunning the council.
       `STATUS: SPEC-DENIED`.
 - [ ] A `## Rejected from the source proposal` section names all four elements with one repo fact each.
 - [ ] A `## Corrections` section records the two false claims this council made and caught.
-- [ ] Issue #686's body is edited so it no longer claims `.oh/docs/rfcs/` is four months dormant;
-      verify with `gh issue view 686 --json body --jq .body | grep -c "four months"` → `0`.
+- [ ] No shipped artifact claims `.oh/docs/rfcs/` is four months dormant. Verified in both places:
+      `gh issue view 686 --repo mifunedev/openharness --json body --jq .body | grep -ciE "four months|one ADR"` → `0`,
+      and the same grep over `.oh/tasks/rfcs-decision-route/*.md` → `0` outside the `## Corrections`
+      section that records the error. *(Checked: the issue body never carried the stat — it appeared
+      only in council drafts, so no issue edit was required. The AC originally assumed otherwise and
+      is corrected here rather than reported as satisfied on a false premise.)*
+- [ ] Issue #686 carries a comment stating the verdict and linking the PR, so a reader of the issue
+      does not have to open the PR to learn the outcome.
 - [ ] `git ls-files .oh/tasks/rfcs-decision-route` lists all five files.
 
 ### US-002: Fix the live RFC index rot

--- a/.oh/tasks/rfcs-decision-route/prd.md
+++ b/.oh/tasks/rfcs-decision-route/prd.md
@@ -1,0 +1,292 @@
+# PRD: Decision-record route and index guard for `.oh/docs/rfcs/` (#686)
+
+## 1. Introduction/Overview
+
+An external conversation produced a proposal to adopt a full ADR/RFC pipeline in this repo:
+repo-root `docs/adr/NNNN-title.md` with YAML frontmatter, a machine-readable `0000-adr-index.json`,
+`> Agent Directive:` normative blockquotes, and a GitHub Action (`rfc-to-adr.yml`) calling OpenAI
+structured outputs to auto-condense merged RFCs into ADRs.
+
+The operator asked for an assessment — pros, cons, and a council **go / no-go** on whether this
+improves on the previous state — with a PRD as the deliverable regardless of verdict.
+
+**Result: NO-GO on the machinery.** The source proposal scored 2/14 with two vetoes. A minimal
+residual design scored 13/14 in synthesis, then failed adversarial review at 8/14 with a veto. This
+PRD records that assessment, ships the two real defects the council found along the way, and sets an
+explicit re-entry bar.
+
+The decisive finding was not about document format. `.oh/docs/rfcs/` already exists, and ADR-0001
+(Accepted 2026-07-03) already decided to keep it lightweight. The question was whether that surface
+is *underspecified* or simply *unused* — and the dating evidence answers **unused**.
+
+## 2. Goals
+
+- Record a scored, falsifiable go/no-go assessment that a future reader can re-run and disagree with.
+- Ship the two orthogonal defects the council discovered, independent of the machinery question.
+- Set a concrete re-entry bar so #686 is not re-litigated without new evidence.
+- Correct the public record: issue #686's body states a dormancy figure that is wrong.
+- Add **zero** always-loaded context cost.
+
+## 3. User Stories
+
+### US-001: Record the council verdict and correct the issue
+
+**Description:** As the operator, I want the go/no-go assessment committed alongside its evidence so
+the decision is auditable without rerunning the council.
+
+**Acceptance Criteria:**
+
+- [ ] `.oh/tasks/rfcs-decision-route/prd.md` contains a `## Council Verdict` section with both
+      scorecards (source proposal and residual), each scoring C1–C7 as 0/1/2 with a total out of 14.
+- [ ] The residual scorecard shows `C2 = 0` and the verdict reads `NO-GO`.
+- [ ] `.oh/tasks/rfcs-decision-route/council.md` contains the three wave-1 analyses, four First Mate
+      rulings, both critics' findings in
+      `[SEVERITY] [STORY] [FINDING] | [EVIDENCE] | [RECOMMENDATION]` format, and ends with
+      `STATUS: SPEC-DENIED`.
+- [ ] A `## Rejected from the source proposal` section names all four elements with one repo fact each.
+- [ ] A `## Corrections` section records the two false claims this council made and caught.
+- [ ] Issue #686's body is edited so it no longer claims `.oh/docs/rfcs/` is four months dormant;
+      verify with `gh issue view 686 --json body --jq .body | grep -c "four months"` → `0`.
+- [ ] `git ls-files .oh/tasks/rfcs-decision-route` lists all five files.
+
+### US-002: Fix the live RFC index rot
+
+**Description:** As a maintainer, I want every file in `.oh/docs/rfcs/` reachable from the index a
+human enters through, so a quarter of the corpus is not invisible.
+
+**Acceptance Criteria:**
+
+- [ ] `.oh/docs/README.md` § Reference gains a link to `rfcs/rfc-runtime-support.md`.
+- [ ] `grep -c "rfc-runtime-support" .oh/docs/README.md` returns `≥1` (returns `0` on `development`).
+- [ ] Every file matching `.oh/docs/rfcs/*.md` except `README.md` is linked from `.oh/docs/README.md`;
+      verify the set difference is empty.
+- [ ] CHANGELOG `## [Unreleased]` gains a `### Fixed` entry referencing #686.
+
+### US-003: Fix the dangling `.claude/rules/` reference in the critic agent
+
+**Description:** As an agent author, I want `critic.md` to reference only paths that exist, so its
+instructions stay internally consistent.
+
+**Acceptance Criteria:**
+
+- [ ] `.oh/agents/critic.md:32`'s `.claude/rules/` bullet is removed or repointed to a path that
+      exists; `ls -d .claude/rules` currently fails.
+- [ ] `grep -c 'claude/rules' .oh/agents/critic.md` returns `0`.
+- [ ] `bash .oh/scripts/link-providers.sh` is run and `diff .oh/agents/critic.md .claude/agents/critic.md`
+      shows the change propagated — `.claude/agents/critic.md` is a **materialized copy, not a
+      symlink**, so editing the `.oh/` original alone does not reach the Claude-facing agent.
+- [ ] `bash .oh/skills/eval/run.sh` shows no probe transitioning green→red.
+
+## 4. Functional Requirements
+
+- **FR-1:** The assessment must score both the source proposal and the residual design against the
+  same seven criteria, fixed before the council ran.
+- **FR-2:** Any veto-row zero (C1, C2, C3, C6) forces `NO-GO` regardless of total.
+- **FR-3:** The PRD must state which of the four operator pain points a decision-record format
+  actually solves, and which it does not.
+- **FR-4:** Every claim carrying "verified" must name the command that verified it.
+- **FR-5:** No file in the always-loaded set may be modified:
+  `git diff upstream/development...HEAD --stat -- AGENTS.md .oh/context/ .oh/memory/` must be empty.
+- **FR-6:** No `SKILL.md` or agent `description:` frontmatter may change — frontmatter is
+  always-injected across 40 skills and 6 agents.
+
+## 5. Non-Goals (Out of Scope)
+
+Explicitly **not** built, each requiring its own future issue with concrete evidence, mirroring
+ADR-0001's own deferral discipline:
+
+- Repo-root `docs/adr/`, YAML frontmatter on rfcs files, `0000-adr-index.json` or any registry.
+- `> Agent Directive:` normative syntax.
+- `rfc-to-adr.yml` or any CI-hosted LLM generation step; any second LLM vendor.
+- A `## Decision Record` block in `.oh/skills/prd/SKILL.md`.
+- Arbitration rows in `.oh/skills/wiki/references/schema.md` or
+  `.oh/skills/retro/references/memory-protocol.md`.
+- An index-freshness probe.
+- Any numbering authority independent of GitHub issue numbers, or a 4th lifecycle state.
+
+## 6. Design Considerations
+
+### The PRD / RFC / ADR system — what each is for
+
+No diagram of this system exists anywhere in the repo, and "nobody knows which document to write" is
+a real share of the scatter problem. Recorded here even under a NO-GO, because the model is correct
+independent of whether new machinery ships.
+
+| | **PRD** | **RFC** | **ADR** |
+|---|---|---|---|
+| Answers | **WHAT** to build & why it's worth doing | **HOW** to build it — options still open | **WHY THIS WAY** — and what lost |
+| Lives at | `.oh/tasks/<slug>/prd.md` | GitHub issue titled `RFC:` (+ optional `.oh/docs/rfcs/rfc-*.md`) | `.oh/docs/rfcs/adr-NNNN-*.md` |
+| Written by | `/prd`, from operator intent | a human or agent opening a proposal | the author who settled the trade-off |
+| Read by | builder agents, critics, operator | reviewers, operator | future agents and future humans |
+| Lifespan | living — overwritten on rerun, spent at merge | `Draft → Accepted` | `Accepted → Superseded`; never edited in place |
+| What it buys | scope a build can be held to | disagreement surfaces before code exists | the next task inherits the constraint |
+
+```mermaid
+flowchart LR
+    OP(["Operator intent<br/>'I want X'"]) --> PRD
+
+    PRD["<b>PRD</b> — WHAT &amp; WHY<br/>.oh/tasks/&lt;slug&gt;/prd.md<br/><i>living · spent at merge</i>"]
+    RFC["<b>RFC</b> — HOW, still open<br/>GitHub issue 'RFC:'<br/><i>Draft → Accepted</i>"]
+    ADR["<b>ADR</b> — WHY THIS WAY<br/>.oh/docs/rfcs/adr-NNNN-*.md<br/><i>Accepted → Superseded</i>"]
+
+    PRD -->|"a choice is contested,<br/>or spans surfaces / other people"| RFC
+    PRD -->|"choice settled inside one build"| ADR
+    RFC -->|"discussion closes"| ADR
+
+    ADR ==>|"<b>THE PAYOFF</b> — inherited as a<br/>constraint by the next PRD"| PRD
+    ADR --> H(["Human asks 'why is it like this?'<br/><b>one file, no archaeology</b>"])
+```
+
+**The thick edge is the whole system; everything else is cost.** This is why the verdict is NO-GO:
+the council could design the write side, but could not show the read side is ever traversed. `git
+grep 'docs/rfcs\|adr-0001'` returns references only from `.oh/docs/*` and `CHANGELOG.md` — **zero**
+from any of the 40 skills, 6 agents, 5 context files, or `AGENTS.md`.
+
+**Which document do I write?** The router below is correct and costs nothing; it is recorded for
+reference, not shipped as a convention.
+
+```mermaid
+flowchart TD
+    START(["I have something worth writing down"]) --> Q1
+    Q1{"Is it about<br/><b>what</b> to build?"}
+    Q1 -->|yes| PRD["<b>PRD</b><br/>.oh/tasks/&lt;slug&gt;/prd.md"]
+    Q1 -->|"no — it's about how or why"| Q2
+
+    Q2{"Is the choice<br/><b>settled</b>?"}
+    Q2 -->|"no — options open,<br/>needs other people"| RFC["<b>RFC</b><br/>GitHub issue 'RFC:'"]
+    Q2 -->|yes| Q3
+
+    Q3{"Does it name an<br/><b>alternative that lost</b>?"}
+    Q3 -->|yes| ADR["<b>ADR</b><br/>.oh/docs/rfcs/adr-NNNN-*.md"]
+    Q3 -->|"no — just a fact<br/>that is true now"| Q4
+
+    Q4{"Would it apply in <b>any</b> repo,<br/>not just this one?"}
+    Q4 -->|"no — this codebase"| WIKI["<b>wiki entry</b><br/>.oh/skills/wiki/corpus/"]
+    Q4 -->|"yes — always do X"| ID["<b>IDENTITY.md</b><br/>via MEMORY → graduation"]
+```
+
+The discriminating test, applied without judgment: **if the sentence would become false once the
+decision is reversed, it is a wiki fact; if it describes the option that lost, it is an ADR.**
+
+## 7. Technical Considerations
+
+- Base is `upstream/development` (mifunedev). `origin` (ryaneggz) is a stale fork.
+- `.oh/tasks/*` is gitignored except `README.md` — this folder requires `git add -f`.
+- Merging into `upstream/development` does not auto-close `Closes #686`; close manually.
+- `.claude/agents/critic.md` is a materialized copy synced by `.oh/scripts/link-providers.sh`, not a
+  symlink (US-003).
+- `.oh/manifest.json` vendors `evals/**` but not `docs/**` — any future probe over `.oh/docs/`
+  must `exit 2` downstream, which is part of why the probe was deferred rather than shipped.
+
+## 8. Success Metrics
+
+- `grep -c "rfc-runtime-support" .oh/docs/README.md` moves `0 → ≥1`.
+- `grep -c 'claude/rules' .oh/agents/critic.md` moves `1 → 0`, propagated to `.claude/agents/`.
+- Always-loaded token delta: **0** bytes across `AGENTS.md`, `.oh/context/`, `.oh/memory/`.
+- Net new executables: **0**. Net new skills: **0**. Net new CI jobs: **0**.
+- `/eval` shows no green→red transition beyond the two REGRESSIONs already on `development`
+  (`cc-safety-net-wiring`, `next-dev-prod`).
+
+## 9. Open Questions
+
+- Does an author ever *attempt* `.oh/docs/rfcs/` and hit friction? That is the re-entry bar and it is
+  currently unobserved in either direction.
+- Is `.oh/tasks/` the right permanent home for decision content given the weekly archive sweep? The
+  cited probe-break instance was refuted, but the hazard class is real for any task whose
+  `progress.txt` genuinely ends with `STATUS: COMPLETE`.
+- `## Wiki Alignment` is omitted from 7 of 8 PRDs despite being a mandatory step. Is that a
+  compliance problem worth its own issue, independent of #686?
+
+---
+
+## Council Verdict
+
+Seven criteria, fixed before the council ran. Veto rows: **C1, C2, C3, C6** — any zero forces NO-GO.
+Thresholds: `GO ≥ 11` · `PARTIAL-GO 7–10` · `NO-GO ≤ 6 or any veto zero`.
+
+### Source proposal, as written
+
+| # | Criterion | Score | Basis |
+|---|---|:--:|---|
+| C1 | Always-loaded delta | 2 | Adds no always-loaded content — but only because nothing reads it. |
+| C2 | Moves a named instrument | **0** | A CI Action moves no probe and no capability benchmark. **VETO** |
+| C3 | Arbitration rows | **0** | None proposed; a 7th surface with no boundary rule. **VETO** |
+| C4 | Evidence vs ADR-0001 | 0 | Cites no repo artifact. |
+| C5 | Net machinery | 0 | New CI job, new vendor, new repo secret. |
+| C6 | Pain-point honesty | 0 | Implicitly claims the format solves all four. |
+| C7 | Reversibility | 0 | Converts 4 tracked docs to YAML; creates a competing root directory. |
+
+**2 / 14 — two veto zeros — NO-GO.**
+
+### Residual design, after adversarial review
+
+| # | Criterion | Synthesis | Post-critique | Why it moved |
+|---|---|:--:|:--:|---|
+| C1 | Always-loaded delta | 2 | **2** | Holds — token delta genuinely 0. |
+| C2 | Moves a named instrument | 1 | **0** | Circular: guards index freshness on a surface with no write traffic, and cannot detect the dominant failure (never written). **VETO** |
+| C3 | Arbitration rows | 2 | **1** | Well-drafted but outside `/audit context` Dimension D's scanned set — unenforced prose. |
+| C4 | Evidence vs ADR-0001 | 2 | **1** | Inverted by dating (below). One cited instance refuted. |
+| C5 | Net machinery | 2 | **1** | One executable, but 6+ scattered edit points for one norm, plus an edit to the protected harness-wide `prd` skill. |
+| C6 | Pain-point honesty | 2 | **1** | Analysis was honest, but shipped one false "verified" claim and one wrong stat. |
+| C7 | Reversibility | 2 | **2** | Holds — purely additive. |
+
+**8 / 14 — one veto zero (C2) — NO-GO.**
+
+### The decisive finding
+
+The question was never "what should an ADR look like." It was **is this surface underspecified or
+unused** — and the dates answer it:
+
+| Artifact | Created | vs. ADR-0001 (2026-07-03) |
+|---|---|---|
+| `.oh/tasks/cc-safety-net/decision.md` | 2026-07-19 | +16 days |
+| `.oh/tasks/first-mate-charter/plan.md` | 2026-07-21 | +18 days |
+| `.oh/docs/open-core.md` § Why not the alternatives | 2026-07-24 | +21 days |
+| `.oh/tasks/slack-admin-command-surface/critique.md` | 2026-07-31 | +28 days |
+
+Four of the seven hand-rolled decision records were authored **after** the formal destination already
+existed. Their authors had the option and chose the ad hoc, local, zero-ceremony file anyway. That is
+evidence of a surface being **routed around**, not one that is missing schema. Adding a contract, two
+arbitration rows, and a probe to a surface authors avoid is
+machinery-growth-without-capability-movement — `/audit eval-quality` Check 7, and precisely what
+ADR-0001 pre-emptively deferred.
+
+### Honest pain-point mapping
+
+| Pain point | Solved by a decision-record format? | What would actually solve it |
+|---|---|---|
+| (a) agents re-litigate settled choices | **Partially at best** — a record nothing loads has no normative force; `git grep` finds zero references to `.oh/docs/rfcs/` from any skill, agent, or context file | A read path, which this design could specify but not demonstrate is traversed |
+| (b) humans can't reconstruct *why* | **Yes, narrowly** — one question, one time | An indexed record. Measured: for "what does the manifest buy," delta is **0** (already 2 files). For "why isn't documenting enough," `grep` returns 3 mechanics files and **0** containing the rejection reasoning |
+| (c) rationale scattered across 6 surfaces | **No — makes it worse** unless arbitration is enforced, and the proposed rows are unenforced prose | Enforced boundaries, which `/audit context` cannot currently provide for these paths |
+| (d) in-build decisions evaporate | **No — they don't evaporate.** `git ls-files .oh/tasks` shows 35 tracked files; the decision docs are all tracked | An indexing step, not a new record type |
+
+### Rejected from the source proposal
+
+| Element | Repo fact that kills it |
+|---|---|
+| YAML frontmatter | Zero YAML delimiters exist in the rfcs corpus and nothing parses them; the wiki earns frontmatter only because `.oh/evals/probes/wiki-readme-index.sh:40` actually invokes the extraction. Converting 4 tracked files is churn for zero consumers. |
+| `0000-adr-index.json` | No JSON-for-*knowledge* precedent exists under `.oh/docs/`; `prd.json` is JSON-for-*work*. A second index beside the existing markdown tables is two sources of truth with no writer/reader pair to sync them. |
+| `> Agent Directive:` | Repo-wide grep returns zero hits. `.oh/manifest.json` excludes `docs/**`, nothing loads `.oh/docs/rfcs/` at session start, so the marker has no runtime carrier. `.oh/context/IDENTITY.md` is the existing carrier of "always do X". |
+| `rfc-to-adr.yml` + OpenAI | Violates the harness-native constraint: new CI job, new vendor, new repo secret, and generation drift with no probe able to detect a wrong-but-plausible generated ADR. |
+
+### Corrections
+
+This council made two errors and caught both. Recorded rather than quietly fixed.
+
+1. **A "verified" claim that was not verified.** The council asserted that
+   `.oh/evals/probes/slack-admin-command-surface.sh` would break when the cleanup cron archived its
+   task folder. It confirmed the probe hard-codes the path (`:12`) and that the cron archives — then
+   asserted the break without checking whether the predicate fires. `.oh/crons/cleanup-tasks.md:76-77`
+   requires `progress.txt` to *end with* a line matching exactly `STATUS: COMPLETE`; in that file the
+   line is 19 of 40. **The instance is refuted.** Checking a proxy rather than the behaviour is
+   `.oh/context/IDENTITY.md:8` — committed inside a document citing it.
+2. **A wrong dormancy statistic.** "One ADR in four months" appears in issue #686 and early council
+   drafts. `.oh/docs/rfcs/README.md` was created 2026-07-02 and ADR-0001 on 2026-07-03 — about one
+   month. The corrected framing (4 of 7 records post-date the formal option) is both accurate and a
+   stronger argument, in the opposite direction.
+
+### Re-entry bar
+
+Per ADR-0001's own discipline, a future issue reopening this should show an author or agent
+**attempting** `.oh/docs/rfcs/` and hitting concrete friction — not merely bypassing it. Absent that,
+the lightweight convention stands as ADR-0001 decided.

--- a/.oh/tasks/rfcs-decision-route/progress.txt
+++ b/.oh/tasks/rfcs-decision-route/progress.txt
@@ -1,0 +1,58 @@
+# Progress — rfcs-decision-route
+
+## Codebase Patterns
+
+- `.oh/tasks/*` is gitignored except `README.md` (`.gitignore:12-13`) — this folder needs `git add -f`.
+- Base and push to `upstream` (mifunedev); `origin` (ryaneggz) is a stale fork. Merging into
+  `upstream/development` does not auto-close `Closes #N` — close manually.
+- `.claude/agents/*.md` are materialized copies synced by `.oh/scripts/link-providers.sh`, NOT
+  symlinks. Editing `.oh/agents/*.md` alone does not reach the provider-facing agent.
+- `.oh/manifest.json` vendors `evals/**` but not `docs/**`, so any probe over `.oh/docs/` must
+  `exit 2` in a downstream `oh init` checkout.
+- `.oh/crons/cleanup-tasks.md:76-77` archives a task only when `progress.txt` **ends with** a line
+  matching exactly `STATUS: COMPLETE`. A `STATUS: COMPLETE` line followed by addenda does not fire.
+
+## US-001 — 2026-08-02
+
+**Title:** Record the council verdict and correct the issue
+**Files changed:** `.oh/tasks/rfcs-decision-route/{prd.md,prd.json,council.md,prompt.md,progress.txt}`
+**Result:** council complete, verdict NO-GO, artifacts committed to draft PR
+
+### What I did
+
+Ran the First Mate council per `.oh/prompts/advisor/plan.yml`: `architect`, `pm`, `designer` in
+parallel with a shared brief preamble, then synthesis with four rulings, then two adversarial critics,
+then the approve gate.
+
+- Wave 1 produced three analyses. All three independently rejected all four source-proposal
+  mechanisms. The designer measured the cold-start path and split it into two sub-questions with very
+  different deltas (0 and 7→3), refusing to inflate the weaker one.
+- Wave 2 synthesis scored the residual 13/14 (GO) and the source proposal 2/14 (NO-GO).
+- Wave 3 critics returned **HALT** (implementer lens) and **REVISE-PRD** (maintainer lens).
+- Wave 4 rescored the residual to **8/14 with a C2 veto → NO-GO**.
+
+Every critic factual challenge was verified by the orchestrator rather than accepted on report, and
+**all of them were upheld** — including two against claims this council had itself asserted.
+
+### Learnings for future iterations
+
+- The decisive question was framing, not design. "Is this surface underspecified or unused" was
+  answerable in one command (`git log --diff-filter=A` on the ad hoc records vs. the destination),
+  and it inverted a verdict three constructive agents had converged on. Date the evidence before
+  scoring it.
+- Constructive agents cannot produce a NO-GO. `architect`, `pm`, and `designer` were each asked "what
+  should this be," so all three produced a design. Only the critics could conclude "nothing."
+- The council asserted a probe-break as "verified" after confirming the probe hard-codes a path and
+  that the cron archives — without checking whether the cron's predicate fires on that file. It does
+  not. That is `.oh/context/IDENTITY.md:8` (asserting a proxy rather than the behaviour) committed
+  inside a document that cites it.
+- `## Wiki Alignment` — the isomorphic precedent for the proposed `## Decision Record` block — is
+  present in 1 of 8 `prd.md` files despite being a mandatory pipeline step. Before adding a PRD
+  field, measure the compliance rate of the field you are copying.
+
+## Status
+
+US-001 complete. US-002 (RFC index rot) and US-003 (dangling `.claude/rules/` reference) are the
+carve-out defects and remain open on this branch.
+
+Not complete — two stories remain.

--- a/.oh/tasks/rfcs-decision-route/progress.txt
+++ b/.oh/tasks/rfcs-decision-route/progress.txt
@@ -5,12 +5,20 @@
 - `.oh/tasks/*` is gitignored except `README.md` (`.gitignore:12-13`) — this folder needs `git add -f`.
 - Base and push to `upstream` (mifunedev); `origin` (ryaneggz) is a stale fork. Merging into
   `upstream/development` does not auto-close `Closes #N` — close manually.
-- `.claude/agents/*.md` are materialized copies synced by `.oh/scripts/link-providers.sh`, NOT
-  symlinks. Editing `.oh/agents/*.md` alone does not reach the provider-facing agent.
+- **CORRECTED:** `.claude/agents` is tracked in git as a **directory symlink** (mode `120000` →
+  `../.oh/agents`, created by `.oh/scripts/link-providers.sh:44`). Editing `.oh/agents/<name>.md`
+  reaches the Claude-facing agent immediately — same inode, no sync step. An earlier revision of this
+  file asserted the opposite ("materialized copies synced by `link-providers.sh`"); that was carried
+  in from prior-session notes and was never true of this repo. Verify with
+  `git ls-files -s .claude | grep '^120000'`.
 - `.oh/manifest.json` vendors `evals/**` but not `docs/**`, so any probe over `.oh/docs/` must
   `exit 2` in a downstream `oh init` checkout.
 - `.oh/crons/cleanup-tasks.md:76-77` archives a task only when `progress.txt` **ends with** a line
   matching exactly `STATUS: COMPLETE`. A `STATUS: COMPLETE` line followed by addenda does not fire.
+- `.claude/rules/` does not exist and is not generated — the B-state M4 collapse moved it to
+  `.oh/context/rules/`. But `.oh/skills/builder/references/rule.md` documents `.claude/rules/<name>.md`
+  as a deliberate Claude-specific exception, and `.oh/evals/probes/builder-skill-consolidation.sh:85`
+  asserts that literal string. Do not "fix" rule.md.
 
 ## US-001 — 2026-08-02
 
@@ -50,9 +58,63 @@ Every critic factual challenge was verified by the orchestrator rather than acce
   present in 1 of 8 `prd.md` files despite being a mandatory pipeline step. Before adding a PRD
   field, measure the compliance rate of the field you are copying.
 
+## US-002 — 2026-08-02
+
+**Title:** Fix the live RFC index rot
+**Files changed:** `.oh/docs/README.md`, `CHANGELOG.md`
+**Result:** all four tracked records reachable from the index; set difference empty
+
+### What I did
+
+Added `rfcs/rfc-runtime-support.md` to `.oh/docs/README.md` § Reference, positioned to keep the
+existing index-then-ADR-then-RFC-alphabetical order. Verified the general property rather than the
+single instance: iterated `.oh/docs/rfcs/*.md` minus `README.md` and asserted each is linked —
+the set difference is empty. CHANGELOG `### Fixed` entry under `## [Unreleased]` references #686.
+
+### Learnings for future iterations
+
+- The single-instance AC (`grep -c rfc-runtime-support`) and the property AC (set difference empty)
+  are not the same check. The first passes forever after one edit; only the second would have caught
+  the *next* unlinked record. Write the property check even when fixing one instance.
+
+## US-003 — 2026-08-02
+
+**Title:** Fix the dangling `.claude/rules/` reference in the crew agents
+**Files changed:** `.oh/agents/critic.md`, `.oh/agents/implementer.md`
+**Result:** both dangling bullets repointed at `.oh/context/IDENTITY.md`; grep returns 0 in both
+
+### What I did
+
+Before editing, verified `.claude/rules/` is genuinely absent rather than generated: absent in the
+worktree *and* the main checkout, zero tracked paths beneath it, and no mention in
+`link-providers.sh`. Repointed both bullets to `.oh/context/IDENTITY.md`, which is the surviving
+"standards an agent might violate" surface after the B-state M4 collapse.
+
+Two deviations from the written plan, both recorded rather than silent:
+
+1. **Scope amendment.** The same grep that found `critic.md:32` found the identical bullet at
+   `implementer.md:31`. Fixed both and amended `allowed_locations`; half-fixing a two-instance defect
+   guarantees a duplicate follow-up.
+2. **AC correction.** US-003's third AC required running `link-providers.sh` because
+   `.claude/agents/*.md` are "materialized copies, not symlinks." They are not. See § Codebase
+   Patterns. The AC and `progress.txt` were both wrong and are both corrected.
+
+Left deliberately unfixed and reported instead: `.oh/docs/harnesses/deepagents.md:113` and
+`.oh/docs/roadmap.md:17` also reference `.claude/rules`. Docs prose on a different surface — widening
+into them is genuine scope creep, unlike a sibling agent file with a byte-identical defect.
+
+### Learnings for future iterations
+
+- Two of this task's three recorded errors are the same failure: a remembered proxy asserted in place
+  of the behaviour. Both were memory-sourced beliefs about *this* repo that were stale. A memory note
+  naming a file, mode, or mechanism is a hypothesis to re-check, not a fact to cite.
+- "Is this path dangling?" is not answered by `ls`. It is answered by `ls` **plus** "is anything
+  generating it" — here, grepping `link-providers.sh` and `git ls-files`. The same check that
+  confirmed the defect also disproved the sync-step AC.
+
 ## Status
 
-US-001 complete. US-002 (RFC index rot) and US-003 (dangling `.claude/rules/` reference) are the
-carve-out defects and remain open on this branch.
+US-001, US-002, and US-003 are complete and verified. The council's NO-GO on the ADR/RFC machinery
+stands; only the two orthogonal defects it surfaced were built.
 
-Not complete — two stories remain.
+STATUS: COMPLETE

--- a/.oh/tasks/rfcs-decision-route/prompt.md
+++ b/.oh/tasks/rfcs-decision-route/prompt.md
@@ -1,0 +1,115 @@
+# Ralph iteration — rfcs-decision-route
+
+You are one iteration of a Ralph loop implementing the `rfcs-decision-route` task. The full plan is in `.oh/tasks/rfcs-decision-route/prd.md` and the structured task list is in `.oh/tasks/rfcs-decision-route/prd.json`. The loop calls you again until `progress.txt` contains a line `STATUS: COMPLETE`.
+
+## Execution model
+
+**This ralph loop is the executor — you do the work yourself.** `/delegate` is **available** as an
+optional tool to fan out a single story's disjoint files in parallel when that clearly helps, but it
+is **optional and never replaces the loop**: do not turn the iteration into a pure `/delegate`
+dispatcher (an Advisor running several independent tasks runs one ralph loop per task in parallel and
+each loop may, but need not, use `/delegate` inside). Default to implementing directly; reach for
+`/delegate` only for genuinely parallelizable, disjoint-file work within your one story.
+
+## Your job in one iteration
+
+Pick **one** user story, implement it, commit, mark it `passes: true`, and append a progress entry. Then exit. The next iteration handles the next story. Do not attempt multiple stories per iteration.
+
+## Steps every iteration
+
+1. **Read context** — in this order:
+   - `.oh/tasks/rfcs-decision-route/prd.json` — find the lowest-`priority` story where `passes: false`. That is your story for this iteration.
+   - `.oh/tasks/rfcs-decision-route/progress.txt` — read the "Codebase Patterns" section at the top (if any) and the most recent few iterations to see what's been done.
+   - `.oh/tasks/rfcs-decision-route/critique.md` — if present, the critic findings the stories must satisfy.
+   - If `.oh/tasks/rfcs-decision-route/prd.md` contains `## Wiki Alignment`, read it before choosing the story. When `Impact: REQUIRED`, the relevant story must keep wiki updates aligned with the PRD and the recorded DeepWiki comparison.
+   - `.oh/skills/wiki/references/schema.md` when your story touches `.oh/skills/wiki/corpus/` or the PRD's Wiki Alignment section says `Impact: REQUIRED`.
+   - `.claude/skills/git/SKILL.md` for branch + commit conventions.
+   - `.oh/skills/t3/references/sandbox-processes.md` for tmux session conventions if your story spawns processes.
+   - `.oh/agents/advisor.md` for any critic-gated story.
+
+2. **Verify branch** — your branch is `task/686-rfcs-decision-route` (per `prd.json` `branchName`). If `/ship-spec`'s Advisor launched you in an isolated worktree at `.oh/worktrees/task/686-rfcs-decision-route`, that directory already has the branch checked out — `cd` into it and skip the checkout below. Otherwise, if you are not on the branch:
+   ```bash
+   : "${SHIP_SPEC_REMOTE:?SHIP_SPEC_REMOTE must name the git remote that matches SHIP_SPEC_REPO}"
+   git fetch "$SHIP_SPEC_REMOTE" "${SHIP_SPEC_BASE:-development}"
+   git checkout -b task/686-rfcs-decision-route "$SHIP_SPEC_REMOTE/${SHIP_SPEC_BASE:-development}" 2>/dev/null \
+     || git checkout task/686-rfcs-decision-route
+   ```
+   Never push to `development` or `main` directly.
+
+3. **Implement the chosen story** — make the file changes, additions, deletions specified in the story's `acceptanceCriteria`. Confine the work to that story; resist scope creep.
+
+4. **Run quality checks** before commit:
+   ```bash
+   pnpm run type-check 2>/dev/null || true
+   pnpm run lint 2>/dev/null || true
+   pnpm run test 2>/dev/null || true
+   ```
+   If checks fail, fix them. Do not commit broken code.
+
+5. **Commit** with this message format (per `.claude/skills/git/SKILL.md`):
+   ```
+   <type>: US-<NNN> — <story title>
+
+   Submitted-by: <active submitter>
+   ```
+   Where `<type>` is `task` for most stories, `feat` for net-new functionality, `fix` for bugs. Example: `task: US-001 — <story title>`. Stage only files touched by this story.
+   The `Submitted-by:` trailer is mandatory. It must name the model/agent that actually submits the commit, using the active harness identity when available (`$RALPH_HARNESS`, e.g. `Claude`, `Codex`, or `Pi`). If Ralph fell back from Claude to Codex, use `Submitted-by: Codex`.
+
+6. **Update `prd.json`** — set `passes: true` for the completed story, and set `notes` to a one-line summary including iteration number and date:
+   ```json
+   "notes": "Completed iteration 3 on <YYYY-MM-DD>; commit abc1234"
+   ```
+
+7. **Append to `progress.txt`** — append (never replace) using this format:
+   ```markdown
+   ## US-<NNN> — <YYYY-MM-DD HH:MM UTC>
+
+   **Title**: <story title>
+   **Files changed**: <list>
+   **Commit**: <short SHA>
+   **Result**: PASS | BLOCKED | DEFERRED
+
+   ### What I did
+   <2-4 sentences>
+
+   ### Learnings for future iterations
+   <patterns, gotchas, useful context>
+
+   ---
+   ```
+
+8. **Codebase Patterns** — if you discovered a pattern other iterations should know (a non-obvious convention, a shared utility, a gotcha), append it to (or create) the `## Codebase Patterns` section at the **top** of `progress.txt`. Keep entries general and reusable, not story-specific.
+
+9. **Stop condition** — after step 7, check whether all stories in `prd.json` now have `passes: true`. If yes, append a final line on its own to `progress.txt`:
+   ```
+   STATUS: COMPLETE
+   ```
+   This terminates the Ralph loop. The runner reads for this exact whole-line string in **two** places — `progress.txt` (at the start of each iteration) and your iteration output (after each iteration) — so either channel ends the loop.
+
+10. **Signal completion in your output only when terminal** — when (and only when) you have just appended `STATUS: COMPLETE` to `progress.txt`, also print `STATUS: COMPLETE` as the sole content of your final line. This lets the runner exit even if the file write was missed. Never print that bare standalone line for any other reason; to refer to it in prose, call it "the completion marker."
+
+## Blocked or deferred stories
+
+If the chosen story cannot be completed this iteration:
+
+- **Blocked** (external dependency, missing context, ambiguity): append to `progress.txt` with `**Result**: BLOCKED` and an explanation. Do NOT mark `passes: true`. The next iteration will skip this story (find the next lowest-priority `passes: false` that isn't already BLOCKED in recent progress entries) or escalate.
+- **Deferred** (out of scope per the PRD's Non-Goals): append with `**Result**: DEFERRED`. Do NOT mark `passes: true`. The story stays for human review.
+
+## Critical rules
+
+- **One story per iteration.** Resist doing two.
+- **Never push** to `development` or `main`. Branch is `task/686-rfcs-decision-route`.
+- **Never skip pre-commit hooks** (`--no-verify`).
+- **Never run `git clone` or `git init`** — you're already in a checkout.
+- **Confine writes** to repo-tracked paths. Do not write outside the repo or to `~/`.
+- **Phase ordering matters.** Stories are priority-ordered by dependency — implement them in `priority` order. If a story depends on an artifact a later story creates, it is mis-ordered; surface it rather than implementing out of order.
+- **CHANGELOG discipline.** Per `.claude/skills/git/SKILL.md`, every story with user-visible impact must add an entry under `## [Unreleased]` in the same commit. The PRD's individual stories spell out which `### Added`, `### Removed`, `### Changed` section to use.
+- **Wiki alignment discipline.** If the PRD says `Wiki Alignment` is `REQUIRED`, update the named wiki entries in the same implementation branch so they match the final spec behavior, preserve the DeepWiki comparison, and pass `bash .oh/evals/probes/wiki-readme-index.sh`.
+- **Don't modify completed stories** unless the current story explicitly requires it.
+
+## Reference
+
+- PRD: `.oh/tasks/rfcs-decision-route/prd.md`
+- Structured stories: `.oh/tasks/rfcs-decision-route/prd.json`
+- Branch: `task/686-rfcs-decision-route`
+- Issue: #<issue>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Update policy and release automation live in [`/git`](.claude/skills/git/SKILL.m
 - Expose the supported GPT-5.6 variants in Pi's model selector ([#684](https://github.com/mifunedev/openharness/issues/684)).
 - Expand Advisor planning with a designer lens and make implementation/PR prompts explicitly finish with delegated audits and retrospectives ([#680](https://github.com/mifunedev/openharness/issues/680)).
 ### Fixed
+- Index `.oh/docs/rfcs/rfc-runtime-support.md` from `.oh/docs/README.md`, which had left a quarter of the RFC/ADR corpus unreachable from the index humans enter through, and repoint the dangling `.claude/rules/` context bullet in the `critic` and `implementer` agents at `.oh/context/IDENTITY.md` — that directory was removed by the B-state M4 rules collapse ([#686](https://github.com/mifunedev/openharness/issues/686)).
 - Make Slack bridge admin commands discoverable and functional by declaring `/help`, `/trusted`, `/channels`, `/enable`, `/disable`, `/revoke`, and `/toggletools` in `.pi/install/slack-manifest.json`, pinning bridge-side Socket Mode command handlers, and separating Slack commands from Pi's `/msg-bridge` surface in docs ([#354](https://github.com/ryaneggz/openharness/issues/354)).
 ### Removed
 ### Deprecated


### PR DESCRIPTION
Closes #686

## Verdict: NO-GO on the machinery

A First Mate council (`.oh/prompts/advisor/plan.yml`) assessed an externally-proposed ADR/RFC pipeline for this repo. No machinery ships. What does ship is the assessment plus the two orthogonal defects the council found on the way.

| | Score | Vetoes | Verdict |
|---|:--:|---|---|
| Source proposal as written | 2 / 14 | C2, C3 | NO-GO |
| Minimal residual — synthesis | 13 / 14 | none | GO |
| Minimal residual — **after adversarial review** | **8 / 14** | **C2** | **NO-GO** |

## The decisive finding

The question was never "what should an ADR look like." It was **is `.oh/docs/rfcs/` underspecified or simply unused** — and the dates answer it:

| Ad hoc decision record | Created | vs ADR-0001 (2026-07-03) |
|---|---|---|
| `.oh/tasks/cc-safety-net/decision.md` | 2026-07-19 | +16 days |
| `.oh/tasks/first-mate-charter/plan.md` | 2026-07-21 | +18 days |
| `.oh/docs/open-core.md` § Why not the alternatives | 2026-07-24 | +21 days |
| `.oh/tasks/slack-admin-command-surface/critique.md` | 2026-07-31 | +28 days |

Four of seven hand-rolled decision records were authored **after** the formal destination already existed. Their authors had the option and chose the local, zero-ceremony file anyway. That is a surface being **routed around**, not one missing schema. Adding a contract, arbitration rows, and a probe to it is machinery-growth-without-capability-movement — `/audit eval-quality` Check 7, and exactly what [ADR-0001](https://github.com/mifunedev/openharness/blob/development/.oh/docs/rfcs/adr-0001-standards-scope.md) pre-emptively deferred.

## Rejected from the source proposal

| Element | Repo fact that kills it |
|---|---|
| YAML frontmatter | Zero YAML delimiters exist in the rfcs corpus and nothing parses them. The wiki earns frontmatter only because `wiki-readme-index.sh:40` actually invokes the extraction. |
| `0000-adr-index.json` | No JSON-for-*knowledge* precedent under `.oh/docs/`; `prd.json` is JSON-for-*work*. A second index is two sources of truth with no sync pair. |
| `> Agent Directive:` | Repo-wide grep: zero hits. `.oh/manifest.json` excludes `docs/**` and nothing loads `.oh/docs/rfcs/` at session start, so the marker has no runtime carrier. |
| `rfc-to-adr.yml` + OpenAI | New CI job, new vendor, new secret, and generation drift no probe can detect. |

## What this PR actually contains

The assessment artifacts plus two one-line defect fixes. **Zero new executables, skills, or CI jobs.**

- **US-001** ✅ — the scored verdict, both scorecards, the honest pain-point mapping, and two mermaid diagrams of the PRD/RFC/ADR usage model. `.oh/tasks/rfcs-decision-route/` (5 files, force-added past `.gitignore:12-13`).
- **US-002** ✅ — live index rot fixed: `.oh/docs/README.md` linked 3 of 4 `rfcs/*.md` files; `rfc-runtime-support.md` was never indexed. Verified as a *property* — the set difference over `.oh/docs/rfcs/*.md` minus `README.md` is now empty — not just the one instance.
- **US-003** ✅ — dangling `.claude/rules/` references repointed at `.oh/context/IDENTITY.md`. That directory was removed by the B-state M4 rules collapse. Confirmed genuinely dangling (absent in worktree *and* main checkout, zero tracked paths beneath it, no mention in `link-providers.sh`) before editing.

### Two deviations from the plan, both recorded rather than applied silently

- **Scope amendment.** The grep that found `.oh/agents/critic.md:32` also found the identical bullet at `.oh/agents/implementer.md:31`. Both are fixed and `allowed_locations` is amended to match — half-fixing a two-instance defect guarantees a duplicate follow-up.
- **Left unfixed and reported instead.** `.oh/docs/harnesses/deepagents.md:113` and `.oh/docs/roadmap.md:17` also reference `.claude/rules` — docs prose on a different surface. And `.oh/skills/builder/references/rule.md` documents `.claude/rules/<name>.md` as a deliberate Claude-specific exception that `.oh/evals/probes/builder-skill-consolidation.sh:85` asserts; it must **not** be "fixed."

## Three corrections the council made against itself

Recorded in the PRD rather than quietly fixed.

1. **A "verified" claim that was not verified.** The council asserted a probe would break when the cleanup cron archived its task folder — after confirming the probe hard-codes the path and that the cron archives, but *without* checking whether the predicate fires. `.oh/crons/cleanup-tasks.md:76-77` requires `progress.txt` to **end with** `STATUS: COMPLETE`; in that file it is line 19 of 40. Instance refuted. Asserting a proxy instead of the behaviour is `IDENTITY.md:8`, committed inside a document citing it.
2. **A wrong statistic.** Early drafts said `.oh/docs/rfcs/` was four months dormant. It was created 2026-07-02 — about one month. The corrected framing is both accurate and a stronger argument in the opposite direction.
3. **A false claim about provider wiring, carried into an acceptance criterion.** US-003 originally required a `link-providers.sh` run because `.claude/agents/*.md` are "materialized copies, not symlinks." They are not. `git ls-files -s .claude` shows `.claude/agents` at mode `120000` → `../.oh/agents` (`link-providers.sh:44`), and `.oh/agents/critic.md` / `.claude/agents/critic.md` share inode `4263547`. Propagation is automatic; no sync step exists. Same failure mode as #1, which is why the pattern is named in `progress.txt`.

## Guards

- Always-loaded delta: **0** — `git diff --stat -- AGENTS.md .oh/context/ .oh/memory/` empty.
- Net new executables **0**, skills **0**, CI jobs **0**.
- No `SKILL.md` or agent `description:` frontmatter touched.
- `bash .oh/skills/eval/run.sh` — 89 PASS / 3 SKIPPED / 1 REGRESSION (`next-dev-prod`, pre-existing on `development`), no `new-fail`.

## Re-entry bar

Per ADR-0001's own discipline, reopening this needs an author or agent **attempting** `.oh/docs/rfcs/` and hitting concrete friction — not merely bypassing it. If it is revisited, invert the build order: build the *read* side first, since the measurement that killed the proposal was that `git grep` finds zero references to `.oh/docs/rfcs/` from any skill, agent, or context file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
