### PR TITLE
FROM fix/753-protected-paths-resolve TO development

### DIFF
--- a/.claude/protected-paths.txt
+++ b/.claude/protected-paths.txt
@@ -10,12 +10,16 @@
 # slash-prefixed. Scripts and files use repo-relative paths.
 # Lines starting with # are comments. Blank lines are ignored.
 #
-# Last reviewed: 2026-05-03 (issue #218)
+# Last reviewed: 2026-08-13 (issue #753)
+#
+# Every entry is checked by .oh/evals/probes/protected-paths-resolve.sh.
+# An entry that resolves to nothing protects nothing, and reads identical
+# to one that passes — so a rename silently disarms the guard.
 
 # --- Orchestrator skills (.claude/skills/) ---
 release
 ci-status
-cloudflared-tunnel
+cloudflared
 agent-browser
 prd
 ralph
@@ -23,10 +27,6 @@ audit
 delegate
 strategic-proposal
 ship-spec
-spec-plan
-spec-critique
-spec-execute
-spec-retro
 eval
 health-check
 retro
@@ -42,7 +42,7 @@ Makefile
 
 # --- Install / runtime scripts wired into the Dockerfile or sourced at boot ---
 .oh/install/banner.sh
-.oh/install/cloudflared-tunnel.sh
+.oh/skills/cloudflared/scripts/run.sh
 .devcontainer/entrypoint.sh
 .devcontainer/Dockerfile
 
@@ -58,9 +58,10 @@ Makefile
 .oh/skills/t3/references/sandbox-processes.md
 .oh/agents/advisor.md  # advisor delegation + recursive-decomposition norm, now an agent (was .oh/skills/advisor/)
 .oh/skills/retro/references/memory-protocol.md
-
-# --- Specs that other artifacts cross-reference ---
-.claude/specs/structure-spec-v0.7.md
+.oh/skills/spec/references/plan.md
+.oh/skills/spec/references/critique.md
+.oh/skills/spec/references/execute.md
+.oh/skills/spec/references/retro.md
 
 # --- Orchestrator identity layer (session-loaded by AGENTS.md bootloader) ---
 .oh/context/SOUL.md

--- a/.oh/evals/probes/protected-paths-resolve.sh
+++ b/.oh/evals/probes/protected-paths-resolve.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# tier: A
+# source: issue #753 — .claude/protected-paths.txt named 7 paths that did not exist.
+#         `cloudflared-tunnel` was listed while the skill is `cloudflared`, so
+#         /cloudflared had no protection at all; four `spec-*` entries had never been
+#         directories (the dispatcher implements them as spec/references/*.md);
+#         `.oh/install/cloudflared-tunnel.sh` was deleted; and
+#         `.claude/specs/structure-spec-v0.7.md` sat under a gitignored path
+#         (.gitignore:66) that could never resolve. A guard entry that matches nothing
+#         protects nothing AND reads identical to one that passes, so a rename
+#         silently disarms it. Only a resolution check catches the next one.
+# desc: every entry in .claude/protected-paths.txt resolves to a file or directory
+#       that exists, so a rename cannot silently disarm a protection
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"; cd "$ROOT"
+LIST=".claude/protected-paths.txt"
+
+[ -f "$LIST" ] || { echo "REGRESSION: $LIST is missing" >&2; exit 1; }
+
+broken=()
+count=0
+
+# Entry format, per the file's own header: bare names are skills; everything else
+# is a repo-relative path. `Makefile` is the one slash-free non-skill entry, so a
+# slash-free entry resolves as either a skill directory or a repo-root path.
+while IFS= read -r raw || [ -n "$raw" ]; do
+  line="${raw%%#*}"                              # strip trailing comment
+  line="${line#"${line%%[![:space:]]*}"}"        # ltrim
+  line="${line%"${line##*[![:space:]]}"}"        # rtrim
+  [ -n "$line" ] || continue
+  count=$((count + 1))
+  case "$line" in
+    */*)
+      [ -e "$line" ] || broken+=("$line  (path does not exist)")
+      ;;
+    *)
+      if [ ! -d ".oh/skills/$line" ] && [ ! -e "$line" ]; then
+        broken+=("$line  (no .oh/skills/$line directory, and no such repo-root path)")
+      fi
+      ;;
+  esac
+done < "$LIST"
+
+[ "$count" -gt 0 ] || { echo "REGRESSION: $LIST parsed to zero entries" >&2; exit 1; }
+
+if ((${#broken[@]})); then
+  printf 'REGRESSION: %d entry/entries in %s resolve to nothing:\n' "${#broken[@]}" "$LIST" >&2
+  printf '  %s\n' "${broken[@]}" >&2
+  echo 'A guard entry that matches nothing protects nothing, and reads identical to one that passes.' >&2
+  exit 1
+fi
+
+echo "PASS: all $count entries in $LIST resolve" >&2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Update policy and release automation live in [`/git`](.claude/skills/git/SKILL.m
 
 ## [Unreleased]
 
+### Fixed
+- Repair seven entries in `.claude/protected-paths.txt` that resolved to nothing, and add `.oh/evals/probes/protected-paths-resolve.sh` so a rename cannot silently disarm a guard again. A guard entry that matches nothing protects nothing **and reads identical to one that passes**, which is why all seven survived since 2026-05-03. `cloudflared-tunnel` was listed while the skill directory is `.oh/skills/cloudflared`, so `/cloudflared` had no protection at all. Four `spec-*` entries had never been directories — the `/spec` dispatcher implements them as `.oh/skills/spec/references/{plan,critique,execute,retro}.md`, which now carry the protection. `.oh/install/cloudflared-tunnel.sh` was deleted at some point and is replaced by `.oh/skills/cloudflared/scripts/run.sh`. `.claude/specs/structure-spec-v0.7.md` sat under a path `.gitignore:66` excludes, so it could never resolve and is removed. The probe parses the file's documented format — bare names are skills, everything else is a repo-relative path, with a slash-free entry allowed to resolve either way so the root `Makefile` entry stays valid — and was verified by rejection against all four original defect shapes ([#753](https://github.com/mifunedev/openharness/issues/753)).
+
 ### Security
 
 - Pin transitive `nanoid` to the patched `^3.3.17` range to close GHSA-2v37-7h3g-55p8 through the Vitest → Vite → PostCSS dependency path.


### PR DESCRIPTION
Closes #753

## The bug is worse than the issue reported

`.claude/protected-paths.txt` guards load-bearing skills and scripts against a critic proposing deletion. The issue named 2 broken entries. A full resolution sweep found **7**:

| Entry | Why it resolved to nothing | Fix |
|---|---|---|
| `cloudflared-tunnel` | the skill directory is `.oh/skills/cloudflared` — **`/cloudflared` had no protection at all** | `cloudflared` |
| `spec-plan` | never a directory; `/spec` implements it as a reference | `.oh/skills/spec/references/plan.md` |
| `spec-critique` | same | `.oh/skills/spec/references/critique.md` |
| `spec-execute` | same | `.oh/skills/spec/references/execute.md` |
| `spec-retro` | same | `.oh/skills/spec/references/retro.md` |
| `.oh/install/cloudflared-tunnel.sh` | deleted at some point; `.oh/install/` now holds only `banner.sh` | `.oh/skills/cloudflared/scripts/run.sh` |
| `.claude/specs/structure-spec-v0.7.md` | sits under a path `.gitignore:66` excludes — **could never resolve** | removed, with its section header |

**Why all seven survived since 2026-05-03 (`Last reviewed`):** an entry that matches nothing protects nothing **and reads identical to one that passes**. There is no output difference between a working guard and a disarmed one. Nothing could have caught this except a resolution check.

## The fix that matters

`.oh/evals/probes/protected-paths-resolve.sh` (tier A) fails when any entry resolves to nothing. Repairing the seven entries without this probe would just reset the clock until the next rename.

It parses the file's own documented format — bare names are skills, everything else is a repo-relative path — with one deliberate allowance: a slash-free entry may resolve as either a skill directory or a repo-root path, because `Makefile` is the one slash-free non-skill entry.

## Testing

**Verified by rejection** against all four original defect shapes — exit 0 on a guard file proves nothing on its own:

```
$ bash .oh/evals/probes/protected-paths-resolve.sh
PASS: all 43 entries in .claude/protected-paths.txt resolve      # rc=0

# 1. a renamed skill
  cloudflared-tunnel  (no .oh/skills/cloudflared-tunnel directory, and no such repo-root path)
# 2. a skill name that never existed
  spec-plan  (no .oh/skills/spec-plan directory, and no such repo-root path)
# 3. a deleted script path
  .oh/install/cloudflared-tunnel.sh  (path does not exist)
# 4. a path under a gitignored directory
  .claude/specs/structure-spec-v0.7.md  (path does not exist)
```

Each produces `rc=1` and names the offending entry. Restoring the file returns `rc=0`.

```
$ bash .oh/skills/eval/run.sh
ran 99 probe(s)                                    # rc=0
protected-paths-resolve          PASS   new-pass
```

No probe changed state. The one `REGRESSION` (`cc-safety-net-wiring`) is pre-existing and outside this diff.

## Note

`Last reviewed` moves to 2026-08-13, and the header now states why a broken entry is invisible — so the next person editing the file knows the probe is what keeps it honest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
