### PR TITLE
feat: close the make/oh lifecycle gap and publish one command mapping

### DIFF
--- a/.oh/cli/README.md
+++ b/.oh/cli/README.md
@@ -65,6 +65,13 @@ oh runtime status               # the measured requirements, not a bare verdict
 oh runtime install              # microsandbox; refuses if the host cannot run it
 ```
 
+Everything else the sandbox ships — a headless browser, the GitHub CLI:
+
+```bash
+oh tool list                    # what is present, and what is installable
+oh tool install agent-browser   # asks before the ~1 GB Chromium download
+```
+
 ## Commands
 
 | Command | What it does |
@@ -75,6 +82,7 @@ oh runtime install              # microsandbox; refuses if the host cannot run i
 | `oh sandbox` | Provision and start the sandbox (`docker compose up -d --build`). |
 | `oh shell [container]` | Open a `zsh` shell in the running sandbox container. |
 | `oh harness <list\|install\|status>` | Install and inspect agent CLI harnesses. `install` sets the `harness.yaml` flag **and** installs into the running sandbox — no rebuild. |
+| `oh tool <list\|install\|status>` | Install and inspect sandbox tooling that is neither an agent CLI nor a runtime (agent-browser, `gh`, `herdr`, `cloudflared`, Docker CLI). A large download is confirmed first. |
 | `oh runtime <list\|install\|status>` | Report the isolation runtime in use (Docker today) and install MicroSandbox. Measures first and refuses an install that cannot succeed (`--force` overrides). Selects no runtime and writes no config. |
 | `oh gateway <args…>` | Manage a messaging client session (Slack bridge for `pi`/`hermes`). |
 | `oh cloud <args…>` | Configure credentials and manage OpenHarness Cloud SSH keys and nodes. |

--- a/.oh/cli/README.md
+++ b/.oh/cli/README.md
@@ -81,6 +81,10 @@ oh tool install agent-browser   # asks before the ~1 GB Chromium download
 | `oh update` | Upgrade only the `.oh/` control plane from a newer source (`--from <dir>` / `--from-remote`); your project source is untouched. |
 | `oh sandbox` | Provision and start the sandbox (`docker compose up -d --build`). |
 | `oh shell [container]` | Open a `zsh` shell in the running sandbox container. |
+| `oh stop` | Stop the sandbox, preserving volumes. |
+| `oh restart` | Restart the sandbox service. |
+| `oh logs` | Tail the sandbox compose logs. |
+| `oh ps` | Show sandbox service status. |
 | `oh harness <list\|install\|status>` | Install and inspect agent CLI harnesses. `install` sets the `harness.yaml` flag **and** installs into the running sandbox — no rebuild. |
 | `oh tool <list\|install\|status>` | Install and inspect sandbox tooling that is neither an agent CLI nor a runtime (agent-browser, `gh`, `herdr`, `cloudflared`, Docker CLI). A large download is confirmed first. |
 | `oh runtime <list\|install\|status>` | Report the isolation runtime in use (Docker today) and install MicroSandbox. Measures first and refuses an install that cannot succeed (`--force` overrides). Selects no runtime and writes no config. |
@@ -88,6 +92,11 @@ oh tool install agent-browser   # asks before the ~1 GB Chromium download
 | `oh cloud <args…>` | Configure credentials and manage OpenHarness Cloud SSH keys and nodes. |
 | `oh --version` | Print the CLI version. |
 | `oh --help` | Show help; every subcommand also accepts `--help`. |
+
+These mirror the root `Makefile`'s targets one-for-one and run the same
+`.oh/scripts/docker-compose.sh`. Which one is canonical depends on where you
+are — see [lifecycle commands](../docs/lifecycle-commands.md), which also
+explains why `oh destroy` deliberately does not exist.
 
 `oh init` and `oh update` fetch their payload on demand — with no local source they shallow-clone
 the public OpenHarness repo into a temp dir and remove it after the run (`--from-remote`, `--ref <ref>`).

--- a/.oh/cli/src/__tests__/compose-verbs.test.ts
+++ b/.oh/cli/src/__tests__/compose-verbs.test.ts
@@ -1,0 +1,180 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  composeVerbs,
+  runComposeVerb,
+  type ComposeVerb,
+} from "../commands/lifecycle.js";
+import type { LifecycleRunner, RunResult } from "../lib/execution/runner.js";
+
+// cli.ts has a top-level side effect: main(process.argv.slice(2)).then(process.exit).
+vi.mock("../cli.js", async (importOriginal) => {
+  const original = process.exit;
+  process.exit = (() => {}) as never;
+  const mod = await importOriginal<typeof import("../cli.js")>();
+  await new Promise((r) => setTimeout(r, 0));
+  process.exit = original;
+  return mod;
+});
+
+const { printComposeVerbHelp, printOhHelp } = await import("../cli.js");
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "..", "..");
+const read = (p: string): string => readFileSync(join(REPO_ROOT, p), "utf8");
+
+const cleanups: string[] = [];
+afterEach(() => {
+  while (cleanups.length > 0) rmSync(cleanups.pop()!, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+/** An equipped-repo fixture with the vendored compose script present. */
+function makeRepo(): string {
+  const d = mkdtempSync(join(tmpdir(), "oh-compose-verb-"));
+  cleanups.push(d);
+  mkdirSync(join(d, ".oh", "scripts"), { recursive: true });
+  writeFileSync(join(d, ".oh", "scripts", "docker-compose.sh"), "#!/usr/bin/env bash\n");
+  return d;
+}
+
+interface RecordedCall {
+  cmd: string;
+  args: string[];
+}
+
+function makeRunner(result: RunResult = { status: 0 }): {
+  calls: RecordedCall[];
+  run: LifecycleRunner;
+} {
+  const calls: RecordedCall[] = [];
+  const run: LifecycleRunner = (cmd, args) => {
+    calls.push({ cmd, args: [...args] });
+    return result;
+  };
+  return { calls, run };
+}
+
+describe("compose verbs — the surface gap they close", () => {
+  it("exposes exactly the four non-destructive verbs", () => {
+    // `destroy` and a `config` equivalent are deliberately absent — see
+    // .oh/docs/lifecycle-commands.md and the probe that keeps them documented.
+    expect(composeVerbs()).toEqual(["stop", "restart", "logs", "ps"]);
+  });
+
+  it("does not expose destroy", () => {
+    // `down -v` wipes the volumes holding provider auth. It needs a
+    // confirmation policy, not a passthrough.
+    expect(composeVerbs()).not.toContain("destroy" as ComposeVerb);
+  });
+});
+
+describe("runComposeVerb", () => {
+  it.each([
+    ["stop", ["stop"]],
+    ["restart", ["restart"]],
+    ["ps", ["ps"]],
+    ["logs", ["logs", "-f"]],
+  ] as [ComposeVerb, string[]][])(
+    "runs the vendored script with the %s argv the Makefile uses",
+    (verb, expected) => {
+      const root = makeRepo();
+      const { calls, run } = makeRunner();
+      expect(runComposeVerb(verb, { cwd: root, run })).toBe(0);
+      expect(calls).toHaveLength(1);
+      expect(calls[0].cmd).toBe("bash");
+      expect(calls[0].args[0]).toBe(join(root, ".oh", "scripts", "docker-compose.sh"));
+      expect(calls[0].args.slice(1)).toEqual(expected);
+    },
+  );
+
+  it("never names docker — the script owns the engine argv", () => {
+    const root = makeRepo();
+    const { calls, run } = makeRunner();
+    for (const verb of composeVerbs()) runComposeVerb(verb, { cwd: root, run });
+    for (const c of calls) {
+      expect(c.cmd).not.toBe("docker");
+      expect(c.args.join(" ")).not.toContain("docker compose");
+    }
+  });
+
+  it("forwards extra arguments after the verb", () => {
+    const root = makeRepo();
+    const { calls, run } = makeRunner();
+    runComposeVerb("logs", { cwd: root, run }, ["--tail", "50"]);
+    expect(calls[0].args.slice(1)).toEqual(["logs", "-f", "--tail", "50"]);
+  });
+
+  it("propagates the child's exit code", () => {
+    const root = makeRepo();
+    const { run } = makeRunner({ status: 3 });
+    expect(runComposeVerb("ps", { cwd: root, run })).toBe(3);
+  });
+
+  it("reports a signal-killed child as failure, not success", () => {
+    const root = makeRepo();
+    const { run } = makeRunner({ status: null } as RunResult);
+    expect(runComposeVerb("logs", { cwd: root, run })).toBe(1);
+  });
+
+  it("fails with the re-vendor hint when the script is missing", () => {
+    const d = mkdtempSync(join(tmpdir(), "oh-compose-bare-"));
+    cleanups.push(d);
+    mkdirSync(join(d, ".oh", "scripts"), { recursive: true });
+    const { run } = makeRunner();
+    expect(() => runComposeVerb("ps", { cwd: d, run })).toThrow(/oh update/);
+  });
+});
+
+describe("help", () => {
+  it("lists every verb in the top-level usage block", () => {
+    const spy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    printOhHelp();
+    const text = spy.mock.calls.map((c) => String(c[0])).join("");
+    for (const verb of composeVerbs()) expect(text, verb).toContain(`oh ${verb}`);
+  });
+
+  it("names the make equivalent, so neither door looks like the only one", () => {
+    const spy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    printComposeVerbHelp("stop");
+    const text = spy.mock.calls.map((c) => String(c[0])).join("");
+    expect(text).toContain("make stop");
+    expect(text).toContain("lifecycle-commands.md");
+  });
+});
+
+/**
+ * The consolidation's real invariant: the two front doors must keep agreeing.
+ * These read the repo's own Makefile, not a fixture.
+ */
+describe("parity with the Makefile", () => {
+  const MAKEFILE = read("Makefile");
+
+  it("has an oh verb for every compose target the Makefile exposes", () => {
+    for (const verb of composeVerbs()) {
+      expect(MAKEFILE, verb).toMatch(new RegExp(`^${verb}:`, "m"));
+    }
+  });
+
+  it("keeps the Makefile free of direct `docker compose` calls", () => {
+    // Both doors run .oh/scripts/docker-compose.sh; a raw call in a recipe
+    // would fork overlay resolution and project naming.
+    const recipes = MAKEFILE.split("\n").filter((l) => l.startsWith("\t"));
+    for (const line of recipes) expect(line).not.toContain("docker compose");
+  });
+
+  it("leaves the pinned `make shell` line verbatim", () => {
+    // execution-target-contract.sh C5 asserts this too. Restated here so that
+    // changing it fails from both sides.
+    expect(MAKEFILE).toContain("docker exec -it -u $(SHELL_USER) $(SHELL_CONTAINER) zsh");
+  });
+
+  it("documents each make-only target in the mapping doc", () => {
+    const map = read(".oh/docs/lifecycle-commands.md");
+    for (const target of ["destroy", "config", "shell"]) {
+      expect(map, target).toContain(`make ${target}`);
+    }
+  });
+});

--- a/.oh/cli/src/__tests__/tool-catalog.test.ts
+++ b/.oh/cli/src/__tests__/tool-catalog.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  findTool,
+  installableToolIds,
+  toolIds,
+  TOOL_CATALOG,
+} from "../lib/tools/catalog.js";
+import { HARNESS_CATALOG } from "../lib/harnesses/catalog.js";
+import { RUNTIME_CATALOG } from "../lib/runtimes/catalog.js";
+
+// src/__tests__ -> src -> .oh/cli -> .oh -> repo root
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "..", "..");
+const read = (p: string): string => readFileSync(join(REPO_ROOT, p), "utf8");
+
+describe("tool catalog shape", () => {
+  it("lists the five known tools", () => {
+    expect(toolIds()).toEqual([
+      "agent-browser",
+      "herdr",
+      "cloudflared",
+      "docker-cli",
+      "gh",
+    ]);
+  });
+
+  it("has exactly one installable tool", () => {
+    // The rest are baked into the image. This is the same shape as the runtime
+    // catalog (3 entries, 1 installable): reporting on something you cannot
+    // install is the point, not filler.
+    expect(installableToolIds()).toEqual(["agent-browser"]);
+  });
+
+  it("makes every non-installable tool say why", () => {
+    for (const t of TOOL_CATALOG) {
+      if (t.installArgv === undefined) expect(t.notInstallableReason, t.id).toBeTruthy();
+    }
+  });
+
+  it("gives every entry a docs path that exists", () => {
+    for (const t of TOOL_CATALOG) {
+      expect(() => read(t.docsPath), t.id).not.toThrow();
+    }
+  });
+
+  it("checks presence with `command -v`, never a version flag", () => {
+    // Presence and version are different questions, and the shell cannot be
+    // wrong about PATH.
+    for (const t of TOOL_CATALOG) {
+      expect(t.verifyArgv.join(" "), t.id).toContain(`command -v ${t.binary}`);
+    }
+  });
+
+  it("declares a version probe only where the flag is a safe standard", () => {
+    // herdr and agent-browser are omitted deliberately: neither binary was
+    // available to confirm its flag, and the repo's rule (set by `msb`) is to
+    // cite a verified source or omit, never guess.
+    const withVersion = TOOL_CATALOG.filter((t) => t.versionArgv !== undefined).map((t) => t.id);
+    expect(withVersion).toEqual(["cloudflared", "docker-cli", "gh"]);
+    for (const t of TOOL_CATALOG) {
+      if (t.versionArgv) expect(t.versionArgv, t.id).toEqual([t.binary, "--version"]);
+    }
+  });
+
+  it("passes argv arrays with no interpolation this process performs", () => {
+    for (const t of TOOL_CATALOG) {
+      for (const argv of [t.installArgv, t.verifyArgv, t.versionArgv]) {
+        if (!argv) continue;
+        // `${` would be a template hole. `$PNPM_HOME` is fine — the container's
+        // own login shell expands it, and nothing user-supplied reaches it.
+        for (const token of argv) expect(token, `${t.id}: ${token}`).not.toContain("${");
+      }
+    }
+  });
+});
+
+/**
+ * The three catalogs must stay disjoint. A tool appearing in two tables means
+ * two commands claim it and two drift tests assert different ground truths.
+ */
+describe("the three catalogs are disjoint", () => {
+  it("shares no id with the harness or runtime catalog", () => {
+    const harness = new Set(HARNESS_CATALOG.map((h) => h.id));
+    const runtime = new Set(RUNTIME_CATALOG.map((r) => r.id));
+    for (const t of TOOL_CATALOG) {
+      expect(harness.has(t.id), `${t.id} is also a harness`).toBe(false);
+      expect(runtime.has(t.id), `${t.id} is also a runtime`).toBe(false);
+    }
+  });
+
+  it("has unique ids within itself", () => {
+    expect(new Set(toolIds()).size).toBe(TOOL_CATALOG.length);
+  });
+
+  it("keeps docker-cli distinct from the docker RUNTIME", () => {
+    // Not a duplicate: one is the client binary in the image, the other is the
+    // isolation boundary and its daemon. The ids differ on purpose.
+    expect(findTool("docker-cli")).toBeDefined();
+    expect(findTool("docker")).toBeUndefined();
+    expect(RUNTIME_CATALOG.some((r) => r.id === "docker")).toBe(true);
+  });
+
+  it("leaves agent_browser excluded from the harness catalog", () => {
+    // harness-catalog.test.ts asserts this too. Restated here so that moving it
+    // INTO the harness table fails from both sides.
+    expect(HARNESS_CATALOG.some((h) => h.harnessKey === "agent_browser")).toBe(false);
+  });
+});
+
+/**
+ * Drift test for agent-browser. Its ground truth is `entrypoint.sh` — NOT the
+ * Dockerfile — and the inverse assertion is what keeps this catalog honest.
+ */
+describe("agent-browser matches the entrypoint that really installs it", () => {
+  const ab = findTool("agent-browser")!;
+  const ENTRYPOINT = read(".devcontainer/entrypoint.sh");
+
+  it("carries the entrypoint guard, not a build arg", () => {
+    expect(ab.entrypointGuard).toBe("INSTALL_AGENT_BROWSER");
+    expect(Object.keys(ab)).not.toContain("buildArg");
+    expect(ab.toolKey).toBe("agent_browser");
+  });
+
+  it("is installed by the entrypoint and is ABSENT from the Dockerfile", () => {
+    // This absence is the whole reason `entrypointGuard` exists as a separate
+    // field. An unasserted premise is how these tables drift.
+    expect(ENTRYPOINT).toContain("INSTALL_AGENT_BROWSER");
+    expect(read(".devcontainer/Dockerfile")).not.toContain("INSTALL_AGENT_BROWSER");
+  });
+
+  it("pins the same version the entrypoint pins", () => {
+    expect(ab.installArgv!.join(" ")).toContain("agent-browser@0.8.5");
+    expect(ENTRYPOINT).toContain("agent-browser@0.8.5");
+  });
+
+  it("reproduces each of the entrypoint's three install steps", () => {
+    const argv = ab.installArgv!.join(" ");
+    for (const step of [
+      "pnpm add -g agent-browser@0.8.5",
+      "-exec chmod +x",
+      "agent-browser install --with-deps",
+    ]) {
+      expect(argv, step).toContain(step);
+      expect(ENTRYPOINT, step).toContain(step);
+    }
+  });
+
+  it("drops the entrypoint's log cosmetics, which would eat the exit code", () => {
+    const argv = ab.installArgv!.join(" ");
+    expect(argv).not.toContain("tail -5");
+    expect(argv).not.toContain("[entrypoint]");
+  });
+
+  it("arms the download gate with the size the wizard also quotes", () => {
+    expect(ab.downloadSize).toBe("~1 GB");
+    expect(read(".oh/cli/src/commands/init.ts")).toContain("~1 GB");
+  });
+
+  it("keeps the env plumbing wired end to end", () => {
+    expect(read(".devcontainer/docker-compose.yml")).toContain("INSTALL_AGENT_BROWSER");
+    expect(read(".oh/scripts/harness-config.sh")).toContain(
+      'envmap["install.agent_browser"] = "INSTALL_AGENT_BROWSER"',
+    );
+    expect(read("harness.yaml.example")).toMatch(/agent_browser/);
+  });
+});
+
+describe("baked-in tools", () => {
+  it("declare no install key — the installer must not invent one", () => {
+    for (const t of TOOL_CATALOG) {
+      if (t.kind !== "baked-in") continue;
+      expect(t.toolKey, t.id).toBeUndefined();
+      expect(t.entrypointGuard, t.id).toBeUndefined();
+      expect(t.installArgv, t.id).toBeUndefined();
+    }
+  });
+
+  it("are each actually in the Dockerfile", () => {
+    const dockerfile = read(".devcontainer/Dockerfile");
+    for (const id of ["herdr", "cloudflared"]) {
+      expect(dockerfile, id).toContain(id);
+    }
+  });
+});

--- a/.oh/cli/src/__tests__/tool.test.ts
+++ b/.oh/cli/src/__tests__/tool.test.ts
@@ -1,0 +1,352 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { copyFileSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  runToolInstall,
+  runToolList,
+  runToolStatus,
+  type ToolIO,
+} from "../commands/tool.js";
+import type { LifecycleRunner, RunResult } from "../lib/execution/runner.js";
+
+// cli.ts has a top-level side effect: main(process.argv.slice(2)).then(process.exit).
+// Same guard as harness.test.ts: stub process.exit around the import so the
+// module body's main() call cannot terminate the vitest worker.
+vi.mock("../cli.js", async (importOriginal) => {
+  const original = process.exit;
+  process.exit = (() => {}) as never;
+  const mod = await importOriginal<typeof import("../cli.js")>();
+  await new Promise((r) => setTimeout(r, 0));
+  process.exit = original;
+  return mod;
+});
+
+const { parseToolArgs, printToolHelp, printOhHelp } = await import("../cli.js");
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "..", "..");
+const REAL_EXAMPLE = join(REPO_ROOT, "harness.yaml.example");
+
+const cleanups: string[] = [];
+afterEach(() => {
+  while (cleanups.length > 0) rmSync(cleanups.pop()!, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+/** An equipped-repo fixture. mkdtemp only — never the real worktree root. */
+function makeRepo(): string {
+  const d = mkdtempSync(join(tmpdir(), "oh-tool-"));
+  cleanups.push(d);
+  mkdirSync(join(d, ".oh", "scripts"), { recursive: true });
+  writeFileSync(join(d, ".oh", "scripts", "harness-config.sh"), "#!/bin/sh\n");
+  copyFileSync(REAL_EXAMPLE, join(d, "harness.yaml.example"));
+  copyFileSync(REAL_EXAMPLE, join(d, "harness.yaml"));
+  return d;
+}
+
+interface RecordedCall {
+  cmd: string;
+  args: string[];
+}
+
+function makeRunner(
+  reply: (cmd: string, args: string[]) => RunResult | undefined = () => undefined,
+): { calls: RecordedCall[]; run: LifecycleRunner } {
+  const calls: RecordedCall[] = [];
+  const run: LifecycleRunner = (cmd, args) => {
+    calls.push({ cmd, args: [...args] });
+    return reply(cmd, args) ?? { status: 0, stdout: "", stderr: "" };
+  };
+  return { calls, run };
+}
+
+function makeIo(confirmWith?: boolean): {
+  io: ToolIO;
+  out: string[];
+  err: string[];
+  asked: string[];
+} {
+  const out: string[] = [];
+  const err: string[] = [];
+  const asked: string[] = [];
+  const io: ToolIO = { stdout: (s) => out.push(s), stderr: (s) => err.push(s) };
+  if (confirmWith !== undefined) {
+    io.confirm = async (q) => {
+      asked.push(q);
+      return confirmWith;
+    };
+  }
+  return { io, out, err, asked };
+}
+
+const isInspect = (cmd: string, args: string[]): boolean =>
+  cmd === "docker" && args[0] === "inspect";
+const isExecOf = (cmd: string, args: string[], token: string): boolean =>
+  cmd === "docker" && args[0] === "exec" && args.some((a) => a.includes(token));
+
+const running: RunResult = { status: 0, stdout: "running\n", stderr: "" };
+const exited: RunResult = { status: 0, stdout: "exited\n", stderr: "" };
+
+/** Container running; agent-browser absent. */
+function liveHost(extra: (cmd: string, args: string[]) => RunResult | undefined = () => undefined) {
+  return makeRunner((cmd, args) => {
+    const custom = extra(cmd, args);
+    if (custom) return custom;
+    if (isInspect(cmd, args)) return running;
+    if (isExecOf(cmd, args, "command -v agent-browser")) {
+      return { status: 1, stdout: "", stderr: "" };
+    }
+    return undefined;
+  });
+}
+
+/** The `docker exec` that actually runs the installer. */
+const isInstallCall = (c: RecordedCall): boolean =>
+  c.cmd === "docker" && c.args[0] === "exec" && c.args.some((a) => a.includes("--with-deps"));
+
+/**
+ * The `install.agent_browser` KEY line, not the prose above it.
+ *
+ * The `install:` section carries a comment mentioning `agent_browser`, so a
+ * plain substring search finds the comment first and every assertion below
+ * would test the wrong line.
+ */
+const flagLine = (root: string): string | undefined =>
+  readFileSync(join(root, "harness.yaml"), "utf8")
+    .split("\n")
+    .find((l) => /^\s*#?\s*agent_browser:/.test(l));
+
+describe("oh tool — argument parsing", () => {
+  it("shows help with no args", () => {
+    const r = parseToolArgs([]);
+    expect(r.ok).toBe(true);
+    expect(r.ok && r.args.help).toBe(true);
+  });
+
+  it("requires a name for install — there is no obvious default", () => {
+    // Unlike `oh runtime install`, most tools are baked in, so no single tool
+    // is the sensible implicit target.
+    const r = parseToolArgs(["install"]);
+    expect(r.ok).toBe(false);
+    expect(!r.ok && r.showHelp).toBe(true);
+  });
+
+  it("parses the flags", () => {
+    const r = parseToolArgs(["install", "agent-browser", "--yes", "--json"]);
+    expect(r.ok && r.args.yes).toBe(true);
+    expect(r.ok && r.args.json).toBe(true);
+    expect(parseToolArgs(["install", "x", "-y"]).ok).toBe(true);
+  });
+
+  it("rejects the conflicting persist flags", () => {
+    expect(parseToolArgs(["install", "x", "--persist-only", "--no-persist"]).ok).toBe(false);
+  });
+
+  it("rejects unknown flags, subcommands, and stray arguments", () => {
+    expect(parseToolArgs(["list", "--wat"]).ok).toBe(false);
+    expect(parseToolArgs(["frobnicate"]).ok).toBe(false);
+    expect(parseToolArgs(["list", "gh"]).ok).toBe(false);
+    expect(parseToolArgs(["install", "gh", "extra"]).ok).toBe(false);
+  });
+});
+
+describe("oh tool — help", () => {
+  it("is listed in the top-level usage block", () => {
+    const w = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+    printOhHelp();
+    expect(w.mock.calls.map((c) => String(c[0])).join("")).toContain("oh tool");
+  });
+
+  it("names the sibling commands so the category is unambiguous", () => {
+    const w = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+    printToolHelp();
+    const text = w.mock.calls.map((c) => String(c[0])).join("");
+    expect(text).toContain("oh harness");
+    expect(text).toContain("oh runtime");
+    // Distinguishes "known" from "installable" — most tools are report-only.
+    expect(text).toContain("agent-browser");
+    expect(text).toContain("gh");
+  });
+});
+
+describe("oh tool list / status", () => {
+  it("lists every tool with its kind", async () => {
+    const root = makeRepo();
+    const { io, out } = makeIo();
+    expect(await runToolList({ cwd: root, run: liveHost().run }, io)).toBe(0);
+    const text = out.join("");
+    for (const id of ["agent-browser", "herdr", "cloudflared", "docker-cli", "gh"]) {
+      expect(text, id).toContain(id);
+    }
+    expect(text).toContain("baked-in");
+    expect(text).toContain("opt-in");
+  });
+
+  it("reports a version for tools that declare a probe", async () => {
+    const root = makeRepo();
+    const { run } = liveHost((cmd, args) =>
+      isExecOf(cmd, args, "--version")
+        ? { status: 0, stdout: "gh version 2.63.2 (2026-01-01)\n", stderr: "" }
+        : undefined,
+    );
+    const { io, out } = makeIo();
+    await runToolStatus("gh", { cwd: root, run, json: true }, io);
+    expect(JSON.parse(out.join("")).version).toContain("2.63.2");
+  });
+
+  it("reports null, not a guess, for a tool with no version probe", async () => {
+    const root = makeRepo();
+    const { io, out } = makeIo();
+    await runToolStatus("herdr", { cwd: root, run: liveHost().run, json: true }, io);
+    expect(JSON.parse(out.join("")).version).toBeNull();
+  });
+
+  it("never asks an absent binary for its version", async () => {
+    const root = makeRepo();
+    const { calls, run } = liveHost((cmd, args) =>
+      isExecOf(cmd, args, "command -v gh") ? { status: 1, stdout: "", stderr: "" } : undefined,
+    );
+    const { io } = makeIo();
+    await runToolStatus("gh", { cwd: root, run }, io);
+    expect(calls.some((c) => isExecOf(c.cmd, c.args, "gh --version"))).toBe(false);
+  });
+
+  it("execs nothing when the container is stopped", async () => {
+    const root = makeRepo();
+    const { calls, run } = makeRunner((cmd, args) => (isInspect(cmd, args) ? exited : undefined));
+    const { io, out } = makeIo();
+    expect(await runToolList({ cwd: root, run }, io)).toBe(0);
+    expect(calls.some((c) => c.args[0] === "exec")).toBe(false);
+    expect(out.join("")).toContain("oh sandbox");
+  });
+
+  it("rejects an unknown tool with the known list", async () => {
+    const root = makeRepo();
+    const { io, err } = makeIo();
+    expect(await runToolStatus("chromium", { cwd: root, run: liveHost().run }, io)).toBe(1);
+    expect(err.join("")).toContain("agent-browser");
+  });
+});
+
+describe("oh tool install — the ~1 GB download gate", () => {
+  it("fails closed when non-interactive without --yes", async () => {
+    const root = makeRepo();
+    const { calls, run } = liveHost();
+    // No injected confirm and no TTY in vitest → the fail-closed path.
+    const { io, err } = makeIo();
+    expect(await runToolInstall("agent-browser", { cwd: root, run }, io)).toBe(1);
+    expect(calls.some(isInstallCall)).toBe(false);
+    const text = err.join("");
+    expect(text).toContain("~1 GB");
+    expect(text).toContain("--yes");
+  });
+
+  it("still persists the flag when the download is declined", async () => {
+    const root = makeRepo();
+    const { io, out } = makeIo(false);
+    await runToolInstall("agent-browser", { cwd: root, run: liveHost().run }, io);
+    // The durable half is the whole reason persist runs first.
+    expect(flagLine(root)).toMatch(/^ {2}agent_browser: true/);
+    expect(out.join("")).toContain("next container start");
+  });
+
+  it("asks before downloading, naming the size", async () => {
+    const root = makeRepo();
+    const { io, asked } = makeIo(true);
+    await runToolInstall("agent-browser", { cwd: root, run: liveHost().run }, io);
+    expect(asked.join("")).toContain("~1 GB");
+  });
+
+  it("installs when the prompt is accepted", async () => {
+    const root = makeRepo();
+    const { calls, run } = liveHost();
+    const { io } = makeIo(true);
+    expect(await runToolInstall("agent-browser", { cwd: root, run }, io)).toBe(0);
+    expect(calls.some(isInstallCall)).toBe(true);
+  });
+
+  it("--yes bypasses the prompt entirely", async () => {
+    const root = makeRepo();
+    const { calls, run } = liveHost();
+    const { io, asked } = makeIo(false); // would decline if consulted
+    expect(await runToolInstall("agent-browser", { cwd: root, run, yes: true }, io)).toBe(0);
+    expect(asked).toEqual([]);
+    expect(calls.some(isInstallCall)).toBe(true);
+  });
+
+  it("--persist-only never prompts and never downloads", async () => {
+    const root = makeRepo();
+    const { calls, run } = liveHost();
+    const { io, asked } = makeIo(false);
+    expect(await runToolInstall("agent-browser", { cwd: root, run, persistOnly: true }, io)).toBe(0);
+    expect(asked).toEqual([]);
+    expect(calls.some((c) => c.args[0] === "exec")).toBe(false);
+    expect(flagLine(root)).toMatch(/^ {2}agent_browser: true/);
+  });
+
+  it("does not ask when the tool is already installed", async () => {
+    const root = makeRepo();
+    const { calls, run } = liveHost((cmd, args) =>
+      isExecOf(cmd, args, "command -v agent-browser")
+        ? { status: 0, stdout: "", stderr: "" }
+        : undefined,
+    );
+    const { io, asked, out } = makeIo(true);
+    expect(await runToolInstall("agent-browser", { cwd: root, run }, io)).toBe(0);
+    // Nobody should approve a download that would not have happened.
+    expect(asked).toEqual([]);
+    expect(calls.some(isInstallCall)).toBe(false);
+    expect(out.join("")).toContain("already installed");
+  });
+});
+
+describe("oh tool install — the other exits", () => {
+  it("refuses a baked-in tool and points at the installable ones", async () => {
+    const root = makeRepo();
+    const { calls, run } = liveHost();
+    const { io, err } = makeIo(true);
+    expect(await runToolInstall("gh", { cwd: root, run }, io)).toBe(1);
+    const text = err.join("");
+    expect(text).toContain("base image");
+    expect(text).toContain("agent-browser");
+    expect(calls.length).toBe(0);
+  });
+
+  it("persists and exits 0 when the sandbox is stopped", async () => {
+    const root = makeRepo();
+    const { calls, run } = makeRunner((cmd, args) => (isInspect(cmd, args) ? exited : undefined));
+    const { io, out } = makeIo(true);
+    expect(await runToolInstall("agent-browser", { cwd: root, run }, io)).toBe(0);
+    expect(calls.some((c) => c.args[0] === "exec")).toBe(false);
+    expect(flagLine(root)).toMatch(/^ {2}agent_browser: true/);
+    expect(out.join("")).toContain("oh sandbox");
+  });
+
+  it("--no-persist leaves harness.yaml untouched", async () => {
+    const root = makeRepo();
+    const before = readFileSync(join(root, "harness.yaml"), "utf8");
+    const { io } = makeIo(true);
+    await runToolInstall("agent-browser", { cwd: root, run: liveHost().run, noPersist: true }, io);
+    expect(readFileSync(join(root, "harness.yaml"), "utf8")).toBe(before);
+  });
+
+  it("keeps the flag set when the installer fails", async () => {
+    const root = makeRepo();
+    const { run } = liveHost((cmd, args) =>
+      isExecOf(cmd, args, "--with-deps") ? { status: 7, stdout: "", stderr: "" } : undefined,
+    );
+    const { io, err } = makeIo(true);
+    expect(await runToolInstall("agent-browser", { cwd: root, run }, io)).toBe(7);
+    expect(flagLine(root)).toMatch(/^ {2}agent_browser: true/);
+    expect(err.join("")).toContain("next container start");
+  });
+
+  it("rejects an unknown tool", async () => {
+    const root = makeRepo();
+    const { calls, run } = liveHost();
+    const { io } = makeIo(true);
+    expect(await runToolInstall("chromium", { cwd: root, run }, io)).toBe(1);
+    expect(calls.length).toBe(0);
+  });
+});

--- a/.oh/cli/src/cli.ts
+++ b/.oh/cli/src/cli.ts
@@ -6,10 +6,13 @@ import { runInit, type InitIO, type InitOptions } from "./commands/init.js";
 import { runUpdate } from "./commands/update.js";
 import { runCloud } from "./commands/cloud.js";
 import {
+  runComposeVerb,
   runGateway,
   runSandbox,
   runShell,
+  composeVerbs,
   DEFAULT_CONTAINER_NAME,
+  type ComposeVerb,
   type LifecycleIO,
 } from "./commands/lifecycle.js";
 import {
@@ -102,6 +105,10 @@ Usage:
   oh update                 Upgrade the .oh/ control plane from a newer source
   oh sandbox                Provision and start the sandbox (docker compose up)
   oh shell [container]      Open a zsh shell in the running sandbox container
+  oh stop                   Stop the sandbox, preserving volumes
+  oh restart                Restart the sandbox service
+  oh logs                   Tail sandbox logs (follows)
+  oh ps                     Show sandbox service status
   oh harness <args...>      Install and inspect agent CLI harnesses
   oh runtime <args...>      Inspect the sandbox's isolation runtime
   oh tool <args...>         Install and inspect sandbox tooling
@@ -363,6 +370,32 @@ Flags:
 
 Tools:
 ${toolIds().map((t) => `  ${t}`).join("\n")}
+`);
+}
+
+/**
+ * One help block for all four compose verbs — they differ only in the word.
+ * `oh destroy` and a `make config` equivalent are deliberately absent; see
+ * `.oh/docs/lifecycle-commands.md` for why.
+ */
+export function printComposeVerbHelp(verb: ComposeVerb): void {
+  const what: Record<ComposeVerb, string> = {
+    stop: "Stop the sandbox, preserving volumes for a later restart",
+    restart: "Restart the sandbox service",
+    logs: "Tail the sandbox compose logs (follows until interrupted)",
+    ps: "Show sandbox service status",
+  };
+  process.stdout.write(`oh ${verb} — ${what[verb]}
+
+Usage:
+  oh ${verb} [-- <extra docker compose args>]
+
+Equivalent to \`make ${verb}\` — both run .oh/scripts/docker-compose.sh, which is
+the single implementation. Use whichever is available: \`make\` needs no Node and
+works in a source checkout; \`oh\` works anywhere, including an \`oh init\` repo
+that has no Makefile.
+
+See .oh/docs/lifecycle-commands.md for the full mapping.
 `);
 }
 
@@ -1067,6 +1100,25 @@ async function main(argv: string[]): Promise<number> {
       return 0;
     }
     return runShell({ container: parsed.args.container }, lifecycleIo());
+  }
+
+  // The compose lifecycle verbs. `--`-separated extras pass straight through to
+  // docker compose; anything else is rejected rather than silently forwarded.
+  if ((composeVerbs() as string[]).includes(first)) {
+    const verb = first as ComposeVerb;
+    const rest = argv.slice(1);
+    if (isHelpFlag(rest[0])) {
+      printComposeVerbHelp(verb);
+      return 0;
+    }
+    const sep = rest.indexOf("--");
+    if (sep === -1 && rest.length > 0) {
+      process.stderr.write(
+        `oh ${verb}: unexpected argument "${rest[0]}" — pass extra docker compose args after \`--\`\n`,
+      );
+      return 1;
+    }
+    return runComposeVerb(verb, {}, sep === -1 ? [] : rest.slice(sep + 1));
   }
 
   if (first === "harness") {

--- a/.oh/cli/src/cli.ts
+++ b/.oh/cli/src/cli.ts
@@ -27,6 +27,13 @@ import {
 } from "./commands/runtime.js";
 import { DEFAULT_RUNTIME, runtimeIds } from "./lib/runtimes/catalog.js";
 import {
+  runToolInstall,
+  runToolList,
+  runToolStatus,
+  type ToolIO,
+} from "./commands/tool.js";
+import { installableToolIds, toolIds } from "./lib/tools/catalog.js";
+import {
   fetchRemoteSource,
   DEFAULT_REPO_URL,
   type FetchRemoteSourceOptions,
@@ -97,6 +104,7 @@ Usage:
   oh shell [container]      Open a zsh shell in the running sandbox container
   oh harness <args...>      Install and inspect agent CLI harnesses
   oh runtime <args...>      Inspect the sandbox's isolation runtime
+  oh tool <args...>         Install and inspect sandbox tooling
   oh gateway <args...>      Manage a messaging client session (pi|hermes)
   oh cloud <args...>        Manage OpenHarness Cloud nodes
   oh --version              Print version
@@ -324,6 +332,37 @@ Flags:
 
 Runtimes:
 ${runtimeIds().map((r) => `  ${r}`).join("\n")}
+`);
+}
+
+export function printToolHelp(): void {
+  process.stdout.write(`oh tool — Install and inspect sandbox tooling
+
+Tooling that is neither an agent CLI (see \`oh harness\`) nor an isolation
+runtime (see \`oh runtime\`) — a headless browser, a tunnel client, the
+GitHub CLI.
+
+Usage:
+  oh tool list                      List known tools and their state
+  oh tool status [name]             Show installed state and version
+  oh tool install <name>            Install a tool into the sandbox
+
+Most tools are baked into the image and are report-only; \`install\` works on:
+${installableToolIds().map((t) => `  ${t}`).join("\n")}
+
+\`install\` does BOTH halves: it sets the harness.yaml \`install:\` flag so the
+choice survives the next container start, AND installs into the already-running
+container. It never rebuilds or restarts the sandbox. A large download is
+confirmed first, and a non-interactive run without --yes installs nothing.
+
+Flags:
+  --persist-only   Only set the harness.yaml install: flag (no container work)
+  --no-persist     Live-install only; leave harness.yaml unchanged
+  --yes            Accept a large download without prompting
+  --json           Machine-readable output (list/status)
+
+Tools:
+${toolIds().map((t) => `  ${t}`).join("\n")}
 `);
 }
 
@@ -644,6 +683,68 @@ export function parseRuntimeArgs(rest: string[]): ParseResult<RuntimeArgs> {
   else if (sub === "install") args.name = DEFAULT_RUNTIME;
   return { ok: true, args };
 }
+
+/** Parsed `oh tool` args. */
+interface ToolArgs {
+  help: boolean;
+  persistOnly: boolean;
+  noPersist: boolean;
+  yes: boolean;
+  json: boolean;
+  subcommand?: "list" | "install" | "status";
+  name?: string;
+}
+
+export function parseToolArgs(rest: string[]): ParseResult<ToolArgs> {
+  const args: ToolArgs = {
+    help: false, persistOnly: false, noPersist: false, yes: false, json: false,
+  };
+  if (rest.length === 0 || isHelpFlag(rest[0])) {
+    return { ok: true, args: { ...args, help: true } };
+  }
+
+  const positionals: string[] = [];
+  for (const token of rest) {
+    if (token === "--persist-only") args.persistOnly = true;
+    else if (token === "--no-persist") args.noPersist = true;
+    else if (token === "--yes" || token === "-y") args.yes = true;
+    else if (token === "--json") args.json = true;
+    else if (token.startsWith("-")) {
+      return { ok: false, error: `oh tool: unknown flag "${token}"` };
+    } else positionals.push(token);
+  }
+
+  const [sub, name, ...extra] = positionals;
+  if (sub !== "list" && sub !== "install" && sub !== "status") {
+    return {
+      ok: false,
+      error: `oh tool: unknown subcommand "${sub}" — expected list, install, or status`,
+      showHelp: true,
+    };
+  }
+  if (extra.length > 0) {
+    return { ok: false, error: `oh tool: unexpected argument "${extra[0]}"` };
+  }
+  // No default name: most tools are baked in, so there is no one obvious
+  // thing to install. `oh runtime install` can default; this cannot.
+  if (sub === "install" && name === undefined) {
+    return { ok: false, error: "oh tool install: a tool name is required", showHelp: true };
+  }
+  if (sub === "list" && name !== undefined) {
+    return { ok: false, error: `oh tool list: unexpected argument "${name}"` };
+  }
+  if (args.persistOnly && args.noPersist) {
+    return {
+      ok: false,
+      error: "oh tool: --persist-only conflicts with --no-persist — pass at most one",
+    };
+  }
+
+  args.subcommand = sub;
+  if (name !== undefined) args.name = name;
+  return { ok: true, args };
+}
+
 
 
 /** Parsed `oh gateway` args — everything after a leading help flag is verbatim. */
@@ -1022,6 +1123,36 @@ async function main(argv: string[]): Promise<number> {
     }
     // parseRuntimeArgs defaults `name` for `install`.
     return await runRuntimeInstall(a.name as string, { force: a.force }, io);
+  }
+
+  if (first === "tool") {
+    const parsed = parseToolArgs(argv.slice(1));
+    if (!parsed.ok) {
+      process.stderr.write(`${parsed.error}\n`);
+      if (parsed.showHelp) printToolHelp();
+      return 1;
+    }
+    if (parsed.args.help) {
+      printToolHelp();
+      return 0;
+    }
+    const a = parsed.args;
+    const io: ToolIO = {
+      stdout: (s) => process.stdout.write(s),
+      stderr: (s) => process.stderr.write(s),
+    };
+    if (a.subcommand === "list") {
+      return await runToolList({ json: a.json }, io);
+    }
+    if (a.subcommand === "status") {
+      return await runToolStatus(a.name, { json: a.json }, io);
+    }
+    // parseToolArgs guarantees `name` is set for `install`.
+    return await runToolInstall(
+      a.name as string,
+      { persistOnly: a.persistOnly, noPersist: a.noPersist, yes: a.yes },
+      io,
+    );
   }
 
   if (first === "cloud") {

--- a/.oh/cli/src/commands/lifecycle.ts
+++ b/.oh/cli/src/commands/lifecycle.ts
@@ -301,6 +301,67 @@ export function runShell(opts: ShellOptions, io: LifecycleIO): number {
  * the execution contract would put a brain responsibility on the hands side of
  * the boundary. See `.oh/docs/rfcs/rfc-brain-hands-boundary.md`.
  */
+/**
+ * The compose verbs `oh` exposes 1:1 with the Makefile's targets.
+ *
+ * WHY THESE FOUR AND NOT SIX. `make destroy` runs `down -v`, which wipes the
+ * named volumes holding provider auth — a passthrough with no confirmation
+ * policy would make data loss one typo away, so it stays make-only until that
+ * policy is designed. `make config` has no entry either: `oh config` already
+ * means "configure an integration", and overloading it would be worse than the
+ * gap. Both exceptions are recorded in `.oh/docs/lifecycle-commands.md`, and a
+ * probe asserts they stay recorded rather than silently growing.
+ */
+const COMPOSE_VERBS = Object.freeze({
+  stop: Object.freeze(["stop"]),
+  restart: Object.freeze(["restart"]),
+  logs: Object.freeze(["logs", "-f"]),
+  ps: Object.freeze(["ps"]),
+});
+
+/** The verbs `runComposeVerb` accepts — the keys of `COMPOSE_VERBS`. */
+export type ComposeVerb = keyof typeof COMPOSE_VERBS;
+
+/** Every compose verb name, for help text and the dispatcher. */
+export function composeVerbs(): ComposeVerb[] {
+  return Object.keys(COMPOSE_VERBS) as ComposeVerb[];
+}
+
+/**
+ * `oh stop | restart | logs | ps` — the compose lifecycle verbs the Makefile
+ * already had and the CLI did not.
+ *
+ * THIS CLOSES A SURFACE GAP, NOT A LOGIC GAP. `make stop` and this verb run the
+ * same `.oh/scripts/docker-compose.sh`; the script has always been the single
+ * implementation, and `oh sandbox` reaches it too (via the compose target's
+ * `provision()`). What was missing was only that a user who had `oh` still had
+ * to switch tools mid-lifecycle — and an `oh init` repo has no Makefile at all.
+ *
+ * BRAIN-SIDE, deliberately NOT routed through `ExecutionTarget`. These manage
+ * the environment from outside rather than executing work inside a provisioned
+ * one, which is the same reasoning that keeps `runGateway` off the contract.
+ * `contractVersion: 1` has exactly `provision()` and `attach()`; adding methods
+ * for them would widen a versioned interface to no benefit.
+ *
+ * No compose argv is assembled here beyond the constant verb — the script owns
+ * overlay resolution, project naming, and env plumbing, and duplicating any of
+ * that in TypeScript is how the two front doors would start to drift.
+ */
+export function runComposeVerb(
+  verb: ComposeVerb,
+  opts: LifecycleOptions,
+  extra: string[] = [],
+): number {
+  const run = opts.run ?? spawnRunner;
+  const root = resolveProjectRoot(opts.cwd);
+  const script = requireLifecycleScript(root, "docker-compose.sh");
+  const r = run("bash", [script, ...COMPOSE_VERBS[verb], ...extra], {
+    stdio: "inherit",
+  });
+  assertSpawned(r, `bash ${script} ${verb}`);
+  return r.status ?? 1;
+}
+
 export function runGateway(args: string[], opts: LifecycleOptions): number {
   const run = opts.run ?? spawnRunner;
   const root = resolveProjectRoot(opts.cwd);

--- a/.oh/cli/src/commands/tool.ts
+++ b/.oh/cli/src/commands/tool.ts
@@ -1,0 +1,405 @@
+import { existsSync } from "node:fs";
+import {
+  ExecutionSpawnError,
+  resolveExecutionTarget,
+} from "../lib/execution/index.js";
+import { spawnRunner, type LifecycleRunner } from "../lib/execution/runner.js";
+import type { ExecutionTarget } from "../lib/execution/target.js";
+import { resolveProjectRoot } from "../lib/project.js";
+import { confirm } from "../lib/prompt.js";
+import {
+  harnessYamlPath,
+  isInstallFlagEnabled,
+  seedHarnessYaml,
+  setInstallFlag,
+} from "../lib/harness-yaml.js";
+import {
+  findTool,
+  installableToolIds,
+  toolIds,
+  TOOL_CATALOG,
+  type ToolEntry,
+} from "../lib/tools/catalog.js";
+import { configuredContainerName, DEFAULT_CONTAINER_NAME } from "./lifecycle.js";
+
+/**
+ * `oh tool <list|install|status>` — the sandbox tooling that is neither an
+ * agent CLI (`oh harness`) nor an isolation runtime (`oh runtime`).
+ *
+ * WHAT THIS SOLVES: `agent-browser` shares the `harness.yaml` `install:` section
+ * with the optional harnesses but is not one, so `oh harness` deliberately
+ * refuses it — leaving the only way to add it a hand-edit of `harness.yaml`
+ * followed by a full container recreate, because the entrypoint installs it at
+ * boot. And nothing could answer "is `gh` actually in this image, and what
+ * version" without opening a shell.
+ *
+ * INSTALL IS PERSIST-FIRST, like `oh harness` and unlike `oh runtime`:
+ *
+ *   1. persist `install.agent_browser: true` in harness.yaml — cheap, always
+ *      possible, and the reason the choice survives the next container recreate;
+ *   2. install into the ALREADY-RUNNING container, so it is usable now.
+ *
+ * `oh runtime`'s refusal to persist anything is specific to the unmade #731
+ * selector decision and does NOT transfer here: `install.agent_browser` already
+ * exists in `harness-config.sh`'s envmap and in `harness.yaml.example`, so this
+ * command writes a key the schema already defines and changes no schema.
+ *
+ * THE DOWNLOAD GATE. agent-browser pulls Chromium, roughly 1 GB. No harness
+ * install downloads anything comparable, so this is the one place the CLI asks
+ * before spending the operator's bandwidth. It FAILS CLOSED: a non-interactive
+ * run without `--yes` installs nothing and says which flag it wanted. The
+ * durable half still lands, so the next container recreate picks it up.
+ *
+ * WHAT THIS COMMAND NEVER DOES: rebuild or restart the sandbox. A stopped or
+ * absent container is the normal "not started yet" case, so it persists the
+ * flag, prints the hint, and exits 0.
+ *
+ * All container work goes through the `ExecutionTarget` contract — `status()`
+ * and `exec()` — never a direct `docker exec` spawn, and never a `kind` check.
+ */
+
+/** Output channels, plus the injectable confirmation seam. */
+export interface ToolIO {
+  stdout: (s: string) => void;
+  stderr: (s: string) => void;
+  /**
+   * Confirmation prompt. Tests inject a fake; production leaves it undefined
+   * and the real `confirm()` is used behind an `isTTY` gate. Mirrors the
+   * `io.ask` seam in `init.ts`.
+   */
+  confirm?: (question: string) => Promise<boolean>;
+}
+
+/** Options shared by every `oh tool` verb. */
+export interface ToolOptions {
+  cwd?: string;
+  run?: LifecycleRunner;
+  json?: boolean;
+}
+
+export interface ToolInstallOptions extends ToolOptions {
+  /** Only set the harness.yaml flag; do no container work. */
+  persistOnly?: boolean;
+  /** Live-install only; leave harness.yaml untouched. */
+  noPersist?: boolean;
+  /** Skip the large-download confirmation. */
+  yes?: boolean;
+}
+
+/** Per-tool state as reported by `list` / `status`. */
+interface ToolRow {
+  id: string;
+  title: string;
+  kind: string;
+  /** `install.<key>` reads `true` in harness.yaml. `null` when it has no key. */
+  enabled: boolean | null;
+  /** Binary present in the container, or `null` when unreachable. */
+  installed: boolean | null;
+  /** First line of `versionArgv` output, or `null` when not declared/readable. */
+  version: string | null;
+  installable: boolean;
+  docs: string;
+}
+
+function isReachable(status: string): boolean {
+  return status === "ready" || status === "starting";
+}
+
+function targetFor(root: string, run: LifecycleRunner): ExecutionTarget {
+  const name = configuredContainerName(root, run) ?? DEFAULT_CONTAINER_NAME;
+  return resolveExecutionTarget({ projectRoot: root, container: name, run });
+}
+
+/** Run an argv in the container, returning `null` if it could not spawn. */
+async function tryExec(
+  target: ExecutionTarget,
+  argv: readonly string[],
+  user: "root" | "sandbox",
+): Promise<{ exitCode: number; stdout: string } | null> {
+  try {
+    const r = await target.exec({ argv: [...argv], user, stdio: "capture" });
+    return { exitCode: r.exitCode, stdout: r.stdout };
+  } catch (err) {
+    if (err instanceof ExecutionSpawnError) return null;
+    throw err;
+  }
+}
+
+/** Is the tool's binary present? `null` when the probe could not run at all. */
+async function probeInstalled(
+  target: ExecutionTarget,
+  entry: ToolEntry,
+): Promise<boolean | null> {
+  const r = await tryExec(target, entry.verifyArgv, entry.installUser ?? "sandbox");
+  return r === null ? null : r.exitCode === 0;
+}
+
+/**
+ * Read the tool's version, when it declares a probe.
+ *
+ * Returns `null` for a tool with no `versionArgv` — the catalog omits it rather
+ * than guess an unverified flag — and `null` when the probe fails, because a
+ * failed read is not a version.
+ */
+async function probeVersion(
+  target: ExecutionTarget,
+  entry: ToolEntry,
+): Promise<string | null> {
+  if (entry.versionArgv === undefined) return null;
+  const r = await tryExec(target, entry.versionArgv, entry.installUser ?? "sandbox");
+  if (r === null || r.exitCode !== 0) return null;
+  const first = r.stdout.trim().split("\n")[0] ?? "";
+  return first === "" ? null : first;
+}
+
+async function collectRows(
+  root: string,
+  run: LifecycleRunner,
+  only?: ToolEntry,
+): Promise<ToolRow[]> {
+  const entries = only ? [only] : [...TOOL_CATALOG];
+  const target = targetFor(root, run);
+
+  let reachable = false;
+  try {
+    reachable = isReachable(await target.status());
+  } catch (err) {
+    if (!(err instanceof ExecutionSpawnError)) throw err;
+  }
+
+  const configured = existsSync(harnessYamlPath(root));
+  const rows: ToolRow[] = [];
+  for (const entry of entries) {
+    const installed = reachable ? await probeInstalled(target, entry) : null;
+    rows.push({
+      id: entry.id,
+      title: entry.title,
+      kind: entry.kind,
+      enabled:
+        entry.toolKey === undefined
+          ? null
+          : configured && isInstallFlagEnabled(root, entry.toolKey, run),
+      installed,
+      // Only ask a present binary for its version.
+      version: reachable && installed === true ? await probeVersion(target, entry) : null,
+      installable: entry.installArgv !== undefined,
+      docs: entry.docsPath,
+    });
+  }
+  return rows;
+}
+
+/** Render one cell: yes / no / n/a (no flag) / ? (container unreachable). */
+function cell(value: boolean | null, absent: string): string {
+  if (value === null) return absent;
+  return value ? "yes" : "no";
+}
+
+function renderTable(rows: ToolRow[], io: ToolIO): void {
+  const header = ["TOOL", "KIND", "ENABLED", "INSTALLED"];
+  const body = rows.map((r) => [
+    r.id,
+    r.kind,
+    cell(r.enabled, "n/a"),
+    cell(r.installed, "?"),
+  ]);
+  const widths = header.map((h, i) =>
+    Math.max(h.length, ...body.map((b) => b[i].length)),
+  );
+  const line = (cols: string[]): string =>
+    cols.map((c, i) => c.padEnd(widths[i])).join("  ").trimEnd() + "\n";
+  io.stdout(line(header));
+  for (const row of body) io.stdout(line(row));
+  if (rows.some((r) => r.installed === null)) {
+    io.stdout("\nINSTALLED is `?` — the sandbox is not running. Start it with `oh sandbox`.\n");
+  }
+}
+
+/** `status` adds the version, where the catalog declares a probe for it. */
+function renderDetail(rows: ToolRow[], io: ToolIO): void {
+  renderTable(rows, io);
+  for (const r of rows) {
+    io.stdout(`\n${r.id} — ${r.title}\n`);
+    // `—` distinguishes "no probe declared" from a failed read; the catalog
+    // omits unverified flags rather than guessing them.
+    io.stdout(`  version:    ${r.version ?? "—"}\n`);
+    io.stdout(`  installable: ${r.installable ? "yes" : "no"}\n`);
+    io.stdout(`  see ${r.docs}\n`);
+  }
+}
+
+/** `oh tool list` — every known tool and its state. */
+export async function runToolList(opts: ToolOptions, io: ToolIO): Promise<number> {
+  const run = opts.run ?? spawnRunner;
+  const root = resolveProjectRoot(opts.cwd);
+  const rows = await collectRows(root, run);
+  if (opts.json) {
+    io.stdout(`${JSON.stringify(rows, null, 2)}\n`);
+  } else {
+    renderTable(rows, io);
+  }
+  return 0;
+}
+
+function unknownTool(name: string, io: ToolIO): number {
+  io.stderr(`oh tool: unknown tool "${name}"\n\n`);
+  io.stderr(`Known tools:\n${toolIds().map((t) => `  ${t}`).join("\n")}\n`);
+  return 1;
+}
+
+/** `oh tool status [name]` — the same data as `list`, plus versions. */
+export async function runToolStatus(
+  name: string | undefined,
+  opts: ToolOptions,
+  io: ToolIO,
+): Promise<number> {
+  const run = opts.run ?? spawnRunner;
+  const root = resolveProjectRoot(opts.cwd);
+
+  let only: ToolEntry | undefined;
+  if (name !== undefined) {
+    only = findTool(name);
+    if (!only) return unknownTool(name, io);
+  }
+
+  const rows = await collectRows(root, run, only);
+  if (opts.json) {
+    io.stdout(`${JSON.stringify(only ? rows[0] : rows, null, 2)}\n`);
+  } else {
+    renderDetail(rows, io);
+  }
+  return 0;
+}
+
+/**
+ * Ask before a large download.
+ *
+ * Precedence: `--yes` wins; then an injected confirm (tests); then the real
+ * prompt, but ONLY on a TTY. A non-interactive run with no `--yes` returns
+ * false — fail closed. Silently proceeding would spend a gigabyte of someone's
+ * bandwidth in CI.
+ */
+async function confirmDownload(
+  entry: ToolEntry,
+  opts: ToolInstallOptions,
+  io: ToolIO,
+): Promise<boolean> {
+  if (entry.downloadSize === undefined) return true;
+  if (opts.yes === true) return true;
+
+  const question = `${entry.id} downloads ${entry.downloadSize}. Continue?`;
+  if (io.confirm !== undefined) return io.confirm(question);
+  if (process.stdin.isTTY === true) return confirm(question, false);
+
+  io.stderr(
+    `${entry.id} downloads ${entry.downloadSize} and this is not an interactive terminal.\n` +
+      "Re-run with --yes to accept the download, or --persist-only to set the flag\n" +
+      "and let the next container start install it.\n",
+  );
+  return false;
+}
+
+/**
+ * `oh tool install <name>` — persist the flag, then install into the running
+ * container.
+ *
+ * ORDER MATTERS: persist FIRST, exactly as `oh harness install` does. The write
+ * is cheap and always possible, and it stays correct even when the download is
+ * then declined or fails — the next container start picks the tool up either
+ * way, and the message says so.
+ */
+export async function runToolInstall(
+  name: string,
+  opts: ToolInstallOptions,
+  io: ToolIO,
+): Promise<number> {
+  const run = opts.run ?? spawnRunner;
+  const root = resolveProjectRoot(opts.cwd);
+
+  const entry = findTool(name);
+  if (!entry) return unknownTool(name, io);
+
+  if (entry.installArgv === undefined) {
+    io.stderr(`oh tool: ${entry.id} cannot be installed by this command.\n\n`);
+    io.stderr(`${entry.notInstallableReason ?? ""}\n\n`);
+    io.stderr(`Installable tools:\n${installableToolIds().map((t) => `  ${t}`).join("\n")}\n`);
+    return 1;
+  }
+
+  // ---- 1. persist -------------------------------------------------------
+  if (!opts.noPersist && entry.toolKey !== undefined) {
+    if (seedHarnessYaml(root)) {
+      io.stdout("create harness.yaml (from harness.yaml.example)\n");
+    }
+    const outcome = setInstallFlag(root, entry.toolKey);
+    io.stdout(
+      outcome === "already-set"
+        ? `harness.yaml: install.${entry.toolKey} already true\n`
+        : `harness.yaml: set install.${entry.toolKey}: true (${outcome})\n`,
+    );
+  }
+
+  if (opts.persistOnly) return 0;
+
+  // ---- 2. live install --------------------------------------------------
+  const target = targetFor(root, run);
+  let status: string;
+  try {
+    status = await target.status();
+  } catch (err) {
+    if (err instanceof ExecutionSpawnError && err.code === "ENOENT") {
+      io.stderr("docker is required to install into the running sandbox but was not found on PATH\n");
+      return 1;
+    }
+    throw err;
+  }
+
+  if (!isReachable(status)) {
+    io.stdout(
+      `sandbox not running (${status}) — skipping the live install.\n` +
+        "Start it with `oh sandbox`, then re-run this command; or the next container start picks it up.\n",
+    );
+    return 0;
+  }
+
+  const already = await probeInstalled(target, entry);
+  if (already === true) {
+    io.stdout(`${entry.id}: already installed (${entry.binary})\n`);
+    return 0;
+  }
+  if (already === null) {
+    io.stderr("docker is required to install into the running sandbox but was not found on PATH\n");
+    return 1;
+  }
+
+  // The gate sits AFTER the persist and AFTER the already-installed check, so
+  // declining costs nothing that was already done and nobody is asked to
+  // approve a download that would not have happened.
+  if (!(await confirmDownload(entry, opts, io))) {
+    if (!opts.noPersist && entry.toolKey !== undefined) {
+      io.stdout(
+        `harness.yaml keeps install.${entry.toolKey}: true — the next container start will install it.\n`,
+      );
+    }
+    return 1;
+  }
+
+  io.stdout(`installing ${entry.title} into the sandbox…\n`);
+  const r = await target.exec({
+    argv: [...entry.installArgv],
+    user: entry.installUser ?? "sandbox",
+    stdio: "inherit",
+  });
+  if (r.exitCode !== 0) {
+    io.stderr(
+      `oh tool: installing ${entry.id} failed (exit ${r.exitCode}).\n` +
+        (entry.toolKey !== undefined && !opts.noPersist
+          ? `harness.yaml keeps install.${entry.toolKey}: true — the next container start will retry it.\n`
+          : ""),
+    );
+    return r.exitCode;
+  }
+
+  io.stdout(`${entry.id}: installed — see ${entry.docsPath}\n`);
+  return 0;
+}

--- a/.oh/cli/src/lib/tools/catalog.ts
+++ b/.oh/cli/src/lib/tools/catalog.ts
@@ -1,0 +1,189 @@
+/**
+ * The sandbox-tooling catalog — the single source of truth `oh tool` reads.
+ *
+ * THE THREE CATALOGS, AND THE LINE BETWEEN THEM:
+ *
+ *   ../harnesses/catalog.ts  agent CLIs you drive       (claude, codex, pi …)
+ *   ../runtimes/catalog.ts   the isolation boundary     (docker, microsandbox …)
+ *   this file                everything else the sandbox ships
+ *
+ * `agent-browser` is the entry that forced the third table. It lives in the
+ * same `harness.yaml` `install:` section as the optional harnesses, so it looks
+ * like one — but it is a headless browser, not an agent, and
+ * `__tests__/harness-catalog.test.ts` asserts its exclusion from that catalog.
+ * The exclusion was always correct; until now it had no destination.
+ *
+ * WHY FIVE ENTRIES WHEN ONLY ONE IS INSTALLABLE:
+ *
+ * A table containing only `agent-browser` WOULD be the false singleton the
+ * runtime catalog's header argues against — one row, no shape, a schema change
+ * waiting to happen. The fix is not to pad it. The fix is that the category is
+ * "sandbox tooling that is neither an agent CLI nor an isolation runtime", and
+ * that category already has five real members, four of which are baked into the
+ * image and therefore report-only.
+ *
+ * This is structurally the same table as `../runtimes/catalog.ts`: three
+ * entries, exactly one installable. Reporting on a tool you cannot install is
+ * the point, not filler — "is `gh` actually here, and what version" is a real
+ * question the harness could not answer before.
+ *
+ * SHELL-STRING RULE, inherited from the harness catalog: argv arrays only. The
+ * agent-browser installer is genuinely a three-step pipeline, so its argv is
+ * `["bash", "-lc", "<constant>"]` where the string is a LITERAL in this file
+ * with zero interpolation. `$PNPM_HOME` inside it is expanded by the container's
+ * own login shell, not by this process, and nothing user-supplied reaches it.
+ */
+
+/** How a tool reaches the sandbox. */
+export type ToolKind =
+  /** In the base image, unconditionally. Nothing to install. */
+  | "baked-in"
+  /** Behind an `install:` key, installed by the entrypoint at container start. */
+  | "opt-in";
+
+/** One tool the CLI knows how to inspect and (maybe) install. */
+export interface ToolEntry {
+  /** The name the user types. */
+  readonly id: string;
+  readonly title: string;
+  readonly kind: ToolKind;
+  /** Executable this tool puts on PATH. */
+  readonly binary: string;
+  /**
+   * Presence check. Exit 0 → installed.
+   *
+   * ALWAYS `command -v`, never `<binary> --version`. Presence and version are
+   * different questions, and the shell cannot be wrong about PATH — see
+   * `versionArgv` for why that distinction is load-bearing here.
+   */
+  readonly verifyArgv: readonly string[];
+  /**
+   * Optional version probe, reported by `status`.
+   *
+   * DECLARED ONLY WHERE `--version` IS AN INDUSTRY-STANDARD FLAG ON A
+   * UBIQUITOUS TOOL (docker, gh, cloudflared). It is deliberately ABSENT for
+   * `herdr` and `agent-browser`: neither binary exists on the machine this
+   * catalog was written on, so their flags could not be confirmed, and the
+   * repo's rule — set by `msb` in the runtime catalog — is to cite a verified
+   * source or omit, never to guess a flag. `status` renders the absence as `—`.
+   */
+  readonly versionArgv?: readonly string[];
+  /**
+   * `harness.yaml` key WITHOUT the `install.` prefix. Only `opt-in` tools have
+   * one; the installer must never invent a key for a baked-in tool.
+   */
+  readonly toolKey?: string;
+  /**
+   * Environment variable the ENTRYPOINT reads to decide whether to install.
+   *
+   * NOT `buildArg`. The harness catalog's `buildArg` carries an invariant —
+   * "this name appears in .devcontainer/Dockerfile" — that its drift test
+   * enforces. agent-browser has no Dockerfile presence at all; it is installed
+   * at container start by `.devcontainer/entrypoint.sh`. Reusing `buildArg`
+   * would quietly falsify the harness invariant, so this is a distinct field
+   * with a distinct ground truth, and the drift test asserts BOTH that the name
+   * is in entrypoint.sh/compose/harness-config.sh AND that it is absent from
+   * the Dockerfile.
+   */
+  readonly entrypointGuard?: string;
+  /** Install command, argv form. Absent for baked-in tools. */
+  readonly installArgv?: readonly string[];
+  /** User the install runs as inside the container. */
+  readonly installUser?: "root" | "sandbox";
+  /**
+   * Approximate download size, when it is large enough that the operator
+   * should be asked first. Presence of this field is what arms the
+   * confirmation gate in `../../commands/tool.ts`.
+   */
+  readonly downloadSize?: string;
+  /** Why `install` refuses. Required when there is no `installArgv`. */
+  readonly notInstallableReason?: string;
+  /** Repo-relative doc path, printed in list/status output. */
+  readonly docsPath: string;
+}
+
+/** Docs live in one shared table; there is no per-tool page. */
+const TOOLS_DOC = ".oh/docs/installation.md";
+
+export const TOOL_CATALOG: readonly ToolEntry[] = Object.freeze([
+  Object.freeze({
+    id: "agent-browser",
+    title: "agent-browser",
+    kind: "opt-in",
+    binary: "agent-browser",
+    verifyArgv: Object.freeze(["bash", "-lc", "command -v agent-browser >/dev/null"]),
+    toolKey: "agent_browser",
+    entrypointGuard: "INSTALL_AGENT_BROWSER",
+    // Copied from `.devcontainer/entrypoint.sh`. The `2>&1 | tail -5` and the
+    // echo/|| cosmetics are dropped: they shape the entrypoint's boot log, and
+    // here they would swallow the installer's own output and its exit code.
+    installArgv: Object.freeze([
+      "bash",
+      "-lc",
+      "pnpm add -g agent-browser@0.8.5 && find \"$PNPM_HOME\" -name \"agent-browser-linux-*\" -exec chmod +x {} \\; && agent-browser install --with-deps",
+    ]),
+    installUser: "sandbox",
+    // Chromium. No harness install downloads anything close to this, which is
+    // why this tool gets a confirmation the harness installs never needed.
+    downloadSize: "~1 GB",
+    docsPath: TOOLS_DOC,
+  }),
+  Object.freeze({
+    id: "herdr",
+    title: "Herdr",
+    kind: "baked-in",
+    binary: "herdr",
+    verifyArgv: Object.freeze(["bash", "-lc", "command -v herdr >/dev/null"]),
+    notInstallableReason:
+      "herdr is installed in the base image with a pinned, sha256-verified binary (.devcontainer/Dockerfile). Rebuild the image to change it.",
+    docsPath: TOOLS_DOC,
+  }),
+  Object.freeze({
+    id: "cloudflared",
+    title: "cloudflared",
+    kind: "baked-in",
+    binary: "cloudflared",
+    verifyArgv: Object.freeze(["bash", "-lc", "command -v cloudflared >/dev/null"]),
+    versionArgv: Object.freeze(["cloudflared", "--version"]),
+    notInstallableReason:
+      "cloudflared is installed in the base image from Cloudflare's apt repository (.devcontainer/Dockerfile). Rebuild the image to change it.",
+    docsPath: TOOLS_DOC,
+  }),
+  Object.freeze({
+    id: "docker-cli",
+    title: "Docker CLI + Compose",
+    kind: "baked-in",
+    binary: "docker",
+    verifyArgv: Object.freeze(["bash", "-lc", "command -v docker >/dev/null"]),
+    versionArgv: Object.freeze(["docker", "--version"]),
+    notInstallableReason:
+      "The Docker CLI is installed in the base image. Note that the CLI being present says nothing about whether a daemon is reachable — `oh runtime status docker` answers that.",
+    docsPath: TOOLS_DOC,
+  }),
+  Object.freeze({
+    id: "gh",
+    title: "GitHub CLI",
+    kind: "baked-in",
+    binary: "gh",
+    verifyArgv: Object.freeze(["bash", "-lc", "command -v gh >/dev/null"]),
+    versionArgv: Object.freeze(["gh", "--version"]),
+    notInstallableReason:
+      "The GitHub CLI is installed in the base image. Run `gh auth login` inside the sandbox to authenticate it.",
+    docsPath: TOOLS_DOC,
+  }),
+]);
+
+/** Look up one tool by the name the user typed. */
+export function findTool(id: string): ToolEntry | undefined {
+  return TOOL_CATALOG.find((t) => t.id === id);
+}
+
+/** Every known tool id, in catalog order. */
+export function toolIds(): string[] {
+  return TOOL_CATALOG.map((t) => t.id);
+}
+
+/** The tools `oh tool install` can actually act on. */
+export function installableToolIds(): string[] {
+  return TOOL_CATALOG.filter((t) => t.installArgv !== undefined).map((t) => t.id);
+}

--- a/.oh/docs/installation.md
+++ b/.oh/docs/installation.md
@@ -278,7 +278,7 @@ Default CLIs are always present. Optional CLIs are excluded from the default ima
 | DeepAgents | `deepagents` | LangChain's multi-provider terminal agent (`deepagents-cli` via `uv tool install`) | optional: set `install.deepagents: true` in `harness.yaml` (or `INSTALL_DEEPAGENTS=true` in `.devcontainer/.env`) |
 | Hermes | `hermes` | Nous Research's self-improving agent CLI | optional: set `install.hermes: true` in `harness.yaml` (or `INSTALL_HERMES=true` in `.devcontainer/.env`) |
 | Grok Build | `grok` | xAI's proprietary Grok Build CLI (`@xai-official/grok@0.2.39`, Node >=20) | optional: set `install.grok_build: true` in `harness.yaml` (or `INSTALL_GROK_BUILD=true` in `.devcontainer/.env`) |
-| agent-browser | `agent-browser` | Headless Chromium for web-capable agents | optional: set `install.agent_browser: true` in `harness.yaml` (or `INSTALL_AGENT_BROWSER=true` in `.devcontainer/.env`) |
+| agent-browser | `agent-browser` | Headless Chromium for web-capable agents | optional: `oh tool install agent-browser`, or set `install.agent_browser: true` in `harness.yaml` (or `INSTALL_AGENT_BROWSER=true` in `.devcontainer/.env`) |
 
 ### Runtimes & package managers
 
@@ -291,11 +291,16 @@ Default CLIs are always present. Optional CLIs are excluded from the default ima
 
 ### DevOps & infrastructure
 
+`oh tool list` reports which of these are present, and `oh tool status <name>`
+adds a version where the tool has a verified version flag. They are baked into
+the image, so there is nothing to install.
+
 | Tool | Purpose |
 |------|---------|
 | Herdr (`herdr`) | Default multi-agent terminal workspace; state persists across rebuilds in dedicated volumes |
 | Docker CLI + Compose | Container management from inside the sandbox (host docker socket bind-mounted by the base compose) |
 | GitHub CLI (`gh`) | PRs, issues, releases from the terminal |
+| cloudflared | Cloudflare Tunnel client, for exposing a sandbox port (see the `/cloudflared` skill) |
 | tmux | Detachable terminal sessions for long-running agents |
 | croner | Markdown-frontmatter cron scheduler for autonomous agent tasks |
 

--- a/.oh/docs/lifecycle-commands.md
+++ b/.oh/docs/lifecycle-commands.md
@@ -1,0 +1,84 @@
+---
+title: "Lifecycle commands: make vs oh"
+---
+
+# Lifecycle commands: `make` vs `oh`
+
+There are two front doors to the sandbox lifecycle. This page is the single
+source of truth for which is which. Every other document links here rather than
+restating the table.
+
+**They are not two implementations.** Every compose target — from both doors —
+runs `.oh/scripts/docker-compose.sh`. `make sandbox` calls it directly;
+`oh sandbox` reaches the same script through the Docker Compose execution
+target. The script owns overlay resolution, project naming, and env plumbing.
+Nothing is duplicated except the name you type.
+
+## Which one is canonical
+
+It depends on where you are, not on preference.
+
+| Where | Canonical | Why |
+|---|---|---|
+| **On the host, in a source checkout** | `make` | Host prerequisites are Docker, Git, and `make` — deliberately **no Node**. Host `oh` needs Node ≥ 20, so `make` is the one that always works. |
+| **Inside the sandbox** | `oh` | `oh` is baked into the image at `/usr/local/bin/oh`. (`make` is present too, via `build-essential`, but the repo may be mounted anywhere.) |
+| **In a repo equipped by `oh init`** | `oh` | An equipped repo gets the `.oh/` control plane and no Makefile. `oh` is the only door. |
+
+This is why neither surface delegates to the other: making the Makefile call
+`oh` would add Node to the host prerequisites and break the headline promise.
+
+## The mapping
+
+| `make` | `oh` | Runs |
+|---|---|---|
+| `make sandbox` | `oh sandbox` | `docker-compose.sh up -d --build` |
+| `make shell [container]` | `oh shell [container]` | an interactive `zsh` in the container |
+| `make stop` | `oh stop` | `docker-compose.sh stop` |
+| `make restart` | `oh restart` | `docker-compose.sh restart` |
+| `make logs` | `oh logs` | `docker-compose.sh logs -f` |
+| `make ps` | `oh ps` | `docker-compose.sh ps` |
+| `make gateway <pi\|hermes>` | `oh gateway <args…>` | `.oh/scripts/gateway.sh` |
+| `make destroy` | — | see below |
+| `make config` | — | see below |
+| `make harness-config` | *(implicit in `oh sandbox`)* | seeds `harness.yaml` from the example |
+| — | `oh init` · `oh update` · `oh harness` · `oh runtime` · `oh tool` · `oh cloud` · `oh config <integration>` | no `make` equivalent, by design |
+
+`oh <verb> -- <args>` forwards extra arguments to `docker compose`, e.g.
+`oh logs -- --tail 50`.
+
+## The three deliberate exceptions
+
+A probe (`.oh/evals/probes/make-oh-lifecycle-parity.sh`) asserts that every
+`make` target either has an `oh` verb or is named here. The list cannot grow
+silently.
+
+### `make destroy` — no `oh destroy`
+
+`down -v` wipes the named volumes, which hold provider authentication. A
+passthrough with no confirmation policy would put that one typo away. The verb
+is deferred until that policy is designed, not forgotten.
+
+### `make config` — no `oh` equivalent
+
+`oh config` already means *"configure an integration"* (`oh config <name>`).
+Overloading it to also print resolved compose config would be worse than the
+gap. A different verb name may resolve this later.
+
+### `make shell` — the one raw `docker exec`
+
+`oh shell` routes through the execution target's `attach()`; the Makefile spawns
+`docker exec -it -u … zsh` directly. That is **intentional and pinned**:
+`.oh/evals/probes/execution-target-contract.sh` check C5 asserts that line
+verbatim. The Makefile is host-side orchestration, not work executed inside a
+provisioned environment, so it sits outside the brain/hands contract — the same
+reasoning that keeps `oh gateway` off it. See
+[`rfc-brain-hands-boundary.md`](rfcs/rfc-brain-hands-boundary.md).
+
+## What is not consolidated, and why
+
+- **The two `harness.yaml` seeds.** `make harness-config` and the CLI's
+  `seedHarnessYaml()` both copy the example. Unifying them means the Makefile
+  shelling into Node, which the host-prerequisite promise forbids. Two small
+  implementations of one `cp` is the cheaper trade.
+- **The ~60 `make …` references across the docs.** They are correct — `make`
+  stays canonical on the host. A sweep would be churn.

--- a/.oh/evals/probes/make-oh-lifecycle-parity.sh
+++ b/.oh/evals/probes/make-oh-lifecycle-parity.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# tier: A
+# source: the Makefile/oh surface-gap consolidation — two front doors onto
+#         .oh/scripts/docker-compose.sh, one mapping doc
+# desc: every Makefile lifecycle target has a matching `oh` verb or is a documented
+#       exception; both doors keep going through docker-compose.sh; the mapping lives in
+#       exactly one place and the other docs link to it.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+MAKEFILE="$ROOT/Makefile"
+CLI="$ROOT/.oh/cli/src/cli.ts"
+LIFECYCLE="$ROOT/.oh/cli/src/commands/lifecycle.ts"
+MAP="$ROOT/.oh/docs/lifecycle-commands.md"
+
+# A published `oh init` repo has no Makefile, and a non-source checkout has no
+# CLI sources. Neither is a regression.
+if [[ ! -f "$MAKEFILE" || ! -f "$CLI" ]]; then
+  echo "SKIPPED: not a source checkout (Makefile or .oh/cli/src absent)" >&2
+  exit 2
+fi
+
+missing=()
+
+# Targets that deliberately have NO `oh` verb. Each must be justified in the
+# mapping doc (A2), so this list cannot grow silently.
+#   help/harness-config — build plumbing, not lifecycle
+#   shell               — has `oh shell`, but the recipe is pinned raw (see A3)
+#   destroy             — `down -v` wipes auth volumes; needs a confirm policy
+#   config              — `oh config` already means "configure an integration"
+EXCEPTIONS=(help harness-config shell destroy config)
+is_exception() {
+  local t=$1 e
+  for e in "${EXCEPTIONS[@]}"; do [[ $t == "$e" ]] && return 0; done
+  return 1
+}
+
+# --- A1: every .PHONY target has an `oh` verb, or is a listed exception -------
+#
+# Fails in BOTH directions: a new make target with no verb, and a verb whose
+# dispatch was removed while the target stayed.
+phony=$(sed -n 's/^\.PHONY:[[:space:]]*//p' "$MAKEFILE" | tr ' ' '\n' | sed '/^$/d')
+if [[ -z $phony ]]; then
+  missing+=("A1: no .PHONY line found in the Makefile — cannot enumerate targets")
+fi
+for target in $phony; do
+  is_exception "$target" && continue
+  # `sandbox`, `shell` and `gateway` dispatch by name; the compose verbs come
+  # from COMPOSE_VERBS. Either form counts as a verb existing.
+  if grep -qF "first === \"$target\"" "$CLI"; then continue; fi
+  if grep -qE "^  $target: " "$LIFECYCLE"; then continue; fi
+  missing+=("A1: make target \`$target\` has no \`oh $target\` verb and is not a documented exception")
+done
+
+# --- A2: every exception is named in the mapping doc --------------------------
+if [[ ! -f "$MAP" ]]; then
+  missing+=("A2: .oh/docs/lifecycle-commands.md is missing — the mapping has no home")
+else
+  for target in "${EXCEPTIONS[@]}"; do
+    # help/harness-config are plumbing; the three real exceptions must be argued.
+    case "$target" in help|harness-config) continue;; esac
+    grep -qF "make $target" "$MAP" \
+      || missing+=("A2: exception \`make $target\` is not explained in lifecycle-commands.md")
+  done
+fi
+
+# --- A3: both doors go through docker-compose.sh ------------------------------
+#
+# The single implementation is the script. A recipe calling `docker compose`
+# directly would fork overlay resolution and project naming.
+while IFS= read -r line; do
+  # Recipe lines only (tab-indented), and skip the documented `docker exec`.
+  [[ $line == *"docker compose"* ]] || continue
+  missing+=("A3: a Makefile recipe calls \`docker compose\` directly — go through \$(COMPOSE)")
+done < <(grep -P '^\t' "$MAKEFILE" || true)
+
+# The one permitted raw invocation. Deliberately consistent with
+# execution-target-contract.sh C5, which pins this same line verbatim.
+if ! sed 's/^[[:space:]]*//' "$MAKEFILE" |
+  grep -Fxq 'docker exec -it -u $(SHELL_USER) $(SHELL_CONTAINER) zsh'; then
+  missing+=("A3: the pinned \`make shell\` line changed — see execution-target-contract.sh C5")
+fi
+
+# --- A4: the new verbs assemble no compose argv in TypeScript -----------------
+#
+# The failure mode: someone "improves" a verb by building the overlay list in
+# TS, and the two doors start to drift.
+if [[ -f "$LIFECYCLE" ]]; then
+  code=$(perl -0pe 's{/\*.*?\*/}{}gs; s{(^|[^:])//[^\n]*}{$1}gm' "$LIFECYCLE")
+  if ! grep -qF 'COMPOSE_VERBS' <<<"$code"; then
+    missing+=("A4: COMPOSE_VERBS is gone — the compose verb table moved or was inlined")
+  fi
+  if ! grep -qF 'docker-compose.sh' <<<"$code"; then
+    missing+=("A4: lifecycle.ts no longer names docker-compose.sh — a verb may bypass the script")
+  fi
+  # `runComposeVerb` must not name an engine; the script owns that.
+  body=$(awk '/export function runComposeVerb/,/^}/' <<<"$code")
+  if grep -qE '"docker"|docker compose' <<<"$body"; then
+    missing+=("A4: runComposeVerb names docker directly — the script owns the engine argv")
+  fi
+fi
+
+# --- A5: exactly one mapping table, and the others link to it -----------------
+if [[ -f "$MAP" ]]; then
+  for doc in AGENTS.md README.md .oh/cli/README.md; do
+    [[ -f "$ROOT/$doc" ]] || continue
+    grep -qF 'lifecycle-commands.md' "$ROOT/$doc" \
+      || missing+=("A5: $doc does not link to lifecycle-commands.md — a second mapping will drift from it")
+  done
+fi
+
+if ((${#missing[@]})); then
+  printf 'REGRESSION: %s\n' "${missing[@]}" >&2
+  exit 1
+fi
+
+echo 'PASS: make and oh lifecycle surfaces agree, and the mapping has one home' >&2

--- a/.oh/evals/probes/tool-catalog-boundary.sh
+++ b/.oh/evals/probes/tool-catalog-boundary.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# tier: A
+# source: agent-browser's exclusion from the harness catalog (#821) and the
+#         three-catalog split introduced with `oh tool`
+# desc: the harness/runtime/tool catalogs stay disjoint; agent-browser's ground truth stays
+#       .devcontainer/entrypoint.sh and NOT the Dockerfile; the ~1 GB download stays gated
+#       and fails closed without --yes.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+TOOLS="$ROOT/.oh/cli/src/lib/tools/catalog.ts"
+CMD="$ROOT/.oh/cli/src/commands/tool.ts"
+HARNESSES="$ROOT/.oh/cli/src/lib/harnesses/catalog.ts"
+ENTRY="$ROOT/.devcontainer/entrypoint.sh"
+DOCKERFILE="$ROOT/.devcontainer/Dockerfile"
+
+if [[ ! -f "$TOOLS" ]]; then
+  echo "SKIPPED: tool catalog absent: $TOOLS" >&2
+  exit 2
+fi
+if [[ ! -f "$CMD" ]]; then
+  echo "SKIPPED: tool command absent: $CMD" >&2
+  exit 2
+fi
+
+missing=()
+
+# Comments describe the very patterns being banned, so code-level assertions
+# read stripped source. Line comments whose `//` follows `:` are left alone so a
+# `https://` inside a string literal is not truncated.
+strip_comments() {
+  perl -0pe 's{/\*.*?\*/}{}gs; s{(^|[^:])//[^\n]*}{$1}gm' "$1"
+}
+
+# --- 1. agent-browser is installed by the ENTRYPOINT, not the image ----------
+#
+# This is the premise that justifies a separate `entrypointGuard` field instead
+# of reusing the harness catalog's `buildArg`. The harness drift test enforces
+# "buildArg names appear in the Dockerfile"; agent-browser has no Dockerfile
+# presence at all, so borrowing that field would quietly falsify the invariant.
+if ! grep -qF 'INSTALL_AGENT_BROWSER' "$ENTRY"; then
+  missing+=("entrypoint.sh: no INSTALL_AGENT_BROWSER guard — the tool catalog's ground truth moved")
+fi
+if grep -qF 'INSTALL_AGENT_BROWSER' "$DOCKERFILE"; then
+  missing+=("Dockerfile: INSTALL_AGENT_BROWSER appeared — agent-browser now has a build arg, so buildArg is the right field, not entrypointGuard")
+fi
+if ! grep -qF 'entrypointGuard' "$TOOLS"; then
+  missing+=("tools/catalog.ts: no entrypointGuard field — the entrypoint install shape is unrecorded")
+fi
+# Stripped: the field's own doc comment explains why buildArg is NOT reused, and
+# that explanation must survive while the field itself stays absent.
+if grep -qE '\bbuildArg\b' <<<"$(strip_comments "$TOOLS")"; then
+  missing+=("tools/catalog.ts: uses buildArg — that field carries a Dockerfile invariant this catalog cannot satisfy")
+fi
+
+# The version pin must match the entrypoint's, or the CLI installs a different
+# agent-browser than a container rebuild would.
+pin=$(grep -oE 'agent-browser@[0-9]+\.[0-9]+\.[0-9]+' "$ENTRY" | head -1 || true)
+if [[ -z $pin ]]; then
+  missing+=("entrypoint.sh: no pinned agent-browser version found")
+elif ! grep -qF "$pin" "$TOOLS"; then
+  missing+=("tools/catalog.ts: version pin disagrees with entrypoint.sh ($pin)")
+fi
+
+# --- 2. The three catalogs stay disjoint -------------------------------------
+#
+# A tool in two tables means two commands claim it and two drift tests assert
+# different ground truths.
+if grep -qE 'harnessKey: *"agent_browser"' "$HARNESSES"; then
+  missing+=("harnesses/catalog.ts: agent_browser moved into the harness catalog — it is a browser, not an agent CLI")
+fi
+if grep -qE 'id: *"docker"' <<<"$(strip_comments "$TOOLS")"; then
+  missing+=("tools/catalog.ts: declares id \"docker\" — that id belongs to the runtime catalog; the CLI binary is \"docker-cli\"")
+fi
+
+# --- 3. The large download stays gated ---------------------------------------
+#
+# The failure mode: someone removes the gate and a CI run silently pulls ~1 GB
+# of Chromium.
+cmd_code=$(strip_comments "$CMD")
+if ! grep -qF 'downloadSize' "$TOOLS"; then
+  missing+=("tools/catalog.ts: no downloadSize — nothing arms the confirmation gate")
+fi
+if ! grep -qF 'confirmDownload' <<<"$cmd_code"; then
+  missing+=("commands/tool.ts: no confirmDownload gate — a ~1 GB pull can start unprompted")
+fi
+# Fail closed: the non-interactive path must return false, not fall through.
+if ! grep -qF 'process.stdin.isTTY' <<<"$cmd_code"; then
+  missing+=("commands/tool.ts: the gate does not check for a TTY — it cannot fail closed")
+fi
+if ! grep -qF -e '--yes' <<<"$cmd_code"; then
+  missing+=("commands/tool.ts: no --yes escape hatch for non-interactive installs")
+fi
+
+# --- 4. Container work stays behind the ExecutionTarget contract -------------
+if grep -qE '\("docker"|\bdocker exec\b' <<<"$cmd_code"; then
+  missing+=("commands/tool.ts: names docker directly — go through ExecutionTarget.exec")
+fi
+if grep -qE '\.kind ===' <<<"$cmd_code"; then
+  missing+=("commands/tool.ts: branches on target.kind — use capability discovery")
+fi
+
+# --- 5. The command is reachable ---------------------------------------------
+CLI="$ROOT/.oh/cli/src/cli.ts"
+if [[ -f "$CLI" ]]; then
+  grep -qF 'first === "tool"' "$CLI" \
+    || missing+=("cli.ts: no dispatch for `oh tool`")
+  grep -qF 'oh tool <args...>' "$CLI" \
+    || missing+=("cli.ts: `oh tool` missing from the top-level usage block")
+fi
+
+if ((${#missing[@]})); then
+  printf 'REGRESSION: %s\n' "${missing[@]}" >&2
+  exit 1
+fi
+
+echo 'PASS: the three catalogs are disjoint and the large download stays gated' >&2

--- a/.oh/tasks/oh-tool-install/prd.md
+++ b/.oh/tasks/oh-tool-install/prd.md
@@ -1,0 +1,149 @@
+# PRD — `oh tool`: the third catalog
+
+## Problem
+
+`agent-browser` shares the `harness.yaml` `install:` section with the optional
+harnesses but is not one — it is a headless browser, not an agent CLI. #821's
+catalog excluded it deliberately, and `harness-catalog.test.ts:64` asserts that
+exclusion. The exclusion was right; it just had nowhere to send the user.
+
+So adding agent-browser still means hand-editing `harness.yaml` and then
+recreating the container, because `.devcontainer/entrypoint.sh` installs it at
+boot. And separately, nothing could answer "is `gh` actually in this image, and
+what version" without opening a shell.
+
+## Goal
+
+One command for the sandbox tooling that is neither an agent CLI (`oh harness`)
+nor an isolation runtime (`oh runtime`): report what is present, and install the
+one thing that is installable.
+
+## Non-goals
+
+- **Changing how agent-browser is installed.** The entrypoint's runtime install
+  is deliberate; this PR describes it, and does not move it into the Dockerfile.
+- **Renaming `INSTALL_AGENT_BROWSER` or `install.agent_browser`.**
+- **Bumping the `0.8.5` pin.**
+- **Creating `.oh/docs/tools/<id>.md` pages.** Five stubs for a table that fits
+  in `installation.md` would be worse than one good table.
+- **Touching the `init.ts` wizard**, which already offers `agent_browser`.
+- **Rebuilding or restarting the sandbox.**
+
+## Decisions
+
+### D1 — five entries, not one
+
+A catalog containing only `agent-browser` **would** be the false singleton the
+runtime catalog's header argues against — one row, no shape, a schema change
+waiting to happen. The fix is not to pad it.
+
+The fix is that the category is *"sandbox tooling that is neither an agent CLI
+nor an isolation runtime"*, and that category already has five real members:
+`agent-browser` (opt-in) plus `herdr`, `cloudflared`, `docker-cli`, and `gh`,
+all baked into the image and therefore report-only.
+
+This is structurally the same table as `../runtimes/catalog.ts`: three entries,
+exactly one installable. Reporting on a tool you cannot install is the point,
+not filler.
+
+**Rejected: defer the command until a second installable tool exists.** That
+leaves agent-browser with no home indefinitely, and the reporting half has value
+on its own today.
+
+**Rejected: put agent-browser in the harness catalog.** It is not an agent, the
+exclusion test is correct, and the harness drift test asserts a Dockerfile
+invariant agent-browser cannot satisfy (D3).
+
+### D2 — persist-first, like `oh harness` and unlike `oh runtime`
+
+`oh runtime` deliberately writes no config, because #806 § B1 leaves the
+substrate selector undecided. That reasoning does **not** transfer:
+`install.agent_browser` already exists in `harness-config.sh`'s envmap and in
+`harness.yaml.example`, so this command writes a key the schema already defines
+and changes no schema.
+
+Persist first, then install live — so the choice survives the next container
+recreate even if the download is declined or fails.
+
+### D3 — `entrypointGuard`, not `buildArg`
+
+agent-browser is **absent from `.devcontainer/Dockerfile`**. It is installed by
+`.devcontainer/entrypoint.sh:708-715` at container start.
+
+The harness catalog's `buildArg` field carries an invariant its drift test
+enforces — "this name appears in the Dockerfile". Reusing it here would quietly
+falsify that invariant. So this catalog declares a distinct field with a
+distinct ground truth, and the drift test asserts **both** directions: the name
+is in entrypoint.sh / docker-compose.yml / harness-config.sh, **and** it is
+absent from the Dockerfile. The absence is the load-bearing half; an unasserted
+premise is how these tables drift.
+
+### D4 — the ~1 GB download is gated, and fails closed
+
+agent-browser pulls Chromium. No harness install downloads anything comparable,
+so this is the one place the CLI asks before spending the operator's bandwidth.
+
+Precedence: `--yes` wins; then an injected confirm (tests); then the real prompt,
+but only on a TTY. A non-interactive run without `--yes` installs **nothing** and
+names the flag it wanted. Silently proceeding would pull a gigabyte in CI.
+
+The gate sits *after* the persist and *after* the already-installed check, so
+declining costs nothing already done and nobody approves a download that would
+not have happened.
+
+### D5 — version probes only where the flag is verified
+
+`versionArgv` is declared for `cloudflared`, `docker-cli`, and `gh`, where
+`--version` is an industry-standard flag on a ubiquitous tool. It is **omitted**
+for `herdr` and `agent-browser`: neither binary exists on the machine this
+catalog was written on, so their flags could not be confirmed, and the repo's
+rule — set by `msb` in the runtime catalog — is to cite a verified source or
+omit, never guess. `status` renders the absence as `—`, distinct from a failed
+read.
+
+Presence is always `command -v`, never a version flag: presence and version are
+different questions, and the shell cannot be wrong about PATH.
+
+### D6 — `docker-cli` is not `docker`
+
+The runtime catalog owns `docker` (the isolation boundary and its daemon); this
+one owns `docker-cli` (the client binary in the image). Different questions —
+the CLI can be present while no daemon answers — so the ids differ on purpose
+and a test asserts the three catalogs stay disjoint.
+
+## Requirements
+
+| # | Requirement |
+|---|---|
+| FR-1 | `oh tool list [--json]` prints every tool with kind, enabled, installed. Exit 0. |
+| FR-2 | `oh tool status [name] [--json]` adds a version where one is declared, `—` where not. Exit 0. |
+| FR-3 | `oh tool install <name>` requires a name — no default, since most tools are baked in. |
+| FR-4 | Installing a baked-in tool exits 1 with the reason and the installable list. |
+| FR-5 | A large download prompts first; `--yes` bypasses; non-interactive without `--yes` installs nothing and exits 1. |
+| FR-6 | The flag is persisted even when the download is declined or fails. |
+| FR-7 | `--persist-only` never prompts and never execs; `--no-persist` leaves harness.yaml byte-identical. |
+| FR-8 | A stopped or absent container persists the flag, hints, and exits 0 with zero `docker exec`. |
+| FR-9 | An absent binary is never asked for its version. |
+| FR-10 | Every container call goes through `ExecutionTarget`; no direct `docker` spawn, no `kind` branch. |
+| FR-11 | The three catalogs share no id; `agent_browser` stays out of the harness catalog. |
+
+## Test plan
+
+- `tool-catalog.test.ts` — shape; the three catalogs disjoint; the agent-browser
+  drift test against `entrypoint.sh` (three install steps, the `0.8.5` pin, the
+  dropped log cosmetics) **plus** the inverse assertion that
+  `INSTALL_AGENT_BROWSER` is absent from the Dockerfile; version probes declared
+  only where verified.
+- `tool.test.ts` — parse, help, and every exit path on DI-injected runner fakes,
+  with the gate covered in six ways: fail-closed non-interactive, decline still
+  persists, the prompt names the size, accept installs, `--yes` bypasses,
+  `--persist-only` never prompts, and already-installed never asks.
+- `.oh/evals/probes/tool-catalog-boundary.sh` — tier A, source-grep only.
+  Verified by rejection: 11 injected defects, each turning it red.
+
+## Note
+
+`harness.yaml.example`'s `install:` comment said `agent_browser` "is not managed
+by that command" — true, and now incomplete. It names `oh tool` instead. The
+harness catalog and its exclusion test are unchanged and still pass; the
+exclusion was never wrong, it just now has a destination.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,10 @@ Provision the agent sandbox. The sandbox uses `.devcontainer/` as the base envir
    ```bash
    make shell     # default; bash also available
    ```
+   Inside the sandbox (or in an `oh init` repo, which has no Makefile) the same
+   verbs are `oh sandbox` / `oh shell` / `oh stop` / `oh restart` / `oh logs` /
+   `oh ps`. Both doors run `.oh/scripts/docker-compose.sh` — the single mapping
+   is [.oh/docs/lifecycle-commands.md](.oh/docs/lifecycle-commands.md).
    Pass an optional container name to attach to a different running container, e.g. `make shell portfolio-advisor` (add `SHELL_USER=<user>` if the target has no `sandbox` user).
 
    **Option B — VS Code Attach to Container (local):**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Update policy and release automation live in [`/git`](.claude/skills/git/SKILL.m
 ### Added
 - Add `oh harness <list|install|status>` to install optional harnesses into a running sandbox without a rebuild, persisting the choice to `install.<key>` for the next build ([#821](https://github.com/mifunedev/openharness/pull/821)).
 - Add `oh runtime <list|install|status>`, reporting the container runtime in use and gating a MicroSandbox install on the measured glibc and `/dev/kvm` blockers. It selects no runtime ([#823](https://github.com/mifunedev/openharness/pull/823)).
+- Add `oh tool <list|install|status>` for sandbox tooling that is neither an agent CLI nor a runtime, making `agent-browser` installable without a rebuild behind a ~1 GB download gate ([#824](https://github.com/mifunedev/openharness/pull/824)).
 
 ## [0.1.0] - 2026-08-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Update policy and release automation live in [`/git`](.claude/skills/git/SKILL.m
 - Add `oh harness <list|install|status>` to install optional harnesses into a running sandbox without a rebuild, persisting the choice to `install.<key>` for the next build ([#821](https://github.com/mifunedev/openharness/pull/821)).
 - Add `oh runtime <list|install|status>`, reporting the container runtime in use and gating a MicroSandbox install on the measured glibc and `/dev/kvm` blockers. It selects no runtime ([#823](https://github.com/mifunedev/openharness/pull/823)).
 - Add `oh tool <list|install|status>` for sandbox tooling that is neither an agent CLI nor a runtime, making `agent-browser` installable without a rebuild behind a ~1 GB download gate ([#824](https://github.com/mifunedev/openharness/pull/824)).
+- Add `oh stop|restart|logs|ps`, closing the lifecycle gap where `make` had verbs the CLI did not, and publish one `make` vs `oh` mapping doc that the other docs link to ([#825](https://github.com/mifunedev/openharness/pull/825)).
 
 ## [0.1.0] - 2026-08-23
 

--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,8 @@ config: harness-config ## Print effective harness.yaml-derived env and resolved 
 help: ## List available targets with descriptions
 	@printf "Open Harness — Make targets:\n"
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?##/ {printf "  \033[36m%-10s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
-	@printf "\nSandbox CLI (run \033[36minside\033[0m the sandbox after \033[36mmake shell\033[0m):\n"
+	@printf "\nSame verbs via the \033[36moh\033[0m CLI (inside the sandbox, or in an \033[36moh init\033[0m repo):\n"
+	@printf "  \033[36moh sandbox\033[0m / \033[36mshell\033[0m / \033[36mstop\033[0m / \033[36mrestart\033[0m / \033[36mlogs\033[0m / \033[36mps\033[0m / \033[36mgateway\033[0m\n"
+	@printf "  Both run .oh/scripts/docker-compose.sh. Mapping: \033[36m.oh/docs/lifecycle-commands.md\033[0m\n"
 	@printf "  \033[36moh --help\033[0m  List all \033[36moh\033[0m subcommands\n"
 	@printf "  Slack bridge setup: see \033[36m.oh/docs/integrations/slack.md\033[0m\n"

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 - **Parallel by design.** The worktrees skill fans one sandbox into isolated git worktrees — parallel branches, delegated sub-agents, even other cloned repos.
 - **Remote-first, lights-out.** Runs the same on your laptop or a cloud VM; on a VM it's an unattended software factory — agents build on a schedule, reachable over Slack.
 - **Agents that work while you sleep.** A tiny croner runtime reads `.oh/crons/*.md` markdown and wakes the agent on a schedule.
-- **Host dependencies: Docker, Git, and make.** No Node, no Python, no toolchain rot on your laptop. (`make` runs the `make sandbox` / `make shell` wrappers — see [Prerequisites](.oh/docs/installation.md#prerequisites).)
+- **Host dependencies: Docker, Git, and make.** No Node, no Python, no toolchain rot on your laptop. (`make` runs the `make sandbox` / `make shell` wrappers — see [Prerequisites](.oh/docs/installation.md#prerequisites). Inside the sandbox the same verbs are `oh sandbox` / `oh shell` — see [lifecycle commands](.oh/docs/lifecycle-commands.md).)
 - **Composable infra.** Cherry-pick Cloudflare tunnels, SSH, Caddy gateway, or pack-supplied services via Compose overlays.
 - **Slack-ready.** The `pi-messenger-bridge` package bridges Slack (and other messengers) to a Pi agent — see [.oh/docs/integrations/slack.md](.oh/docs/integrations/slack.md).
 - **Herdr-first interactive work.** Claude, Codex, and Pi ship by default (Hermes, Grok, and more are opt-in). After entering the sandbox, run [Herdr](.oh/docs/integrations/herdr.md) first; keep setup, agents, tests, and servers organized in its persistent panes. Headless Slack and cron infrastructure remain independent.

--- a/harness.yaml.example
+++ b/harness.yaml.example
@@ -30,7 +30,8 @@ install:
   # `oh harness install <name>` writes these keys for you — it uncomments the
   # line in place AND installs into the running sandbox, no rebuild. The four
   # harness keys map to `oh harness` names: opencode, grok-build, deepagents,
-  # hermes. `agent_browser` is not a harness and is not managed by that command.
+  # hermes. `agent_browser` is not a harness — `oh tool install agent-browser`
+  # manages that one.
   # opencode: false            # INSTALL_OPENCODE — OpenCode CLI (build arg)
   # grok_build: false          # INSTALL_GROK_BUILD — Grok Build CLI (build arg)
   # deepagents: false          # INSTALL_DEEPAGENTS — DeepAgents CLI (build arg)


### PR DESCRIPTION
> **Stacked on #824.** Review order: **#821 → #823 → #824 → this.** `.oh/cli/src/cli.ts`
> is edited by all four; retargets to `development` as the stack lands.

The exploration asked for, and the consolidation it actually justified.

## What the redundancy turned out to be

**Surface, not logic.** Every compose target from both doors runs
`.oh/scripts/docker-compose.sh` — `make sandbox` calls it directly, and `oh sandbox`
reaches the same script through the compose execution target. The script has always
been the single implementation of overlay resolution, project naming, and env
plumbing. Nothing was duplicated except the name you type.

**The real friction was that `oh` stopped halfway through the lifecycle:**

| | `make` | `oh` (before) |
|---|---|---|
| provision | `make sandbox` | `oh sandbox` |
| shell in | `make shell` | `oh shell` |
| stop / restart / logs / ps | ✅ | ❌ **nothing** |
| destroy / config | ✅ | ❌ |

So a user with `oh` had to switch tools mid-task — and an **`oh init` repo has no
Makefile at all**, meaning those verbs were simply unreachable there.

This PR adds `oh stop`, `oh restart`, `oh logs`, `oh ps` as thin passthroughs, 1:1
with the make target names. `oh <verb> -- <args>` forwards extras to docker compose;
anything else is rejected rather than silently forwarded.

## Why neither door delegates to the other

`README.md` and `.oh/docs/intro.md` promise host dependencies of **Docker, Git, and
make — explicitly no Node**. Host `oh` needs Node ≥ 20.

Routing any make target through `oh` would break that headline promise. So the
Makefile stays Node-free, and the split is **audience-scoped, not preference-scoped**:

| Where | Canonical | Why |
|---|---|---|
| Host, source checkout | `make` | No Node required |
| Inside the sandbox | `oh` | Baked in at `/usr/local/bin/oh` |
| `oh init` repo | `oh` | There is no Makefile |

New `.oh/docs/lifecycle-commands.md` states that **once**. `AGENTS.md`, `README.md`,
and `.oh/cli/README.md` link to it rather than growing a second table — the probe
enforces that.

## A correction to my own first read

I initially flagged `make shell`'s raw `docker exec -it -u … zsh` as an
un-contracted second path to `oh shell`, which routes through
`ExecutionTarget.attach()`.

**It isn't.** `.oh/evals/probes/execution-target-contract.sh` check **C5** asserts
that line *verbatim* — #733 examined this exact question and pinned the current state
as correct. The Makefile is host-side orchestration, not work executed inside a
provisioned environment, which is the same reasoning that keeps `oh gateway` off the
contract. Editing it would fail an existing tier-A probe **and** add Node to the host
prerequisites.

So this PR is a cleanup, not a correctness fix. Good to have established that before
"fixing" something that was deliberate.

## Three verbs deliberately not added

Each is recorded in the mapping doc, and assertion A2 keeps them recorded:

- **`oh destroy`** — `down -v` wipes the named volumes holding provider auth. A
  passthrough with no confirmation policy puts data loss one typo away. That's design,
  not a passthrough.
- **A `make config` equivalent** — `oh config` already means *"configure an
  integration"*. Overloading it would be worse than the gap.
- **`make shell` parity** — see above.

## Nothing is deleted

Reference inventory taken before touching anything: **~60** `make <target>` mentions
across `.oh/docs/**`, `README.md`, `AGENTS.md`, the issue template,
`.oh/scripts/install.sh`, and four skills — and **zero** in CI workflows, crons, or
skill scripts. No target is removed regardless; those docs are *correct*, because
`make` stays canonical on the host.

`make help` now also prints the `oh` equivalents, so whichever door a user finds first
shows them the other.

## Verification

```bash
pnpm exec vitest run .oh/cli/src/__tests__/compose-verbs.test.ts
# 17 passed

bash .oh/evals/probes/make-oh-lifecycle-parity.sh
# PASS: make and oh lifecycle surfaces agree, and the mapping has one home
```

**17 tests**, including four that read the repo's own `Makefile` rather than a
fixture — parity can't rot silently.

**Probe assertions** (tier A), each **verified by rejection** — 9 injected defects,
each turning it red, green on restore:

| | Asserts |
|---|---|
| A1 | Every `.PHONY` target has an `oh` verb or is a listed exception — fails in *both* directions |
| A2 | Every exception is argued in the mapping doc |
| A3 | No recipe calls `docker compose` directly; the pinned `make shell` line is intact |
| A4 | The verbs build no compose argv in TypeScript |
| A5 | Exactly one mapping table exists, and the other docs link to it |

Rejection cases: a new make target with no verb, a removed verb, an undocumented
exception, a raw `docker compose` recipe, an edited `make shell` line, `COMPOSE_VERBS`
inlined away, `runComposeVerb` naming docker, a removed `AGENTS.md` link, and the
mapping doc deleted.

Full suite: **808 passed**. Probes: **PASS=105 SKIPPED=3**. One test failure
(`cron-runtime > buildTmuxWrapper`) and one probe failure (`audit-run-root-contract`)
reproduce on the unmodified baseline and are sandbox-local.

## Deferred to follow-ups

- `oh destroy` with a confirmation policy
- A `make config` equivalent, once the `oh config` name collision is resolved
- Unifying the two `harness.yaml` seed implementations — blocked by the same Node
  constraint, and two small `cp` implementations is the cheaper trade

🤖 Generated with [Claude Code](https://claude.com/claude-code)
