### PR TITLE
skill: add /fanout — ship a set of coupled issues as parallel PRs

### DIFF
--- a/.oh/skills/fanout/SKILL.md
+++ b/.oh/skills/fanout/SKILL.md
@@ -1,0 +1,213 @@
+---
+name: fanout
+description: |
+  Ship a set of related issues as parallel PRs — one isolated worktree and one
+  briefed agent session per unit of work, then merge, verify closure, and tear
+  down. Runner-agnostic: herdr, tmux, or background shells.
+  TRIGGER when: asked to work several issues at once, "ship these issues in
+  parallel", "spawn an agent per issue", "fan out", or clearing a queue before
+  a larger refactor.
+argument-hint: "<issue numbers or task slugs> [--runner herdr|tmux|bg] [--dry-run]"
+disable-model-invocation: true
+allowed-tools: Bash Read Write
+---
+
+# Fanout
+
+Take N units of work to N merged PRs, in parallel, without the agents colliding.
+
+**The runner is a swappable detail.** What makes this work is worktree isolation, a
+brief that front-loads the traps, and a merge phase that assumes conflicts are
+semantic. Encode those; pick whatever runner is installed.
+
+Mechanics this skill does not own: `/worktrees` for worktree lifecycle, `/herdr`
+for the herdr CLI, `/git` for branch and PR conventions. Compose them; do not
+restate them. `/delegate` is the sibling for in-process Agent-tool waves — use it
+when the work does not need isolated checkouts or long-running interactive sessions.
+
+## Terminal states
+
+| State | Meaning |
+|-------|---------|
+| `SHIPPED` | Every unit merged, every issue verified closed, all worktrees removed. |
+| `PARTIAL` | Some units merged; the rest named with their blocker and left intact. |
+| `BLOCKED` | Stopped before launching. Nothing created. |
+| `DRY-RUN` | Plan reported; no worktree, branch, or session created. |
+
+## 1. Group by coupling — before anything is created
+
+Do not treat the issue list as the unit list. Read each issue and find the
+dependencies **between** them.
+
+- If fixing A alone would create or multiply the defect B fixes, A and B are **one
+  unit and one PR**. Splitting them ships a regression.
+- If two issues touch the same component, note it — they will conflict at merge.
+- If an issue's priority depends on an unmade decision, drop it from this run and
+  say so rather than guessing.
+
+State the grouping and the reason for each merge before continuing. This step is
+the highest-leverage part of the skill; a wrong grouping cannot be recovered by a
+good brief.
+
+Stop with `BLOCKED` if the units cannot be separated into independently mergeable
+PRs.
+
+## 2. Check the ground
+
+```bash
+git -C "$REPO" fetch origin --quiet
+git -C "$REPO" log --oneline -1
+git -C "$REPO" status --short
+git -C "$REPO" worktree list
+ps aux | grep -Ei 'vite|uvicorn|next|taskiq|worker' | grep -v grep
+```
+
+Establish and record:
+
+- the **base branch** (per `/worktrees` DETECT BASE — usually `development`);
+- whether the primary checkout is **occupied** by a running dev stack, and which
+  ports it holds. If it is, every brief must forbid entering it and forbid binding
+  those ports.
+
+## 3. One worktree per unit
+
+Create each off the freshly-fetched base, never off local HEAD. Follow `/worktrees`
+and `/git` for paths and branch names.
+
+```bash
+git -C "$REPO" worktree add -b "fix/<n>-<slug>" "$WORKTREES_ROOT/<repo>-<n>" origin/"$BASE"
+```
+
+Confirm every worktree reports the same base commit before launching anything.
+
+## 4. Write one brief per unit
+
+Follow `references/brief-template.md`. Author the briefs yourself rather than
+delegating brief-writing — the orchestrator holds context the executors cannot
+recover, and passing it through another agent loses exactly the constraints that
+matter.
+
+Write each brief to a **gitignored** path inside its worktree so it never enters
+the PR diff, and prove it:
+
+```bash
+git -C "$WT" check-ignore -q .claude/brief.md || echo "NOT IGNORED — pick another path"
+```
+
+## 5. Launch
+
+The launch command must `cd` into the worktree **inside the command itself**.
+Runner flags that claim to set a working directory frequently set only metadata
+while the shell starts somewhere else, and the failure is silent.
+
+```bash
+# herdr
+herdr pane run "$PANE" "cd $WT && claude \"$PROMPT\""
+# tmux
+tmux new-session -d -s "$NAME" -c "$WT" "claude \"$PROMPT\""
+```
+
+Then **verify the resulting cwd, not the accepted argument**:
+
+```bash
+herdr pane list --workspace "$WS" | jq -r '.result.panes[] | "\(.pane_id)\t\(.foreground_cwd)"'
+```
+
+Relaunch any session that did not land in its worktree. Do not send work to a
+misplaced session.
+
+## 6. Monitor without attaching
+
+Poll status; never attach to a running agent's terminal. Prefer server-side waits
+over sleep loops.
+
+```bash
+herdr agent list | jq -r '.result.agents[] | select(.pane_id|startswith("'"$WS"'")) | "\(.pane_id)\t\(.agent_status)"'
+herdr agent wait "$PANE" --status idle --timeout 1800000
+```
+
+Read a pane only to confirm it is on-brief or to diagnose a stall.
+
+## 7. Pre-merge verification
+
+For every PR, before merging:
+
+```bash
+gh pr view "$N" --json closingIssuesReferences,mergeable,mergeStateStatus
+gh pr checks "$N"
+```
+
+- **Confirm the closing refs are earned.** GitHub matches a closing keyword
+  anywhere in the body and ignores surrounding negation, so a PR that says it does
+  *not* close an issue can still close it. If a unit was partially delivered, the
+  issue must stay open and a follow-up must exist.
+- Treat CI as the authority for suites you could not run locally, and say which is
+  which when reporting.
+
+## 8. Merge sequentially, and expect semantic conflicts
+
+Merge one at a time. After each merge, the remaining branches are stale.
+
+Changelog-style conflicts are mechanical — keep both sides, merged-first order.
+**Conflicts in shared source are not.** When two units changed the same component,
+each side usually carries a distinct intent, and taking either side alone silently
+drops the other's fix. Combine the intents.
+
+After resolving, run the affected suite **in the worktree** before pushing:
+
+```bash
+cd "$WT/<package>" && <test command> && <typecheck command>
+```
+
+A cross-unit merge can violate a guard one unit just added. Do not delegate this
+check to CI when you can run it locally in seconds.
+
+## 9. Verify closure — do not trust the keyword
+
+```bash
+for i in $ISSUES; do gh issue view "$i" --json number,state --jq '"#\(.number)=\(.state)"'; done
+```
+
+Close by hand any issue that is genuinely complete but still open. Leave open any
+issue whose unit shipped partially, and confirm its follow-up exists.
+
+## 10. Tear down
+
+```bash
+git -C "$REPO" worktree remove "$WT" --force
+git -C "$REPO" checkout "$BASE" && git -C "$REPO" pull --ff-only
+git -C "$REPO" branch -D "$BRANCH"; git -C "$REPO" push origin --delete "$BRANCH"
+herdr workspace close "$WS"
+```
+
+Delete only branches this run created, plus merged branches the user names. Close
+only runner workspaces this run created. Then confirm the primary checkout is clean
+and still holds any dev stack that was running before.
+
+## Report
+
+```markdown
+## Fanout: <SHIPPED|PARTIAL|BLOCKED|DRY-RUN>
+
+**Units**: <grouping and why each was grouped>
+**Merged**: <PR → issue, one line each>
+**Issues closed**: <verified list>
+**Follow-ups filed**: <new issues, and why they were not folded in>
+**Verified locally vs by CI**: <split>
+**Teardown**: <worktrees removed, branches deleted, workspace closed>
+```
+
+Report follow-ups explicitly. Several agents each filing their own can grow a queue
+faster than the run drains it — that is often correct, but it must be visible.
+
+## Anti-patterns
+
+- **Fanning out before grouping.** The coupling analysis is the skill.
+- **Trusting a runner's cwd flag.** Verify the resulting state.
+- **Delegating brief authorship.** The orchestrator holds the context.
+- **Artifacts in a tracked path.** They land in the PR diff.
+- **Taking one side of a semantic conflict.** Combine the intents.
+- **Trusting a closing keyword.** Read `closingIssuesReferences`.
+- **Merging in parallel.** Each merge stales the others.
+- **Attaching to a running agent's terminal.** Read status instead.
+- **Reporting agent state you did not observe.** Show the listing you based it on.

--- a/.oh/skills/fanout/references/brief-template.md
+++ b/.oh/skills/fanout/references/brief-template.md
@@ -1,0 +1,112 @@
+# Brief template
+
+The contract for one fanout unit. A brief is the only context its executor gets
+that it could not derive itself — everything here exists because omitting it cost
+a real run.
+
+## Contents
+
+1. [Sections](#sections)
+2. [Boundaries](#boundaries)
+3. [Scope](#scope)
+4. [Known traps](#known-traps)
+5. [Verification](#verification)
+6. [Definition of done](#definition-of-done)
+7. [Worked shape](#worked-shape)
+
+## Sections
+
+Every brief has six, in this order. Omit none; an empty section means "verify
+there is nothing here", not "skip it".
+
+## Boundaries
+
+- The worktree path and branch, stated as already checked out.
+- **Named forbidden paths.** If the primary checkout runs a dev stack, forbid
+  entering it and forbid binding its ports, by number.
+- Sibling units running concurrently, by path, with "do not touch their branches".
+- Repo-specific read prohibitions, quoted verbatim from the repo's own
+  `AGENTS.md` (for example: never read a `.env*` file).
+- Where task artifacts go — a **gitignored** path, verified with `git check-ignore`.
+  This may contradict a generic prompt convention; say so explicitly, and say why.
+- Commit, branch, and changelog conventions, deferring to `/git`.
+- The closing-keyword rule: never write a GitHub closing keyword for an issue the
+  PR does not fully close. GitHub matches the keyword and ignores negation, so
+  "this does not close #N" closes #N. Phrase as "does not complete #N (leave it
+  open)" and check `closingIssuesReferences` before marking ready.
+
+## Scope
+
+- The issue number and an instruction to read the whole body, not a summary.
+- **Anything folded in, and why.** If two issues are one unit, the brief must
+  explain the coupling — an executor that does not understand it will split the
+  work back apart.
+- What is deliberately excluded, so the executor does not expand into it.
+- Where a product judgment is genuinely open: name the conservative option, tell
+  the executor to take it and state the call in one line, rather than stalling or
+  silently choosing the largest change.
+
+## Known traps
+
+Every non-obvious failure the orchestrator already knows about. These are cheap to
+write and expensive to rediscover:
+
+- Test doubles or overrides that are inert for structural reasons.
+- Commands that exit 0 without doing anything.
+- Framing corrections — if the issue text misstates the mechanism, say so and give
+  the real one, so the PR does not repeat the error.
+- Existing correct implementations of the same pattern, cited by path, as the
+  reference to copy.
+
+## Verification
+
+State the exact commands. Then constrain what counts as evidence:
+
+- **Prove each new test fails against the pre-fix code.** A test that passes before
+  and after pins nothing. This single instruction has repeatedly surfaced defects
+  beyond the issue as filed, including in the orchestrator's own briefing.
+- **Measure, do not assert.** Where a number is the claim, compute it and show the
+  before/after.
+- Name what cannot be verified in this environment and require it to be stated
+  plainly in the PR rather than implied.
+- Never work around an environment restriction (operator-only paths, denied
+  credentials). Report the gap instead.
+
+## Definition of done
+
+A ready-for-review PR against the base branch, CI green, `closingIssuesReferences`
+matching what was actually delivered, and a report back naming: the PR number, what
+was verified locally versus by CI, and anything deferred to a follow-up.
+
+Prefer a follow-up issue over silently expanding the PR — but require the deferral
+to be visible in the PR body.
+
+## Worked shape
+
+```markdown
+# Brief — <unit>
+
+You are the First Mate advisor. Run <plan prompt> then <pr prompt>. Delegate the
+sub-agents each names. Deliverable: a ready-for-review PR against <base>.
+
+## Boundaries — read first
+- Worktree <path>, branch <branch>, already checked out. Never cd into <occupied
+  checkout> — it runs the operator's dev stack on :<ports>. Siblings in <paths>.
+- NEVER read a .env* file. (repo AGENTS.md, verbatim.)
+- Artifacts in .claude/tasks/<slug>/ — verified gitignored. NOT .oh/tasks/, which
+  this repo tracks.
+- Commits per /git. Changelog entry expected to conflict with siblings; keep both.
+- Never write a closing keyword for an issue this PR does not fully close.
+
+## Scope
+<issue + what is folded in and the coupling + what is excluded>
+
+## Known traps
+<the inert override, the no-op command, the corrected framing, the reference impl>
+
+## Verification
+<commands> — and prove each new test fails against the pre-fix code.
+
+## Definition of done
+<ready PR, CI green, honest closing refs, report back>
+```


### PR DESCRIPTION
Encodes the pattern that cleared the orchestra pre-refactor queue this session — three issues, three worktrees, three briefed agent sessions, three merged PRs — as a reusable command skill.

## Why it exists

The pattern worked, but it was assembled ad hoc and most of its leverage is **not** in the runner. Herdr supplied the supervision layer (concurrent interactive sessions, `agent list` status, `agent read` without attaching, one-call teardown). Everything that actually made the run succeed is runner-independent: worktree isolation, a brief that front-loads the traps, coupling analysis before fan-out, and a merge phase that assumes conflicts are semantic. `/fanout` encodes those as invariants and treats the runner as swappable (herdr, tmux, or background shells), so it survives on a host without herdr installed.

## Composition, not duplication

- `/worktrees` keeps worktree lifecycle mechanics
- `/herdr` keeps the CLI surface
- `/git` keeps branch, commit, and PR conventions
- `/delegate` remains the sibling for in-process Agent-tool waves — `/fanout` is for work needing isolated checkouts and long-running sessions

## What the session actually taught, now encoded

Each of these cost a real run:

- **Group by coupling before fan-out.** Two issues where fixing one alone multiplies the other's defect are one unit and one PR. Splitting them ships a regression.
- **Verify the resulting cwd, not the accepted argument.** A runner's `--cwd` set tab metadata while the shell started elsewhere, silently. Same lesson as PR #721.
- **Expect semantic conflicts, not just changelog ones.** Two units changed the same component; each side carried a distinct intent, and taking either alone would have dropped the other's fix.
- **Prove each new test fails against the pre-fix code.** This surfaced defects beyond the issues as filed, and caught three of the orchestrator's own briefing errors.
- **Never trust a closing keyword.** GitHub matches it anywhere in the body and ignores negation.

## Scope

Two new files under `.oh/skills/fanout/`. No existing files modified. `disable-model-invocation: true` — the workflow creates branches, launches sessions, and merges PRs, so it is explicit-invocation only.

## Validation

- `SKILL.md` 213 lines (limit 500); reference 112 lines with a contents list (required over 100)
- Frontmatter delimiters valid; `name` matches the directory
- Every referenced skill and bundled path verified to exist
- `bash .oh/scripts/link-providers.sh --check` → `Providers OK`
- `/fanout` resolves through the provider symlink at `.claude/skills/fanout/SKILL.md`
- `git diff --check` clean

Not validated: an end-to-end `/fanout` invocation. The skill is documentation-only and its procedure is the one this session executed by hand, but it has not been run *as a skill*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)