### PR TITLE
task: promote CHANGELOG and bump to 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Update policy and release automation live in [`/git`](.claude/skills/git/SKILL.m
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-08-26
+
 ### Added
 - Add `oh harness <list|install|status>` to install optional harnesses into a running sandbox without a rebuild, persisting the choice to `install.<key>` for the next build ([#821](https://github.com/mifunedev/openharness/pull/821)).
 - Add `oh runtime <list|install|status>`, reporting the container runtime in use and gating a MicroSandbox install on the measured glibc and `/dev/kvm` blockers. It selects no runtime ([#823](https://github.com/mifunedev/openharness/pull/823)).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openharness",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "description": "Open Harness \u2014 AI Agent Sandbox Orchestrator",
   "license": "Apache-2.0",


### PR DESCRIPTION
Cuts **v0.2.0**. Supersedes #829, which was cut before [#820](https://github.com/mifunedev/openharness/pull/820) landed and would have shipped a `[0.2.0]` section missing that entry.

Four new CLI command groups since v0.1.0 — `oh harness`, `oh runtime`, `oh tool`, `oh stop|restart|logs|ps` — so MINOR, not a patch. No breaking changes to existing verbs, though `### Removed` is substantial (see below).

## Verified

Ran #820's new `index()` extractor against this exact CHANGELOG:

```
32 bullets across ### Added / Changed / Fixed / Removed
#820's own entry included
clean stop before v0.1.0 content
changelog-entry-length probe: PASS
```

## Worth a reviewer's eye

`### Removed` carries the `/spec` simplification from [#817](https://github.com/mifunedev/openharness/pull/817), which deletes `/ship-spec`, `ralph.sh`, `/teach`, and the critique/approve gate. User-visible to anyone scripting against those. MINOR is still correct at `0.x` under SemVer, and the section documents it.

## After merge

The release fires when `development` reaches `main`. `main` is **not** a fast-forward from `development` (1,642 commits, prior promotions were merge commits), so promotion follows the v0.1.0 precedent at `3798d3fe` rather than the fast-forward path `/release` documents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)