### PR TITLE
FROM task/700-luna-max-defaults TO development

### DIFF
--- a/.pi/settings.json
+++ b/.pi/settings.json
@@ -1,7 +1,7 @@
 {
   "defaultProvider": "openai-codex",
-  "defaultModel": "gpt-5.6-sol",
-  "defaultThinkingLevel": "medium",
+  "defaultModel": "gpt-5.6-luna",
+  "defaultThinkingLevel": "max",
   "enabledModels": [
     "openai-codex/gpt-5.6-sol",
     "openai-codex/gpt-5.6-terra",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ Update policy and release automation live in [`/git`](.claude/skills/git/SKILL.m
 
 ### Added
 ### Changed
-- Release every push to `main` or `master` only after validation, using retry-safe UTC CalVer reservations, immutable CalVer/`sha-<full-SHA>` GHCR tags, canonical-branch digest promotion for `latest`, gated CLI publication, and post-image GitHub Release finalization ([#689](https://github.com/mifunedev/openharness/issues/689)).
+- Set the default Pi driver to `openai-codex/gpt-5.6-luna` with `max` reasoning while retaining Sol, Terra, and Luna in the model selector ([#700](https://github.com/mifunedev/openharness/issues/700)).
+- Release every push to `main` or `master` only after validation, using retry-safe UTC CalVer reservations, immutable CalVer/`sha-<full-SHA>` GHCR tags, canonical-branch digest promotion for `latest`, gated CLI publication, and post-image GitHub Release finalization ([#689](https://github.com/ryaneggz/openharness/issues/689)).
 - Expose the supported GPT-5.6 variants in Pi's model selector ([#684](https://github.com/mifunedev/openharness/issues/684)).
 - Expand Advisor planning with a designer lens and make implementation/PR prompts explicitly finish with delegated audits and retrospectives ([#680](https://github.com/mifunedev/openharness/issues/680)).
 ### Fixed


### PR DESCRIPTION
## Summary

- set Pi's repository default driver to `openai-codex/gpt-5.6-luna` with `max` reasoning
- retain Sol, Terra, and Luna in the enabled model selector
- record the operator-facing default change in `CHANGELOG.md`

The separate local role-policy PRD defines Sol high/xhigh/max advisor escalation; this commit only establishes the Luna daily-driver baseline and does not change the advisor route.

## Validation

- `jq` settings assertion: pass
- `/delegate` model/effort policy probe: pass
- `git diff --check`: pass

Closes #700
