### PR TITLE
FROM fix/release-skill-table-drift TO development

### DIFF
--- a/.oh/templates/AGENTS.md
+++ b/.oh/templates/AGENTS.md
@@ -54,7 +54,7 @@ Skills are loaded from `.oh/skills/` via each provider's `skills` symlink, so
 | `/eval` | run the probe suite, write `.oh/evals/RESULTS.md` |
 | `/git` | issues, branches, commits, PR titles/bodies, releases |
 | `/ci-status` | after a push — poll CI, report pass/fail |
-| `/release` | CalVer release — branch, tag, push, image |
+| `/release` | CalVer release — push to `main`/`master`; the workflow validates, reserves the CalVer, and publishes |
 | `/health-check` | triage host memory/disk/Docker before a heavy build |
 | `/agent-browser` | open a URL headless for screenshots / preview checks |
 | `/cloudflared` | expose a sandbox port via a public tunnel |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -173,7 +173,7 @@ The `/spec` dispatcher operates on a `.oh/tasks/<slug>/` folder (the universal i
 
 | Skill | When |
 |-------|------|
-| `/release` | CalVer release — branch, tag, push, GHCR |
+| `/release` | CalVer release — push to `main`/`master`; the workflow validates, reserves the CalVer, and publishes |
 | `/ci-status` | After `git push` — poll CI, report pass/fail |
 | `/git` | Provider-portable source of truth for issue titles, branch/worktree conventions, PR titles/bodies, commits, changelog, stacked PRs, releases, and after-push checks. Use this instead of relying on `.oh/context/rules/git.md`, which is now only a pointer for providers that load rules. |
 | `/builder` | Author or refine one provider-portable artifact via `/builder <agent\|skill\|command\|rule> <name-or-request>`; shared discovery and validation live in the dispatcher, with one authoritative reference per type. |


### PR DESCRIPTION
Follow-up to #689 / PR #690, which is already merged.

That PR replaced tag-triggered release publication with "release on every push to `main`/`master`",
and `.oh/skills/release/SKILL.md` now says explicitly:

> Do not pre-create a release tag, draft, or `release/<version>` branch.

Two skill-table rows did not move with it and still list `tag` as an operator step:

| file:line | was | why it matters |
|---|---|---|
| `AGENTS.md:176` | `CalVer release — branch, tag, push, GHCR` | **`CLAUDE.md` is a symlink to `AGENTS.md`**, so this row is in always-loaded context for every agent in the repo |
| `.oh/templates/AGENTS.md:57` | `CalVer release — branch, tag, push, image` | seeded into every new agent workspace; also said `image` where the root file says `GHCR` |

Both now read: `CalVer release — push to main/master; the workflow validates, reserves the CalVer,
and publishes`.

An always-loaded instruction to perform a step the skill it points at explicitly forbids is the
most expensive kind of doc drift — it is read by default and contradicts its own authority.

Two lines, no runtime change. Surfaced by a designer-lens review of what #689's merge left behind.