### PR TITLE
FROM task/726-agent-research-wiki TO development

### DIFF
--- a/.oh/skills/wiki/corpus/README.md
+++ b/.oh/skills/wiki/corpus/README.md
@@ -29,6 +29,8 @@ Schema rule, frontmatter spec, and all authoring conventions: `.oh/skills/wiki/r
 
 | Slug | Title | Tags | Updated |
 | --- | --- | --- | --- |
+| molt-agentic-reinforcement-learning | Molt: A Scalable PyTorch-Native Training Framework for Agentic Reinforcement Learning | [agentic-rl, training, readability, observability, trajectories, async, correctness, agent-harness, nvidia] | 2026-08-08 |
+| managed-agents | Scaling Managed Agents: Decoupling the brain from the hands | [agents, meta-harness, sessions, sandbox, resilience, security, scaling, anthropic, model-evolution] | 2026-08-08 |
 | document-ingestion | Local Document Ingestion | [wiki, ingestion, markitdown, documents, provenance, security] | 2026-07-18 |
 | audit-architecture | Audit Architecture | [audit, pr, workflow, safety, observability] | 2026-07-17 |
 | runtime-isolation-landscape | Runtime Isolation Landscape (2026) | [runtime, isolation, sandbox, gvisor, firecracker, kata, microvm, cloudflare, e2b, daytona, fly, modal] | 2026-07-04 |

--- a/.oh/skills/wiki/corpus/managed-agents.md
+++ b/.oh/skills/wiki/corpus/managed-agents.md
@@ -1,0 +1,52 @@
+---
+title: "Scaling Managed Agents: Decoupling the brain from the hands"
+slug: managed-agents
+tags: [agents, meta-harness, sessions, sandbox, resilience, security, scaling, anthropic, model-evolution]
+created: 2026-08-08
+updated: 2026-08-08
+sources:
+  - raw/2026-08-08-managed-agents.md
+related: [audit-architecture, runtime-isolation-landscape, recursive-language-models]
+confidence: provisional
+---
+
+# Scaling Managed Agents: Decoupling the brain from the hands
+
+## Relevant Source Files
+- `raw/2026-08-08-managed-agents.md` — immutable capture of Anthropic's article, published 2026-04-08.
+- `.oh/docs/rfcs/rfc-trace-ledger.md:33-101,125-155` — Open Harness's proposed append-only event ledger, session index, privacy rules, and replay/diagnosis minimums.
+- `.devcontainer/docker-compose.yml:30-104` — the current single sandbox service, bind-mounted checkout, persistent auth/tool volumes, optional credential environment, and restart policy.
+- `.oh/docs/security-considerations.md:34-43,121-134` — current secret-path hooks, named-volume state, and the Docker-socket isolation caveat.
+- `.oh/docs/rfcs/rfc-runtime-support.md:20-40` — separate substrate, deploy, and fan-out axes and the per-task isolation gap.
+- `.oh/docs/harnesses/overview.md:7-9` — current product boundary: one developer, one project, one agent.
+
+## Summary
+Anthropic's Managed Agents article treats an agent as three replaceable components: a durable session log, a harness/brain that interprets it, and sandbox/tool “hands” that perform actions. Stable interfaces let each component fail, scale, or evolve independently; the session can be replayed outside the model's context window and credentials remain outside generated-code sandboxes.
+
+For Open Harness, the article validates the existing trace-ledger direction while exposing the next architectural seam: the current long-lived sandbox is still an operational anchor. The goal is not to copy a hosted multi-agent product, but to make sessions, tools, and sandboxes rehydratable without coupling their lifetimes.
+
+## Detail
+**1. Make the session the recovery surface.** The trace RFC already specifies immutable JSONL events, `run_id`/`session_id`, redacted side effects, and replay-required `Run`, `Step`, tool, file, validation, and handoff events (`.oh/docs/rfcs/rfc-trace-ledger.md:33-70,125-155`). It also explicitly reserves `.oh/traces/` and `.oh/sessions/` but says they are not implemented (`.oh/docs/rfcs/rfc-trace-ledger.md:77-101`). The article turns that proposal into a concrete contract: a crashed provider process should be replaceable by `wake(session_id)`-style rehydration that resumes from a durable cursor, rather than relying on a tmux pane, context window, or container to contain the truth.
+
+**2. Decouple brains from hands.** Compose currently defines one `sandbox` service that stays alive with `sleep infinity`, while the checkout and auth/tool state are mounted into it (`.devcontainer/docker-compose.yml:30-64,93-104`). Treat provider CLIs, Herdr, and future runners as brains; expose worktrees, sandboxes, MCP services, browsers, and deploy targets as narrow, typed hands. A hand failure should become a classified tool error and be recoverable by reprovisioning from a recipe. This would make the runtime RFC's substrate/fan-out taxonomy operational instead of making “one container” the implicit control plane (`.oh/docs/rfcs/rfc-runtime-support.md:20-40`).
+
+**3. Make credential isolation structural.** Open Harness already keeps real credentials out of git, uses named volumes, and installs deterministic secret-exposure hooks (`.oh/docs/security-considerations.md:34-43`). But the compose surface can pass `GH_TOKEN` into the sandbox (`.devcontainer/docker-compose.yml:78-81`), and the sandbox owns the XDG auth volume. The Managed Agents lesson is to audit a stronger boundary: generated code should receive task-scoped capabilities or call a credential proxy, not inherit broad tokens that hooks merely try to stop it reading. The optional Docker socket remains an explicit host-root trade-off (`.oh/docs/security-considerations.md:121-134`).
+
+**4. Measure model evolution and delete dead weight.** Anthropic's “context anxiety” example shows a harness workaround becoming harmful after a model change. Every Open Harness compensation should therefore have a capability/regression probe and a retirement condition. The existing `/eval` floor, capability ceiling, and self-improvement roadmap provide the right vocabulary; a green probe alone is not evidence that a workaround remains useful (`.oh/docs/rfcs/rfc-selfimprove-roadmap.md:29-39`).
+
+**5. Scale hands before defaulting to many brains.** The current product deliberately remains one developer/project/agent (`.oh/docs/harnesses/overview.md:7-9`). Preserve that simple default. Design the interfaces so one brain can attach multiple isolated hands and optional parallel brains can share durable session/artifact references later. This is safer than making multi-agent concurrency a requirement before the session, failure, and credential boundaries exist.
+
+## System Relationships
+```mermaid
+flowchart LR
+  B[Provider CLI / brain] --> H[Stable hand interface]
+  H --> S[Rehydratable sandbox or worktree]
+  B --> L[Durable session ledger]
+  L --> R[Replay / wake / resume]
+  E[Eval + capability benchmark] --> B
+```
+
+## See Also
+- [[audit-architecture]]
+- [[runtime-isolation-landscape]]
+- [[recursive-language-models]]

--- a/.oh/skills/wiki/corpus/molt-agentic-reinforcement-learning.md
+++ b/.oh/skills/wiki/corpus/molt-agentic-reinforcement-learning.md
@@ -1,0 +1,56 @@
+---
+title: "Molt: A Scalable PyTorch-Native Training Framework for Agentic Reinforcement Learning"
+slug: molt-agentic-reinforcement-learning
+tags: [agentic-rl, training, readability, observability, trajectories, async, correctness, agent-harness, nvidia]
+created: 2026-08-08
+updated: 2026-08-08
+sources:
+  - raw/2026-08-08-molt-agentic-reinforcement-learning.md
+related: [managed-agents, audit-architecture, recursive-language-models, runtime-isolation-landscape]
+confidence: provisional
+---
+
+# Molt: A Scalable PyTorch-Native Training Framework for Agentic Reinforcement Learning
+
+## Relevant Source Files
+- `raw/2026-08-08-molt-agentic-reinforcement-learning.md` — immutable capture of arXiv:2607.21653v1, published 2026-07-22.
+- `.oh/docs/rfcs/rfc-trace-ledger.md:33-155` — the proposed append-only run/session event model and replay, diagnosis, and scoring minimums.
+- `.oh/docs/artifact-contract-schema.md:3-49` — required-artifact and verification-command contracts enforced by audit.
+- `.oh/evals/README.md:3-49,90-124` — real-state probes, three-state outcomes, and regression gate behavior.
+- `.oh/docs/rfcs/rfc-selfimprove-roadmap.md:12-39` — normalized traces, diagnostic reports, benchmarks, and promotion gates.
+- `.oh/docs/harnesses/overview.md:7-9` — Open Harness's deliberate one-developer/project/agent default.
+
+## Summary
+Molt is a compact, PyTorch-native framework for agentic reinforcement learning. Its design bet is that readable code, a single visible asynchronous loop, ordinary Python agent contracts, token-first trajectory capture, and explicit correctness invariants can preserve research velocity without giving up frontier-scale performance. Its reported throughput parity is scoped to a matched protocol; the paper also exposes a model-routing mismatch that makes one benchmark throughput-only.
+
+Open Harness should borrow the shape of Molt's interfaces and evidence discipline, not its single-backend RL stack. The strongest lesson is to make every agent run inspectable end to end—from task and model call through hand/tool effects, artifacts, validation, and handoff—while keeping provider-specific machinery at replaceable boundaries.
+
+## Detail
+**1. Make inspectability a first-class capability.** Molt treats source-code readability for humans and AI coding assistants as a design requirement: a change should be traceable from flag to executed branch, data, metric, and test without hidden registries. Open Harness should apply the same test to skills, runners, and task artifacts. Provider portability remains a product requirement, so this does not mean one backend; it means each provider route should expose a small, direct contract instead of making task semantics depend on adapter indirection.
+
+**2. Define an ordinary, provider-neutral agent contract.** Molt can drive an `Env` or capture an existing SDK-based `ChatAgent` through a loopback boundary without agent-side integration code. Open Harness's analogous contract should be: task/spec in; normalized run/session events, hand/tool outcomes, artifacts, validations, and a terminal handoff out. The trace RFC already names those event classes and stable `run_id`, `session_id`, and `step_id` fields (`.oh/docs/rfcs/rfc-trace-ledger.md:39-71`). This would let Claude, Codex, Pi, or a future agent participate without each inventing its own evidence vocabulary.
+
+**3. Preserve provenance when context or control flow changes.** Molt keeps token IDs and behavior log-probabilities rather than reconstructing trajectories from text; when compaction rewrites a prompt prefix, it seals one segment and starts another. Open Harness should apply the same invariant at the harness level: never infer success from a prose transcript after a reset, retry, or handoff. Record the exact run/step, provider/model, command exit, artifact hash, validation result, and completion-marker parse. Context resets should create an explicit segment/cursor that remains replayable, complementing [[managed-agents]] and the proposed session ledger (`.oh/docs/rfcs/rfc-trace-ledger.md:77-155`).
+
+**4. Disaggregate brains and hands, then scale by configuration.** Molt's asynchronous queue, persistent prompt-group pool, pause/refit/resume path, and explicit policy-version correction let generation and training fail or scale independently. For Open Harness, the brain is a provider CLI; hands are sandboxes, worktrees, browsers, MCP tools, deploy targets, and GitHub operations. A run should attach or reprovision hands lazily, classify hand failures, and preserve artifacts outside the live process. This turns the runtime RFC's substrate/deploy/fan-out axes into stable interfaces while retaining the documented one-agent default (`.oh/docs/harnesses/overview.md:7-9`).
+
+**5. Fail fast on correctness mismatches, not only unsupported configuration.** Molt rejects partial rollout without off-policy correction and guards token, policy-version, and model-semantic alignment. Open Harness should similarly reject unverifiable completion: a missing required artifact is already an audit failure, and verification commands are explicit contracts (`.oh/docs/artifact-contract-schema.md:17-49`). The eval suite's real-state, `PASS`/`REGRESSION`/`SKIPPED` oracle prevents an absent environment from becoming silent green (`.oh/evals/README.md:20-49`).
+
+**6. Measure the outcome on the same visible path.** Molt's author → launch → observe workflow logs per-step reward, rollout, latency, and stage timings, then compares against a matched counterfactual. Open Harness's trace roadmap calls for `cost_time`, validation, artifact, and handoff events plus a capability benchmark and promotion gate (`.oh/docs/rfcs/rfc-selfimprove-roadmap.md:29-39`). Adopt the discipline: a smaller or cleaner skill is not progress unless task success, unattended completion, cost/time, or evidence quality improves. The paper's disclosed routing mismatch is a reminder to separate throughput claims from behavioral correctness claims.
+
+## System Relationships
+```mermaid
+flowchart LR
+  T[Task or spec] --> B[Provider-neutral brain contract]
+  B --> H[Hands: sandbox, worktree, tools]
+  B --> L[Trace and session ledger]
+  H --> A[Artifacts and validation]
+  A --> G[Audit, eval, benchmark]
+  L --> G
+```
+
+## See Also
+- [[managed-agents]]
+- [[audit-architecture]]
+- [[recursive-language-models]]
+- [[runtime-isolation-landscape]]


### PR DESCRIPTION
Closes #726

## What changed

- Add the curated `managed-agents` wiki entry covering durable sessions, replaceable brains/hands, credential boundaries, model evolution, and the one-agent default.
- Add the curated `molt-agentic-reinforcement-learning` entry covering readable/provider-neutral contracts, provenance across context changes, correctness invariants, and outcome measurement.
- Regenerate the wiki index for both entries.

## Why

These are source-backed architecture references that directly inform the existing trace-ledger, runtime-support, artifact-contract, eval, and self-improvement roadmap. Keeping the synthesis in the curated corpus makes the lessons reusable without mixing external research into executable skill guidance.

Immutable raw captures remain operator-local under the wiki's documented provenance policy; this PR contains only the reviewed entity pages and generated index.

## Verification

- `bash .oh/evals/probes/wiki-readme-index.sh`
- canonical frontmatter extraction for both new entries
- `git diff --cached --check`
- both entries use `confidence: provisional` and existing-corpus cross-links
