### PR TITLE
task: promote CHANGELOG and bump to 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Update policy and release automation live in [`/git`](.claude/skills/git/SKILL.m
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-08-26
+
 ### Added
 - Add `oh harness <list|install|status>` to install optional harnesses into a running sandbox without a rebuild, persisting the choice to `install.<key>` for the next build ([#821](https://github.com/mifunedev/openharness/pull/821)).
 - Add `oh runtime <list|install|status>`, reporting the container runtime in use and gating a MicroSandbox install on the measured glibc and `/dev/kvm` blockers. It selects no runtime ([#823](https://github.com/mifunedev/openharness/pull/823)).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openharness",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "description": "Open Harness \u2014 AI Agent Sandbox Orchestrator",
   "license": "Apache-2.0",


### PR DESCRIPTION
Cuts **v0.2.0**. Four new CLI command groups have landed since v0.1.0 — `oh harness`, `oh runtime`, `oh tool`, and `oh stop|restart|logs|ps` — so this is a minor bump rather than a patch. No breaking changes.

Promotes `[Unreleased]` to `## [0.2.0] - 2026-08-26` and sets root `package.json` to `0.2.0`, which is the only file recording the version.

Merging this to `development` is not the release trigger. The release fires when `development` reaches `main`, where `.github/workflows/release.yml` reserves `v0.2.0`, publishes GHCR and the CLI, then publishes the GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)