### PR TITLE
skill: add herdr CLI skill for socket-API workspace control

### DIFF
--- a/.oh/skills/herdr/SKILL.md
+++ b/.oh/skills/herdr/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: herdr
+description: |
+  Drive the Herdr terminal workspace manager from the CLI inside the Open
+  Harness sandbox — inspect and control workspaces, tabs, panes, agents,
+  and git worktrees over the Herdr socket API, and read or steer other
+  running agents headlessly.
+  TRIGGER when: asked to run a `herdr` command, list/read/send to another
+  agent or pane, check what agents are running or whether one is idle,
+  split/focus/close panes or tabs, open or create a worktree in Herdr,
+  wait for a pane's output or an agent's status, check Herdr server/session
+  status, or install a Herdr provider integration.
+  Do NOT trigger for tmux-managed headless services (cron, Slack gateway,
+  watchdog) — those stay in their own tmux sessions.
+allowed-tools: Bash, Read
+---
+
+# Herdr CLI
+
+Herdr (`herdr`, v0.7.4 in this image) is Open Harness's primary interactive
+workspace: a server process plus attached clients, with workspaces → tabs →
+panes, and agent-state detection per pane. This skill covers driving it from a
+non-interactive agent run. Operator-facing setup, persistence volumes, and the
+attach story live in `.oh/docs/integrations/herdr.md` — do not duplicate them
+here.
+
+Full subcommand catalog: `references/command-map.md`. Read it when you need a
+flag you do not already know; `herdr <group> --help` is the ground truth and
+prints a usage block for every group.
+
+## Never do these from an agent run
+
+- **Do not run bare `herdr`, `herdr agent attach`, or `herdr session attach`.**
+  They take over the terminal and hijack the operator's client. Use
+  `herdr agent read` / `herdr pane read` to observe instead.
+- **Do not run `herdr update` or `herdr channel set`.** Herdr is pinned in the
+  Open Harness image; upgrade by rebuilding against a reviewed release.
+- **Do not run `herdr server stop`.** It kills every attached client. Only the
+  operator decides that.
+- **Do not read or write `~/.config/herdr/`** (config.toml, logs, `herdr.sock`).
+  A `.config` path segment is denied to agent tooling repo-wide. Use
+  `herdr config check` and `herdr status`, which report the same facts.
+- **Do not close, kill, or send text to a pane you did not create** without the
+  operator asking. Other panes hold live agents mid-task.
+
+## Output contract
+
+Socket-API-backed groups (`workspace`, `worktree`, `tab`, `pane`, `agent`,
+`wait`, `notification`, `api`) print a single JSON line:
+
+```json
+{"id":"cli:agent:list","result":{"agents":[...],"type":"agent_list"}}
+```
+
+Pipe them through `jq` rather than eyeballing — `herdr pane list` on a busy
+workspace is thousands of characters. Plain-text groups are `status`,
+`session list`, `integration status`, `config check`, `channel show`.
+
+Identifiers:
+
+| Shape | Example | Meaning |
+|-------|---------|---------|
+| `w<N>` | `w1` | workspace id |
+| `w<N>:t<HEX>` | `w1:t1K` | tab id |
+| `w<N>:p<HEX>` | `w1:p1E` | pane id |
+| `term_<hex>` | `term_6587653c830dc14` | terminal id |
+
+An `agent <target>` accepts a terminal id, a unique agent name, a
+detected/reported agent label, or a legacy pane id — so `herdr agent read w1:p1E`
+works. Pane ids are the safest thing to thread through a script; they appear in
+every listing.
+
+## Recipes
+
+**Survey what is running.** Agent state is detected without any integration
+installed (`herdr integration status` reporting `not installed` does not mean
+detection is off — integrations only add richer status and session restore).
+
+```bash
+herdr agent list | jq -r '.result.agents[] | "\(.pane_id)\t\(.agent)\t\(.agent_status)\t\(.terminal_title_stripped)"'
+herdr workspace list | jq -r '.result.workspaces[] | "\(.workspace_id)\t\(.label)\t\(.pane_count) panes"'
+```
+
+`agent_status` is one of `idle`, `working`, `blocked`, `done`, `unknown`.
+
+**Read another agent's screen** without attaching:
+
+```bash
+herdr agent read w1:p1E --source recent --lines 80 | jq -r '.result.read.text'
+```
+
+`--source visible` is the current viewport, `recent` includes scrollback,
+`recent-unwrapped` keeps long lines intact. Add `--format ansi` only when colors
+matter.
+
+**Send work to another agent.** `agent send` writes literal text and does not
+press Enter; `pane run` sends a command plus Enter. Pick deliberately:
+
+```bash
+herdr agent send w1:p1E 'summarize the last test failure'   # types it, no submit
+herdr pane run w1:p1E 'pnpm test'                            # types it and submits
+herdr pane send-keys w1:p1E Enter                            # submit what you typed
+```
+
+**Wait instead of polling.** Both waits block server-side with a timeout in ms:
+
+```bash
+herdr agent wait w1:p1E --status idle --timeout 600000
+herdr wait output w1:p1E --match 'BUILD OK' --source recent --timeout 120000
+herdr wait output w1:p1E --match '^\s*PASS' --regex --timeout 120000
+```
+
+The `wait` group answers with an event object rather than the usual `id`/`result`
+envelope — `{"event":"pane.agent_status_changed","data":{...}}` — so read
+`.data`, not `.result`. Only `wait agent-status` accepts `done`; `agent wait`
+does not.
+
+**Start a new agent in its own pane** (everything after `--` is the argv):
+
+```bash
+herdr agent start reviewer --cwd /home/sandbox/harness --split right -- claude
+```
+
+**Open a worktree as a workspace.** Open Harness automation worktrees live under
+`.oh/worktrees/`; Herdr-created ones default to `~/.herdr/worktrees`. Prefer
+opening an existing harness worktree over letting Herdr create one, so
+`/worktrees` conventions keep owning the layout:
+
+```bash
+herdr worktree list --json | jq -r '.result.worktrees[] | "\(.branch // "detached")\t\(.path)"'
+herdr worktree open --cwd /home/sandbox/harness --path .oh/worktrees/bug/715-pi-langfuse-shutdown --no-focus
+```
+
+Pass `--no-focus` on anything you create in the background — stealing focus
+yanks the operator out of their pane.
+
+**Notify the operator** when a long run finishes:
+
+```bash
+herdr notification show 'CI green' --body 'branch development' --sound done
+```
+
+## Health check
+
+```bash
+herdr status          # client + server version, protocol, compatibility, socket
+herdr session list    # named sessions and their status
+herdr config check    # validates config.toml, prints "config: ok"
+herdr api snapshot    # full runtime state as one JSON blob
+```
+
+`herdr status` reporting `compatible: no` or `restart_needed: yes` means the
+client and server drifted — report it to the operator; do not self-update.
+
+If a socket command fails with a connection error, the server is not running;
+that is an operator problem (they attach with bare `herdr`), not something to
+fix by starting a server from an agent run.
+
+## Report
+
+State the pane/agent ids you touched, what you read versus what you sent, and
+any pane you created (with its workspace/tab). Never claim you observed an
+agent's state without showing the `agent list` / `agent read` output you based
+it on.

--- a/.oh/skills/herdr/references/command-map.md
+++ b/.oh/skills/herdr/references/command-map.md
@@ -1,0 +1,221 @@
+# Herdr command map
+
+Full subcommand catalog for `herdr` 0.7.4 as shipped in the Open Harness image,
+transcribed from `herdr --help` and each `herdr <group> --help`. Read the group
+you need; `herdr <group> --help` remains ground truth if the pinned version
+changes.
+
+## Contents
+
+1. [Top level](#top-level)
+2. [Global options](#global-options)
+3. [session](#session)
+4. [workspace](#workspace)
+5. [worktree](#worktree)
+6. [tab](#tab)
+7. [pane](#pane)
+8. [agent](#agent)
+9. [wait](#wait)
+10. [notification](#notification)
+11. [api, config, channel, server](#api-config-channel-server)
+12. [integration](#integration)
+13. [Paths](#paths)
+
+## Top level
+
+```text
+herdr                              launch or attach to the persistent session (interactive; never from an agent run)
+herdr status [server|client]       local client and running server status
+herdr update [--handoff]           download and install the latest version (forbidden: image-pinned)
+herdr completion <shell>           generate shell completions, e.g. `herdr completion zsh`
+herdr server                       run as headless server
+herdr server stop                  stop the running server via the API socket
+herdr server reload-config         reload config.toml in the running server
+```
+
+## Global options
+
+```text
+--no-session                       run monolithically, no server/client (escape hatch)
+--session <name>                   use or create a named persistent session
+--remote <ssh-target>              attach through SSH to a remote Herdr server
+--remote-keybindings <local|server>  keybindings for --remote attach (default: local)
+--handoff                          opt into live handoff for update or remote attach
+--default-config                   print default configuration and exit
+--version, -V                      print version
+--help, -h                         show help
+```
+
+## session
+
+Plain-text output except where `--json` is offered.
+
+```text
+herdr session list [--json]
+herdr session attach <name>        interactive; never from an agent run
+herdr session stop <name> [--json]
+herdr session delete <name> [--json]
+```
+
+`default` is a valid `<name>` for targeting the default session with `stop`.
+
+## workspace
+
+```text
+herdr workspace list
+herdr workspace create [--cwd PATH] [--label TEXT] [--env KEY=VALUE] [--focus|--no-focus]
+herdr workspace get <workspace_id>
+herdr workspace focus <workspace_id>
+herdr workspace rename <workspace_id> <label>
+herdr workspace report-metadata <workspace_id> --source ID [--token NAME=VALUE] [--clear-token NAME] [--seq N] [--ttl-ms N]
+herdr workspace close <workspace_id>
+```
+
+`report-metadata` is for integrations publishing state into Herdr's UI, not for
+ordinary task work.
+
+## worktree
+
+```text
+herdr worktree list [--workspace ID | --cwd PATH] [--json]
+herdr worktree create [--workspace ID | --cwd PATH] [--branch NAME] [--base REF] [--path PATH] [--label TEXT] [--focus|--no-focus] [--json]
+herdr worktree open [--workspace ID | --cwd PATH] (--path PATH | --branch NAME) [--label TEXT] [--focus|--no-focus] [--json]
+herdr worktree remove --workspace ID [--force] [--json]
+```
+
+`list` reports `branch`, `path`, `is_linked_worktree`, `is_prunable`, and the
+`open_workspace_id` when the worktree is already open. In Open Harness, create
+worktrees through `/worktrees` under `.oh/worktrees/` and use `worktree open`
+here; `worktree create` defaults elsewhere (`~/.herdr/worktrees`).
+
+## tab
+
+```text
+herdr tab list [--workspace <workspace_id>]
+herdr tab create [--workspace <workspace_id>] [--cwd PATH] [--label TEXT] [--env KEY=VALUE] [--focus|--no-focus]
+herdr tab get <tab_id>
+herdr tab focus <tab_id>
+herdr tab rename <tab_id> <label>
+herdr tab close <tab_id>
+```
+
+## pane
+
+Inspection:
+
+```text
+herdr pane list [--workspace <workspace_id>]
+herdr pane current [--pane ID|--current]
+herdr pane get <pane_id>
+herdr pane layout [--pane ID|--current]
+herdr pane process-info [--pane ID|--current]
+herdr pane neighbor --direction left|right|up|down [--pane ID|--current]
+herdr pane edges [--pane ID|--current]
+herdr pane read <pane_id> [--source visible|recent|recent-unwrapped] [--lines N] [--format text|ansi] [--ansi]
+```
+
+Layout control:
+
+```text
+herdr pane focus --direction left|right|up|down [--pane ID|--current]
+herdr pane resize --direction left|right|up|down [--amount FLOAT] [--pane ID|--current]
+herdr pane zoom [<pane_id>|--pane ID|--current] [--toggle|--on|--off]
+herdr pane split [<pane_id>|--pane ID|--current] --direction right|down [--ratio FLOAT] [--cwd PATH] [--env KEY=VALUE] [--focus|--no-focus]
+herdr pane swap --direction left|right|up|down [--pane ID|--current]
+herdr pane swap --source-pane ID --target-pane ID
+herdr pane move <pane_id> --tab <tab_id> --split right|down [--target-pane ID] [--ratio FLOAT] [--focus|--no-focus]
+herdr pane move <pane_id> --new-tab [--workspace ID] [--label TEXT] [--focus|--no-focus]
+herdr pane move <pane_id> --new-workspace [--label TEXT] [--tab-label TEXT] [--focus|--no-focus]
+herdr pane rename <pane_id> <label>|--clear
+herdr pane close <pane_id>
+```
+
+Input:
+
+```text
+herdr pane send-text <pane_id> <text>     literal text, no Enter
+herdr pane send-keys <pane_id> <key> ...  named keys, e.g. Enter, Escape
+herdr pane run <pane_id> <command>        command text plus Enter
+```
+
+Integration reporting (for provider hooks, not task work):
+
+```text
+herdr pane report-agent <pane_id> --source ID --agent LABEL --state idle|working|blocked|unknown [--message TEXT] [--seq N] [--agent-session-id ID] [--agent-session-path PATH]
+herdr pane report-agent-session <pane_id> --source ID --agent LABEL [--seq N] [--agent-session-id ID] [--agent-session-path PATH]
+herdr pane release-agent <pane_id> --source ID --agent LABEL [--seq N]
+herdr pane report-metadata <pane_id> --source ID [--agent LABEL] [--applies-to-source ID] [--title TEXT|--clear-title] [--display-agent TEXT|--clear-display-agent] [--state-label STATUS=TEXT] [--clear-state-labels] [--token NAME=VALUE] [--clear-token NAME] [--seq N] [--ttl-ms N]
+```
+
+## agent
+
+```text
+herdr agent list
+herdr agent get <target>
+herdr agent read <target> [--source visible|recent|recent-unwrapped] [--lines N] [--format text|ansi] [--ansi]
+herdr agent send <target> <text>          literal text, no Enter
+herdr agent rename <target> <name>|--clear
+herdr agent focus <target>
+herdr agent wait <target> --status idle|working|blocked|unknown [--timeout MS]
+herdr agent attach <target> [--takeover]  interactive; never from an agent run
+herdr agent start <name> [--cwd PATH] [--workspace ID] [--tab ID] [--split right|down] [--env KEY=VALUE] [--focus|--no-focus] -- <argv...>
+herdr agent explain <target> [--json]
+herdr agent explain --file PATH --agent LABEL [--json]
+```
+
+Targets accept terminal ids, unique agent names, detected/reported agent labels,
+and legacy pane ids.
+
+## wait
+
+```text
+herdr wait output <pane_id> --match <text> [--source visible|recent|recent-unwrapped] [--lines N] [--timeout MS] [--regex] [--raw]
+herdr wait agent-status <pane_id> --status idle|working|blocked|done|unknown [--timeout MS]
+```
+
+`wait agent-status` accepts `done`; `agent wait` does not — use the `wait` group
+when you need to block on a finished agent. `--match` is required; omitting it
+fails immediately with `missing required --match`.
+
+## notification
+
+```text
+herdr notification show <title> [--body TEXT] [--position top-left|top-right|bottom-left|bottom-right] [--sound none|done|request]
+```
+
+## api, config, channel, server
+
+```text
+herdr api snapshot                 full live runtime state as JSON
+herdr api schema [--json | --output PATH]
+herdr config check                 validate config.toml, print diagnostics
+herdr config reset-keys            back up config.toml, remove custom keybindings
+herdr channel show
+herdr channel set <stable|preview> forbidden: image-pinned
+```
+
+## integration
+
+Optional provider hooks giving richer status and session restore. They modify
+provider configuration and are never installed automatically; basic agent
+detection works without them.
+
+```text
+herdr integration install <provider>
+herdr integration uninstall <provider>
+herdr integration status [--outdated-only]
+```
+
+Providers: `pi`, `omp`, `claude`, `codex`, `copilot`, `devin`, `droid`, `kimi`,
+`opencode`, `kilo`, `hermes`, `qodercli`, `cursor`, `mastracode`.
+
+## Paths
+
+```text
+config   ~/.config/herdr/config.toml        operator-only; agent tooling is denied this path
+logs     ~/.config/herdr/herdr.log          plus herdr-client.log, herdr-server.log
+socket   ~/.config/herdr/herdr.sock
+data     ~/.herdr/                          Herdr-created worktrees and related data
+env      HERDR_CONFIG_PATH                  overrides the config file path
+home     https://herdr.dev
+```


### PR DESCRIPTION
## Summary
Adds `/herdr` — a provider-portable reference skill for driving the Herdr terminal workspace manager from a non-interactive agent run. Grounded in `herdr --help` plus all 12 `herdr <group> --help` outputs for the image-pinned v0.7.4 CLI.

- `.oh/skills/herdr/SKILL.md` (164 lines) — agent-run safety rules (no bare `herdr`/`attach`, no self-update, no `~/.config/herdr` reads), JSON output contract, id shapes (`w1`/`w1:t1K`/`w1:p1E`/`term_*`), and recipes for surveying agents, reading a pane without attaching, `agent send` vs `pane run`, blocking waits, `agent start`, and opening `.oh/worktrees/` paths.
- `.oh/skills/herdr/references/command-map.md` (221 lines) — full subcommand catalog for session/workspace/worktree/tab/pane/agent/wait/notification/api/config/channel/integration.

Operator-facing setup and persistence stay in `.oh/docs/integrations/herdr.md`; the skill points at it rather than duplicating it.

## Non-obvious findings captured
- The `wait` group answers with `{"event":...,"data":...}`, not the `{"id":...,"result":...}` envelope every other socket-API group uses.
- `wait agent-status` accepts `done`; `agent wait` does not.
- `integration status` reporting `not installed` does not disable agent detection — integrations only add richer status and session restore.

## Validation
- Every documented recipe executed live against the running server (`agent list|jq`, `agent read`, `worktree list|jq`, `wait agent-status`, `pane current`).
- `bash .oh/scripts/link-providers.sh --check` → Providers OK (`.claude`/`.pi`/`.codex` mirrors resolve).
- `git diff --check` clean; frontmatter delimiters valid; SKILL.md under the 500-line cap; reference over 100 lines carries a contents list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)