### PR TITLE
task: track the timezone follow-up review artifacts

### DIFF
--- a/.oh/tasks/timezone-followups/council.md
+++ b/.oh/tasks/timezone-followups/council.md
@@ -1,0 +1,285 @@
+# Council verdicts — which follow-ups are worth proceeding with
+
+Grounding: `grounding.md` (the sole source of truth all three members were pointed at).
+Members: **architect** (solution shape), **pm** (sequencing/scope), **designer** (user harm).
+
+Item key:
+1 console never deployed · 2a website CTA 4.02:1 AA failure · 2b cloud ThemeControl 1.04/1.23:1 ·
+2c docs link 4.53:1 · 3a website OS-dark · 3b cloud OS-dark (doc-blocked) · 4 artifact placement ·
+5 sub-frame flash · 6 next-pwa (refuted) · 7 cloud dead code
+
+---
+
+## PM verdict (received)
+
+| # | Verdict | Reason |
+|---|---|---|
+| 1 | **PROCEED NOW** | Feature is dark in production on the console; blocks browser verification of 2b/3b/7 |
+| 2a | **PROCEED NOW** | Genuine AA failure, live, one line, unrelated to the merge |
+| 2b | **PROCEED NOW** | Real 1.4.11 failure on 100% of first-touch traffic; small isolated fix |
+| 2c | **DROP** | Passes AA; underline satisfies 1.4.1. Not a defect |
+| 3a | **PROCEED NOW** | Real regression for the photophobia/migraine cohort; one ternary; no test to break |
+| 3b | **PROCEED LATER** | Blocked on a design-authority doc amendment — a decision, not an engineering task |
+| 4 | **PROCEED LATER** | Real process gap, zero user impact |
+| 5 | **DROP** | Closed structurally; frame capture is optional and expensive — don't fund it |
+| 6 | **DROP** | Refuted; remove from the list entirely |
+| 7 | **PROCEED LATER** | Real drift risk (`THEMES`), zero user impact |
+
+**If only one:** #1 — cheapest item on the list (XS, no code), and half the remaining work (the whole
+cloud track) is unverifiable without it.
+
+**Sequencing.** Wave 0: #1 (blocking gate for the cloud track only). Wave 1 (parallel, independent):
+#2a, #3a — both `website`, both shippable immediately. Wave 2 (cloud, after #1): #2b first (fastest,
+zero deps), then #7, then #3b *only* once `console-mvp.md` §3 is amended. Wave 3: #4, no urgency.
+
+**Batching ruling — three PRs, not one, in `openharness-cloud`.** 2b is a visual a11y fix, 3b is a
+behaviour change gated on a doc amendment, 7 is a deletion. Mixing them forces a reviewer to weigh
+three unrelated risk profiles in one diff, and 3b's doc dependency would stall 2b and 7.
+
+**Scope boundaries PM insisted on:**
+- **2a**: fix *only* the one usage at `CTASection.tsx:114`. Do **not** touch the shared
+  `text-oh-accent` / `#15803d` token — ~40 usages, and grounding confirms the same pair passes at
+  4.53:1 elsewhere. A token-wide change would re-break something currently fine.
+- **2b**: cover **both** modes — dark also fails at 1.23:1; don't ship a light-only fix. Leave
+  `user-menu.tsx` and `aria-pressed` alone (4.1.2 already passes).
+- **3a**: seeding behaviour must not change; don't touch the explicit-choice branch.
+- **7**: decide the template-string question *in the PR description* before deleting; leave the
+  hydration-race guard alone.
+- **4**: do **not** retroactively move the already-merged artifacts — churn with no value.
+- **#1 OUT**: don't build a deploy-verification CI job as part of it; that's separate hardening.
+
+**Sizes:** 1 = XS (a check, not code) · 2a = S · 2b = S · 3a = S · 3b = M (doc gate + `matchMedia`
+test-harness stubbing) · 4 = XS · 7 = S. **Tickets:** only 3b needs one, because a doc-approval
+dependency can stall silently. The rest are small enough to just do in a PR.
+
+**PM's over-confidence flags on the grounding doc:**
+- G-6 leads with a ready-made function signature for the cloud fix, which undersells that the real
+  blocker is the **doc amendment**. Sequence doc-gate first, code second.
+- G-7's "trivially green" framing for the hydration-race guard risks waving through the
+  string-only-copy decision, which the same section admits is a real regression surface.
+- G-9 calling `git add -f` / wiki promotion "established, working" is true but is a workaround for a
+  process bug — not a reason to deprioritise fixing the placement mistake.
+
+---
+
+## Architect verdict (received)
+
+| # | Verdict | Reason |
+|---|---|---|
+| 1 | **PROCEED NOW** | Live incident, not a code fix — confirm the monitor, escalate to Netlify config if still stale past the build window |
+| 2a | **PROCEED NOW** | The only genuine unreported AA failure in the batch; one class, one file, no blast radius |
+| 2b | **PROCEED NOW** | Real 1.4.11 failure on 100% of first-touch; ARIA covers screen readers, not sighted users |
+| 2c | **DROP** | Passes AA with margin, already underlined. "Do not open a ticket for a passing check" |
+| 3a | **PROCEED NOW** | Unblocked, small; the seeding mechanism already anti-freezes |
+| 3b | **PROCEED LATER** | Correctly blocked behind the `console-mvp.md` §3 amendment — sequence the doc first |
+| 4 | **PROCEED NOW** (process, not code) | Fix by convention going forward, per-repo |
+| 5 | **DROP** | Proven against shipped bytes; frame capture is disproportionate for a closed question |
+| 6 | **DROP** | Refuted with hard evidence — remove from tracking entirely |
+| 7 | **SPLIT: partial PROCEED / partial DROP** | Delete `readThemePreference`, wire `THEMES` — but **keep** `resolveTimeOfDayTheme` |
+
+### Item 7 — the architect overrules the premise, with evidence
+
+The council brief offered three options (delete / keep / invert so the shipped string derives from
+the tested function). The architect **rejects the invert**, and rejects deleting
+`resolveTimeOfDayTheme`, on a fact nobody had checked:
+
+> `openharness-web`'s own `resolveTimeOfDayTheme` (`src/plugins/time-of-day-theme/index.ts:60`) has
+> **zero executable callers either — not even in a test.** That repo has no test for the plugin at
+> all; the only reference is a JSDoc `{@link}` at `:20`. Its `INLINE_SCRIPT` independently
+> re-encodes the same comparison as a literal string, exactly like cloud's.
+
+So the reference implementation this pattern was going to be "fixed" against does the *same thing*,
+less rigorously. What makes it trustworthy is not that the function runs — it's the post-build
+guard. And **cloud already has a tighter equivalent**: `theme-preference.test.ts:263-275` pins the
+source-text/constant relationship pre-build, `:115-125` unit-tests the function's full boundary
+table, and `:205-245` behaviourally executes the real template via `new Function(...)` — *two*
+independent pins where docs has one.
+
+**Ruling:** cloud is at parity with, arguably ahead of, the repo it was being compared against. The
+function is the *tested spec the string is checked against*, not orphaned code. Keep it; strengthen
+its doc comment to say it is intentionally unreachable at runtime, so a future cleanup pass doesn't
+delete it. The `toString()` inversion is technically buildable (the Node build process has full
+access; the no-import constraint applies only to the browser) but is a bigger, more fragile change
+than the reference implementation itself uses.
+
+**What item 7 *should* be:** delete `readThemePreference` (`:49-51`) + its tests, and fix
+`theme-provider.tsx:65` to pass the exported `THEMES` constant instead of the hardcoded
+`["dark","light"]`. That literal is the one genuinely unguarded drift risk in the item — the only
+place where "unused" is a bug rather than a design necessity.
+
+### The structural finding — one pattern, three unequal safety nets
+
+> All three repos independently invented the same "pre-paint inline script duplicates the tested rule
+> as an unreachable string" shape, with three different and unequally rigorous pinning strategies,
+> and no shared awareness that it is one recurring pattern.
+
+Docs pins post-build via HTML content signature. Cloud pins pre-build via source-text **plus** two
+behavioural tests. **Website pins via nothing.** Items 3a and 7 are opposite ends of that same
+spectrum. A fourth surface would invent it a fourth time.
+
+### The under-scoped fact in the grounding doc
+
+G-6 noted "no test file exists" only as a *cost note for item 3a*. The architect verified it is true
+of the **entire `website` repo** — no test file, no test script in `package.json`, anywhere. So
+**item 2a also ships with zero regression coverage**, which the grounding doc never says. Both
+website items land in a repo with no safety net; keep both diffs minimal for that reason.
+
+Architect found nothing in the grounding doc actually incorrect, and explicitly **retracted** an
+initial suspicion about G-7 after reading the tests more closely.
+
+**Orchestrator independently verified all three load-bearing claims**, because this ruling overturns
+a recommendation:
+
+- `openharness-web/src/plugins/time-of-day-theme/index.ts` — `resolveTimeOfDayTheme` appears exactly
+  twice: the JSDoc `{@link}` at `:20` and its own definition at `:60`. **Zero executable callers**,
+  and a repo-wide find turns up **no test or spec file anywhere**. Confirmed.
+- `website` — **no test/spec file anywhere and no `"test"` script** in `package.json`. Confirmed, so
+  both 2a and 3a land with no regression net.
+- `openharness-cloud/apps/web/components/theme-provider.tsx:65` — literally
+  `themes={["dark", "light"]}`, not the exported constant. Confirmed as a real drift risk.
+
+### Architect's note for item 4 — no uniform rule exists
+
+Only `openharness-cloud` has an established `.oh/tasks/<slug>/` convention (already used, and
+referenced from `netlify.toml`). `openharness-web` and `website` have **no `.oh/` directory at all**.
+So: cloud follow-ups put artifacts in cloud's own `.oh/tasks/` and `git add -f` them per precedent;
+website/docs follow-ups ride in the PR body, because inventing scaffolding for a single ticket is
+scope creep. A cross-repo document like `grounding.md` legitimately lives in the harness — but
+should be `git add -f`'d rather than left to the soft ignore.
+
+## Designer verdict (received)
+
+| # | Verdict | Reason |
+|---|---|---|
+| 1 | **PROCEED NOW** | Gates 2b and the cloud half of 3 — and it is the *closing free window* to fix 3 before any user sees the regression |
+| 2a | **PROCEED NOW** | Live AA failure in the mode the feature just routed 11 h/day into — and it is a **token-pair defect with a second instance**, not a one-liner |
+| 2b | **PROCEED NOW** (bundle with 1 + 3) | Real 1.4.11 failure, one class, but **zero live harm today** — ship it in the PR you're opening anyway |
+| 2c | **DROP as a fix / LATER as a CI guard** | Passes 1.4.3, underlined. "Do not spend credibility ticketing a passing check" |
+| 3 | **PROCEED NOW — both website *and* cloud** | Accessibility regression the project already argued against in its own words |
+| 4 | **PROCEED LATER** | Zero user impact; abstains on priority |
+| 5 | **DROP** | Settled structurally |
+| 6 | **DROP** | Refuted |
+| 7 | **PROCEED LATER** | No user impact; fold `THEMES` into the item-3 cloud change |
+| **A** *(new)* | **PROCEED NOW** | Website flips theme in an already-open tab, no reload, no user action |
+| **B** *(new)* | **PROCEED NOW** (fold into 2a) | `CTASection.tsx:158` hover — same failing pair on the error-recovery link |
+| **C** *(new)* | **PROCEED NOW** | Website toggle never reports which theme is active, to anyone |
+| **D/E** *(new)* | **PROCEED LATER** | The auto default is a one-way door and is never explained |
+
+### Harm ranking: **2a > 2b > 2c** — deliberately inverting the ratio order
+
+2b's 1.04:1 is the scariest number and the *least* harmful of the three. Designer's reasoning:
+the unselected label measures **5.20:1** against its own background (passes 1.4.3 comfortably);
+`aria-pressed` covers 4.1.2; and decisively — **the state that control fails to convey is
+redundantly conveyed by the entire viewport.** A user who can't tell which button is pressed can
+see whether the page is dark. The buttons are labelled with the *destination* ("Dark"/"Light"),
+not the state, so clicking the one you want is correct either way. Plus it has **zero live harm
+today** because the console never deployed.
+
+### Finding A — website flips theme in an already-open tab · **VERIFIED BY ORCHESTRATOR**
+
+The most consequential thing the council found, and it is feature-caused and new.
+
+> Tab A open since 06:40, no stored choice (`theme=dark`, `theme-auto=dark`). At 07:05 the user opens
+> mifune.dev in Tab B. Tab B's head script re-resolves to `light` and writes both keys.
+> **Tab A goes light instantly, mid-read, with no reload and no interaction.**
+
+I verified both halves in source rather than take it on report:
+
+- `website/src/lib/time-of-day-theme.ts:108` — the no-choice path writes **both** keys:
+  `s.setItem(A,t);s.setItem(K,t);`
+- `website/node_modules/next-themes/dist/index.mjs` — registers
+  `window.addEventListener("storage", o)` with
+  `o = r => r.key===m && (r.newValue ? n(r.newValue) : f(l))`.
+
+Storage events fire in *other* documents of the same origin, so the listener adopts the new value
+immediately. **The flip is real.** The harmful direction — dark→light at 07:00 — hits precisely the
+photophobia/migraine cohort item 3 is about, and `disableTransitionOnChange` makes it instantaneous
+rather than eased, which is right for vestibular safety but makes it more startling.
+
+This is **new**: pre-merge the no-choice path never wrote `theme`, so no default ever emitted a
+storage event. G-3 does not cover it — G-3 reasons only about pre-*paint* flash. **Cloud is immune**
+(never seeds) and **docs is immune** (writes nothing, by design).
+
+Requirement: *an already-open tab must never change theme without user action.*
+
+### Finding B — the contrast sweep found a floor, not a total · **VERIFIED BY ORCHESTRATOR**
+
+`CTASection.tsx:158` puts `hover:text-oh-accent` on the support-email link inside the
+`status === "error"` banner, which sits on the `bg-oh-raised` aside at `:113`. Confirmed in source.
+So **hovering the only recovery path from a failed form submission** drops it to the same 4.02:1.
+That is task-critical, unlike `:114`'s eyebrow (whose meaning is carried by the paragraph beneath it).
+
+Method finding that matters more than the instance: my scan ran against *rendered default state*, so
+it structurally cannot see `hover:` colours or conditionally-rendered branches. **"The one genuine AA
+violation" is a floor, not a total.** Any sweep informing these tickets must enumerate state-dependent
+colours from source.
+
+Consequence: 2a is a **token-level** fix, not a line fix. `--oh-accent: #15803d` is fine on white
+(5.01:1) and fails on `--oh-raised: #eae6db` (4.02:1). Designer proposes the in-family
+`--oh-focus: #166534` — **5.72:1 on `#eae6db`, 7.13:1 on white** — with the open question of whether
+collapsing accent/focus into one light-mode green is acceptable.
+
+### Ruling on OS-dark: **fix it, on both — and cloud FIRST**
+
+Designer rules it an accessibility regression, not a preference call, on four grounds:
+
+1. **The project already ruled on this in writing, in its own code.**
+   `openharness-web/src/plugins/time-of-day-theme/index.ts:15-19` states it as a design constraint:
+   *"Forcing light at 14:00 on someone who set OS dark removes an accommodation they configured… the
+   time rule may only ever upgrade light → dark, never dark → light."* One surface implemented that;
+   two did not. This is internal inconsistency against an adopted position, not an imported opinion.
+2. **The two inputs are not symmetric.** OS is a *declared* preference; the hour is an *inferred*
+   one. `prefers-color-scheme: dark` is the only channel a platform gives a user to say "light
+   surfaces hurt me". Overriding it with a timezone guess is the one case where the rule reasons
+   about a user who already answered.
+3. **Converging costs no user anything** — an OS-dark user who wants light can still choose it, and
+   that choice is permanent. There is no user on the other side of this trade.
+4. **Journey-level incoherence**: `TopNavBar.tsx:117` links mifune.dev → console; an OS-dark user at
+   14:00 flips light→dark mid-flow across subdomains that share no storage.
+
+**Cloud first**, for two reasons: dwell time inverts the priority (the console is where a
+light-sensitive user spends *hours*; marketing is read once), and **the console hasn't deployed** —
+the cheapest fix window that will ever exist, and it closes the moment Netlify catches up. Ship it
+inside the first deploy and no OS-dark console user ever experiences the regression at all.
+
+**The design doc does not forbid this fix.** `console-mvp.md:69`'s user-facing contract — two explicit
+choices, no System option, only explicit choices persisted — stays fully intact when OS-dark is
+respected in the *never-chose default resolution*. The only sentence that breaks is the rationale
+"the two are unrelated inputs". **Explicitly do NOT add a System option to cloud.**
+
+### Boundary ruling — the boundary is fine; don't touch it
+
+| Case | Behaviour | Ruling |
+|---|---|---|
+| Same tab, single load | No flip; all three read the clock once per load | Correct |
+| User reloads across the boundary | Theme changes | **Acceptable** — user initiated the load; that's the feature |
+| Open tab, no reload, no action | **Website only** flips live | **Actively bad — fix** (finding A) |
+
+Explicitly: **no grace windows, no hysteresis, no smoothing.** Those add hidden state to a rule whose
+only virtue is that it is trivially explainable.
+
+### Finding C — the state-communication gap is on the surface nobody flagged
+
+`website/src/components/mode-toggle.tsx:47-66` uses plain `DropdownMenuItem`s — no `aria-checked`,
+no radio group, no checkmark — and the trigger's accessible name is just "Toggle theme". **There is
+nowhere in the website UI that reports the active theme to a non-sighted user.** Ironic against 2b:
+cloud *does* expose `aria-pressed` and a literal "On"/"Off" in the authenticated menu. Fix is pure
+reuse — `DropdownMenuRadioGroup`/`RadioItem` already exist at `ui/dropdown-menu.tsx:120,191`.
+
+**On discoverability** (which the council asked about): **no gap on any surface.** This matches my own
+live measurement (44×44 on website, 32×32 on docs, both above the fold). *The gap is current-state
+and mental model, not findability.*
+
+### Designer's challenges to the grounding doc
+
+1. **The 2.82:1 figure is not a WCAG measurement.** It compares two *foregrounds*; no SC does that.
+   The relevant number is unselected label vs. its own background = **5.20:1**, a comfortable pass.
+   The "weak, not broken" verdict survives; the evidence cited for it does not. **Accepted.**
+2. **"The item nobody reported" over-claims.** It is a floor (see finding B). **Accepted.**
+3. **G-6's matrix is a weaker evidence grade than G-2's but is labelled with equal weight.** G-2 was
+   re-derived in-browser on production; G-6's OS-signal table was derived from code reading, with no
+   production run under emulated OS-dark for *any* surface. **Accepted — this is a fair hit.**
+4. **"No test file exists… no regression net either" was offered as evidence the fix is cheap.** The
+   absence of a net is a **cost, not a saving**, on an accessibility default. **Accepted.**
+5. **G-3's "settled structurally" is correctly scoped to the two shipped surfaces** — the console is
+   unverified for flash and takes a genuinely different provider path. Check it on the deploy.

--- a/.oh/tasks/timezone-followups/critique.md
+++ b/.oh/tasks/timezone-followups/critique.md
@@ -1,0 +1,219 @@
+# Adversarial critique of the council's rulings
+
+Two critics, run in parallel per `pr.yml`, each pointed at `grounding.md` + `council.md` and told to
+refute. Critic A = implementer lens (will the changes work?). Critic B = decision-quality lens
+(are the priorities right?).
+
+---
+
+## Critic B — decision quality (received)
+
+### Survives unattacked
+Items **1, 2b, 3a, 4, 7** (including the architect's split verdict on 7), the DROPs on **5** and **6**,
+and the underlying decision to fix OS-dark on both surfaces. Four of designer's five grounding
+challenges survive as stated.
+
+### 1 · "DROP 2c + add a CI guard later" is incoherent — **HIGH, REFINES**
+
+Independently confirmed: `openharness-web` has **zero** contrast/a11y tooling — no axe-core, pa11y or
+lighthouse in `package.json`, no workflow beyond `pages.yml`, no test mentioning "contrast". With a
++0.026 margin, one half-shade token nudge crosses AA silently and nothing catches it.
+
+Two members said flat DROP; designer said "DROP as a fix / LATER as a guard" — and the council's own
+ticket rule ("only 3b needs a ticket") files nothing for the guard. So the "later" **evaporates with
+no record**. Critic B's sharpest point: this is the exact failure mode grounding G-4 identified
+("already tracked is not an available disposition") happening to *the council's own output*.
+
+**Required:** either write the one-line guard ticket, or state explicitly "no guard, margin accepted".
+Right now it is silently neither.
+
+### 2 · DROPs on 5 and 6 hold — **LOW**
+
+Item 6 independently re-derivable from the SW config. Item 5's byte-order proof is solid for
+first-paint FOUC. One residual nobody mentioned: **bfcache** restores a previous paint before script
+re-execution on some browsers, so "settled structurally" slightly overclaims. Not enough to reopen.
+
+### 3 · "Cloud first, race the deploy" — **HIGH, REFUTES the sequencing** (not the fix)
+
+PM and architect both placed 3b in Wave 2 behind the doc amendment. Designer was the lone voice for
+"cloud FIRST" to beat Netlify. Critic B rejects it:
+
+- The "free window" is **not confirmed to outlive the review it requires** — a design-doc amendment
+  plus code review versus a build pipeline is a race you cannot schedule.
+- It makes an accessibility fix's *quality* depend on beating a build, not on getting the amendment
+  right.
+- `console-mvp.md:13` explicitly frames itself as requiring deliberate authority — "exactly the kind
+  of doc that shouldn't be amended under self-imposed time pressure."
+
+**The underlying fix is correctly PROCEED by all three; only the sequencing is wrong.**
+
+Critic B leaves one door open, and it turns out to matter: *"If the window is later shown to be
+structurally longer — e.g. the stale build requires manual Netlify intervention rather than being
+in-flight — that would legitimately restore urgency."*
+
+> **Orchestrator note:** that condition has since been met. At **22:22 UTC, 44 minutes post-merge**,
+> the console was still byte-identically pre-feature (23129 bytes, `getHours=0`, unchanged since
+> 21:53) while the repo's own CI for that commit finished in ~4 minutes. See the synthesis — this
+> does not vindicate racing; it **removes the race entirely**, which satisfies both positions.
+
+### 4 · Item 2a scope — **both PM and designer are partly wrong; resolvable by counting** — MEDIUM
+
+Critic B counted rather than argued:
+
+- **55** raw `text-oh-accent` usages in `website` (38 non-hover).
+- `bg-oh-raised` appears **exactly 3 times** repo-wide; only **2** wrap accent-styled elements:
+  `CTASection.tsx:114` and `:158`.
+- The `:80` "CLOUD · DEPLOYMENT" eyebrow sits on `bg-oh-paper` and independently measures 4.53:1 —
+  passing — **in the same page**.
+
+**Ruling: fix the two raised-background instances only; leave the shared token alone.** PM's
+magnitude was right but "only line 114" misses the functionally worse `:158`. Designer's second
+instance was right but "fix at token level" would needlessly touch ~53 currently-passing usages.
+
+Also flagged: PM's "the same pair passes at 4.53:1 elsewhere" is ambiguous between the docs figure
+and website's own. The claim holds either way (re-verified), but the citation should point at the
+website-specific measurement to avoid a genuine cross-repo conflation trap.
+
+### 5 · The four new items — discipline mostly holds, **one mischaracterisation** — MEDIUM
+
+- **A** (cross-tab flip): verified in source, genuinely feature-caused. **PROCEED NOW survives.**
+- **B**: not really a separate item — same fix as finding 4. Fold it.
+- **C** (website toggle has no `aria-checked`): `git show 2b66e7a -- mode-toggle.tsx` shows the merge
+  **only** wrapped `onClick` in `chooseTheme()`. The plain-`DropdownMenuItem` structure is
+  **pre-existing and untouched**. The council is **annexing unrelated a11y debt** onto this list under
+  the urgency of items it did cause. Real, but it ships as its own ticket — not as PROCEED NOW
+  alongside A.
+- **D/E**: correctly deferred; the clearest "finding work to justify itself" candidate. Leave at LATER.
+
+### 6 · Designer's grounding challenges — accepted correctly, one under-diagnosed — MEDIUM
+
+"2.82:1 is not a WCAG measurement" is **right**: SCs compare a foreground to its background at one
+point in time, not a before/after delta. The legitimate 1.4.11 figures are the 1.04:1 / 1.23:1
+background pairs. Survives cleanly.
+
+"G-6 is a weaker evidence grade" was accepted for the wrong reason. It is *not* that code-reading is
+generically weaker for a deterministic function. It is that **G-1 already proved code-vs-deployed
+reality diverges in this exact environment** — the console has been serving stale bytes — so a
+source-derived claim about cloud's `matchMedia` behaviour cannot be checked against anything live at
+all right now. Sharper, and it feeds finding 3.
+
+### Critic B's single change
+
+> Reject "cloud first, race the deploy". Sequence 3b exactly as PM and architect ruled — doc
+> amendment first, deliberately, no artificial deadline. Treat the free window as a nice-to-have
+> outcome if it lands in time, never as the reason to move the item earlier or compress review.
+
+---
+
+## Critic A — implementer lens (received)
+
+### Survives
+Item 3a's core mechanism, item 3b's "no new hydration race" claim, item 7 in full, and the designer's
+raw contrast arithmetic.
+
+### 1 · The website OS-dark ternary works — but on an unnamed invariant — LOW/informational
+
+Traced both cases at `time-of-day-theme.ts:100-113`. The no-choice branch always writes
+`s.setItem(A,t);s.setItem(K,t)` — **both keys get the same computed `t`**, however complex the formula.
+The marker check `raw!==null && raw!==auto` is agnostic to *how* `t` was derived, so adding a
+`matchMedia` term cannot break the auto-marker.
+
+- OS dark 14:00 first visit → `{theme:dark, auto:dark}`; OS→light, revisit 14:00 → `raw===auto` →
+  still the no-choice branch → `light`. Correct.
+- OS dark 21:00 → `dark` (night window, OS irrelevant); revisit 14:00 OS light → `light`. Correct.
+
+**But the safety is non-obvious and must become an explicit acceptance criterion:** if an implementer
+hoists the `matchMedia` read out of the no-choice branch, or writes A and K with different values,
+the invariant breaks silently.
+
+### 2 · **Shipping 3a before finding A makes A worse — HIGH, and nobody caught it**
+
+The single highest-severity gap in the whole council output, and it fell in the **seam between two
+members' rulings that nobody read together** (PM ruled 3a; designer raised A; neither cross-read).
+
+> Tab A open at 14:00, OS light, no choice → `light`. User flips OS to dark **without closing Tab A**
+> and opens Tab B at the same hour. **Pre-3a** Tab B also resolves `light` — no divergence, no flip.
+> **Post-3a** Tab B resolves `dark`, writes storage, and Tab A flips live, mid-read.
+
+So 3a introduces a **brand-new trigger axis** for finding A — OS toggling, on top of clock-boundary
+crossing. PM's Wave 1 ships 2a + 3a "in parallel, independent" with no gate on A, because A postdates
+the PM and architect tables entirely. **3a and A must land in the same diff.**
+
+### 3 · **Neither proposed fix for finding A actually works — HIGH, REFUTES both**
+
+Critic A first notes the council recorded only a *requirement*, not a mechanism. Evaluating the two
+obvious implementations anyway:
+
+- **"Only write when the value differs" — a no-op.** Per the WHATWG Storage spec, `setItem` with an
+  unchanged value **already fires no `storage` event** in other tabs; browsers do this natively. The
+  harmful case is precisely when the value *does* differ. This suppresses only writes that were
+  already harmless.
+- **"Port cloud's `forcedTheme` + adopt-DOM pattern" — silently strands "System".** Cloud runs
+  `forcedTheme={theme}` with `enableSystem={false}` (`theme-provider.tsx:59-66`); website runs
+  `enableSystem` with no `forcedTheme` and offers a System item (`mode-toggle.tsx:60-65`).
+  `forcedTheme` overrides all internal resolution *including* the system watcher, so clicking
+  "System" would do nothing observable. Preserving it means hand-rolling a `matchMedia` change
+  listener — **which reintroduces a second live-update channel that can flip an open tab without user
+  action, i.e. a variant of the very bug being fixed.**
+
+**Verdict:** finding A is real and PROCEED stands; both shortcut implementations are refuted. This is
+genuine design work, not a one-liner.
+
+### 4 · The cloud `matchMedia` fix breaks two currently-green tests — MEDIUM-HIGH · **VERIFIED**
+
+`openharness-cloud/apps/web/vitest.config.ts:5` is `environment: "node"` — **no jsdom, no `window`
+global at all** (orchestrator confirmed). `runBootstrapScript` at `theme-preference.test.ts:31-47`
+binds only two identifiers via `new Function("localStorage","document", …)`. Adding
+`window.matchMedia(...)` to the bootstrap makes the no-choice tests at `:205-217` throw
+`ReferenceError: window is not defined` — **two green assertions go red the moment the feature lands.**
+
+Not a refutation (PM sized 3b at M citing exactly this), but "update both existing no-choice bootstrap
+tests to pass a `matchMedia` stub" belongs in the PR as a gating criterion, not as incidental scope.
+
+**No new hydration race**, though: `resolveMountedTheme` (`:60-65`) calls only
+`readStoredThemePreference` — never `matchMedia` or the clock — so the read stays confined to the one
+pre-paint execution *provided the provider is left untouched*. That claim survives.
+
+### 5 · PM's stated reason for keeping 2a local is factually wrong — MEDIUM
+
+Designer's arithmetic independently reproduced: `#166534` on `#eae6db` = **5.7179:1**, on white =
+**7.1303:1**. And PM's mechanism ("a token change would re-break something currently fine") **does not
+hold**: `#166534` is strictly darker than `#15803d`, so against any lighter background the ratio can
+only increase.
+
+But there is a **real, different** risk both members missed: `--oh-accent` is used as a **non-text**
+value at `TopNavBar.tsx:99` (`shadow-[inset_0_-2px_0_0_var(--oh-accent)]`) and is visually paired with
+**hardcoded, non-token** `green-500` utilities in ~6 places (`RegisterButton.tsx:21`,
+`PricingSection.tsx:101,111,151`, `pricing/page.tsx:144,206,253`, `services/page.tsx:184,408`). A
+token-wide swap darkens the text while those adjacent borders stay `#22c55e` — a **brand-consistency**
+regression, not an accessibility one. So the conclusion (stay local) is right for a reason neither
+member gave.
+
+### 6 · **The council's own new finding has the wrong number — the failure is worse** · **VERIFIED**
+
+`CTASection.tsx:148-158`: the `<a>` sits inside a `bg-red-500/10` alert div, which itself sits on the
+`bg-oh-raised` card — **not** directly on `bg-oh-raised` like `:114`'s eyebrow. Orchestrator recomputed
+the composite:
+
+| | background | `#15803d` (current) | `#166534` (proposed) |
+|---|---|---|---|
+| `:114` eyebrow | flat `#eae6db` | **4.02:1** FAIL | 5.72:1 pass |
+| `:158` hover | `bg-red-500/10` over `#eae6db` = **`#ead6cc`** | **3.58:1** FAIL (worse) | 5.09:1 pass |
+
+The remediation still works, but **QA must measure the composited colour, not the flat token pair**, or
+it signs off on the wrong number. This also confirms PM's "fix only `:114`" is stale.
+
+### 7 · `readThemePreference` is safe to delete — architect vindicated
+
+`theme-preference.test.ts:109-144` calls `resolveTimeOfDayTheme(hour)` **directly** — the `it.each`
+boundary table at `:115-125` (hours 0, 6, 7, 12, 17, 18, 23) and the "resolves without reading the
+clock" guard at `:127-144` never touch `readThemePreference`. Its own tests are a **disjoint** set
+(`:66-77`, `:146-152`, `:154-160`). Deleting it leaves the boundary coverage fully intact, and the
+hydration guard at `:193-201` is unaffected either way.
+
+### 8 · Procedural: findings A–E had one rapporteur and were never cross-examined — MEDIUM
+
+PM's and architect's tables cover items 1–7 only; A–E appear solely in the designer's section. Treating
+"PROCEED NOW" on A–C with the same confidence as the fully-adjudicated items overstates consensus —
+and finding 2 above is the proof, since it required reading PM's 3a ruling against designer's finding A
+and nobody did.

--- a/.oh/tasks/timezone-followups/decision.md
+++ b/.oh/tasks/timezone-followups/decision.md
@@ -1,0 +1,179 @@
+# Final determination — which follow-ups are worth proceeding with
+
+Produced by: grounding (3 agents + orchestrator live verification) → council (architect, pm, designer
+in parallel, per `plan.yml`) → 2 adversarial critics (per `pr.yml`). Every number below was
+recomputed or measured; where the council itself was wrong, the correction is recorded.
+
+Sources: `grounding.md` · `council.md` · `critique.md` · `progress.txt`
+
+---
+
+## Verdict
+
+| # | Item | Verdict | Confidence |
+|---|---|---|---|
+| 1 | Console never deployed | **PROCEED — first** | Unanimous + escalated by new evidence |
+| A | Website cross-tab live theme flip | **PROCEED — with 3a, same diff** | Verified in source; both proposed fixes refuted |
+| 3a | Website OS-dark convergence | **PROCEED — with A, same diff** | Unanimous; mechanism validated |
+| 2a | Website contrast (`:114` **and** `:158`) | **PROCEED — locally, not token-wide** | Scope settled by count |
+| 2b | Cloud `ThemeControl` 1.4.11 | **PROCEED — with the deploy fix** | Unanimous; zero live harm today |
+| 3b | Cloud OS-dark | **PROCEED — doc amendment first** | Unanimous on fix; sequencing corrected |
+| 7 | Cloud dead code | **PROCEED LATER — partial only** | Architect's split, critic-verified |
+| C | Website toggle has no `aria-checked` | **PROCEED LATER — own ticket** | Proven pre-existing |
+| 4 | Task-artifact placement | **PROCEED LATER — convention** | Low stakes |
+| D/E | "Auto" is a one-way door, never explained | **LATER** | Real, unmeasured |
+| 2c | Docs link 4.53:1 | **DROP — needs an explicit call** | Passes AA; see open question |
+| 5 | Sub-frame flash | **DROP** | Settled structurally |
+| 6 | `next-pwa` staleness | **DROP** | Refuted outright |
+
+---
+
+## The four things that actually matter
+
+### 1 · The console deploy is the only thing that is *broken right now* — go look at the Netlify log
+
+Not "spot-check the console". `console.mifune.dev/signin` has served a **byte-identical pre-feature
+build** (23129 bytes, `getHours=0`) at every check from 21:53 through 22:22 UTC — **44 minutes** after
+a merge whose own CI finished in ~4 minutes, on a pipeline demonstrably working (the merge's *parent*
+`de81006` is live). Working hypothesis is now **failed or never-triggered build**, not slow build.
+
+Nothing else on this list is a live defect. This one is.
+
+### 2 · `3a` and finding `A` must ship in the same diff — the council's own seam
+
+Critic A's best catch, and the highest-severity gap in the entire council output. It fell between two
+members' rulings that nobody read together.
+
+Shipping the OS-dark fix alone **widens** the cross-tab bug: today an open tab can flip at the
+07:00/18:00 boundary; after 3a it can *also* flip when the user toggles their OS theme at any hour.
+PM's plan shipped them independently because finding A postdates the PM and architect tables.
+
+And **neither obvious fix for A works**:
+- *"Only write when the value differs"* is a **no-op** — per the WHATWG Storage spec browsers already
+  suppress same-value `storage` events; the harm happens precisely when the value differs.
+- *"Port cloud's `forcedTheme` pattern"* **silently strands the "System" option**, and hand-rolling a
+  `matchMedia` listener to keep it reintroduces a live-update channel — a variant of the same bug.
+
+This is real design work. Do not let it be estimated as a one-liner.
+
+### 3 · The contrast fix is two lines in one file — and one of them is worse than reported
+
+Scope was disputed (PM: only `:114`, don't touch the token / designer: it's a token defect). **Settled
+by counting**: `bg-oh-raised` appears exactly **3 times repo-wide**, only **2** wrap accent-styled
+text. So fix both, leave the token alone — a token swap would touch ~53 currently-passing usages and,
+per critic A, would darken text while ~6 hardcoded `green-500` neighbours stay `#22c55e` (a brand
+regression, which is the *right* reason to stay local — PM's stated reason was factually wrong, since
+`#166534` is strictly darker and can only *raise* ratios).
+
+| Target | Background | Now | With `#166534` |
+|---|---|---|---|
+| `CTASection.tsx:114` eyebrow | flat `#eae6db` | **4.02:1** FAIL | 5.72:1 |
+| `CTASection.tsx:158` hover | `bg-red-500/10` over `#eae6db` = `#ead6cc` | **3.58:1** FAIL | 5.09:1 |
+
+`:158` is the **hover state of the only recovery path from a failed form submission** — task-critical,
+unlike `:114`'s eyebrow whose meaning is carried by the paragraph beneath it. Its true ratio is
+**3.58:1**, not the 4.02:1 the council reported, because the alert div composites a 10% red overlay.
+**QA must measure the composited colour**, or it will sign off on the wrong number.
+
+### 4 · Cloud OS-dark: do the doc amendment properly — the deploy being stuck *removes* the race
+
+Designer argued "cloud first, race Netlify" — the un-deployed console is a free window to fix the
+regression before any user sees it. Critic B refuted the *sequencing*: it makes an accessibility fix's
+quality depend on beating a build, and `console-mvp.md:13` explicitly demands deliberate authority for
+its own amendment.
+
+**Both are satisfied by the new evidence.** Because the deploy is *stuck*, not merely slow, there is no
+closing window to race — so amend `console-mvp.md` §3 deliberately **and** still land ahead of users.
+Critic B named this exact condition as the one that would legitimately change its ruling.
+
+The amendment is one sentence. The user-facing contract survives intact: **no System option, no third
+control state, nothing new persisted.** Only the rationale sentence "the two are unrelated inputs"
+changes.
+
+**Gating criterion the PR must state:** `vitest.config.ts:5` is `environment: "node"` — no `window`
+global. Adding `window.matchMedia` to the bootstrap makes two currently-green tests at
+`theme-preference.test.ts:205-217` throw `ReferenceError`. Stubbing them is on the critical path, not
+incidental scope.
+
+---
+
+## Corrections to the original seven recommendations
+
+Three of seven were wrong or misdirected, and the grounding pass is what caught it:
+
+| Original | Reality |
+|---|---|
+| "next-pwa may delay rollout" | **Refuted.** Documents are NetworkFirst; zero loads of staleness |
+| "fix these two contrast spots" | **Both were the wrong targets.** The docs link *passes* AA; the cloud control is ARIA-covered with zero live harm. The one genuine AA failure went unmentioned |
+| "artifacts are gitignored, so lost" | **Diagnosis wrong.** The ignore is soft — 35 `.oh/tasks` + 15 wiki files are already tracked. The real miss is `pr.yml:17-19` placement |
+| "spot-check the console" | **Reframed and more urgent** — the feature never deployed there |
+| "OS-dark divergence" | Right, but missed that the *property* is old while the **harm is new** |
+| "dead code" | Understated — `resolveTimeOfDayTheme` is transitively dead and `THEMES` is unused entirely |
+| "flash never observed" | Now settled structurally against shipped bytes |
+
+## Corrections to the council, by the critics
+
+- **PM**: "fix only `:114`" is stale; the stated risk mechanism for staying token-local is wrong
+  (right answer, wrong reason).
+- **Designer**: finding B's ratio is wrong — 3.58:1, not 4.02:1; "cloud first, race the deploy" is
+  rejected as sequencing; finding C is **pre-existing** (`git show 2b66e7a` shows the merge only
+  wrapped `onClick`), so it is annexed debt, not feature fallout.
+- **Architect**: vindicated on item 7 — `resolveTimeOfDayTheme` has independent direct coverage at
+  `theme-preference.test.ts:109-144`, disjoint from `readThemePreference`'s tests.
+- **Process**: findings A–E had a single rapporteur and were never cross-examined by the other two
+  members. That is exactly how the 3a↔A interaction was missed.
+
+## Item 7, as corrected
+
+Delete `readThemePreference` (`:49-51`) + its three disjoint test blocks. **Keep
+`resolveTimeOfDayTheme`** — it is the tested spec the shipped string is pinned against, and
+`openharness-web`'s equivalent is *also* unreachable with **no test at all**, so cloud is already ahead
+of the repo it would have been "fixed" toward. Wire `THEMES` into `theme-provider.tsx:65`, which today
+hardcodes `themes={["dark", "light"]}` — the one genuinely unguarded drift risk in the item.
+
+## Outcome
+
+Everything on this list was executed. Six PRs, three tickets, one item descoped by the
+operator.
+
+| # | Item | Where it landed |
+|---|---|---|
+| A + 3a | automatic theme out of storage; OS dark outranks the hour | website **#54** |
+| 2a + B | CTA accent to AA on raised surfaces | website **#55** |
+| C | toggle reports the active theme | website **#56** (stacked on #54) |
+| 2b | `ThemeControl` state indicator meets 1.4.11 | cloud **#110** |
+| 7 | delete `readThemePreference`, keep `resolveTimeOfDayTheme`, wire `THEMES` | cloud **#111** |
+| 3b | OS dark outranks the clock + `console-mvp.md` §3 amendment | cloud **#112** |
+| 2c | contrast guard — filed *stating the link passes*, not as a fix request | openharness-web **#23** |
+| D/E | the automatic default is a one-way door, never explained | website **#57** |
+| — | the architect's structural finding: this script is pinned by nothing | website **#58** |
+| 1 | console deploy | **descoped by the operator mid-run** |
+| 4 | artifact placement | closed by acting: this folder is `git add -f`'d into the harness |
+| 5, 6 | sub-frame flash, `next-pwa` | dropped, as ruled |
+
+**Both open questions below are now closed.** 2c has a record either way — the ticket says
+plainly that the link passes at 4.526:1 and that changing the colour is *not* being asked
+for. Holding the deploy turned out moot: 3b landed while the console was still serving the
+pre-feature build, so no OS-dark user ever meets the regression, and the amendment was
+written on its own terms rather than against a build deadline.
+
+### What execution found that the council and both critics missed
+
+- **The fix for A needed a third move neither critic considered.** They correctly refuted
+  the differs-check and the `forcedTheme` port. But removing the seed is *also* not enough
+  on its own: next-themes' own inline script applies the **server-serialised** default, so
+  the correction had to move from `<head>` to run *after* it. Verified against built bytes.
+- **2b could not be tidied.** Hoisting the shared class string into a constant fails
+  `final-design-remediation-presentation.test.ts:34-35`, which counts `min-h-11 min-w-11`
+  twice as a 44px target-size contract. The duplication stays, deliberately.
+- **2a's third instance has a reason, not just an exclusion.** `--oh-accent` on a 20px
+  `aria-hidden` icon measures 4.02:1, which *passes* the 3:1 non-text threshold.
+
+## Open questions for the operator (both now closed — see Outcome)
+
+1. **Item 2c** — the docs link passes AA by +0.026 with **no contrast tooling anywhere in that repo**.
+   Two members said DROP, one said "drop the fix, add a CI guard later", and no ticket was filed for
+   the guard. Decide explicitly: **write the guard ticket, or accept the margin on the record.** Right
+   now it is silently neither — the same failure mode grounding flagged as G-4.
+2. **Hold the console deploy for 3b?** Recommended: yes, if the deploy turns out to need manual
+   intervention anyway. It costs nothing extra and no OS-dark console user ever sees the regression.

--- a/.oh/tasks/timezone-followups/grounding.md
+++ b/.oh/tasks/timezone-followups/grounding.md
@@ -1,0 +1,246 @@
+# Grounding — verified facts. The council rules on THIS, not on recollection.
+
+Parent task `timezone-default-theme` is merged:
+`openharness-cloud` #108 `dca1af6` (main) · `website` #53 `2b66e7a` (development) · `openharness-web` #22 `22f5aec` (main).
+Local defaults match `origin`; no branches or worktrees outstanding.
+
+Every number below was recomputed or re-measured. Where the original recommendation was **wrong**,
+it is marked. Three of the seven items changed status under grounding.
+
+---
+
+## G-1 · Production deploy state — **one surface never shipped**
+
+| Surface | URL | Feature live? |
+|---|---|---|
+| docs (`openharness-web`) | `https://oh.mifune.dev` | **Yes** |
+| marketing (`website`) | `https://mifune.dev` | **Yes** |
+| console (`openharness-cloud`) | `https://console.mifune.dev` | **NO — serving the pre-feature build** |
+
+`console.mifune.dev/signin` returns 200, 23129 bytes, **no auth required**, and its `<head>` bootstrap
+is byte-identical to `dca1af6^` (the parent of the merge):
+
+```js
+try { value = localStorage.getItem(key) === "light" ? "light" : "dark"; } catch {}
+```
+
+`grep -c getHours` = **0**. Checked by the grounding agent at 21:53/21:54/21:55 UTC and independently
+re-checked by the orchestrator at 21:56 UTC. The merge landed ~21:38 UTC, so an in-flight Netlify
+build is not yet excluded — GitHub Deployments returns `[]` and `homepageUrl` is `""`, so build state
+is not observable from here. **A monitor is polling that URL for `getHours` as the go/no-go signal.**
+
+Deploy topology: `netlify.toml` (`base = "apps/web"`, `@netlify/plugin-nextjs`), host named at
+`README.md:18`. No deploy job in `.github/workflows/`. `us.mifune.dev` and `docs.mifune.dev` → 421,
+not hosts. `promptengineers.ai` is a legacy 19 KB page, unrelated to these repos.
+
+GitHub Actions on `main` for `dca1af6`: **completed/success** (21:38:30 UTC). So CI is not the
+blocker — Netlify builds independently of Actions here, and its state is what is unobservable.
+
+**Escalation — at 22:22 UTC, 44 minutes after the merge, the console was still serving the
+pre-feature build** (23129 bytes, `getHours=0`, unchanged across every check from 21:53 onward).
+The repo's own CI for this commit finished in ~4 minutes. 44 minutes with a byte-identical response
+is well past a plausible build window, so the working hypothesis shifts from *"the build is in
+flight"* to **"the build failed or never triggered"**. That is a materially different item: not
+"wait", but "go look at the Netlify deploy log". A monitor remains armed and will report the moment
+`getHours` appears.
+
+**Auto-deploy demonstrably works — this is a build in flight or failed, not a missing pipeline.**
+The bootstrap now live is byte-identical to `dca1af6^` = `de81006`, which landed 19:56 UTC and *is*
+serving. The theme merge `dca1af6` landed 21:38 UTC; at 22:01 UTC (23 min later) the old build is
+still being served. So the pipeline exists and fires on `main` — the specific build for `dca1af6`
+either has not finished or has failed. That narrows the diagnosis considerably: the question is not
+"is deployment configured" but "did this build succeed".
+
+**This reframes recommendation #1.** It is not "spot-check the console" — loading it today validates
+the *old* bootstrap. It is "confirm the console deployed at all", which is more urgent and cheaper.
+Relevant prior lesson: this repo's web auto-deploys but its migrations do not; deploy lag here has
+bitten before.
+
+## G-2 · Live-production verification of the two shipped surfaces — **PASS**
+
+Expectation re-derived in-browser each run (never a hardcoded per-zone table); `TZ` drives the
+browser's own clock.
+
+| Surface | Zone | Hour | Result |
+|---|---|---|---|
+| docs (OS light emulated) | `America/Denver` | 15 | `data-theme=light`, `choice=system`, `localStorage.theme=null` — PASS |
+| docs (OS light emulated) | `UTC` | 21 | `data-theme=dark`, `choice=system`, `localStorage.theme=null` — PASS |
+| website | `America/Denver` | 15 | `class=light`, `theme=light`, `auto=light`, meta `#ffffff`, body `rgb(255,255,255)` — PASS |
+| website | `UTC` | 21 | `class=dark`, `theme=dark`, `auto=dark`, meta `#09090b`, body `rgb(9,9,11)` — PASS |
+
+Upgrades the earlier deploy-preview evidence to **production**. The docs runs also re-confirm the
+no-seed design end-to-end: `data-theme-choice` stays `"system"` and storage stays `null`, so the
+value keeps re-deriving.
+
+## G-3 · Sub-frame flash — **settled structurally** (was only *argued*)
+
+Byte order in shipped production HTML:
+
+- **docs**: `<body>`=3896 → docusaurus script=4534 → plugin script=5082 → `<div id="__docusaurus">`=5165.
+  The only non-script markup before the plugin script is `<svg style="display: none;">` — **paints
+  nothing**. The shipped tag also carries `data-time-of-day-theme="1"` as a **tag attribute**
+  (a comment marker would have been stripped by terser).
+- **website**: theme script at 4252, `<body>` at 4965 → script is **entirely in `<head>`**; zero markup
+  precedes it; 11 of the 12 preceding `<script>` tags are `defer`/`async`/`module`.
+
+**There is no paint opportunity before the theme is settled on either shipped surface.** This is now
+proof against the bytes that ship — not a captured frame. Frame-level proof is a separate, far more
+expensive instrument.
+
+## G-4 · Nothing is tracked
+
+No open issue in any repo covers any of the seven items (`openharness-cloud` #107/#104/#102/#12,
+`website` #38/#35/#28/#27/#26, `openharness-web` none). "Already tracked" is not an available
+disposition — each item is worth a ticket or worth dropping.
+
+---
+
+## G-5 · Contrast — **the reported items are the wrong ones**
+
+### Docs light link — VERIFIED, but it *passes* AA
+
+True ratio **4.5260:1** (`#15803d` on `#f6f3ec`), margin **+0.026**, not +0.03. Tokens are at
+`custom.css:17` and `:48` — the reported lines 22/47 were **wrong**. Dark mode is fine (12.05:1).
+
+Measured live in production on blog articles: prose links render `rgb(21,128,61)` on `rgb(246,243,236)`
+= **4.53:1**, and are **underlined** (9 and 4 prose links on two articles; `hash-link`s excluded).
+So blast radius is real — body prose on the highest-volume reading surface — but **WCAG 1.4.1 is
+already satisfied by the underline, and 1.4.3 passes.** Navbar, sidebar, footer, TOC, admonitions and
+DocCards all override the token away from green, so the exposure is narrower than "all links".
+
+Note `/docs/intro` and `/` carry **no** green prose links at all — lowest visible there is a 4.81:1
+grey. This is a *marginal* item, not a defect.
+
+### Cloud `ThemeControl` — PARTIALLY VERIFIED, and **understated**
+
+`1.04:1` is correct to the digit (light). Lines `:15/:23/:35` were **exact**. But the original
+recommendation was wrong in two directions:
+
+- **Dark mode also fails** (1.23:1) — the claim implied light-only.
+- Selection is *not* conveyed by background alone: unselected text also shifts `#17211a → #5a685e`,
+  a **2.82:1** step. Visible, but still under the 3:1 bar. So the control is **weak, not broken**.
+- `aria-pressed` is present (`:19`, `:31`), so **WCAG 4.1.2 passes** and screen-reader users are
+  unaffected. The failure is **sighted-user-only**: 1.4.11 (non-text contrast) on every colour channel.
+
+Blast radius: `/signin`, `/invite`, `/r/[login]` — i.e. **100% of first-touch traffic**, and only
+first-touch. The authenticated console uses a *different* control (`user-menu.tsx:110-118`) with an
+explicit "On"/"Off" text label, and a test pins that the nav must not contain `ThemeControl`.
+
+Fix that works: `ring-1 ring-ring` on the selected branch → **4.92:1** light / **9.67:1** dark.
+(`bg-card` is a dead end: 1.13:1 / 1.15:1.)
+
+### The item nobody reported — **an actual AA failure, live in production**
+
+`website/src/sections/CTASection.tsx:114` — `text-oh-accent` (`#15803d`) on a `bg-oh-raised`
+(`#eae6db`) parent = **4.02:1** at 12 px semibold. Not large text, so the 4.5 threshold applies.
+**This fails WCAG AA.**
+
+Confirmed by the orchestrator on live `https://mifune.dev` in light mode: element
+`<p class="font-mono text-xs font-semibold uppercase tracking-[0.18em] …">` text "What happens next",
+`rgb(21,128,61)` on `rgb(234,230,219)`, **ratio 4.02, FAIL**. The same scan re-confirmed the
+4.53:1 pass for `#15803d` on `#f6f3ec` in the same page, which validates the measurement method.
+
+So: of the two items the original recommendation named, **one passes AA and the other is an ARIA-covered
+1.4.11 issue** — while the one genuine AA violation went unmentioned. Same shared token pair, same
+light-mode traffic increase.
+
+**Both named items are PRE-EXISTING** and untouched by the merges: docs tokens from `b4d40fe`
+(2026-06-27, ~5 weeks prior); `theme-control.tsx` + `.light` tokens from `506bbabe` (2026-07-17,
+~2 weeks prior). `git show --stat` confirms neither merge touched either file.
+
+### Escape-hatch discoverability, measured live at 1280 px (orchestrator)
+
+Because the theme now changes by itself during the day, the "I didn't choose this" escape hatch
+matters more than before. Both shipped surfaces pass:
+
+| Surface | Control | Accessible name | Size | Position |
+|---|---|---|---|---|
+| `mifune.dev` | `<button>` | "Toggle theme" | 44 × 44 | top-right, above the fold |
+| `oh.mifune.dev` | `<button>` | "Switch between dark and light mode (current…)" | 32 × 32 | top-right, above the fold |
+
+Both are visible without scrolling and both clear WCAG 2.5.8 target size (24 px min); the website's
+44 px also clears 2.5.5 AAA. The docs control additionally announces the *current* mode in its label.
+So there is **no discoverability gap on the two live surfaces** — which weakens any argument that the
+automatic default needs an in-page banner or explanation.
+
+## G-6 · OS-preference divergence — CONFIRMED, with the harm correctly located
+
+First-time visitor, no stored choice:
+
+| OS signal | Hour | docs | website | cloud |
+|---|---|---|---|---|
+| dark | 14 | **dark** | light | light |
+| dark | 21 | dark | dark | dark |
+| light *or* silent | 14 | light | light | light |
+| light *or* silent | 21 | dark | dark | dark |
+
+The divergence is **exactly one cell**: OS-dark during daytime.
+
+Mechanism: with `respectPrefersColorScheme: true`, Docusaurus 3.10.1 emits **no `defaultMode` branch**,
+so `defaultMode: "dark"` is dead code on the no-choice path. The plugin bails on non-`system` choice,
+missing `matchMedia`, and OS-dark; it only ever upgrades light→dark and never writes storage.
+`website` has one `matchMedia` call but it sits in the *explicit-choice* branch and only feeds
+`<meta name="theme-color">`. `openharness-cloud` has **zero** `matchMedia`/`prefers-color-scheme` hits.
+
+**The nuance the original recommendation missed.** Ignoring the OS is *pre-existing* in both. But
+before this change a no-choice visitor got **dark at every hour**, so an OS-dark user coincidentally
+got what they wanted. Now that user gets a **light page 07:00–17:59**. The property is old; **the
+regression for OS-dark users is new** — and this is the accessibility cohort named in the docs PR
+rationale (photophobia, migraine, light sensitivity).
+
+**Cost to converge:**
+- `website` — **unblocked, small**: one extra ternary in the no-choice branch of
+  `time-of-day-theme.ts:105-113`; seeding must stay. No provider/layout change. **No test file exists
+  in the repo** — nothing to update, and no regression net either.
+- `openharness-cloud` — **doc-blocked**. `docs/design/console-mvp.md:69` (a self-declared *design
+  authority*) states the console *"never consults `prefers-color-scheme`: no OS signal resolves the
+  theme… the two are unrelated inputs."* §3 must be amended first. §11's non-negotiable contract does
+  **not** mention theme, so amending §3 breaches nothing. Code: a pure
+  `resolveDefaultTheme(hour, prefersDark)`, no provider change, plus a stubbed `matchMedia` in the
+  `new Function(...)` harness at `theme-preference.test.ts:41`.
+
+## G-7 · Dead code in cloud — VERIFIED, and **larger than reported**
+
+`readThemePreference` (`theme-preference.ts:49`) has **zero** production consumers; all references are
+in `theme-preference.test.ts`. Two things the recommendation missed:
+
+- **`resolveTimeOfDayTheme` (`:25`) is transitively dead** — its only caller is `readThemePreference:50`.
+  So the *typed, tested, pure* implementation is unreachable, and the rule that ships to users exists
+  **only as a template string** at `:106`. A test (`:264-274`) pins the emitted script to the shared
+  constants, so it is *managed* duplication, not a live bug — but deleting the function leaves the
+  sole executable copy of the logic as a string. Decide that before approving a delete.
+- **`THEMES` (`:3`) is unused by everything, including tests** — `theme-provider.tsx:65` hardcodes
+  `themes={["dark","light"]}`. A genuine drift risk, covered by no guard.
+
+The hydration-race guard (`:193-201`) asserts strings are *absent* from a **different** file, so
+removal leaves it trivially green. Removal cost: one test file (import `:9`, blocks `:66-72`,
+`:146-152`, `:154-160`).
+
+## G-8 · `next-pwa` service-worker staleness — **REFUTED**
+
+Document navigations are **NetworkFirst**, not CacheFirst: `/` → `NetworkFirst` (`start-url`),
+everything else same-origin non-`/api/` → `NetworkFirst` (`pages`). **No `networkTimeoutSeconds`** on
+either, so no path silently prefers cache. Precache holds exactly **one** document (`/offline`); all
+other entries are content-hashed `_next/static`. `skipWaiting()` + `clientsClaim()` +
+`cleanupOutdatedCaches()` all unconditional; registration automatic.
+
+**Returning visitors get the new head script on their very next navigation. Zero loads of staleness.**
+This item is dead — remove it from the list.
+
+(Side note, not actionable: `public/sw.js` is tracked and was last regenerated in `05247af`, two
+commits before the theme merge; the deployed SW comes from `next build`, so the committed copy lags.)
+
+## G-9 · Artifact durability — **PARTIALLY VERIFIED; the diagnosis was wrong**
+
+`.gitignore:12` (`.oh/tasks/*`, `!.oh/tasks/README.md`) does match — confirmed by `git check-ignore -v`.
+The four artifacts (~35 KB) are untracked.
+
+But **the ignore is soft and routinely overridden**: 35 `.oh/tasks` files are already tracked
+(`apache-relicense/`, `archive/2026-07-27/audit-consolidation/`, `markitdown-wiki-pilot/`,
+`cc-safety-net/critique.md`). Same for the wiki corpus — gitignored at `.gitignore:80`, yet 15 corpus
+files are tracked. `git add -f` and wiki promotion are **established, working** paths.
+
+**The real miss is process.** `pr.yml:17-19` says task artifacts belong in the *scoped worktree
+project* so they ship with the diff. None of the three merge commits carries any (4/3/4 files, all
+source). They were written to the **harness** repo's `.oh/tasks/`, where the ignore applies. That is
+an orchestrator placement mistake, not an inescapable rule.

--- a/.oh/tasks/timezone-followups/progress.txt
+++ b/.oh/tasks/timezone-followups/progress.txt
@@ -1,0 +1,154 @@
+TASK: timezone-followups — council ruling on the 7 outstanding recommendations
+OBJECTIVE: determine which recommendations are worth proceeding with, AFTER grounding.
+PARENT: timezone-default-theme (merged: cloud #108 dca1af6 | website #53 2b66e7a | web #22 22f5aec)
+
+GROUNDING PHASE (orchestrator, done before any council opinion)
+[x] all three clones confirmed at merged default; local == origin
+    cloud main dca1af6 | website development 2b66e7a | openharness-web main 22f5aec
+[x] read-only worktrees cut at the merge commits for agent grounding:
+    .oh/worktrees/task/ground-recs/{openharness-cloud,openharness-web,website}
+[x] PRODUCTION deploy confirmed by fetching real CDN HTML (not deploy previews):
+    - https://oh.mifune.dev  -> shipped docusaurus plugin script present (data-theme-choice guard,
+      matchMedia bail-out, getHours) — 1 occurrence of getHours in an inline script
+    - https://mifune.dev     -> shipped bootstrap present incl. the orchestrator's themeColor fix:
+      K/A keys, DAY=7 NIGHT=18, C={"light":"#ffffff","dark":"#09090b"}
+    - https://promptengineers.ai is a DIFFERENT, legacy 19KB page — no bootstrap. Not this repo's deploy.
+[x] LIVE-PRODUCTION browser verification, expectation re-derived in-browser each run:
+    DOCS  (OS light emulated)  Denver h15 -> data-theme=light, choice=system, localStorage.theme=null  PASS
+    DOCS  (OS light emulated)  UTC    h21 -> data-theme=dark,  choice=system, localStorage.theme=null  PASS
+    SITE  Denver h15 -> class light, theme=light, auto=light, meta theme-color #ffffff, body rgb(255,255,255) PASS
+    SITE  UTC    h21 -> class dark,  theme=dark,  auto=dark,  meta theme-color #09090b, body rgb(9,9,11)     PASS
+    => docs + website are now verified IN PRODUCTION, upgrading the earlier deploy-preview evidence.
+    => the docs run also re-confirms the no-seed design: choice stays "system", storage stays null.
+[x] FLASH question settled STRUCTURALLY against shipped production HTML (was "argued from position"):
+    DOCS byte order: <body>=3896 < docusaurus color-mode script=4534 < plugin script=5082
+                     < <div id="__docusaurus">=5165  — strictly ordered, ORDER OK: True
+      the ONLY non-script markup before the plugin script is <svg style="display: none;"> (sprite
+      sheet) => nothing paintable exists before the correction runs. Shipped tag also carries the
+      data-time-of-day-theme="1" attribute marker (tag attr, not a comment — minifier-proof).
+    SITE  theme script at byte 4252, <body> at 4965 => script is entirely in <head>; zero markup
+      precedes it. 11 of the 12 preceding script tags are defer/async/module, so they cannot
+      preempt it.
+    => on BOTH public surfaces there is no paint opportunity before the theme is settled. This is
+       now a structural proof, not an inference. It still is not a frame capture.
+[x] no existing issue in any of the 3 repos tracks any of the 7 follow-ups (checked open issues):
+    cloud #107/#104/#102/#12, website #38/#35/#28/#27/#26, openharness-web none. All unrelated.
+[x] grounding agents (3, parallel) ALL RETURNED -> full writeup in grounding.md
+    THREE ITEMS CHANGED STATUS UNDER GROUNDING:
+    - REFUTED  next-pwa staleness: documents are NetworkFirst (start-url + pages), no
+      networkTimeoutSeconds, only /offline is precached, skipWaiting+clientsClaim unconditional.
+      Returning visitors get the new head script on the very next navigation. Item is dead.
+    - REFRAMED console spot-check -> console.mifune.dev is STILL SERVING THE PRE-FEATURE BUILD.
+      /signin 200, 23129 bytes, no auth, head script byte-identical to dca1af6^, getHours=0.
+      Agent checked 21:53/54/55Z; orchestrator independently re-checked 21:56Z (2 fetches).
+      Merge was ~21:38Z so an in-flight Netlify build is not yet excluded; GH deployments=[] and
+      homepageUrl="" so build state is not observable. MONITOR ARMED polling for getHours.
+    - NEW      website/src/sections/CTASection.tsx:114 is a REAL WCAG AA FAILURE at 4.02:1
+      (#15803d on #eae6db, 12px semibold => 4.5 threshold applies). Nobody had reported it.
+      CONFIRMED LIVE by orchestrator on https://mifune.dev: "What happens next",
+      rgb(21,128,61) on rgb(234,230,219), ratio 4.02 FAIL. Same scan re-measured the 4.53:1
+      pass on #f6f3ec in the same page, which validates the method.
+[x] orchestrator live cross-checks of both contrast claims (agents read files; I measured the DOM):
+    - docs prose links DO render #15803d on #f6f3ec = 4.53:1 and ARE underlined (9 links on
+      /blog/compound-engineering, 4 on /blog/containers-microvms-vms, hash-links excluded).
+      So blast radius is real, but 1.4.1 is already satisfied and 1.4.3 PASSES. Marginal, not a defect.
+      /docs/intro and / carry no green prose links at all (lowest visible there is 4.81:1 grey).
+    - corrected reported line numbers: custom.css:17 + :48 (reported 22/47 was wrong);
+      theme-control.tsx:15/23/35 was exact.
+[x] corrections to my own earlier recommendations, recorded honestly:
+    - #6 next-pwa was WRONG (refuted).
+    - #2 named the two wrong contrast items; the one genuine AA violation went unmentioned.
+    - #3 was right about divergence but missed that the HARM is new even though the property is old.
+    - #7 understated: resolveTimeOfDayTheme is transitively dead and THEMES is unused entirely.
+    - #4 diagnosis was wrong: the ignore is soft (35 .oh/tasks + 15 wiki files already tracked);
+      the real miss is that pr.yml:17-19 scoped-worktree placement was not followed.
+
+COUNCIL PHASE (plan.yml: architect + pm + designer in parallel)
+[x] all three delegated in parallel, each pointed at grounding.md as sole source of truth
+[ ] awaiting verdicts
+
+[x] all three verdicts received and recorded in council.md
+[x] orchestrator independently verified every load-bearing council claim before accepting it:
+    - openharness-web resolveTimeOfDayTheme: only a JSDoc @link :20 + its own def :60 => zero
+      callers, and that repo has NO test file at all. Architect's parity argument holds.
+    - website: no test/spec file anywhere, no "test" script => BOTH 2a and 3a ship with no net.
+    - cloud theme-provider.tsx:65 literally hardcodes themes={["dark","light"]}. Drift risk real.
+    - finding A mechanism: time-of-day-theme.ts:108 writes BOTH keys on the no-choice path, and
+      next-themes registers addEventListener("storage", r => r.key===m && (r.newValue ? n(...) : ...)).
+      Cross-tab live flip CONFIRMED.
+    - finding B: CTASection.tsx:158 hover:text-oh-accent inside the error banner. CONFIRMED.
+
+CRITIQUE PHASE (pr.yml: 2 adversarial critics)
+[x] 2 adversarial critics delegated in parallel, each told to REFUTE the council
+[x] critic B (decision quality): REFUTES designer's "cloud first, race the deploy"; resolves the 2a
+    scope dispute BY COUNTING (bg-oh-raised appears 3x repo-wide, only 2 wrap accent text => fix
+    both instances, leave the token); proves finding C is PRE-EXISTING via git show 2b66e7a;
+    flags DROP-2c + "guard later" as incoherent with no ticket filed.
+[x] critic A (implementer): finds the HIGHEST-severity gap in the whole council output -- shipping
+    3a before finding A WIDENS finding A (adds an OS-toggle trigger axis on top of the clock
+    boundary). Fell in the seam between PM's 3a ruling and designer's finding A; nobody cross-read.
+    Also REFUTES both obvious fixes for A (differs-check is a no-op per WHATWG; forcedTheme port
+    strands "System"). Vindicates architect on item 7 (boundary coverage at :109-144 is disjoint
+    from readThemePreference's tests).
+[x] orchestrator verified critic A's two highest-severity claims:
+    - cloud vitest.config.ts:5 environment:"node" => no window global; adding window.matchMedia
+      to the bootstrap throws ReferenceError in the two green tests at :205-217. CONFIRMED.
+    - CTASection.tsx:158 sits in bg-red-500/10 OVER bg-oh-raised => composited #ead6cc, so the
+      true ratio is 3.58:1, WORSE than the 4.02:1 the council reported. #166534 clears it at 5.09:1.
+      CONFIRMED by recomputation. The council's own new finding had the wrong number.
+
+DETERMINATION
+[x] decision.md written: 6 PROCEED (1, A+3a together, 2a, 2b, 3b), 4 LATER (7 partial, C, 4, D/E),
+    3 DROP (2c, 5, 6). Two open questions left for the operator (2c guard-or-accept; hold deploy).
+[x] console deploy monitor re-armed after the earlier one was orphaned.
+
+EXECUTION (operator directive: "Complete all recommendations until clean slate")
+[x] every PROCEED and LATER item shipped as a PR; every DROP closed with a record.
+    website  #54  A + 3a   automatic theme out of storage + OS dark outranks the hour
+    website  #55  2a + B   CTA accent to AA on raised surfaces (#166534)
+    website  #56  C        toggle reports active theme (menuitemradio + aria-checked)
+                           stacked on #54; both touch mode-toggle.tsx
+    cloud    #110 2b       ThemeControl selected state gets a 1.4.11-passing indicator
+    cloud    #111 7        delete readThemePreference, KEEP resolveTimeOfDayTheme, wire THEMES
+    cloud    #112 3b       OS dark outranks the clock + console-mvp.md §3 amendment
+[x] #1 console deploy: EXPLICITLY DESCOPED by the operator mid-run ("Don't need to
+    diagnose deploy. I only want the council recommendations."). Last observation
+    22:39Z: still byte-identical pre-feature, 61 min post-merge. Not investigated further.
+[x] open question 1 (2c guard-or-accept) RESOLVED by filing the record:
+    openharness-web #23 — contrast guard, states plainly that the link PASSES at 4.526:1
+    and that this is not a request to change the colour.
+[x] open question 2 (hold the deploy for 3b) MOOT: 3b landed while the console is still
+    serving the pre-feature build, so no OS-dark user ever sees the regression. The
+    amendment was written on its own terms, not against a build deadline.
+[x] LATER items filed rather than dropped:
+    website #57 — D/E, the automatic default is a one-way door and is never explained
+    website #58 — the architect's structural finding: the pre-paint script is pinned by
+                  nothing in this repo, while cloud has 3 pins and docs has 1
+[x] item 4 (artifact placement) closed by ACTING on it: this folder is git add -f'd into
+    the harness per the architect's per-repo ruling (cloud -> cloud .oh/tasks; website and
+    docs -> PR body; cross-repo -> harness, force-added). Not retroactively moving the
+    already-merged artifacts, per PM.
+
+VERIFICATION STANDARD USED (no claim rests on reading the source alone)
+- website: the emitted bootstrap executed against a fake DOM, 12/12 scenarios, asserting
+  ZERO storage writes on every automatic path — that is finding A closed at the mechanism,
+  not by argument.
+- website: real browser, TZ matrix + emulated OS preference, state read AFTER hydration;
+  contrast read as computed styles, with the error banner forced by aborting /api/contact
+  because a hover colour in a conditional branch is invisible to any default-state scan.
+- website: script order re-proved against the BUILT html after relocating the script -
+  <body>@4207, next-themes@5834, correction@6063, only <script> tags between.
+- cloud: 2800 / 2797 / 2812 tests green across the three PRs, tsc --noEmit clean on each.
+- cloud: critic A's ReferenceError trap defused by construction (typeof window), proved by
+  running the NEW script under the OLD 2-arg harness.
+
+CORRECTIONS FOUND DURING EXECUTION (things the council/critics did not catch)
+- 2b: hoisting the shared class string into a constant FAILS
+  final-design-remediation-presentation.test.ts:34-35, which counts "min-h-11 min-w-11"
+  twice as a 44px target-size contract. Kept the duplication deliberately.
+- 2a: the third bg-oh-raised instance carries --oh-accent on a 20px aria-hidden ICON at
+  4.02:1, which PASSES the 3:1 non-text threshold. Correctly excluded, now for a stated reason.
+- A: BOTH of the fixes the critics refuted were refuted for the right reasons, but the
+  actual fix needed a third thing neither considered - next-themes' own inline script
+  applies the SERVER-serialised default, so removing the seed also required moving the
+  correction script to run after it, not before.


### PR DESCRIPTION
Closes the artifact-placement gap by **acting on it** rather than by writing a convention down.

## The actual problem was not the ignore rule

`.gitignore:12` ignores `.oh/tasks/*`, but the ignore is **soft** — 35 files under that path are already tracked via `git add -f`. So "it's gitignored, the artifacts are lost" was a misdiagnosis: the mechanism existed and simply wasn't used.

That is the same failure mode the review flagged elsewhere — a real disposition evaporating because nothing records it.

## Placement

Per the per-repo rule the review settled on:

| Repo | Where follow-up artifacts go |
|---|---|
| this one | `.oh/tasks/<slug>/`, `git add -f`'d — the only repo with an established convention |
| `openharness-cloud` | its own `.oh/tasks/`, same mechanism |
| `openharness-web`, `website` | the PR body — neither has an `.oh/` directory, and growing scaffolding for one ticket is scope creep |

A cross-repo document legitimately lives here.

## Contents

| File | What it is |
|---|---|
| `grounding.md` | the verified ground truth all three council members were pointed at |
| `council.md` | architect / PM / designer verdicts, with orchestrator verification notes |
| `critique.md` | both adversarial critiques |
| `decision.md` | the determination, plus the outcome table and what execution found that nobody else did |
| `progress.txt` | the verification ledger, including corrections to my own earlier claims |

The already-merged artifacts from the parent task are deliberately **not** moved retroactively — churn with no reader.

## Why it is worth keeping

Three of the original seven recommendations were wrong, and the record says so explicitly: `next-pwa` was refuted outright, both named contrast targets were the wrong ones while the genuine AA failure went unmentioned, and the artifact-placement diagnosis was itself incorrect. That is the part worth preserving — the shape of what grounding caught, not the conclusions.