### PR TITLE
FROM feat/703-default-image-utils TO development

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -9,7 +9,10 @@ ENV TZ=America/Denver
 RUN apt-get update && apt-get install -y --no-install-recommends \
     openssh-client openssh-server build-essential ca-certificates curl wget sudo gosu git jq gnupg \
     lsb-release nano ripgrep tmux unzip bash-completion procps less \
-    iproute2 zsh cron \
+    iproute2 zsh cron lsof htop inetutils-telnet \
+ && command -v lsof >/dev/null \
+ && command -v htop >/dev/null \
+ && command -v telnet >/dev/null \
  && rm -rf /var/lib/apt/lists/*
 
 # ─── Node.js 22.x ──────────────────────────────────────────────────

--- a/.oh/docs/installation.md
+++ b/.oh/docs/installation.md
@@ -307,6 +307,9 @@ Default CLIs are always present. Optional CLIs are excluded from the default ima
 | jq | JSON processing |
 | ripgrep (`rg`) | Fast code search |
 | curl, wget | HTTP clients |
+| lsof | Inspect open files and the processes using them inside the sandbox |
+| htop | Interactive process viewer for the sandbox |
+| telnet | Plaintext network diagnostic client supplied by `inetutils-telnet`; not SSH or a secure shell |
 | nano | Text editor |
 | openssh-client | `ssh-keygen` for GitHub auth flows |
 | bash-completion | Tab completion |

--- a/.oh/scripts/__tests__/sandbox-boot-smoke.test.ts
+++ b/.oh/scripts/__tests__/sandbox-boot-smoke.test.ts
@@ -7,11 +7,14 @@ import { describe, expect, it } from "vitest";
 const ROOT = join(import.meta.dirname, "../../..");
 const SCRIPT = join(ROOT, ".oh", "scripts", "sandbox-boot-smoke.sh");
 
-function fixture(opts: { dockerExecAlwaysFails?: boolean } = {}) {
+function fixture(
+  opts: { dockerExecAlwaysFails?: boolean; runtimeExecFails?: boolean } = {},
+) {
   const dir = mkdtempSync(join(tmpdir(), "sandbox-boot-smoke-"));
   const bin = join(dir, "bin");
   mkdirSync(bin, { recursive: true });
   const composeLog = join(dir, "compose.log");
+  const dockerLog = join(dir, "docker.log");
   const execCount = join(dir, "exec-count");
 
   const compose = join(dir, "compose.sh");
@@ -36,6 +39,7 @@ exit 0
   writeFileSync(
     docker,
     `#!/usr/bin/env bash
+printf '%s\n' "$*" >> ${JSON.stringify(dockerLog)}
 case "$1" in
   exec)
     count=0
@@ -44,6 +48,10 @@ case "$1" in
     printf '%s' "$count" > ${JSON.stringify(execCount)}
     if [ "${opts.dockerExecAlwaysFails ? "1" : "0"}" = "1" ] || [ "$count" -lt 2 ]; then
       echo 'health not ready' >&2
+      exit 1
+    fi
+    if [ "${opts.runtimeExecFails ? "1" : "0"}" = "1" ] && [ "$count" -ge 3 ]; then
+      echo 'required utility unavailable' >&2
       exit 1
     fi
     echo 'sandbox healthcheck ok'
@@ -64,7 +72,7 @@ exit 2
   );
   chmodSync(docker, 0o755);
 
-  return { dir, bin, compose, composeLog };
+  return { dir, bin, compose, composeLog, dockerLog };
 }
 
 function runSmoke(fx: ReturnType<typeof fixture>, extraEnv: Record<string, string> = {}) {
@@ -95,6 +103,30 @@ describe("sandbox boot smoke", () => {
     const composeCalls = readFileSync(fx.composeLog, "utf8");
     expect(composeCalls).toContain("up -d --no-build sandbox");
     expect(composeCalls).toContain("ps -q sandbox");
+    expect(composeCalls).toContain("down -v --remove-orphans");
+    const dockerCalls = readFileSync(fx.dockerLog, "utf8");
+    expect(dockerCalls).toContain("exec -u sandbox cid-123 sh -lc");
+    expect(dockerCalls).toContain("command -v lsof");
+    expect(dockerCalls).toContain("lsof -v");
+    expect(dockerCalls).toContain("command -v htop");
+    expect(dockerCalls).toContain("htop --version");
+    expect(dockerCalls).toContain("command -v telnet");
+    expect(dockerCalls).toContain("telnet --version");
+  });
+
+  it("diagnoses a failed sandbox-user runtime assertion and tears down", () => {
+    const fx = fixture({ runtimeExecFails: true });
+
+    const result = runSmoke(fx);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      "required utilities, Herdr runtime, or writable state is unavailable",
+    );
+    expect(result.stderr).toContain("--- docker compose ps");
+    expect(result.stderr).toContain("--- container health inspect (cid-123)");
+    expect(result.stderr).toContain("entrypoint log tail");
+    const composeCalls = readFileSync(fx.composeLog, "utf8");
     expect(composeCalls).toContain("down -v --remove-orphans");
   });
 

--- a/.oh/scripts/sandbox-boot-smoke.sh
+++ b/.oh/scripts/sandbox-boot-smoke.sh
@@ -52,8 +52,8 @@ while [ "$(date +%s)" -le "$end" ]; do
     # shellcheck disable=SC2086 # HEALTH_CMD intentionally splits into command argv.
     if docker exec "$cid" $HEALTH_CMD >/tmp/sandbox-boot-smoke-health.out 2>/tmp/sandbox-boot-smoke-health.err; then
       if ! docker exec -u sandbox "$cid" sh -lc \
-        'test "$(herdr --version)" = "herdr 0.7.4" && test -w "$HOME/.config" && test -w "$HOME/.herdr"'; then
-        echo "sandbox boot smoke failed: Herdr runtime or writable state is unavailable" >&2
+        'test "$(herdr --version)" = "herdr 0.7.4" && test -w "$HOME/.config" && test -w "$HOME/.herdr" && command -v lsof >/dev/null && lsof -v >/dev/null 2>&1 && command -v htop >/dev/null && htop --version >/dev/null && command -v telnet >/dev/null && telnet --version >/dev/null'; then
+        echo "sandbox boot smoke failed: required utilities, Herdr runtime, or writable state is unavailable" >&2
         status_diagnostics "$cid"
         exit 1
       fi

--- a/.oh/tasks/default-image-utils/audit.md
+++ b/.oh/tasks/default-image-utils/audit.md
@@ -42,6 +42,18 @@ No high- or medium-severity findings.
 | US-003 | Installation Utilities table + changelog | PASS |
 | US-004 | Local gates pass; PR/CI and deterministic PR audit pending | PENDING |
 
+## Deterministic PR audit
+
+After required checks completed, the repository's production acquisition/classifier pipeline returned:
+
+```json
+{"ci":"PASS","evidenceComplete":true,"isDraft":false,"mergeStateStatus":"CLEAN","mergeable":"MERGEABLE","primaryState":"ready","promotable":true,"readyToMerge":true}
+```
+
+Native verdict: **PR-AUDIT-PROMOTABLE**.
+
 ## Verdict
 
-**IMPLEMENTATION-AUDIT-PASS (pre-PR)** — no unmitigated high/medium issue. Promotion remains gated on a ready PR, required CI including Sandbox Boot Guard, and the deterministic focused PR classifier.
+**IMPLEMENTATION-AUDIT-PASS** — all four stories pass, no unmitigated high/medium issue, local verification is green, required Harness and Sandbox Boot Guard CI is green, and deterministic PR evidence is complete/promotable. The PR remains unmerged for human review.
+
+AUDIT-PASS

--- a/.oh/tasks/default-image-utils/audit.md
+++ b/.oh/tasks/default-image-utils/audit.md
@@ -40,7 +40,7 @@ No high- or medium-severity findings.
 | US-001 | Dockerfile diff + image/dpkg/command evidence | PASS |
 | US-002 | Smoke script + 3 focused Vitests + shellcheck | PASS |
 | US-003 | Installation Utilities table + changelog | PASS |
-| US-004 | Local gates pass; PR/CI and deterministic PR audit pending | PENDING |
+| US-004 | Local gates, required current-head PR CI, and deterministic PR audit complete; see `evidence.md` | PASS |
 
 ## Deterministic PR audit
 

--- a/.oh/tasks/default-image-utils/audit.md
+++ b/.oh/tasks/default-image-utils/audit.md
@@ -1,0 +1,47 @@
+# Adversarial Implementation Self-Audit
+
+Date: 2026-08-03
+Scope: real working-tree diff against `origin/development@b0288f37`
+
+## Auditor A — Correctness/operations lens
+
+- **PASS:** The exact Debian packages are in the existing first apt layer; no second update/install layer was added.
+- **PASS:** `--no-install-recommends`, Bookworm slim, apt-list cleanup, all existing users/ports/entrypoint, and unrelated package layers are unchanged.
+- **PASS:** Build-time `command -v` guards cover all three command names.
+- **PASS:** Runtime checks execute after the exact compose healthcheck and as `docker exec -u sandbox`; each tool is both resolved and version-executed.
+- **PASS:** Existing Herdr/version/state assertions, timeout/unhealthy paths, diagnostics, and EXIT teardown remain intact.
+- **PASS:** Tests inspect actual fake-Docker argv for every required command and add a distinct runtime-assertion failure path that verifies diagnostics and teardown.
+- **PASS:** A full image build and direct unprivileged runtime checks prove package identity, command target, and executable versions.
+
+### Findings
+
+1. **LOW — Runtime failure summary groups utilities, Herdr, and state.** The failed inner command's stderr plus existing compose/health/log diagnostics accompany the summary, and the unit test locks this behavior. Per-tool shell branching would add complexity without changing the gate outcome.
+   - Disposition: accepted; non-blocking.
+2. **LOW — Local full compose smoke is unavailable through this container's host-socket path namespace.** Direct image validation covers the changed behavior; the required GitHub Sandbox Boot Guard must be green before completion.
+   - Disposition: CI gate required; tracked in `evidence.md`.
+
+## Auditor B — User/security/scope lens
+
+- **PASS:** Telnet comes from `inetutils-telnet`; direct runtime evidence confirms transitional package `telnet` is absent and `/usr/bin/telnet` resolves to `/usr/bin/inetutils-telnet`.
+- **PASS:** The documentation calls telnet a plaintext diagnostic client and explicitly says it is not SSH or a secure shell.
+- **PASS:** No telnet server, daemon, service, port, compose surface, or runtime install was added.
+- **PASS:** Documentation scopes process views to inside the sandbox and makes no host-process or new architecture promise.
+- **PASS:** Changelog is under Unreleased/Added and links issue #703.
+- **PASS:** Changed implementation files are exactly the canonical image, boot smoke, test, docs, and changelog surfaces; task artifacts are evidence only.
+
+### Findings
+
+No high- or medium-severity findings.
+
+## Acceptance traceability
+
+| Story | Implementation/evidence | Verdict |
+|---|---|---|
+| US-001 | Dockerfile diff + image/dpkg/command evidence | PASS |
+| US-002 | Smoke script + 3 focused Vitests + shellcheck | PASS |
+| US-003 | Installation Utilities table + changelog | PASS |
+| US-004 | Local gates pass; PR/CI and deterministic PR audit pending | PENDING |
+
+## Verdict
+
+**IMPLEMENTATION-AUDIT-PASS (pre-PR)** — no unmitigated high/medium issue. Promotion remains gated on a ready PR, required CI including Sandbox Boot Guard, and the deterministic focused PR classifier.

--- a/.oh/tasks/default-image-utils/critique.md
+++ b/.oh/tasks/default-image-utils/critique.md
@@ -1,0 +1,53 @@
+# Adversarial Plan Critique
+
+Date: 2026-08-03
+Scope: `plan.md`, `prd.md`, and `prd.json` before implementation
+
+## Critic A — Implementer lens
+
+### Alignment checks
+
+- **PASS:** All four PRD stories map one-to-one to Ralph stories with identical IDs, dependency order, and concrete acceptance criteria.
+- **PASS:** The plan modifies only the canonical implementation, smoke test and test contract, canonical installation doc, changelog, and task evidence.
+- **PASS:** Package selection is exact: `inetutils-telnet`, never transitional `telnet`; the command-level contract remains `/usr/bin/telnet`/`telnet`.
+- **PASS:** Docker constraints explicitly preserve Bookworm slim, `--no-install-recommends`, existing apt layer and cleanup, unpinned policy, user/runtime configuration, ports, and entrypoint.
+- **PASS:** Runtime checks are explicitly unprivileged and non-interactive; `lsof -v`, `htop --version`, and `telnet --version` are suitable version probes.
+- **PASS:** The test plan covers both the command wiring and the more important failure behavior: diagnostics plus EXIT teardown.
+
+### Findings
+
+1. **LOW — Test fixture must distinguish health failure from runtime-command failure.** The current fake Docker implementation keys only on exec count. The implementation should add an explicit runtime failure mode and a Docker argv log so tests prove command wiring rather than merely successful call count.
+   - **Mitigation incorporated:** US-002 and `plan.md` require command recording plus a runtime-assertion failure case.
+2. **LOW — Full boot smoke can collide with an operator stack.** It should run through the repository wrapper and preserve teardown semantics; local execution must first inspect stack state and use the existing bounded script rather than ad hoc lifecycle commands.
+   - **Mitigation incorporated:** US-004 allows an exact feasibility blocker and requires evidence; no acceptance criterion is waived silently.
+
+## Critic B — User/security lens
+
+### Alignment checks
+
+- **PASS:** The user-visible outcome is immediate availability in the default image, not a runtime install or optional profile.
+- **PASS:** Documentation must state telnet is plaintext and not a secure shell; no server, daemon, service, or exposed port is introduced.
+- **PASS:** The plan makes no host-process visibility promise for containerized `lsof`/`htop` and no new architecture promise.
+- **PASS:** Package/version policy remains consistent with existing unpinned Debian Bookworm packages.
+- **PASS:** Delivery includes a ready, non-draft PR targeting `development`, required CI, and no merge.
+
+### Findings
+
+1. **MEDIUM — A command-presence-only smoke would not prove utility executability.** `command -v` alone can pass for a broken binary or inaccessible runtime.
+   - **Mitigation incorporated:** PRD FR-4 and US-002 require successful version execution as user `sandbox` for every command.
+2. **LOW — Telnet wording could be misconstrued as remote-shell guidance.** The canonical table must call it a plaintext diagnostic client supplied by `inetutils-telnet`, and explicitly say it is not SSH/a secure shell.
+   - **Mitigation incorporated:** US-003 and FR-6 require this exact distinction.
+
+## Cross-artifact traceability
+
+| Requirement | Plan | PRD | Ralph JSON | Result |
+|---|---|---|---|---|
+| Exact packages and apt hygiene | US-001 | US-001, FR-1..3 | US-001 | Aligned |
+| Runtime sandbox-user checks | US-002 | US-002, FR-4..5 | US-002 | Aligned |
+| Docs and security warning | US-003 | US-003, FR-6 | US-003 | Aligned |
+| Full gates, audits, ready PR/CI | US-004 | US-004 | US-004 | Aligned |
+| Non-goals | Constraints | Non-Goals | Story criteria/notes | Aligned |
+
+## Gate decision
+
+**APPROVED** — no unmitigated high-severity findings. The one medium finding is explicitly closed by executable version checks in both PRD and Ralph acceptance criteria. Implementation may begin.

--- a/.oh/tasks/default-image-utils/evidence.md
+++ b/.oh/tasks/default-image-utils/evidence.md
@@ -54,11 +54,13 @@ The bounded smoke was attempted with a unique compose project, prebuilt test ima
 
 Ready PR: [#704](https://github.com/mifunedev/openharness/pull/704), targeting `development`.
 
-| Workflow / check | Result | Duration | URL |
-|---|---|---|---|
-| CI: Harness — Lint, Typecheck, Build & Test | PASS | 30s | https://github.com/mifunedev/openharness/actions/runs/30836061561/job/91761402736 |
-| CI: Harness — Boot Path Lint (shellcheck + hadolint) | PASS | 18s | https://github.com/mifunedev/openharness/actions/runs/30836061561/job/91761402724 |
-| CI: Harness — Eval Probe Regression Gate | PASS | 24s | https://github.com/mifunedev/openharness/actions/runs/30836061561/job/91761402646 |
-| CI: Sandbox Boot Guard — Validate sandbox compose and image build | PASS | 1m59s | https://github.com/mifunedev/openharness/actions/runs/30836061459/job/91761402184 |
+Current-head source of truth: [PR #704 checks](https://github.com/mifunedev/openharness/pull/704/checks). This PR-scoped link follows the current head; commit-specific job links are intentionally omitted because an evidence-only follow-up commit would make them stale.
 
-Deterministic focused PR acquisition/classification after checks completed returned `ci=PASS`, `evidenceComplete=true`, `promotable=true`, `mergeable=MERGEABLE`, `mergeStateStatus=CLEAN`, `primaryState=ready`, and `readyToMerge=true`.
+| Required workflow / check | Current-head result |
+|---|---|
+| CI: Harness — Lint, Typecheck, Build & Test | PASS |
+| CI: Harness — Boot Path Lint (shellcheck + hadolint) | PASS |
+| CI: Harness — Eval Probe Regression Gate | PASS |
+| CI: Sandbox Boot Guard — Validate sandbox compose and image build | PASS |
+
+Deterministic focused PR acquisition/classification after the current-head checks completed returned `ci=PASS`, `evidenceComplete=true`, `promotable=true`, `mergeable=MERGEABLE`, `mergeStateStatus=CLEAN`, `primaryState=ready`, and `readyToMerge=true`.

--- a/.oh/tasks/default-image-utils/evidence.md
+++ b/.oh/tasks/default-image-utils/evidence.md
@@ -1,0 +1,55 @@
+# Verification Evidence
+
+Date: 2026-08-03
+Base: `origin/development@b0288f37`
+Issue: [#703](https://github.com/mifunedev/openharness/issues/703)
+
+## Focused checks
+
+| Check | Result | Evidence |
+|---|---|---|
+| Frozen dependency install | PASS | `pnpm install --frozen-lockfile`; lockfile current, 162 packages installed; security preinstall found no vulnerabilities |
+| Focused smoke Vitest | PASS | `pnpm exec vitest run .oh/scripts/__tests__/sandbox-boot-smoke.test.ts`; 1 file, 3 tests passed |
+| Bash syntax | PASS | `bash -n .oh/scripts/sandbox-boot-smoke.sh` |
+| Shellcheck | PASS | CI-equivalent `shellcheck -S warning` across all workflow globs; no warnings |
+| Hadolint | PASS | hadolint 2.12.0 with repository `.hadolint.yaml` policy (`DL4006`, `DL3008`, `DL3016`, `DL3003` ignores; warning threshold); only non-gating existing info findings |
+| Diff whitespace | PASS | `git diff --check` |
+
+## Image checks
+
+Command: `DOCKER_BUILDKIT=0 docker build -f .devcontainer/Dockerfile -t openharness-default-image-utils:test .`
+
+Result: PASS; image ID `464320d309be`.
+
+Runtime command used `docker run --rm --entrypoint /bin/bash -u sandbox openharness-default-image-utils:test -lc ...` and established:
+
+- `dpkg-query -W`: `lsof 4.95.0-1`, `htop 3.2.2-2`, `inetutils-telnet 2:2.4-2+deb12u3`.
+- `dpkg -s telnet` reports absent; no transitional `telnet` package is installed.
+- Commands resolve as `/usr/bin/lsof`, `/usr/bin/htop`, and `/usr/bin/telnet`.
+- `lsof -v`, `htop --version` (`htop 3.2.2`), and `telnet --version` (`GNU inetutils 2.4`) succeed as `sandbox`.
+- `/usr/bin/telnet` resolves to `/usr/bin/inetutils-telnet`, owned by package `inetutils-telnet`.
+
+## Full local gates
+
+| Gate | Result |
+|---|---|
+| `pnpm run security:audit` | PASS; no known vulnerabilities |
+| `pnpm run lint` | PASS; repository reports no root lint configured |
+| `pnpm run format:check` | PASS; repository reports no root format check configured |
+| `pnpm run typecheck` | PASS; `.oh/cli` `tsc --noEmit` |
+| `pnpm run build:harness` | PASS; CLI bundle built |
+| `pnpm test:scripts` | PASS in CI-clean environment; 39 files and 478 tests passed |
+| `bash .oh/scripts/check-pnpm-pin.sh` | PASS; Dockerfile and package.json both pin pnpm 10.33.0 |
+| Base compose config | PASS |
+| Hermes dashboard compose config | PASS |
+| `bash .oh/skills/eval/run.sh` | PASS; 95 probes run, 91 PASS/4 SKIPPED, no new regression |
+
+The first unisolated full-test attempt inherited live sandbox variables (`SANDBOX_SSH=true` and Slack variables), causing four environment-dependent fixture failures. Re-running with those live-service variables unset—the clean CI environment—passed all 478 tests. No source change was needed.
+
+## Full sandbox boot smoke feasibility
+
+The bounded smoke was attempted with a unique compose project, prebuilt test image, `SKIP_PNPM_INSTALL=1`, and SSH port 32223. It could not exercise boot in this agent container because the host Docker daemon cannot see this container-only linked-worktree bind source; compose mounted an empty path, then health failed with missing `.oh/scripts/sandbox-healthcheck.sh` and host UID 0 ownership symptoms. The EXIT trap ran and `down -v --remove-orphans` removed the test stack. This is an execution-environment bind-namespace blocker, not an image failure. GitHub's Sandbox Boot Guard uses a runner workspace shared with its Docker daemon and remains the authoritative full-smoke gate.
+
+## CI
+
+Pending PR creation and required GitHub checks.

--- a/.oh/tasks/default-image-utils/evidence.md
+++ b/.oh/tasks/default-image-utils/evidence.md
@@ -52,4 +52,13 @@ The bounded smoke was attempted with a unique compose project, prebuilt test ima
 
 ## CI
 
-Pending PR creation and required GitHub checks.
+Ready PR: [#704](https://github.com/mifunedev/openharness/pull/704), targeting `development`.
+
+| Workflow / check | Result | Duration | URL |
+|---|---|---|---|
+| CI: Harness — Lint, Typecheck, Build & Test | PASS | 30s | https://github.com/mifunedev/openharness/actions/runs/30836061561/job/91761402736 |
+| CI: Harness — Boot Path Lint (shellcheck + hadolint) | PASS | 18s | https://github.com/mifunedev/openharness/actions/runs/30836061561/job/91761402724 |
+| CI: Harness — Eval Probe Regression Gate | PASS | 24s | https://github.com/mifunedev/openharness/actions/runs/30836061561/job/91761402646 |
+| CI: Sandbox Boot Guard — Validate sandbox compose and image build | PASS | 1m59s | https://github.com/mifunedev/openharness/actions/runs/30836061459/job/91761402184 |
+
+Deterministic focused PR acquisition/classification after checks completed returned `ci=PASS`, `evidenceComplete=true`, `promotable=true`, `mergeable=MERGEABLE`, `mergeStateStatus=CLEAN`, `primaryState=ready`, and `readyToMerge=true`.

--- a/.oh/tasks/default-image-utils/plan.md
+++ b/.oh/tasks/default-image-utils/plan.md
@@ -1,0 +1,52 @@
+# Implementation Plan: Default Image Utilities
+
+Issue: [#703](https://github.com/mifunedev/openharness/issues/703)
+Branch: `feat/703-default-image-utils`
+Base: `origin/development@b0288f37`
+
+## Approach
+
+Install the requested diagnostics in the existing Debian Bookworm system-package layer, prove their presence both while building and at runtime as the unprivileged `sandbox` user, then document the user-visible image contract. Preserve all unrelated image and sandbox behavior.
+
+## Dependency graph
+
+```text
+US-001 Image packages
+  ├──> US-002 Runtime smoke + contract tests
+  ├──> US-003 Documentation + changelog
+  └──> US-004 Verification, implementation audit, PR audit, CI
+US-002 ────────────────────────────────────────────────> US-004
+US-003 ────────────────────────────────────────────────> US-004
+```
+
+## Work units
+
+1. **US-001 — Image packages**
+   - Add `lsof`, `htop`, and `inetutils-telnet` to the existing first apt install layer.
+   - Retain `--no-install-recommends`, the single update/install operation, index cleanup, Debian Bookworm base, and all existing image runtime configuration.
+   - Add build-time `command -v` checks for `lsof`, `htop`, and `telnet`.
+2. **US-002 — Runtime verification**
+   - Extend the successful `docker exec -u sandbox` smoke assertion to resolve and run/version all three commands while retaining Herdr and writable-state checks.
+   - Extend Vitest fixtures to record the command wiring and cover a runtime-assertion failure that emits diagnostics and tears down.
+3. **US-003 — User documentation**
+   - Add all three tools to the canonical installation Utilities table.
+   - Identify telnet as an insecure plaintext diagnostic client supplied by `inetutils-telnet`, not a secure shell.
+   - Add an Unreleased/Added changelog entry linked to issue #703.
+4. **US-004 — Verification and delivery**
+   - Run focused static/tests, build the image, inspect packages and commands as `sandbox`, and run the full boot smoke where feasible.
+   - Run repository gates, eval, adversarial implementation audit, deterministic PR audit, push, create a ready PR, and wait for required CI.
+
+## Constraints and non-goals
+
+No telnet server/daemon, port, service, runtime apt install, package profile, base image change, compose change, host-process visibility claim, or new multi-architecture promise. Do not install transitional package `telnet`; `/usr/bin/telnet` must come from `inetutils-telnet`.
+
+## Verification plan
+
+- `pnpm vitest run .oh/scripts/__tests__/sandbox-boot-smoke.test.ts`
+- `bash -n .oh/scripts/sandbox-boot-smoke.sh`
+- `shellcheck .oh/scripts/sandbox-boot-smoke.sh`
+- `hadolint .devcontainer/Dockerfile`
+- Docker build from the repository Dockerfile
+- Container run as `sandbox`: `dpkg-query` for exact packages, `command -v`, and version execution for every utility
+- `.oh/scripts/sandbox-boot-smoke.sh` against a built image/compose stack if feasible
+- Frozen install and all actual root/CLI/CI scripts, compose config checks, security audit, pin checks, and `.oh/evals/run.sh`

--- a/.oh/tasks/default-image-utils/prd.json
+++ b/.oh/tasks/default-image-utils/prd.json
@@ -1,0 +1,72 @@
+{
+  "schemaVersion": 1,
+  "project": "OpenHarness",
+  "branchName": "feat/703-default-image-utils",
+  "description": "Equip the default Debian Bookworm sandbox image with lsof, htop, and the inetutils-telnet diagnostic client.",
+  "userStories": [
+    {
+      "id": "US-001",
+      "title": "Install diagnostic utilities in the default image",
+      "description": "As an OpenHarness user, I want common diagnostics baked into the default image so that I can inspect processes and test plaintext network endpoints without runtime package installation.",
+      "acceptanceCriteria": [
+        ".devcontainer/Dockerfile adds lsof, htop, and inetutils-telnet to the existing first system-package apt install layer",
+        "The layer preserves debian:bookworm-slim, --no-install-recommends, one update/install operation, and apt-list cleanup",
+        "The transitional telnet package is not installed; inetutils-telnet is installed and provides /usr/bin/telnet",
+        "A build-time guard resolves lsof, htop, and telnet",
+        "Existing users, ports, entrypoint, and unrelated image behavior remain unchanged",
+        "Typecheck passes"
+      ],
+      "priority": 1,
+      "passes": true,
+      "notes": "Validated by successful image build 464320d309be and sandbox-user dpkg/command/version evidence in evidence.md."
+    },
+    {
+      "id": "US-002",
+      "title": "Verify utilities during sandbox boot smoke",
+      "description": "As an OpenHarness maintainer, I want runtime assertions as the sandbox user so that a successful image build cannot hide unusable diagnostic commands.",
+      "acceptanceCriteria": [
+        "The successful boot path runs command resolution and successful version invocations for lsof, htop, and telnet through docker exec -u sandbox",
+        "Existing healthcheck, Herdr version, writable state, timeout diagnostics, and EXIT teardown behavior remain covered",
+        "Vitest proves all utility commands are wired into the runtime assertion",
+        "Vitest proves runtime assertion failure emits diagnostics and still tears down",
+        "Focused Vitest and shell syntax checks pass",
+        "Typecheck passes"
+      ],
+      "priority": 2,
+      "passes": true,
+      "notes": "Focused Vitest passed 3/3; CI-equivalent shellcheck passed; runtime-failure diagnostics and teardown are covered."
+    },
+    {
+      "id": "US-003",
+      "title": "Document the image utility contract",
+      "description": "As an OpenHarness user, I want the bundled diagnostics documented accurately so that I understand their purpose and security limitations.",
+      "acceptanceCriteria": [
+        ".oh/docs/installation.md lists lsof, htop, and telnet in the canonical Utilities table",
+        "Documentation states that telnet is a plaintext diagnostic client supplied by inetutils-telnet, not a secure shell",
+        "CHANGELOG.md adds an Unreleased/Added entry linked to issue #703",
+        "No documentation claims host-process visibility or new multi-architecture support",
+        "Typecheck passes"
+      ],
+      "priority": 3,
+      "passes": true,
+      "notes": "Canonical Utilities table and Unreleased/Added changelog entry updated with required security wording and issue link."
+    },
+    {
+      "id": "US-004",
+      "title": "Validate and deliver a ready PR",
+      "description": "As an OpenHarness maintainer, I want reproducible local and CI evidence so that the default image change is safe to review.",
+      "acceptanceCriteria": [
+        "Focused Vitest, bash -n, shellcheck, and hadolint pass",
+        "Docker build and sandbox-user dpkg-query, command resolution, and version checks pass for all requested utilities",
+        "Full sandbox boot smoke passes where feasible or a concrete blocker is recorded",
+        "Frozen install and actual repository lint, format, typecheck, build, tests, scripts, security, pin, compose, and eval gates are run",
+        "Adversarial implementation audit and deterministic PR audit report PASS or PROMOTABLE",
+        "The commit is pushed and required CI including Harness and Sandbox Boot Guard passes on a ready PR targeting development",
+        "Typecheck passes"
+      ],
+      "priority": 4,
+      "passes": false,
+      "notes": "Depends on US-001 through US-003."
+    }
+  ]
+}

--- a/.oh/tasks/default-image-utils/prd.json
+++ b/.oh/tasks/default-image-utils/prd.json
@@ -65,8 +65,8 @@
         "Typecheck passes"
       ],
       "priority": 4,
-      "passes": false,
-      "notes": "Depends on US-001 through US-003."
+      "passes": true,
+      "notes": "All local gates passed; PR #704 is ready, mergeable, clean, CI-green including Harness and Sandbox Boot Guard, and the deterministic classifier reports promotable=true with complete evidence."
     }
   ]
 }

--- a/.oh/tasks/default-image-utils/prd.md
+++ b/.oh/tasks/default-image-utils/prd.md
@@ -1,0 +1,98 @@
+# PRD: Default Image Diagnostic Utilities
+
+## Introduction
+
+OpenHarness users need common process, system, and plaintext network diagnostics available immediately in the default sandbox. Add `lsof`, `htop`, and the `telnet` client supplied by Debian Bookworm's `inetutils-telnet` package without changing the sandbox's runtime or security model.
+
+## Goals
+
+- Ship `lsof`, `htop`, and `/usr/bin/telnet` in every default locally built sandbox image.
+- Preserve the existing Debian Bookworm apt hygiene and default `sandbox` user behavior.
+- Detect package/command regressions at build time, in sandbox boot smoke testing, and in unit tests for that smoke contract.
+- Clearly document telnet's plaintext diagnostic-only security posture.
+
+## User Stories
+
+### US-001: Install diagnostic utilities in the default image
+
+**Description:** As an OpenHarness user, I want common diagnostics baked into the default image so that I can inspect processes and test plaintext network endpoints without runtime package installation.
+
+**Acceptance Criteria:**
+
+- [ ] `.devcontainer/Dockerfile` adds `lsof`, `htop`, and `inetutils-telnet` to the existing first system-package apt install layer.
+- [ ] The image continues to use `debian:bookworm-slim`, `--no-install-recommends`, one update/install operation for that layer, and `/var/lib/apt/lists/*` cleanup.
+- [ ] The transitional `telnet` package is not installed; `dpkg-query` reports `inetutils-telnet` installed and `/usr/bin/telnet` resolves.
+- [ ] A build-time guard resolves `lsof`, `htop`, and `telnet`.
+- [ ] Existing users, ports, entrypoint, and unrelated image behavior remain unchanged.
+- [ ] Typecheck passes.
+
+### US-002: Verify utilities during sandbox boot smoke
+
+**Description:** As an OpenHarness maintainer, I want runtime assertions as the `sandbox` user so that a successful image build cannot hide unusable diagnostic commands.
+
+**Acceptance Criteria:**
+
+- [ ] The successful boot path uses `docker exec -u sandbox` to resolve `lsof`, `htop`, and `telnet` and execute a successful version command for each.
+- [ ] Existing healthcheck, Herdr version, writable state, timeout diagnostics, and EXIT teardown behavior remain covered.
+- [ ] Vitest proves all utility commands are wired into the runtime assertion.
+- [ ] Vitest proves runtime assertion failure emits diagnostics and still tears down.
+- [ ] Focused Vitest and shell syntax checks pass.
+- [ ] Typecheck passes.
+
+### US-003: Document the image utility contract
+
+**Description:** As an OpenHarness user, I want the bundled diagnostics documented accurately so that I understand their purpose and security limitations.
+
+**Acceptance Criteria:**
+
+- [ ] `.oh/docs/installation.md` lists `lsof`, `htop`, and `telnet` in the canonical Utilities table.
+- [ ] Documentation states that telnet is a plaintext diagnostic client supplied by `inetutils-telnet`, not a secure shell.
+- [ ] `CHANGELOG.md` adds an Unreleased/Added entry linked to issue #703.
+- [ ] No documentation claims host-process visibility or new multi-architecture support.
+- [ ] Typecheck passes.
+
+### US-004: Validate and deliver a ready PR
+
+**Description:** As an OpenHarness maintainer, I want reproducible local and CI evidence so that the default image change is safe to review.
+
+**Acceptance Criteria:**
+
+- [ ] Focused Vitest, `bash -n`, shellcheck, and hadolint pass.
+- [ ] Docker image build passes; as user `sandbox`, `dpkg-query`, resolution, and version checks pass for all requested utilities.
+- [ ] Full sandbox boot smoke passes if the local environment supports it, or a concrete blocker is recorded.
+- [ ] Frozen install and actual repository lint/format/typecheck/build/test/script/security/pin/compose/eval gates are run; change-caused failures are fixed and pre-existing blockers are identified.
+- [ ] Adversarial implementation audit and deterministic PR audit report PASS/PROMOTABLE.
+- [ ] Commit is pushed and required GitHub CI, including Harness and Sandbox Boot Guard, passes on a ready PR targeting `development`.
+- [ ] Typecheck passes.
+
+## Functional Requirements
+
+- **FR-1:** Install Debian Bookworm packages `lsof`, `htop`, and `inetutils-telnet` in the existing system package layer.
+- **FR-2:** Do not install package `telnet`; `inetutils-telnet` must provide the `telnet` command.
+- **FR-3:** Fail image build if any requested command cannot be resolved.
+- **FR-4:** Fail boot smoke if any requested command cannot resolve or successfully execute its version output as `sandbox`.
+- **FR-5:** Runtime assertion failures must print existing compose/container diagnostics and trigger existing teardown.
+- **FR-6:** Documentation must explain each utility and warn that telnet is plaintext and is not SSH.
+
+## Non-Goals
+
+- No telnet server or daemon.
+- No port, service, entrypoint, compose, or base-image change.
+- No runtime apt installation or opt-in package profile.
+- No host-process visibility guarantee for `lsof` or `htop`.
+- No package pinning change beyond the repository's existing unpinned Bookworm policy.
+- No new multi-architecture support promise.
+
+## Technical Considerations
+
+Keep the Dockerfile edit in the first apt layer to avoid extra image layers and stale package indexes. Use non-interactive/version invocations suitable for CI: `lsof -v`, `htop --version`, and `telnet --version`. The smoke test must invoke these in the same `docker exec -u sandbox` assertion that currently validates Herdr and state directories.
+
+## Success Metrics
+
+- All three Debian packages are installed in a newly built default image.
+- All three commands resolve and return success for their version invocation as `sandbox`.
+- Focused, full local, and required GitHub CI gates are green.
+
+## Open Questions
+
+None. The user supplied package choice, runtime checks, non-goals, and delivery constraints.

--- a/.oh/tasks/default-image-utils/progress.txt
+++ b/.oh/tasks/default-image-utils/progress.txt
@@ -1,0 +1,11 @@
+# progress
+
+2026-08-03T00:00:00Z PR phase initialized from origin/development@b0288f37; issue #703 created; branch feat/703-default-image-utils created.
+2026-08-03T00:00:01Z Plan, PRD, and Ralph task graph generated. Awaiting adversarial plan critique before implementation.
+2026-08-03T00:00:02Z Two-lens adversarial plan critique completed; APPROVED with medium executable-check concern mitigated in acceptance criteria.
+2026-08-03T17:13:00Z US-001 PASS: image 464320d309be built; exact packages and command/version checks passed as sandbox; transitional telnet absent.
+2026-08-03T17:14:00Z US-002 PASS: focused smoke tests 3/3 and CI-equivalent shellcheck passed; diagnostics/teardown failure path covered.
+2026-08-03T17:14:01Z US-003 PASS: canonical Utilities table and Unreleased/Added changelog updated.
+2026-08-03T17:15:00Z Local full gates PASS in CI-clean environment: 39 files/478 tests, typecheck/build/security/pin/compose/eval green. Full local compose smoke blocked by host-daemon bind namespace; CI Sandbox Boot Guard pending.
+2026-08-03T17:16:00Z Two-lens implementation self-audit PASS with no unmitigated high/medium findings; US-004 awaits PR, required CI, and deterministic PR audit.
+STATUS: VERIFYING

--- a/.oh/tasks/default-image-utils/progress.txt
+++ b/.oh/tasks/default-image-utils/progress.txt
@@ -8,4 +8,6 @@
 2026-08-03T17:14:01Z US-003 PASS: canonical Utilities table and Unreleased/Added changelog updated.
 2026-08-03T17:15:00Z Local full gates PASS in CI-clean environment: 39 files/478 tests, typecheck/build/security/pin/compose/eval green. Full local compose smoke blocked by host-daemon bind namespace; CI Sandbox Boot Guard pending.
 2026-08-03T17:16:00Z Two-lens implementation self-audit PASS with no unmitigated high/medium findings; US-004 awaits PR, required CI, and deterministic PR audit.
-STATUS: VERIFYING
+2026-08-03T17:19:30Z US-004 PASS: ready PR #704 targets development; Harness and Sandbox Boot Guard checks passed; focused deterministic classifier reports evidenceComplete=true, promotable=true, mergeable=MERGEABLE, mergeStateStatus=CLEAN.
+2026-08-03T17:19:31Z All four user stories validated against acceptance criteria. No merge performed.
+STATUS: COMPLETE

--- a/.oh/tasks/default-image-utils/retro.md
+++ b/.oh/tasks/default-image-utils/retro.md
@@ -20,6 +20,6 @@ None. These observations are captured in this task's evidence and are either env
 
 ## Outcome
 
-The implementation stayed within scope, direct image validation passed, and no code rework followed the self-audit. Final completion still depends on PR CI and focused PR classification.
+The implementation stayed within scope, direct image validation passed, and no code rework followed the self-audit. PR #704 is ready and unmerged; required Harness and Sandbox Boot Guard CI passed, and the deterministic focused classifier returned complete, promotable, clean evidence.
 
 STATUS: RETRO-DONE

--- a/.oh/tasks/default-image-utils/retro.md
+++ b/.oh/tasks/default-image-utils/retro.md
@@ -1,0 +1,25 @@
+# Build Retrospective
+
+## Session signals
+
+- Direct image execution proved Debian's `dpkg-query -W telnet` can return success for an uninstalled virtual/transitional package name, while `dpkg -s telnet` correctly established absence.
+- A host Docker socket does not guarantee compose bind mounts can see a container-only linked-worktree path; direct image checks can pass while a bind-mounted full smoke fails before reaching changed behavior.
+- Live sandbox environment variables can contaminate tests intended to model clean CI defaults; the same suite passed with service variables unset.
+
+## Hypotheses
+
+| ID | Subsystem | Hypothesis | Evidence for | Evidence against | Verdict | Confidence | Promotion |
+|---|---|---|---|---|---|---|---|
+| H1 | docs/evidence | Package absence checks for Debian virtual package names should use installed-status evidence (`dpkg -s` or Status), not `dpkg-query -W` exit alone. | `dpkg-query -W telnet` exited 0 with blank metadata while `dpkg -s telnet` reported not installed. | This was observed for one package name only. | supported | medium | task evidence only; re-derivable package behavior |
+| H2 | memory scaffolding | Full compose smoke through a host socket requires the checkout path to exist in the daemon's mount namespace. | Compose mounted an empty source and health reported the expected repository script missing; direct image checks passed. | GitHub runner topology is expected to share its workspace and may pass. | supported | high | task evidence only; environment-specific |
+| H3 | continual learning | Live service variables can produce false local test failures when fixtures inherit `process.env`. | Four failures all disappeared when SSH/Slack service variables were unset; 478 tests then passed. | CI starts clean, so this does not indicate product failure. | supported | high | task evidence only; no public memory change |
+
+## Promotion candidates
+
+None. These observations are captured in this task's evidence and are either environment-specific or quickly re-derived; no `.oh/memory/` or identity change is appropriate for a public PR.
+
+## Outcome
+
+The implementation stayed within scope, direct image validation passed, and no code rework followed the self-audit. Final completion still depends on PR CI and focused PR classification.
+
+STATUS: RETRO-DONE

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Update policy and release automation live in [`/git`](.claude/skills/git/SKILL.m
 ## [Unreleased]
 
 ### Added
+- Add `lsof`, `htop`, and the `inetutils-telnet` plaintext diagnostic client to the default sandbox image ([#703](https://github.com/mifunedev/openharness/issues/703)).
 ### Changed
 - Set the default Pi driver to `openai-codex/gpt-5.6-luna` with `max` reasoning while retaining Sol, Terra, and Luna in the model selector ([#700](https://github.com/mifunedev/openharness/issues/700)).
 - Release every push to `main` or `master` only after validation, using retry-safe UTC CalVer reservations, immutable CalVer/`sha-<full-SHA>` GHCR tags, canonical-branch digest promotion for `latest`, gated CLI publication, and post-image GitHub Release finalization ([#689](https://github.com/ryaneggz/openharness/issues/689)).


### PR DESCRIPTION
Closes #703

## Summary

- install `lsof`, `htop`, and `inetutils-telnet` in the existing Debian Bookworm system-package layer
- guard command resolution at image build time and verify resolution/version execution as user `sandbox` during boot smoke
- extend smoke contract tests for all command wiring and diagnostic teardown on runtime assertion failure
- document the canonical utility contract and telnet's plaintext security posture

## Package rationale

- `lsof`: inspect open files and owning processes within the sandbox
- `htop`: interactive process inspection within the sandbox
- `inetutils-telnet`: provides `/usr/bin/telnet` for plaintext endpoint diagnostics; the transitional `telnet` package is not installed

The existing unpinned Debian Bookworm policy is preserved, as are `--no-install-recommends`, the single system update/install layer, apt-index cleanup, users, ports, entrypoint, and base image.

## Security and non-goals

Telnet is a plaintext diagnostic client, not SSH or a secure shell. This change adds no telnet server/daemon, port, service, runtime apt install, package profile, base-image change, compose change, host-process visibility guarantee, or new multi-architecture promise.

## Exact Docker evidence

```text
DOCKER_BUILDKIT=0 docker build -f .devcontainer/Dockerfile \
  -t openharness-default-image-utils:test .
PASS — image 464320d309be

docker run --rm --entrypoint /bin/bash -u sandbox \
  openharness-default-image-utils:test -lc '<dpkg and command checks>'
htop                  3.2.2-2
inetutils-telnet      2:2.4-2+deb12u3
lsof                  4.95.0-1
transitional telnet package: absent
/usr/bin/lsof
/usr/bin/htop
/usr/bin/telnet
htop 3.2.2
telnet (GNU inetutils) 2.4
inetutils-telnet: /usr/bin/inetutils-telnet
sandbox utility verification: PASS
```

The runtime command also ran `lsof -v`, verified `/usr/bin/telnet` resolves to `/usr/bin/inetutils-telnet`, and executed every check as `sandbox`.

## Exact test and gate evidence

- `pnpm install --frozen-lockfile` — PASS
- `pnpm exec vitest run .oh/scripts/__tests__/sandbox-boot-smoke.test.ts` — PASS, 1 file / 3 tests
- `bash -n .oh/scripts/sandbox-boot-smoke.sh` — PASS
- CI-equivalent `shellcheck -S warning` globs — PASS
- hadolint 2.12.0 with `.hadolint.yaml` and warning threshold — PASS
- `pnpm run security:audit` — PASS, no known vulnerabilities
- `pnpm run lint` / `pnpm run format:check` — PASS (repository no-op scripts)
- `pnpm run typecheck` — PASS
- `pnpm run build:harness` — PASS
- `pnpm test:scripts` in a clean-CI environment — PASS, 39 files / 478 tests
- `bash .oh/scripts/check-pnpm-pin.sh` — PASS
- base and Hermes dashboard `docker compose config --quiet` — PASS
- `bash .oh/skills/eval/run.sh` — PASS, 95 probes (91 PASS / 4 SKIPPED), no new regression

A full local compose boot smoke was attempted with a unique project and the built image. This agent container's host Docker daemon cannot see the container-only linked-worktree bind source, so it mounted an empty checkout and failed before changed behavior (`sandbox-healthcheck.sh` absent); the EXIT teardown completed. The required Sandbox Boot Guard CI runs with a runner workspace shared with Docker and is the authoritative full-smoke result.

## Review evidence

- pre-implementation plan/PRD/Ralph alignment: APPROVED by two adversarial lenses
- post-implementation adversarial self-audit: PASS; no unmitigated high/medium findings
- task artifacts and exact evidence: `.oh/tasks/default-image-utils/`
