### PR TITLE
FROM feat/689-release-branches TO development

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -2,18 +2,27 @@ name: Publish CLI to npm
 
 # Publishes the standalone `oh` CLI (`.oh/cli`) to npm as @mifune/openharness.
 #
-# The CLI's semver is independent of the repo's CalVer release tags, so this is
-# its own workflow rather than a job chained onto Release:
-#   - workflow_dispatch lets a CLI-only change (README, patch bump) publish
-#     WITHOUT cutting a CalVer release.
-#   - the CalVer tag trigger preserves auto-publish on every release.
-# The version guard makes a run a clean no-op when the CLI version is already
-# on the registry, so running on every release tag is safe and idempotent.
+# The CLI's semver is independent of the repo's CalVer release tags. This
+# reusable workflow is called by release.yml after image publication, and can
+# also be dispatched for a CLI-only change. Both callers must identify the exact
+# commit to publish; the version guard makes an existing version a successful
+# no-op.
 on:
+  workflow_call:
+    inputs:
+      ref:
+        description: Exact commit or ref containing the CLI package to publish
+        required: true
+        type: string
+    secrets:
+      NPM_TOKEN:
+        required: true
   workflow_dispatch:
-  push:
-    tags:
-      - "[0-9][0-9][0-9][0-9].[0-9]*.[0-9]*"
+    inputs:
+      ref:
+        description: Exact commit or ref containing the CLI package to publish
+        required: true
+        type: string
 
 jobs:
   publish-npm:
@@ -23,9 +32,10 @@ jobs:
       contents: read
       id-token: write # provenance attestation
     steps:
-      - name: Checkout
+      - name: Checkout the requested commit
         uses: actions/checkout@v7
         with:
+          ref: ${{ inputs.ref }}
           submodules: recursive
 
       - name: Setup Node 22.x

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,21 +1,29 @@
 name: Release
 
+# Run every release-branch push. Do not add one shared concurrency group:
+# GitHub keeps only one pending run per group and could drop intermediate pushes.
 on:
   push:
-    tags:
-      - "[0-9][0-9][0-9][0-9].[0-9]*.[0-9]*"
+    branches:
+      - main
+      - master
+
+permissions:
+  contents: write
+  packages: write
 
 jobs:
   validate:
-    name: "Validate"
+    name: Validate
     runs-on: ubuntu-latest
     permissions:
       contents: read
 
     steps:
-      - name: Checkout
+      - name: Checkout the event commit
         uses: actions/checkout@v7
         with:
+          ref: ${{ github.sha }}
           submodules: recursive
 
       - name: Ensure Mifune submodule
@@ -68,9 +76,10 @@ jobs:
       contents: read
 
     steps:
-      - name: Checkout
+      - name: Checkout the event commit
         uses: actions/checkout@v7
         with:
+          ref: ${{ github.sha }}
           submodules: recursive
 
       - name: Ensure Mifune submodule
@@ -90,15 +99,16 @@ jobs:
           failure-threshold: warning
 
   eval-probes:
-    name: "Eval Probe Regression Gate"
+    name: Eval Probe Regression Gate
     runs-on: ubuntu-latest
     permissions:
       contents: read
 
     steps:
-      - name: Checkout
+      - name: Checkout the event commit
         uses: actions/checkout@v7
         with:
+          ref: ${{ github.sha }}
           submodules: recursive
 
       - name: Link provider skills
@@ -107,52 +117,57 @@ jobs:
       - name: Run eval probe suite
         run: bash .oh/skills/eval/run.sh
 
-  release:
-    name: Build & Release
-    runs-on: ubuntu-latest
+  reserve:
+    name: Reserve UTC CalVer draft
     needs: [validate, boot-lint, eval-probes]
+    runs-on: ubuntu-latest
     permissions:
       contents: write
+    outputs:
+      releaseVersion: ${{ steps.reserve_release.outputs.releaseVersion }}
+      releaseSha: ${{ steps.reserve_release.outputs.releaseSha }}
+      releaseId: ${{ steps.reserve_release.outputs.releaseId }}
+      publishedNoop: ${{ steps.reserve_release.outputs.publishedNoop }}
+
+    steps:
+      - name: Checkout the validated event commit
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Atomically reserve the CalVer tag and ensure its draft release
+        id: reserve_release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_SHA: ${{ github.sha }}
+          # The push event snapshots this repository timestamp as integer epoch
+          # seconds; retries keep it unchanged, including after UTC midnight.
+          RELEASE_TIMESTAMP: ${{ github.event.repository.pushed_at }}
+        run: node .oh/scripts/reserve-github-release.mjs
+
+  publish-image:
+    name: Build, smoke, and publish GHCR image
+    needs: reserve
+    if: ${{ needs.reserve.outputs.publishedNoop != 'true' }}
+    runs-on: ubuntu-latest
+    # `needs` is valid in job concurrency expressions. Atomic reservations give
+    # distinct push SHAs distinct versions; only same-SHA retries share this key.
+    concurrency:
+      group: release-image-${{ needs.reserve.outputs.releaseVersion }}
+      cancel-in-progress: false
+    permissions:
+      contents: read
       packages: write
 
     steps:
-      - name: Checkout
+      - name: Checkout the reserved commit
         uses: actions/checkout@v7
         with:
+          ref: ${{ needs.reserve.outputs.releaseSha }}
           submodules: recursive
 
       - name: Ensure Mifune submodule
         run: bash .oh/scripts/link-providers.sh --init
-
-      - name: Parse tag
-        id: parse
-        run: |
-          VERSION=${GITHUB_REF#refs/tags/}
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-
-      - name: Extract release notes from CHANGELOG
-        id: notes
-        run: |
-          VERSION="${{ steps.parse.outputs.version }}"
-          NOTES_FILE="$RUNNER_TEMP/release-notes.md"
-          awk -v ver="$VERSION" '
-            $0 ~ ("^## \\[" ver "\\] - ") { in_block=1; next }
-            in_block && /^## \[/ { exit }
-            in_block && /^---[[:space:]]*$/ { exit }
-            in_block { print }
-          ' CHANGELOG.md > "$NOTES_FILE"
-          if [ ! -s "$NOTES_FILE" ] || ! grep -q '[^[:space:]]' "$NOTES_FILE"; then
-            echo "Release $VERSION — see CHANGELOG.md and commit history." > "$NOTES_FILE"
-          fi
-          echo "notes_file=$NOTES_FILE" >> "$GITHUB_OUTPUT"
-
-      - name: Setup Node 22.x
-        uses: actions/setup-node@v7
-        with:
-          node-version: "22"
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v6
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -164,19 +179,20 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build Docker image
+      - name: Build immutable Docker image tags
         env:
+          RELEASE_SHA: ${{ needs.reserve.outputs.releaseSha }}
+          RELEASE_VERSION: ${{ needs.reserve.outputs.releaseVersion }}
           SANDBOX_NAME: openharness-release-smoke-${{ github.run_id }}
         run: |
-          IMAGE=ghcr.io/mifunedev/openharness:${{ steps.parse.outputs.version }}
-          LATEST=ghcr.io/mifunedev/openharness:latest
-          SMOKE_IMAGE=sandbox-${SANDBOX_NAME}
+          VERSION_IMAGE="ghcr.io/mifunedev/openharness:${RELEASE_VERSION}"
+          SHA_IMAGE="ghcr.io/mifunedev/openharness:sha-${RELEASE_SHA}"
+          SMOKE_IMAGE="sandbox-${SANDBOX_NAME}"
+          docker buildx build --load -f .devcontainer/Dockerfile \
+            -t "$VERSION_IMAGE" -t "$SHA_IMAGE" -t "$SMOKE_IMAGE" .
 
-          docker build -f .devcontainer/Dockerfile -t "$IMAGE" -t "$LATEST" -t "$SMOKE_IMAGE" .
-
-      # Keep this pre-push smoke gate between build and push: it boots the
-      # exact image object that will be published to GHCR, via the sandbox-* tag
-      # consumed by .devcontainer/docker-compose.yml.
+      # Keep this pre-push smoke gate between build and publication: it boots
+      # the exact image object that carries both immutable GHCR tags.
       - name: Smoke-test Docker image before publish
         env:
           SANDBOX_NAME: openharness-release-smoke-${{ github.run_id }}
@@ -185,20 +201,111 @@ jobs:
           BOOT_SMOKE_UP_ARGS: "up -d --no-build"
         run: bash .oh/scripts/sandbox-boot-smoke.sh
 
-      - name: Push Docker image
+      - name: Push immutable CalVer and sha-full-SHA tags
+        env:
+          RELEASE_SHA: ${{ needs.reserve.outputs.releaseSha }}
+          RELEASE_VERSION: ${{ needs.reserve.outputs.releaseVersion }}
         run: |
-          IMAGE=ghcr.io/mifunedev/openharness:${{ steps.parse.outputs.version }}
-          LATEST=ghcr.io/mifunedev/openharness:latest
+          docker push "ghcr.io/mifunedev/openharness:${RELEASE_VERSION}"
+          docker push "ghcr.io/mifunedev/openharness:sha-${RELEASE_SHA}"
 
-          docker push "$IMAGE"
-          docker push "$LATEST"
+      - name: Promote latest from the canonical branch by digest
+        env:
+          RELEASE_BRANCH: ${{ github.ref_name }}
+          RELEASE_SHA: ${{ needs.reserve.outputs.releaseSha }}
+          RELEASE_VERSION: ${{ needs.reserve.outputs.releaseVersion }}
+        run: .oh/scripts/promote-release-latest.sh promote
 
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v3
+  publish-cli:
+    name: Publish CLI for the released commit
+    needs: [reserve, publish-image]
+    if: ${{ needs.reserve.outputs.publishedNoop != 'true' }}
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/publish-cli.yml
+    with:
+      ref: ${{ needs.reserve.outputs.releaseSha }}
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  finalize:
+    name: Finalize GitHub Release
+    needs: [reserve, publish-image, publish-cli]
+    if: ${{ always() && needs.reserve.outputs.publishedNoop != 'true' && needs.publish-image.result == 'success' && needs.publish-cli.result == 'success' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout the published commit
+        uses: actions/checkout@v7
         with:
-          name: v${{ steps.parse.outputs.version }}
-          body_path: ${{ steps.notes.outputs.notes_file }}
+          ref: ${{ needs.reserve.outputs.releaseSha }}
 
-  # The `oh` CLI publish lives in its own workflow (.github/workflows/publish-cli.yml)
-  # so a CLI-only change can publish via workflow_dispatch without a CalVer release;
-  # it also triggers on the same release tags, independently of this job.
+      - name: Extract release notes from CHANGELOG
+        env:
+          RELEASE_VERSION: ${{ needs.reserve.outputs.releaseVersion }}
+        run: |
+          NOTES_FILE="$RUNNER_TEMP/release-notes.md"
+          awk -v ver="$RELEASE_VERSION" '
+            $0 ~ ("^## \[" ver "\] - ") { in_block=1; next }
+            in_block && /^## \[/ { exit }
+            in_block && /^---[[:space:]]*$/ { exit }
+            in_block { print }
+          ' CHANGELOG.md > "$NOTES_FILE"
+          if [ ! -s "$NOTES_FILE" ] || ! grep -q '[^[:space:]]' "$NOTES_FILE"; then
+            awk '
+              /^## \[Unreleased\]$/ { in_block=1; next }
+              in_block && /^## \[/ { exit }
+              in_block && /^---[[:space:]]*$/ { exit }
+              in_block { print }
+            ' CHANGELOG.md > "$NOTES_FILE"
+          fi
+          if [ ! -s "$NOTES_FILE" ] || ! grep -q '[^[:space:]]' "$NOTES_FILE"; then
+            echo "Release $RELEASE_VERSION — see CHANGELOG.md and commit history." > "$NOTES_FILE"
+          fi
+
+      # Re-run the same canonical main-else-master rule after CLI publication.
+      # This fresh remote read makes noncanonical releases unconditionally
+      # make_latest=false and catches a newer canonical push before finalization.
+      - name: Check canonical branch for GitHub latest-release status
+        id: github_latest
+        env:
+          RELEASE_BRANCH: ${{ github.ref_name }}
+          RELEASE_SHA: ${{ needs.reserve.outputs.releaseSha }}
+        run: .oh/scripts/promote-release-latest.sh check
+
+      - name: Publish the draft after image and CLI publication
+        uses: actions/github-script@v7
+        env:
+          MAKE_LATEST: ${{ steps.github_latest.outputs.makeLatest }}
+          RELEASE_ID: ${{ needs.reserve.outputs.releaseId }}
+          RELEASE_VERSION: ${{ needs.reserve.outputs.releaseVersion }}
+        with:
+          script: |
+            const fs = require("fs");
+            const [owner, repo] = process.env.GITHUB_REPOSITORY.split("/");
+            const releaseId = Number(process.env.RELEASE_ID);
+            const releaseVersion = process.env.RELEASE_VERSION;
+            const body = fs.readFileSync(`${process.env.RUNNER_TEMP}/release-notes.md`, "utf8");
+            if (!Number.isSafeInteger(releaseId) || releaseId <= 0) {
+              throw new Error(`invalid release ID: ${process.env.RELEASE_ID}`);
+            }
+            if (!new Set(["true", "false"]).has(process.env.MAKE_LATEST)) {
+              throw new Error(`invalid make_latest decision: ${process.env.MAKE_LATEST}`);
+            }
+            if (body.trim() === "") {
+              throw new Error(`empty release notes for ${releaseVersion}`);
+            }
+            await github.rest.repos.updateRelease({
+              owner,
+              repo,
+              release_id: releaseId,
+              name: `v${releaseVersion}`,
+              body,
+              draft: false,
+              make_latest: process.env.MAKE_LATEST,
+            });
+
+  # publish-cli.yml also remains independently dispatchable with an explicit ref.

--- a/.oh/scripts/README.md
+++ b/.oh/scripts/README.md
@@ -9,6 +9,9 @@ Provisioning, Ralph execution, and the cron runtime live here.
 | `ralph.sh`        | Ralph loop runner: `scripts/ralph.sh [--harness=…] <taskdesc>`     |
 | `link-providers.sh` | Creates/repairs the provider skill/agent/hook symlinks into `.oh/` and validates the vendored pack is present. |
 | `repo-orientation-benchmark-score.mjs` | Scores the CB-004 repo-orientation A/B benchmark report |
+| `release-reservation.mjs` | Computes UTC CalVer candidates and collision progression for releases |
+| `reserve-github-release.mjs` | Atomically reserves a CalVer tag and recovers its same-SHA GitHub draft |
+| `promote-release-latest.sh` | Fresh-checks canonical `main`-else-`master` and promotes its image to `latest` by digest |
 | `cron-runtime.ts` | Croner runtime — scans `.oh/crons/*.md`, schedules, fires each job     |
 | `prompt-miner-caps.sh` | Origin-scoped PR-cap preflight for `.oh/crons/prompt-miner.md` — execs `autopilot-caps.sh` with `AUTOPILOT_REPO=mifunedev/openharness` + `AUTOPILOT_LABEL=prompt-miner` |
 | `__tests__/`      | Vitest unit tests (`vitest.config.ts` at repo root targets this)   |

--- a/.oh/scripts/__tests__/release-latest.test.ts
+++ b/.oh/scripts/__tests__/release-latest.test.ts
@@ -1,0 +1,150 @@
+import { spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const ROOT = join(import.meta.dirname, "../../..");
+const HELPER = join(ROOT, ".oh", "scripts", "promote-release-latest.sh");
+const MAIN_SHA = "0123456789abcdef0123456789abcdef01234567";
+const MASTER_SHA = "89abcdef0123456789abcdef0123456789abcdef";
+const STALE_SHA = "fedcba9876543210fedcba9876543210fedcba98";
+const DIGEST = `sha256:${"a".repeat(64)}`;
+
+let fixture = "";
+let bin = "";
+let dockerLog = "";
+
+function executable(path: string, source: string) {
+  writeFileSync(path, source, "utf8");
+  chmodSync(path, 0o755);
+}
+
+function run(
+  mode: "check" | "promote",
+  overrides: Record<string, string> = {},
+) {
+  return spawnSync(HELPER, [mode], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      PATH: `${bin}:${process.env.PATH ?? ""}`,
+      FAKE_DOCKER_LOG: dockerLog,
+      FAKE_DOCKER_INSPECTION: `Name: test\nMediaType: application/vnd.oci.image.index.v1+json\nDigest: ${DIGEST}`,
+      FAKE_GIT_REFS: `${MAIN_SHA}\trefs/heads/main`,
+      IMAGE_REPOSITORY: "ghcr.io/example/openharness",
+      RELEASE_BRANCH: "main",
+      RELEASE_SHA: MAIN_SHA,
+      RELEASE_VERSION: "2026.8.3",
+      ...overrides,
+    },
+  });
+}
+
+beforeEach(() => {
+  fixture = mkdtempSync(join(tmpdir(), "release-latest-"));
+  bin = join(fixture, "bin");
+  dockerLog = join(fixture, "docker.log");
+  mkdirSync(bin);
+  executable(
+    join(bin, "git"),
+    `#!/usr/bin/env bash
+set -euo pipefail
+[[ "$*" == "ls-remote --heads origin refs/heads/main refs/heads/master" ]]
+printf '%s\n' "\${FAKE_GIT_REFS}"
+`,
+  );
+  executable(
+    join(bin, "docker"),
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$FAKE_DOCKER_LOG"
+if [[ "$*" == "buildx imagetools inspect "* ]]; then
+  printf '%b\n' "$FAKE_DOCKER_INSPECTION"
+elif [[ "$*" != "buildx imagetools create "* ]]; then
+  echo "unexpected docker invocation: $*" >&2
+  exit 2
+fi
+`,
+  );
+});
+
+afterEach(() => {
+  rmSync(fixture, { force: true, recursive: true });
+});
+
+describe("promote-release-latest.sh", () => {
+  it("promotes a fresh canonical main image by immutable digest", () => {
+    const result = run("promote");
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain("Promoted ghcr.io/example/openharness:2026.8.3");
+    expect(readFileSync(dockerLog, "utf8").trim().split("\n")).toEqual([
+      "buildx imagetools inspect ghcr.io/example/openharness:2026.8.3",
+      `buildx imagetools create --tag ghcr.io/example/openharness:latest ghcr.io/example/openharness:2026.8.3@${DIGEST}`,
+    ]);
+  });
+
+  it("prefers main and never lets a master run regress latest across branches", () => {
+    const result = run("promote", {
+      FAKE_GIT_REFS: `${MAIN_SHA}\trefs/heads/main\n${MASTER_SHA}\trefs/heads/master`,
+      RELEASE_BRANCH: "master",
+      RELEASE_SHA: MASTER_SHA,
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain("Skipping latest: canonical=main");
+    expect(existsSync(dockerLog)).toBe(false);
+  });
+
+  it("falls back to master only when main is absent", () => {
+    const result = run("promote", {
+      FAKE_GIT_REFS: `${MASTER_SHA}\trefs/heads/master`,
+      RELEASE_BRANCH: "master",
+      RELEASE_SHA: MASTER_SHA,
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(readFileSync(dockerLog, "utf8")).toContain("imagetools create --tag");
+  });
+
+  it("skips a stale canonical run before invoking docker", () => {
+    const result = run("promote", { RELEASE_SHA: STALE_SHA });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain(`head=${MAIN_SHA}`);
+    expect(existsSync(dockerLog)).toBe(false);
+  });
+
+  it("writes the same fresh canonical decision for GitHub make_latest", () => {
+    const output = join(fixture, "github-output");
+    const result = run("check", {
+      FAKE_GIT_REFS: `${MAIN_SHA}\trefs/heads/main\n${MASTER_SHA}\trefs/heads/master`,
+      GITHUB_OUTPUT: output,
+      RELEASE_BRANCH: "master",
+      RELEASE_SHA: MASTER_SHA,
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(readFileSync(output, "utf8")).toBe(
+      `canonicalBranch=main\ncanonicalSha=${MAIN_SHA}\nmakeLatest=false\n`,
+    );
+    expect(existsSync(dockerLog)).toBe(false);
+  });
+
+  it("fails closed when registry inspection has no valid top-level digest", () => {
+    const result = run("promote", { FAKE_DOCKER_INSPECTION: "Name: test\nDigest: latest" });
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("one valid top-level digest");
+    expect(readFileSync(dockerLog, "utf8")).not.toContain("imagetools create");
+  });
+});

--- a/.oh/scripts/__tests__/release-reservation.test.ts
+++ b/.oh/scripts/__tests__/release-reservation.test.ts
@@ -1,0 +1,303 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import {
+  buildUtcCalVerCandidate,
+  formatUtcCalVerBase,
+  reserveReleaseVersion,
+} from "../release-reservation.mjs";
+import {
+  githubOutputLines,
+  parseReleaseTimestamp,
+  reserveGitHubRelease,
+} from "../reserve-github-release.mjs";
+
+const ROOT = join(import.meta.dirname, "../../..");
+const WORKFLOW = join(ROOT, ".github", "workflows", "release.yml");
+const CLI_WORKFLOW = join(ROOT, ".github", "workflows", "publish-cli.yml");
+const RELEASE_SHA = "0123456789abcdef0123456789abcdef01234567";
+const FOREIGN_SHA = "fedcba9876543210fedcba9876543210fedcba98";
+const REPOSITORY = "mifunedev/openharness";
+
+type ExpectedRequest = {
+  body?: unknown;
+  method: string;
+  path: string;
+  responseBody?: unknown;
+  status: number;
+};
+
+function queuedFetch(expected: ExpectedRequest[]): typeof fetch {
+  let index = 0;
+  const mock = async (input: string | URL | Request, init?: RequestInit) => {
+    const next = expected[index++];
+    expect(next, `unexpected request ${String(input)}`).toBeDefined();
+    const url = new URL(typeof input === "string" || input instanceof URL ? input : input.url);
+    const path = `${url.pathname.replace(`/repos/${REPOSITORY}`, "")}${url.search}`;
+    expect(init?.method ?? "GET").toBe(next.method);
+    expect(path).toBe(next.path);
+    expect(new Headers(init?.headers).get("authorization")).toBe("Bearer test-token");
+    if (Object.hasOwn(next, "body")) {
+      expect(JSON.parse(String(init?.body))).toEqual(next.body);
+    }
+    return new Response(next.status === 204 ? null : JSON.stringify(next.responseBody ?? {}), {
+      status: next.status,
+      headers: next.status === 204 ? undefined : { "content-type": "application/json" },
+    });
+  };
+  return Object.assign(mock, {
+    assertDone: () => expect(index).toBe(expected.length),
+  }) as typeof fetch;
+}
+
+function assertFetchDone(fetchImpl: typeof fetch) {
+  (fetchImpl as typeof fetch & { assertDone(): void }).assertDone();
+}
+
+function release(id: number, version: string, draft: boolean) {
+  return { id, tag_name: version, draft };
+}
+
+function tagRef(sha: string) {
+  return { ref: "refs/tags/candidate", object: { type: "commit", sha } };
+}
+
+function createRefBody(version: string) {
+  return { ref: `refs/tags/${version}`, sha: RELEASE_SHA };
+}
+
+function createReleaseBody(version: string) {
+  return {
+    body: "Image publication is pending.",
+    draft: true,
+    prerelease: false,
+    tag_name: version,
+    target_commitish: RELEASE_SHA,
+  };
+}
+
+function options(fetchImpl: typeof fetch, overrides: Record<string, unknown> = {}) {
+  return {
+    fetchImpl,
+    releaseSha: RELEASE_SHA,
+    releaseTimestamp: "2025-03-07T23:59:59.000Z",
+    repository: REPOSITORY,
+    token: "test-token",
+    ...overrides,
+  };
+}
+
+describe("UTC CalVer reservation", () => {
+  it("uses UTC and progresses from the base to -1 and higher", () => {
+    expect(formatUtcCalVerBase(new Date("2025-03-07T23:30:00-02:00"))).toBe("2025.3.8");
+    expect(buildUtcCalVerCandidate("2025.3.8", 0)).toBe("2025.3.8");
+    expect(buildUtcCalVerCandidate("2025.3.8", 1)).toBe("2025.3.8-1");
+  });
+
+  it("keeps foreign-collision progression unbounded by default", async () => {
+    const result = await reserveReleaseVersion({
+      now: new Date("2025-03-07T00:00:00Z"),
+      attemptCreate: ({ collisionCount }: { collisionCount: number }) =>
+        collisionCount < 30 ? { kind: "foreign-collision" } : { kind: "created" },
+    });
+    expect(result).toEqual({ kind: "created", version: "2025.3.7-30" });
+  });
+
+  it("strictly parses immutable integer epoch seconds and offset timestamps", () => {
+    expect(parseReleaseTimestamp("1741391999").toISOString()).toBe("2025-03-07T23:59:59.000Z");
+    expect(parseReleaseTimestamp("2025-03-07T23:59:59-02:00").toISOString()).toBe(
+      "2025-03-08T01:59:59.000Z",
+    );
+    expect(() => parseReleaseTimestamp("01741391999")).toThrow(/integer epoch seconds/);
+    expect(() => parseReleaseTimestamp("1741391999.5")).toThrow(/integer epoch seconds/);
+    expect(() => parseReleaseTimestamp("2025-03-07T23:59:59")).toThrow(/UTC offset/);
+    expect(() => parseReleaseTimestamp("2025-02-30T12:00:00Z")).toThrow(/valid ISO/);
+  });
+});
+
+describe("GitHub reservation bridge", () => {
+  it("atomically creates the unsuffixed tag before its draft", async () => {
+    const fetchImpl = queuedFetch([
+      {
+        method: "POST",
+        path: "/git/refs",
+        status: 201,
+        body: createRefBody("2025.3.7"),
+        responseBody: tagRef(RELEASE_SHA),
+      },
+      {
+        method: "POST",
+        path: "/releases",
+        status: 201,
+        body: createReleaseBody("2025.3.7"),
+        responseBody: release(101, "2025.3.7", true),
+      },
+    ]);
+
+    const result = await reserveGitHubRelease(options(fetchImpl));
+    expect(result).toEqual({
+      publishedNoop: false,
+      releaseId: 101,
+      releaseSha: RELEASE_SHA,
+      releaseVersion: "2025.3.7",
+      reservationKind: "created",
+    });
+    expect(githubOutputLines(result)).toContain("releaseVersion=2025.3.7\n");
+    assertFetchDone(fetchImpl);
+  });
+
+  it("advances a foreign collision to -1", async () => {
+    const fetchImpl = queuedFetch([
+      { method: "POST", path: "/git/refs", status: 422, body: createRefBody("2025.3.7") },
+      {
+        method: "GET",
+        path: "/git/ref/tags/2025.3.7",
+        status: 200,
+        responseBody: tagRef(FOREIGN_SHA),
+      },
+      {
+        method: "POST",
+        path: "/git/refs",
+        status: 201,
+        body: createRefBody("2025.3.7-1"),
+        responseBody: tagRef(RELEASE_SHA),
+      },
+      {
+        method: "POST",
+        path: "/releases",
+        status: 201,
+        body: createReleaseBody("2025.3.7-1"),
+        responseBody: release(102, "2025.3.7-1", true),
+      },
+    ]);
+
+    const result = await reserveGitHubRelease(options(fetchImpl));
+    expect(result.releaseVersion).toBe("2025.3.7-1");
+    assertFetchDone(fetchImpl);
+  });
+
+  it("recovers an exact same-SHA draft through authenticated pagination", async () => {
+    const fullPage = Array.from({ length: 100 }, (_, index) =>
+      release(1_000 + index, `2025.3.6-${index + 1}`, true),
+    );
+    const fetchImpl = queuedFetch([
+      { method: "POST", path: "/git/refs", status: 422, body: createRefBody("2025.3.7") },
+      {
+        method: "GET",
+        path: "/git/ref/tags/2025.3.7",
+        status: 200,
+        responseBody: tagRef(RELEASE_SHA),
+      },
+      { method: "GET", path: "/releases/tags/2025.3.7", status: 404 },
+      {
+        method: "GET",
+        path: "/releases?per_page=100&page=1",
+        status: 200,
+        responseBody: fullPage,
+      },
+      {
+        method: "GET",
+        path: "/releases?per_page=100&page=2",
+        status: 200,
+        responseBody: [release(103, "2025.3.7", true)],
+      },
+    ]);
+
+    const result = await reserveGitHubRelease(options(fetchImpl));
+    expect(result.reservationKind).toBe("reused-draft");
+    expect(result.releaseId).toBe(103);
+    assertFetchDone(fetchImpl);
+  });
+
+  it("treats an already-published same-SHA reservation as a successful no-op", async () => {
+    const fetchImpl = queuedFetch([
+      { method: "POST", path: "/git/refs", status: 422, body: createRefBody("2025.3.7") },
+      {
+        method: "GET",
+        path: "/git/ref/tags/2025.3.7",
+        status: 200,
+        responseBody: tagRef(RELEASE_SHA),
+      },
+      {
+        method: "GET",
+        path: "/releases/tags/2025.3.7",
+        status: 200,
+        responseBody: release(104, "2025.3.7", false),
+      },
+    ]);
+
+    const result = await reserveGitHubRelease(options(fetchImpl));
+    expect(result).toMatchObject({
+      publishedNoop: true,
+      releaseVersion: "2025.3.7",
+      reservationKind: "published-no-op",
+    });
+    assertFetchDone(fetchImpl);
+  });
+});
+
+describe("release workflow contract", () => {
+  const source = readFileSync(WORKFLOW, "utf8");
+
+  it("triggers for main and master without dropping intermediate pushes", () => {
+    expect(source).toMatch(/push:\n\s+branches:\n\s+- main\n\s+- master/);
+    expect(source).not.toMatch(/^concurrency:/m);
+  });
+
+  it("gates the first release mutation on validation and an immutable push timestamp", () => {
+    expect(source).toMatch(/reserve:\n[\s\S]*?needs: \[validate, boot-lint, eval-probes\]/);
+    expect(source).toMatch(/RELEASE_TIMESTAMP: \$\{\{ github\.event\.repository\.pushed_at \}\}/);
+    expect(source).not.toContain("github.event.head_commit.timestamp");
+    expect(source.indexOf("jobs:\n")).toBeLessThan(source.indexOf("  reserve:\n"));
+    expect(source).not.toMatch(/deleteRelease|deleteRef|method:\s*["']DELETE/);
+  });
+
+  it("publishes sha-prefixed immutable tags and promotes latest by digest", () => {
+    const immutablePush = source.indexOf("Push immutable CalVer and sha-full-SHA tags");
+    const latestPromote = source.indexOf("Promote latest from the canonical branch by digest");
+    const cliPublish = source.indexOf("  publish-cli:\n");
+    const finalize = source.indexOf("  finalize:\n");
+    const freshGithubCheck = source.indexOf("Check canonical branch for GitHub latest-release status");
+    const publishDraft = source.indexOf("Publish the draft after image and CLI publication");
+
+    expect(source).toContain("docker buildx build --load");
+    expect(source).toContain('docker push "ghcr.io/mifunedev/openharness:${RELEASE_VERSION}"');
+    expect(source).toContain('docker push "ghcr.io/mifunedev/openharness:sha-${RELEASE_SHA}"');
+    expect(source).not.toContain('openharness:${RELEASE_SHA}"');
+    expect(source).toContain(".oh/scripts/promote-release-latest.sh promote");
+    expect(source).not.toContain("latest_guard");
+    expect(immutablePush).toBeGreaterThan(0);
+    expect(latestPromote).toBeGreaterThan(immutablePush);
+    expect(cliPublish).toBeGreaterThan(latestPromote);
+    expect(finalize).toBeGreaterThan(cliPublish);
+    expect(freshGithubCheck).toBeGreaterThan(finalize);
+    expect(publishDraft).toBeGreaterThan(freshGithubCheck);
+  });
+
+  it("serializes only same-version image publication and gates finalization on CLI success", () => {
+    expect(source).not.toMatch(/^concurrency:/m);
+    expect(source).toMatch(
+      /publish-image:[\s\S]*?concurrency:\n\s+group: release-image-\$\{\{ needs\.reserve\.outputs\.releaseVersion \}\}\n\s+cancel-in-progress: false/,
+    );
+    expect(source).toMatch(/publish-cli:\n[\s\S]*?needs: \[reserve, publish-image\]/);
+    expect(source).toContain("uses: ./.github/workflows/publish-cli.yml");
+    expect(source).toContain("ref: ${{ needs.reserve.outputs.releaseSha }}");
+    expect(source).toMatch(/needs: \[reserve, publish-image, publish-cli\]/);
+    expect(source).toContain("needs.publish-cli.result == 'success'");
+    expect(source).toContain("make_latest: process.env.MAKE_LATEST");
+    expect(source).toContain("draft: false");
+  });
+});
+
+describe("CLI publication workflow contract", () => {
+  const source = readFileSync(CLI_WORKFLOW, "utf8");
+
+  it("is reusable and manually dispatchable with the exact checkout ref", () => {
+    expect(source).toMatch(/workflow_call:\n\s+inputs:\n\s+ref:/);
+    expect(source).toMatch(/workflow_dispatch:\n\s+inputs:\n\s+ref:/);
+    expect(source).toContain("ref: ${{ inputs.ref }}");
+    expect(source).not.toMatch(/push:\n\s+tags:/);
+    expect(source).toContain("npm publish --access public --provenance");
+  });
+});

--- a/.oh/scripts/promote-release-latest.sh
+++ b/.oh/scripts/promote-release-latest.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Promote the canonical release branch's immutable image to latest by digest.
+set -euo pipefail
+
+usage() {
+  echo "usage: promote-release-latest.sh <check|promote>" >&2
+  exit 64
+}
+
+MODE=${1:-}
+case "$MODE" in
+  check|promote) ;;
+  *) usage ;;
+esac
+
+: "${RELEASE_BRANCH:?RELEASE_BRANCH is required}"
+: "${RELEASE_SHA:?RELEASE_SHA is required}"
+
+if [[ ! "$RELEASE_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "RELEASE_SHA must be a full lowercase 40-character commit SHA" >&2
+  exit 64
+fi
+
+REMOTE=${RELEASE_REMOTE:-origin}
+REFS=$(git ls-remote --heads "$REMOTE" refs/heads/main refs/heads/master)
+main_sha=""
+master_sha=""
+while IFS=$'\t' read -r sha ref; do
+  case "$ref" in
+    refs/heads/main)
+      [[ -z "$main_sha" ]] || { echo "duplicate main ref returned by $REMOTE" >&2; exit 1; }
+      main_sha=$sha
+      ;;
+    refs/heads/master)
+      [[ -z "$master_sha" ]] || { echo "duplicate master ref returned by $REMOTE" >&2; exit 1; }
+      master_sha=$sha
+      ;;
+    "") ;;
+    *) echo "unexpected ref returned by $REMOTE: $ref" >&2; exit 1 ;;
+  esac
+done <<< "$REFS"
+
+if [[ -n "$main_sha" ]]; then
+  canonical_branch=main
+  canonical_sha=$main_sha
+elif [[ -n "$master_sha" ]]; then
+  canonical_branch=master
+  canonical_sha=$master_sha
+else
+  echo "neither main nor master exists on $REMOTE" >&2
+  exit 1
+fi
+
+if [[ ! "$canonical_sha" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "$REMOTE returned an invalid $canonical_branch SHA: $canonical_sha" >&2
+  exit 1
+fi
+
+make_latest=false
+if [[ "$RELEASE_BRANCH" == "$canonical_branch" && "$RELEASE_SHA" == "$canonical_sha" ]]; then
+  make_latest=true
+fi
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  {
+    printf 'canonicalBranch=%s\n' "$canonical_branch"
+    printf 'canonicalSha=%s\n' "$canonical_sha"
+    printf 'makeLatest=%s\n' "$make_latest"
+  } >> "$GITHUB_OUTPUT"
+fi
+
+if [[ "$MODE" == check ]]; then
+  printf 'canonical=%s head=%s release_branch=%s release_sha=%s make_latest=%s\n' \
+    "$canonical_branch" "$canonical_sha" "$RELEASE_BRANCH" "$RELEASE_SHA" "$make_latest"
+  exit 0
+fi
+
+if [[ "$make_latest" != true ]]; then
+  printf 'Skipping latest: canonical=%s head=%s release_branch=%s release_sha=%s\n' \
+    "$canonical_branch" "$canonical_sha" "$RELEASE_BRANCH" "$RELEASE_SHA"
+  exit 0
+fi
+
+: "${RELEASE_VERSION:?RELEASE_VERSION is required for promote mode}"
+if [[ ! "$RELEASE_VERSION" =~ ^[0-9]{4}\.[1-9][0-9]*\.[1-9][0-9]*(-[1-9][0-9]*)?$ ]]; then
+  echo "RELEASE_VERSION must be a UTC CalVer version" >&2
+  exit 64
+fi
+
+IMAGE_REPOSITORY=${IMAGE_REPOSITORY:-ghcr.io/mifunedev/openharness}
+VERSION_IMAGE="${IMAGE_REPOSITORY}:${RELEASE_VERSION}"
+LATEST_IMAGE="${IMAGE_REPOSITORY}:latest"
+INSPECTION=$(docker buildx imagetools inspect "$VERSION_IMAGE")
+digest=""
+while IFS= read -r line; do
+  if [[ "$line" =~ ^Digest:[[:space:]]+(sha256:[0-9a-f]{64})[[:space:]]*$ ]]; then
+    [[ -z "$digest" ]] || { echo "multiple top-level digests returned for $VERSION_IMAGE" >&2; exit 1; }
+    digest=${BASH_REMATCH[1]}
+  fi
+done <<< "$INSPECTION"
+
+if [[ -z "$digest" ]]; then
+  echo "docker did not return one valid top-level digest for $VERSION_IMAGE" >&2
+  exit 1
+fi
+
+# Address the immutable source by digest so latest never depends on a mutable
+# local tag or on a second registry tag lookup after the canonical-head check.
+docker buildx imagetools create --tag "$LATEST_IMAGE" "${VERSION_IMAGE}@${digest}"
+printf 'Promoted %s@%s to %s from canonical %s\n' \
+  "$VERSION_IMAGE" "$digest" "$LATEST_IMAGE" "$canonical_branch"

--- a/.oh/scripts/release-reservation.mjs
+++ b/.oh/scripts/release-reservation.mjs
@@ -1,0 +1,119 @@
+// Pure UTC CalVer reservation state machine used by the GitHub release bridge.
+
+export class ReleaseReservationError extends Error {
+  constructor(code, message, options = {}) {
+    super(message, { cause: options.cause });
+    this.name = "ReleaseReservationError";
+    this.code = code;
+    this.attemptNumber = options.attemptNumber;
+    this.version = options.version;
+  }
+}
+
+export function formatUtcCalVerBase(now) {
+  if (!(now instanceof Date) || Number.isNaN(now.getTime())) {
+    throw new ReleaseReservationError("INVALID_DATE", "release reservation requires a valid Date");
+  }
+  return `${now.getUTCFullYear()}.${now.getUTCMonth() + 1}.${now.getUTCDate()}`;
+}
+
+export function buildUtcCalVerCandidate(baseVersion, collisionCount) {
+  if (!/^\d{4}\.[1-9]\d*\.[1-9]\d*$/.test(baseVersion)) {
+    throw new ReleaseReservationError(
+      "INVALID_CALVER_VERSION",
+      `invalid unsuffixed UTC CalVer base ${JSON.stringify(baseVersion)}`,
+      { version: baseVersion },
+    );
+  }
+  const [year, month, day] = baseVersion.split(".").map(Number);
+  const date = new Date(Date.UTC(year, month - 1, day));
+  if (
+    date.getUTCFullYear() !== year ||
+    date.getUTCMonth() + 1 !== month ||
+    date.getUTCDate() !== day
+  ) {
+    throw new ReleaseReservationError(
+      "INVALID_CALVER_VERSION",
+      `invalid unsuffixed UTC CalVer base ${JSON.stringify(baseVersion)}`,
+      { version: baseVersion },
+    );
+  }
+  if (!Number.isInteger(collisionCount) || collisionCount < 0) {
+    throw new ReleaseReservationError(
+      "INVALID_COLLISION_COUNT",
+      `collision count must be a non-negative integer: ${collisionCount}`,
+      { version: baseVersion },
+    );
+  }
+  return collisionCount === 0 ? baseVersion : `${baseVersion}-${collisionCount}`;
+}
+
+export async function reserveReleaseVersion({
+  attemptCreate,
+  maxForeignCollisions,
+  now = new Date(),
+}) {
+  if (
+    maxForeignCollisions !== undefined &&
+    (!Number.isInteger(maxForeignCollisions) || maxForeignCollisions < 0)
+  ) {
+    throw new ReleaseReservationError(
+      "INVALID_COLLISION_COUNT",
+      `maxForeignCollisions must be a non-negative integer: ${maxForeignCollisions}`,
+    );
+  }
+
+  const baseVersion = formatUtcCalVerBase(now);
+  for (
+    let collisionCount = 0;
+    maxForeignCollisions === undefined || collisionCount <= maxForeignCollisions;
+    collisionCount += 1
+  ) {
+    const candidateVersion = buildUtcCalVerCandidate(baseVersion, collisionCount);
+    let outcome;
+    try {
+      outcome = await attemptCreate({
+        attemptNumber: collisionCount + 1,
+        baseVersion,
+        candidateVersion,
+        collisionCount,
+      });
+    } catch (cause) {
+      throw new ReleaseReservationError(
+        "ATTEMPT_FAILED",
+        `release reservation attempt failed for ${candidateVersion}`,
+        { attemptNumber: collisionCount + 1, cause, version: candidateVersion },
+      );
+    }
+
+    switch (outcome.kind) {
+      case "created":
+        return { kind: "created", version: candidateVersion };
+      case "same-sha-draft":
+        return { kind: "reused-draft", version: candidateVersion };
+      case "same-sha-published":
+        return { kind: "published-no-op", version: candidateVersion };
+      case "foreign-collision":
+        continue;
+      case "invalid-state":
+        throw new ReleaseReservationError(
+          "INVALID_ATTEMPT_STATE",
+          `invalid release reservation state for ${candidateVersion}: ${outcome.message}`,
+          { attemptNumber: collisionCount + 1, version: candidateVersion },
+        );
+      default:
+        throw new ReleaseReservationError(
+          "INVALID_ATTEMPT_STATE",
+          `unknown release reservation outcome for ${candidateVersion}`,
+          { attemptNumber: collisionCount + 1, version: candidateVersion },
+        );
+    }
+  }
+
+  const limit = maxForeignCollisions;
+  throw new ReleaseReservationError(
+    "MAX_COLLISIONS_EXCEEDED",
+    `release reservation exceeded ${limit} foreign collisions for ${baseVersion}`,
+    { attemptNumber: limit + 1, version: buildUtcCalVerCandidate(baseVersion, limit) },
+  );
+}

--- a/.oh/scripts/reserve-github-release.mjs
+++ b/.oh/scripts/reserve-github-release.mjs
@@ -1,0 +1,332 @@
+// Reserve a retry-safe GitHub draft release by atomically creating its CalVer tag ref.
+
+import { appendFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { reserveReleaseVersion } from "./release-reservation.mjs";
+
+const GITHUB_API_VERSION = "2022-11-28";
+
+function errorMessage(body) {
+  if (typeof body === "object" && body !== null && "message" in body) {
+    return String(body.message);
+  }
+  return JSON.stringify(body);
+}
+
+function assertRelease(value, candidateVersion) {
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    typeof value.id !== "number" ||
+    typeof value.draft !== "boolean" ||
+    value.tag_name !== candidateVersion
+  ) {
+    throw new Error(`GitHub returned an invalid release for ${candidateVersion}`);
+  }
+  return value;
+}
+
+export function parseReleaseTimestamp(releaseTimestamp) {
+  if (typeof releaseTimestamp !== "string") {
+    throw new Error("RELEASE_TIMESTAMP must be integer epoch seconds or an ISO 8601 timestamp");
+  }
+
+  if (/^(0|[1-9]\d*)$/.test(releaseTimestamp)) {
+    const epochSeconds = Number(releaseTimestamp);
+    const parsed = new Date(epochSeconds * 1_000);
+    if (!Number.isSafeInteger(epochSeconds) || Number.isNaN(parsed.getTime())) {
+      throw new Error("RELEASE_TIMESTAMP epoch seconds are outside the supported range");
+    }
+    return parsed;
+  }
+
+  const match =
+    /^(?<year>\d{4})-(?<month>\d{2})-(?<day>\d{2})T(?<hour>\d{2}):(?<minute>\d{2}):(?<second>\d{2})(?:\.\d+)?(?<offset>Z|[+-](?<offsetHour>\d{2}):(?<offsetMinute>\d{2}))$/.exec(
+      releaseTimestamp,
+    );
+  if (!match?.groups) {
+    throw new Error(
+      "RELEASE_TIMESTAMP must be integer epoch seconds or an ISO 8601 timestamp with a UTC offset",
+    );
+  }
+
+  const values = [
+    match.groups.year,
+    match.groups.month,
+    match.groups.day,
+    match.groups.hour,
+    match.groups.minute,
+    match.groups.second,
+    match.groups.offsetHour ?? "0",
+    match.groups.offsetMinute ?? "0",
+  ].map((value) => Number.parseInt(value, 10));
+  const [year, month, day, hour, minute, second, offsetHour, offsetMinute] = values;
+  const calendarDate = new Date(Date.UTC(year, month - 1, day));
+  if (
+    calendarDate.getUTCFullYear() !== year ||
+    calendarDate.getUTCMonth() + 1 !== month ||
+    calendarDate.getUTCDate() !== day ||
+    hour > 23 ||
+    minute > 59 ||
+    second > 59 ||
+    offsetHour > 23 ||
+    offsetMinute > 59
+  ) {
+    throw new Error("RELEASE_TIMESTAMP must be a valid ISO 8601 timestamp");
+  }
+
+  const parsed = new Date(releaseTimestamp);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error("RELEASE_TIMESTAMP must be a valid ISO 8601 timestamp");
+  }
+  return parsed;
+}
+
+export async function reserveGitHubRelease({
+  apiUrl = "https://api.github.com",
+  fetchImpl = fetch,
+  maxForeignCollisions,
+  releaseSha,
+  releaseTimestamp,
+  repository,
+  token,
+}) {
+  if (!/^[0-9a-f]{40}$/.test(releaseSha)) {
+    throw new Error("RELEASE_SHA must be a full lowercase 40-character commit SHA");
+  }
+  if (!/^[^/]+\/[^/]+$/.test(repository)) {
+    throw new Error("GITHUB_REPOSITORY must have owner/repository form");
+  }
+  if (!token) throw new Error("GITHUB_TOKEN is required");
+
+  // The push event's repository timestamp is stable across workflow retries,
+  // so a retry after UTC midnight keeps the original push's CalVer base. It is
+  // independent of the commit-authored timestamp.
+  const releaseDate = parseReleaseTimestamp(releaseTimestamp);
+  const repositoryUrl = `${apiUrl.replace(/\/$/, "")}/repos/${repository}`;
+  const headers = {
+    accept: "application/vnd.github+json",
+    authorization: `Bearer ${token}`,
+    "content-type": "application/json",
+    "user-agent": "openharness-release-reservation",
+    "x-github-api-version": GITHUB_API_VERSION,
+  };
+
+  async function request(path, init = {}) {
+    const response = await fetchImpl(`${repositoryUrl}${path}`, {
+      ...init,
+      headers: { ...headers, ...init.headers },
+    });
+    const text = await response.text();
+    let body = null;
+    if (text) {
+      try {
+        body = JSON.parse(text);
+      } catch {
+        body = text;
+      }
+    }
+    return { response, body };
+  }
+
+  async function resolveTagCommit(candidateVersion) {
+    const result = await request(`/git/ref/tags/${encodeURIComponent(candidateVersion)}`);
+    if (result.response.status === 404) return null;
+    if (!result.response.ok) {
+      throw new Error(
+        `failed to inspect candidate tag ${candidateVersion}: ${result.response.status} ${errorMessage(result.body)}`,
+      );
+    }
+
+    let object = result.body?.object;
+    for (let depth = 0; depth < 8; depth += 1) {
+      if (!object?.sha || !object.type) {
+        throw new Error(`candidate tag ${candidateVersion} has an invalid Git object`);
+      }
+      if (object.type === "commit") return object.sha;
+      if (object.type !== "tag") {
+        throw new Error(`candidate tag ${candidateVersion} points to unsupported ${object.type}`);
+      }
+      const tagResult = await request(`/git/tags/${encodeURIComponent(object.sha)}`);
+      if (!tagResult.response.ok) {
+        throw new Error(
+          `failed to peel candidate tag ${candidateVersion}: ${tagResult.response.status} ${errorMessage(tagResult.body)}`,
+        );
+      }
+      object = tagResult.body?.object;
+    }
+    throw new Error(`candidate tag ${candidateVersion} exceeds the annotated-tag depth limit`);
+  }
+
+  async function getPublishedRelease(candidateVersion) {
+    const result = await request(`/releases/tags/${encodeURIComponent(candidateVersion)}`);
+    if (result.response.status === 404) return null;
+    if (!result.response.ok) {
+      throw new Error(
+        `failed to inspect published release ${candidateVersion}: ${result.response.status} ${errorMessage(result.body)}`,
+      );
+    }
+    const release = assertRelease(result.body, candidateVersion);
+    if (release.draft) {
+      throw new Error(`GitHub's published tag endpoint returned a draft for ${candidateVersion}`);
+    }
+    return release;
+  }
+
+  async function findExactDraftRelease(candidateVersion) {
+    // GitHub's release-by-tag endpoint excludes drafts. Authenticated listing
+    // is used only after the exact tag resolves to releaseSha, never to choose
+    // the next version candidate.
+    for (let page = 1; ; page += 1) {
+      const result = await request(`/releases?per_page=100&page=${page}`);
+      if (!result.response.ok) {
+        throw new Error(
+          `failed to list releases while recovering draft ${candidateVersion}: ${result.response.status} ${errorMessage(result.body)}`,
+        );
+      }
+      if (!Array.isArray(result.body)) {
+        throw new Error(`GitHub returned an invalid release list while recovering ${candidateVersion}`);
+      }
+      const exactDraft = result.body.find(
+        (entry) =>
+          typeof entry === "object" &&
+          entry !== null &&
+          entry.tag_name === candidateVersion &&
+          entry.draft === true,
+      );
+      if (exactDraft) return assertRelease(exactDraft, candidateVersion);
+      if (result.body.length < 100) return null;
+    }
+  }
+
+  async function recoverExactCandidateRelease(candidateVersion) {
+    return (
+      (await getPublishedRelease(candidateVersion)) ??
+      (await findExactDraftRelease(candidateVersion))
+    );
+  }
+
+  let selectedRelease = null;
+
+  async function ensureDraftRelease(candidateVersion) {
+    const result = await request("/releases", {
+      method: "POST",
+      body: JSON.stringify({
+        body: "Image publication is pending.",
+        draft: true,
+        prerelease: false,
+        tag_name: candidateVersion,
+        target_commitish: releaseSha,
+      }),
+    });
+    if (result.response.status === 201) {
+      const release = assertRelease(result.body, candidateVersion);
+      if (!release.draft) {
+        return { kind: "invalid-state", message: "GitHub created a non-draft reservation" };
+      }
+      selectedRelease = release;
+      return { kind: "created" };
+    }
+    if (result.response.status !== 422) {
+      throw new Error(
+        `GitHub draft release create failed for ${candidateVersion}: ${result.response.status} ${errorMessage(result.body)}`,
+      );
+    }
+
+    // Another same-SHA run may win release creation after this run creates or
+    // observes the tag. Re-read only this exact candidate.
+    const racedRelease = await recoverExactCandidateRelease(candidateVersion);
+    if (!racedRelease) {
+      return {
+        kind: "invalid-state",
+        message: `GitHub rejected the draft but no candidate release exists (${errorMessage(result.body)})`,
+      };
+    }
+    selectedRelease = racedRelease;
+    return racedRelease.draft ? { kind: "same-sha-draft" } : { kind: "same-sha-published" };
+  }
+
+  const reservationOptions = {
+    now: releaseDate,
+    attemptCreate: async ({ candidateVersion }) => {
+      // Creating the exact ref is the atomic version reservation. A crash after
+      // this succeeds is recoverable because a retry recognizes the same SHA.
+      const createRef = await request("/git/refs", {
+        method: "POST",
+        body: JSON.stringify({ ref: `refs/tags/${candidateVersion}`, sha: releaseSha }),
+      });
+      if (createRef.response.status === 201) return ensureDraftRelease(candidateVersion);
+      if (createRef.response.status !== 422) {
+        throw new Error(
+          `GitHub tag ref create failed for ${candidateVersion}: ${createRef.response.status} ${errorMessage(createRef.body)}`,
+        );
+      }
+
+      const candidateSha = await resolveTagCommit(candidateVersion);
+      if (!candidateSha) {
+        return {
+          kind: "invalid-state",
+          message: `GitHub reported a tag collision but the ref is absent (${errorMessage(createRef.body)})`,
+        };
+      }
+      if (candidateSha !== releaseSha) return { kind: "foreign-collision" };
+
+      const candidateRelease = await recoverExactCandidateRelease(candidateVersion);
+      if (!candidateRelease) return ensureDraftRelease(candidateVersion);
+      selectedRelease = candidateRelease;
+      return candidateRelease.draft
+        ? { kind: "same-sha-draft" }
+        : { kind: "same-sha-published" };
+    },
+  };
+  // Production deliberately has no collision cap. Tests may supply one.
+  if (maxForeignCollisions !== undefined) {
+    reservationOptions.maxForeignCollisions = maxForeignCollisions;
+  }
+
+  const reservation = await reserveReleaseVersion(reservationOptions);
+  if (!selectedRelease) {
+    throw new Error(`reservation ${reservation.version} completed without a GitHub Release`);
+  }
+
+  return {
+    publishedNoop: reservation.kind === "published-no-op",
+    releaseId: selectedRelease.id,
+    releaseSha,
+    releaseVersion: reservation.version,
+    reservationKind: reservation.kind,
+  };
+}
+
+export function githubOutputLines(reservation) {
+  return [
+    `releaseVersion=${reservation.releaseVersion}`,
+    `releaseSha=${reservation.releaseSha}`,
+    `releaseId=${reservation.releaseId}`,
+    `publishedNoop=${reservation.publishedNoop}`,
+    `reservationKind=${reservation.reservationKind}`,
+    "",
+  ].join("\n");
+}
+
+async function main() {
+  const outputPath = process.env.GITHUB_OUTPUT;
+  if (!outputPath) throw new Error("GITHUB_OUTPUT is required");
+  const reservation = await reserveGitHubRelease({
+    apiUrl: process.env.GITHUB_API_URL,
+    releaseSha: process.env.RELEASE_SHA ?? "",
+    releaseTimestamp: process.env.RELEASE_TIMESTAMP ?? "",
+    repository: process.env.GITHUB_REPOSITORY ?? "",
+    token: process.env.GITHUB_TOKEN ?? "",
+  });
+  await appendFile(outputPath, githubOutputLines(reservation), "utf8");
+  console.log(
+    `${reservation.reservationKind}: ${reservation.releaseVersion} at ${reservation.releaseSha}`,
+  );
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {
+  await main();
+}

--- a/.oh/skills/ci-status/SKILL.md
+++ b/.oh/skills/ci-status/SKILL.md
@@ -106,7 +106,7 @@ For Eval Probe Regression Gate failures, immediately inspect the failed probe na
   - `ci-harness.yml` — push only: `packages/**`, `.oh/**`, `package.json`, `pnpm-lock.yaml`, `pnpm-workspace.yaml`, itself
   - Docs site CI/deploy lives in `mifunedev/openharness-web`; this repo has no `docs.yml` Docusaurus workflow.
   - `conciseness.yml` — push or PR: `workspace/*.md`, `workspace/.claude/rules/*.md`, itself
-  - `release.yml` — tag push only
+  - `release.yml` — every push to `main` or `master`; validation precedes automatic release publication
 
   Infrastructure-only PRs (devcontainer/scripts/install/) trigger NOTHING on push — that's expected. `pull_request`-event workflows still fire when the PR opens. Diagnose with: `git diff --name-only HEAD~1 HEAD` and compare against each workflow's `on:` block.
 

--- a/.oh/skills/git/SKILL.md
+++ b/.oh/skills/git/SKILL.md
@@ -107,7 +107,7 @@ Entry format: one line, imperative mood, link PR or issue.
 - Slack thread replies in multi-channel mode ([#42](https://github.com/mifunedev/openharness/pull/42)).
 ```
 
-At release time, `/release` promotes `[Unreleased]` to new `## [<VERSION>] - YYYY-MM-DD` section and re-seeds empty `[Unreleased]` block. Do **not** hand-edit versioned sections after tag ships.
+Automatic branch-push releases use the matching `## [<VERSION>] - YYYY-MM-DD` section when one already exists; otherwise they publish the current `[Unreleased]` body. Do **not** hand-edit a versioned section after its tag ships.
 
 ## Worktrees
 
@@ -196,59 +196,33 @@ Keep stacks shallow: one level routine, two levels rare, three levels means some
 
 ## Releases
 
-Versioning: **CalVer** `YYYY.M.D` for first release of day, then `YYYY.M.D-N` (N starts at 2) for subsequent releases.
+Every push to `main` or `master` triggers `.github/workflows/release.yml`. The
+workflow checks out the exact event SHA and requires validation, boot-path lint,
+and eval probes to pass before it mutates a tag, GitHub Release, or package.
+Do **not** manually pre-create a release tag or `release/<version>` branch.
 
-Release branch: `release/<VERSION>` (e.g., `release/2026.4.18-2`).
+Versioning is UTC CalVer: `YYYY.M.D` for the first reservation from a push date,
+then `YYYY.M.D-1`, `-2`, and onward. Git-ref creation is the atomic reservation.
+A retry uses the original event timestamp and reuses a same-SHA draft; a retry of
+an already-published same-SHA release is a successful no-op. Foreign collisions
+advance without a production cap.
 
-Pushing tag triggers `.github/workflows/release.yml` — its release gate runs lint, format check, typecheck, build, test, root-scripts tests, pnpm-pin drift checks, boot-path lint (shellcheck + hadolint), and the eval-probe regression gate (mirroring CI) before it builds `ghcr.io/mifunedev/openharness:<VERSION>`, pushes to GHCR, and creates the GitHub Release.
-
-Branch model: `development` is the integration branch; `main` is the
-release line. A release **promotes `development` into `main`**, cuts the
-release branch from `main`, tags it, then leaves both branches converged.
-The full flow is:
+The artifact sequence is:
 
 ```
-development → main → release/<VERSION> → tag <VERSION> → main & development in sync
+main|master push → validate + boot-lint + eval → reserve tag + draft
+                 → build + smoke → push CalVer + sha-<full-SHA> GHCR tags
+                 → canonical latest-by-digest → publish/no-op CLI
+                 → publish GitHub Release
 ```
 
-`release.yml` triggers purely on the tag push and checks out the **tagged
-commit** (branch-agnostic), so the build is correct regardless of which
-branch the tag sits on. The `main` promotion is what keeps the release
-line authoritative — skipping it silently drifts `main` behind every
-release.
-
-Pre-flight before tagging:
-- On intended source branch (`development`), no uncommitted changes
-- `development` pushed and CI green
-
-Procedure:
-
-```bash
-VERSION=$(date '+%Y.%-m.%-d')                             # append -N if tag exists
-
-# 1. Promote CHANGELOG [Unreleased] → [VERSION], commit on development, push.
-#    (the /release skill automates this; see § Changelog)
-git push origin development
-
-# 2. Promote development → main (fast-forward; main is the release line).
-#    main must be strictly behind development — verify it is fast-forwardable:
-git fetch origin main development
-git merge-base --is-ancestor origin/main origin/development \
-  && echo "FF-safe" || echo "DIVERGED — reconcile before releasing"
-git push origin origin/development:main                   # clean FF, no merge commit
-
-# 3. Cut the release branch from main and tag.
-git checkout -b "release/$VERSION" origin/main
-git push origin "release/$VERSION"
-git tag "$VERSION" && git push origin "$VERSION"          # triggers CI release
-
-# 4. After tag CI passes, main and development are already converged
-#    (both at the promotion commit). No extra sync needed when step 2
-#    was a fast-forward. If main had diverged and a merge was required,
-#    merge main back into development to re-converge.
-```
-
-After pushing tag, monitor `.github/workflows/release.yml` and verify both GitHub Release and GHCR image. Use `/release` skill for full automated procedure (version detection, pre-flight, **main promotion**, tag, CI polling, verification).
+The mutable/latest branch is canonically `main` when it exists, otherwise
+`master`. A helper fetches both refs immediately before digest promotion, so a
+`master` run can never regress `latest` when `main` exists; stale canonical runs
+also skip it. GitHub `make_latest` repeats the same fresh canonical check and is
+always false for the noncanonical branch. The GitHub Release stays draft until
+immutable image and successful/no-op CLI publication finish. See `/release` for
+the fast-forward promotion, monitoring, and verification procedure.
 
 ## After Push
 

--- a/.oh/skills/release/SKILL.md
+++ b/.oh/skills/release/SKILL.md
@@ -1,183 +1,111 @@
 ---
 name: release
 description: |
-  Cut a CalVer release: compute version, pre-flight, push release branch + tag,
-  poll CI, verify GitHub Release + GHCR image.
-  TRIGGER when: asked to release, version, tag, ship, cut a release, or push a new version.
+  Release a validated Open Harness commit by pushing it to main or master, then
+  monitor the automatic UTC CalVer/GHCR/GitHub Release workflow. TRIGGER when:
+  asked to release, version, ship, cut a release, or verify release artifacts.
 argument-hint: "[--dry-run]"
 ---
 
 # Release
 
-Automates the CalVer release procedure defined in `.claude/skills/git/SKILL.md` (§ Releases).
+`.github/workflows/release.yml` owns version allocation and artifact mutation.
+Every push to `main` or `master` is validated first, then atomically reserves a
+UTC CalVer tag, publishes GHCR and the CLI (or confirms the CLI version already
+exists), and finally publishes the GitHub Release. Do not pre-create a release
+tag, draft, or `release/<version>` branch.
 
-This skill exists for the parts that are tedious to run by hand: version auto-increment, CI polling, and post-release verification. Conventions (branch names, commit format, pre-flight checks) live in the rule — read it first.
-
-## Instructions
-
-### Step 1 — Resolve repo + version
+## 1. Resolve the canonical destination
 
 ```bash
-# Resolve the canonical remote: prefer 'upstream' (fork layout where origin is
-# a private fork), else 'origin' (standard single-remote layout). All release
-# pushes target $REMOTE so a release never lands on a private fork by accident.
 if git remote get-url upstream >/dev/null 2>&1; then
   REMOTE=upstream
 else
   REMOTE=origin
 fi
 REPO=$(gh repo view "$(git remote get-url "$REMOTE")" --json nameWithOwner -q .nameWithOwner)
-git fetch "$REMOTE" --tags --quiet                     # version detection needs canonical tags
-TODAY=$(date '+%Y.%-m.%-d')
 
-if ! git tag --list "$TODAY" | grep -q .; then
-  VERSION="$TODAY"
+if git ls-remote --exit-code --heads "$REMOTE" main >/dev/null 2>&1; then
+  TARGET=main
+elif git ls-remote --exit-code --heads "$REMOTE" master >/dev/null 2>&1; then
+  TARGET=master
 else
-  LAST_N=$(git tag --list "${TODAY}-*" --sort=-v:refname | head -1 | grep -oP '\d+$' || echo "1")
-  VERSION="${TODAY}-$((LAST_N + 1))"
-fi
-
-echo "Repo: $REPO · Version: $VERSION"
-```
-
-### Step 2 — Pre-flight
-
-Follow the pre-flight checklist in `.claude/skills/git/SKILL.md` § Releases (clean tree on the intended source branch).
-
-If `--dry-run`, report version + pre-flight results and **stop here**.
-
-### Step 3 — Promote CHANGELOG `[Unreleased]`
-
-Abort if `## [Unreleased]` has no real entries (only category headers / blank lines):
-
-```bash
-UNRELEASED_BODY=$(awk '
-  /^## \[Unreleased\]/ { in_block=1; next }
-  in_block && (/^## \[/ || /^---$/) { exit }
-  in_block { print }
-' CHANGELOG.md | grep -vE '^(### |\s*$)')
-
-if [ -z "$UNRELEASED_BODY" ]; then
-  echo "Aborting: [Unreleased] is empty — nothing user-visible to release." >&2
-  echo "Add changelog entries on this branch (or confirm with the user before continuing)." >&2
+  echo "No main or master release branch exists on $REMOTE" >&2
   exit 1
 fi
+SOURCE=$(git branch --show-current)
+printf 'Repo: %s · source: %s · release branch: %s\n' "$REPO" "$SOURCE" "$TARGET"
 ```
 
-Promote `[Unreleased]` to `[$VERSION]` and re-seed an empty block above it, then commit on the current branch before cutting the release branch:
+## 2. Pre-flight
+
+Require all of the following before a release push:
+
+- The working tree is clean.
+- The source commit is pushed to the canonical remote.
+- CI for the source commit is green.
+- `CHANGELOG.md` has the intended notes under `[Unreleased]` (or an already
+  versioned section when intentionally prepared).
+- The remote release branch is an ancestor of the source commit, so promotion is
+  a fast-forward.
 
 ```bash
-RELEASE_DATE=$(date '+%Y-%m-%d')
-
-awk -v ver="$VERSION" -v rdate="$RELEASE_DATE" '
-  /^## \[Unreleased\]$/ && !done {
-    print "## [Unreleased]"
-    print ""
-    print "### Added"
-    print "### Changed"
-    print "### Fixed"
-    print "### Removed"
-    print "### Deprecated"
-    print "### Security"
-    print ""
-    print "## [" ver "] - " rdate
-    done=1
-    next
-  }
-  { print }
-' CHANGELOG.md > CHANGELOG.md.tmp && mv CHANGELOG.md.tmp CHANGELOG.md
-
-git add CHANGELOG.md
-git commit -m "task: promote CHANGELOG for $VERSION"
-```
-
-The `[$VERSION]` section is the source of truth for the GitHub Release body — `release.yml` extracts it via `body_path` (no `generate_release_notes`).
-
-### Step 4 — Promote `development` → `main`, then cut release branch + tag
-
-`development` is the integration branch; `main` is the release line. Push
-the promotion commit to `development`, fast-forward `main` to it, then cut
-the release branch from `main` (see `.claude/skills/git/SKILL.md` § Releases for
-the branch model).
-
-```bash
-PREV_BRANCH=$(git branch --show-current)               # expected: development
-
-# Push the CHANGELOG promotion commit to development.
-git push "$REMOTE" "$PREV_BRANCH"
-
-# Promote development → main. main MUST be strictly behind development
-# (fast-forwardable). Abort if it has diverged — reconcile manually first.
-git fetch "$REMOTE" main "$PREV_BRANCH"
-if git merge-base --is-ancestor "$REMOTE/main" "$REMOTE/$PREV_BRANCH"; then
-  git push "$REMOTE" "$REMOTE/$PREV_BRANCH:main"       # clean fast-forward
-  echo "main fast-forwarded to $PREV_BRANCH"
-else
-  echo "Aborting: main has diverged from $PREV_BRANCH — reconcile before releasing." >&2
+test -z "$(git status --porcelain)" || { echo "Working tree is dirty" >&2; exit 1; }
+git fetch "$REMOTE" "$SOURCE" "$TARGET" --tags
+SHA=$(git rev-parse "$REMOTE/$SOURCE")
+test "$(git rev-parse HEAD)" = "$SHA" || {
+  echo "Local $SOURCE is not identical to $REMOTE/$SOURCE" >&2
   exit 1
-fi
-
-# Cut the release branch from main and tag it.
-git checkout -b "release/$VERSION" "$REMOTE/main"
-git push "$REMOTE" "release/$VERSION"
-git tag "$VERSION" && git push "$REMOTE" "$VERSION"    # triggers release.yml
+}
+git merge-base --is-ancestor "$REMOTE/$TARGET" "$SHA" || {
+  echo "$TARGET has diverged from $SOURCE; reconcile before release" >&2
+  exit 1
+}
 ```
 
-After step 4, `main` and `development` are converged (both at the
-promotion commit). No extra back-sync is needed when step 4 was a
-fast-forward.
+If `$ARGUMENTS` contains `--dry-run`, report the resolved repo, source, target,
+SHA, clean-tree result, and fast-forward result, then stop without pushing.
 
-### Step 5 — Poll CI (up to 10 min)
+## 3. Trigger the release
+
+Promote the exact checked source SHA. The branch push—not a manually created
+tag—is the release trigger.
 
 ```bash
-sleep 10
-RUN_ID=$(gh api "repos/$REPO/actions/runs?branch=${VERSION}&per_page=1" \
-  --jq '.workflow_runs[0].id')
-
-for i in $(seq 1 40); do
-  STATUS=$(gh api "repos/$REPO/actions/runs/$RUN_ID" --jq '.status')
-  if [ "$STATUS" = "completed" ]; then
-    CONCLUSION=$(gh api "repos/$REPO/actions/runs/$RUN_ID" --jq '.conclusion')
-    echo "Release workflow: $CONCLUSION"
-    break
-  fi
-  echo "Still running... ($i/40)"
-  sleep 15
-done
+git push "$REMOTE" "$SHA:refs/heads/$TARGET"
 ```
 
-### Step 6 — Verify artifacts
+The workflow derives its UTC date from the immutable push-event timestamp.
+Retries reuse a same-SHA draft or published release; foreign CalVer collisions
+advance from `YYYY.M.D` to `YYYY.M.D-1`, `-2`, and onward.
+
+## 4. Monitor and verify
+
+Find the `release.yml` push run for `$SHA` and `$TARGET`, then watch it:
 
 ```bash
+gh run list --repo "$REPO" --workflow release.yml --branch "$TARGET" \
+  --commit "$SHA" --event push --limit 5 \
+  --json databaseId,headSha,status,conclusion,url
+# Once the matching run appears:
+gh run watch <run-id> --repo "$REPO" --exit-status
+```
+
+After success, fetch tags and identify the UTC CalVer tag pointing to the exact
+SHA, then verify both immutable image tags and the GitHub Release:
+
+```bash
+git fetch "$REMOTE" --tags
+VERSION=$(git tag --points-at "$SHA" \
+  | grep -E '^[0-9]{4}\.[1-9][0-9]*\.[1-9][0-9]*(-[1-9][0-9]*)?$' \
+  | sort -V | tail -1)
+test -n "$VERSION" || { echo "No CalVer tag found for $SHA" >&2; exit 1; }
 gh release view "$VERSION" --repo "$REPO"
-
-# GHCR package owner may be an org or a user — try org first, fall back to user.
-# Listing needs the read:packages scope; the release.yml docker-push step is the
-# authoritative confirmation if the token lacks it.
-OWNER=${REPO%%/*}; PKG=${REPO##*/}
-gh api "orgs/$OWNER/packages/container/$PKG/versions" \
-    --jq '.[0] | {tags: .metadata.container.tags, created: .created_at}' 2>/dev/null \
-  || gh api "users/$OWNER/packages/container/$PKG/versions" \
-    --jq '.[0] | {tags: .metadata.container.tags, created: .created_at}' 2>/dev/null \
-  || echo "(package listing needs read:packages scope — verify via the release.yml run's docker push step)"
+printf 'Images: ghcr.io/mifunedev/openharness:%s and :sha-%s\n' "$VERSION" "$SHA"
 ```
 
-### Step 7 — Return to previous branch + report
-
-```bash
-git checkout "$PREV_BRANCH"
-```
-
-```
-Release $VERSION complete!
-
-  Repo:     $REPO
-  Tag:      $VERSION
-  Branch:   release/$VERSION (cut from main)
-  main:     fast-forwarded to $VERSION (in sync with development)
-  Image:    ghcr.io/$REPO:$VERSION
-  Release:  https://github.com/$REPO/releases/tag/$VERSION
-  CI:       <pass/fail with run URL>
-```
-
-If CI failed, include failure details and suggest fixes.
+The canonical mutable/latest branch is `main` when it exists, otherwise
+`master`. Immediately before promotion, the workflow freshly reads both remote
+refs and promotes the canonical head's CalVer image to `latest` by immutable
+digest. Stale canonical runs and every noncanonical-branch run skip `latest`;
+GitHub's `make_latest` flag uses the same rule after a second fresh check.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Update policy and release automation live in [`/git`](.claude/skills/git/SKILL.m
 
 ### Added
 ### Changed
+- Release every push to `main` or `master` only after validation, using retry-safe UTC CalVer reservations, immutable CalVer/`sha-<full-SHA>` GHCR tags, canonical-branch digest promotion for `latest`, gated CLI publication, and post-image GitHub Release finalization ([#689](https://github.com/mifunedev/openharness/issues/689)).
 - Expose the supported GPT-5.6 variants in Pi's model selector ([#684](https://github.com/mifunedev/openharness/issues/684)).
 - Expand Advisor planning with a designer lens and make implementation/PR prompts explicitly finish with delegated audits and retrospectives ([#680](https://github.com/mifunedev/openharness/issues/680)).
 ### Fixed


### PR DESCRIPTION
## Summary
- release every validated push to `main` or `master` with retry-safe UTC CalVer
- publish immutable CalVer and `sha-<fullsha>` GHCR tags, with stale-run guarded `latest`
- make CLI publication reusable and finalize GitHub Releases only after image/CLI success
- update release, Git, CI, and script documentation

## Verification
- focused release tests: 18/18
- full Vitest suite: 472/472
- `pnpm run typecheck`
- `pnpm run build:harness`
- shell syntax and `git diff --check`

Closes #689