### PR TITLE
task: strip explanatory comments from tracked code

### DIFF
--- a/.codex/hooks/deny-env-dump.sh
+++ b/.codex/hooks/deny-env-dump.sh
@@ -1,7 +1,4 @@
 #!/usr/bin/env bash
-# Codex wrapper for the shared Claude Bash secret-exposure guard.
-# Codex PreToolUse currently cannot surface "ask" decisions, so convert those
-# to deny to preserve the no-approval-prompt default without failing open.
 set -euo pipefail
 
 root=$(git rev-parse --show-toplevel)

--- a/.codex/hooks/deny-local-settings.sh
+++ b/.codex/hooks/deny-local-settings.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-# Codex file-tool guard for operator-owned settings.local.json files.
 set -euo pipefail
 
 input=$(cat)

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -5,7 +5,6 @@ ENV OH_PROJECT_ROOT=${OH_PROJECT_ROOT}
 
 ENV TZ=America/Denver
 
-# ─── System packages ────────────────────────────────────────────────
 RUN apt-get update && apt-get install -y --no-install-recommends \
     openssh-client openssh-server build-essential ca-certificates curl wget sudo gosu git jq gnupg \
     lsb-release nano ripgrep tmux unzip bash-completion procps less \
@@ -15,12 +14,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
  && command -v telnet >/dev/null \
  && rm -rf /var/lib/apt/lists/*
 
-# ─── Node.js 22.x ──────────────────────────────────────────────────
 RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
  && apt-get install -y --no-install-recommends nodejs \
  && rm -rf /var/lib/apt/lists/*
 
-# ─── GitHub CLI ─────────────────────────────────────────────────────
 RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
       -o /usr/share/keyrings/githubcli-archive-keyring.gpg \
  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
@@ -28,7 +25,6 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
  && apt-get update && apt-get install -y --no-install-recommends gh \
  && rm -rf /var/lib/apt/lists/*
 
-# ─── Docker CLI + Compose ──────────────────────────────────────────
 RUN install -m 0755 -d /etc/apt/keyrings \
  && curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc \
  && chmod a+r /etc/apt/keyrings/docker.asc \
@@ -37,7 +33,6 @@ RUN install -m 0755 -d /etc/apt/keyrings \
  && apt-get update && apt-get install -y --no-install-recommends docker-ce-cli docker-compose-plugin \
  && rm -rf /var/lib/apt/lists/*
 
-# ─── Cloudflared ───────────────────────────────────────────────────
 RUN curl -fsSL https://pkg.cloudflare.com/cloudflare-main.gpg \
       -o /usr/share/keyrings/cloudflare-main.gpg \
  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/cloudflare-main.gpg] https://pkg.cloudflare.com/cloudflared bookworm main" \
@@ -45,12 +40,8 @@ RUN curl -fsSL https://pkg.cloudflare.com/cloudflare-main.gpg \
  && apt-get update && apt-get install -y --no-install-recommends cloudflared \
  && rm -rf /var/lib/apt/lists/*
 
-# ─── Bun ────────────────────────────────────────────────────────────
 RUN BUN_INSTALL=/usr/local curl -fsSL https://bun.sh/install | bash
 
-# ─── Herdr ──────────────────────────────────────────────────────────
-# Primary interactive workspace. Pin and verify both supported Linux artifacts
-# so every sandbox gets the same reviewed binary without a first-boot download.
 ARG HERDR_VERSION=0.7.4
 RUN case "$(dpkg --print-architecture)" in \
       amd64) herdr_arch=x86_64; herdr_sha=bc0fc02d4ba500f9cac2353a43e67fe036785ecca6eb55378e050fac3c103059 ;; \
@@ -63,17 +54,10 @@ RUN case "$(dpkg --print-architecture)" in \
  && chmod 0755 /usr/local/bin/herdr \
  && test "$(herdr --version)" = "herdr ${HERDR_VERSION}"
 
-# ─── uv ─────────────────────────────────────────────────────────────
 RUN curl -LsSf https://astral.sh/uv/install.sh | env INSTALLER_NO_MODIFY_PATH=1 sh \
  && cp /root/.local/bin/uv /usr/local/bin/uv \
  && cp /root/.local/bin/uvx /usr/local/bin/uvx
 
-# ─── Hermes Agent CLI ───────────────────────────────────────────────
-# Optional image-level install. When INSTALL_HERMES=true, install the
-# executable during image build (like the other image-level CLIs), not at
-# container boot. The Slack and Teams messaging extras ship by default so the
-# gateway adapters work without a post-install step. Runtime config/auth uses
-# the project-local /home/sandbox/harness/.hermes directory via HERMES_HOME.
 ARG INSTALL_HERMES=false
 RUN if [ "${INSTALL_HERMES}" = "true" ]; then \
       curl -fsSL https://hermes-agent.nousresearch.com/install.sh \
@@ -84,9 +68,6 @@ RUN if [ "${INSTALL_HERMES}" = "true" ]; then \
       echo "Skipping Hermes Agent CLI install (INSTALL_HERMES=false)"; \
     fi
 
-# ─── DeepAgents CLI ────────────────────────────────────────────────
-# Optional image-level install. Use build-only uv tool paths so root-owned
-# image paths do not leak into the sandbox user's runtime environment.
 ARG INSTALL_DEEPAGENTS=false
 RUN export UV_TOOL_DIR=/opt/uv/tools UV_TOOL_BIN_DIR=/usr/local/bin \
  && mkdir -p "$UV_TOOL_DIR" \
@@ -96,7 +77,6 @@ RUN export UV_TOOL_DIR=/opt/uv/tools UV_TOOL_BIN_DIR=/usr/local/bin \
       echo "Skipping DeepAgents CLI install (INSTALL_DEEPAGENTS=false)"; \
     fi
 
-# ─── pnpm (via corepack) ───────────────────────────────────────────
 ENV PNPM_HOME="/usr/local/share/pnpm"
 ENV NPM_USER_PREFIX="/home/sandbox/.local"
 ENV PATH="$NPM_USER_PREFIX/bin:$PNPM_HOME:$PATH"
@@ -104,20 +84,6 @@ ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0
 RUN corepack enable && corepack prepare pnpm@10.33.0 --activate \
  && pnpm setup --force 2>/dev/null || true
 
-# ─── Agent CLIs ─────────────────────────────────────────────────────
-# Use npm (not pnpm) for global CLI installs. Agent CLI packages require
-# postinstall scripts to download platform-native binaries; npm executes these
-# by default without extra configuration.
-#
-# AGENTS is a comma-separated list of default agent CLI keys to install.
-# The default is claude-code + codex + pi-coding-agent. Optional CLIs
-# such as OpenCode, Grok Build, DeepAgents, and Hermes are controlled by their own
-# INSTALL_* build flags. pi-coding-agent is installed later under the
-# sandbox user's npm prefix so `pi update` can self-update without sudo.
-# The pi-coding-agent key resolves to @earendil-works/pi-coding-agent
-# (the @mariozechner/... package is deprecated upstream as of late 2026).
-# Downstream harness packs (e.g. @ryaneggz/mifune) install additional CLIs
-# via their install-hook.sh.
 SHELL ["/bin/bash", "-c"]
 
 ARG AGENTS="claude-code,codex,pi-coding-agent"
@@ -146,52 +112,22 @@ RUN set -e; \
         rm -f /usr/local/bin/agent; \
     else echo "Skipping Grok Build CLI install (INSTALL_GROK_BUILD=false)"; fi
 
-# ─── cc-safety-net (destructive-command guard) ─────────────────────
-# Cross-provider PreToolUse guard, pinned. Installed unconditionally at image
-# build time — network is available and retryable here, so boot never touches
-# the registry (avoids the #639/4979b846 boot crash-loop class). Kept as its
-# own standalone RUN block (mirroring the pi-coding-agent pattern below), NOT
-# threaded into the AGENTS/PKG loop above: the guard must not be conditional on
-# agent selection. See .oh/tasks/cc-safety-net/install-decision.md.
 RUN npm install -g cc-safety-net@1.0.6
 
-# ─── Open Harness `oh` CLI ──────────────────────────────────────────
-# Build the in-tree `oh` CLI (.oh/cli/) into a self-contained bundle,
-# install onto $PATH. Source is COPY'd to /opt/oh (outside the
-# bind-mount) so the bundled binary survives the bind-mount overlay.
-# The `oh config` family currently ships no integration wizards (Slack is
-# configured natively by editing files — see .oh/docs/integrations/slack.md).
-# NOTE: COPY does not follow the back-compat `packages/oh` symlink, so the
-# real path `.oh/cli/` is used here; runtime callers still use `packages/oh`.
 COPY .oh/cli/ /opt/oh/
 RUN cd /opt/oh && npm install --no-audit --no-fund && npm run build \
  && chmod +x /opt/oh/dist/oh.js \
  && ln -sf /opt/oh/dist/oh.js /usr/local/bin/oh
 
-# ─── Sandbox user ──────────────────────────────────────────────────
 RUN useradd -m -s /bin/zsh sandbox \
  && echo "sandbox ALL=(ALL) ALL" > /etc/sudoers.d/sandbox \
  && chmod 0440 /etc/sudoers.d/sandbox \
  && groupadd -f docker && usermod -aG docker sandbox
 
-# Runtime uv operations should be owned by the default in-container user.
-# Image-level installs may still place launchers in /usr/local/bin, but
-# ad-hoc `uv tool install` and `uv pip install --python ...` from a shell
-# must not target root-owned tool dirs by default.
 ENV UV_TOOL_DIR=/home/sandbox/.local/share/uv/tools
 ENV UV_TOOL_BIN_DIR=/home/sandbox/.local/bin
-# uv also writes a managed-interpreter dir and a cache dir. Pin both to
-# user-scoped paths so `uv python install` never falls back to /root/.local or
-# /root/.cache — the agent runs as `sandbox`, so a root-owned interpreter is
-# unusable no matter how it got installed.
 ENV UV_PYTHON_INSTALL_DIR=/home/sandbox/.local/share/uv/python
 ENV UV_CACHE_DIR=/home/sandbox/.cache/uv
-# `install -d -o U -g G a/b/c` applies -o/-g to the FINAL component only;
-# intermediate parents it has to create are left root-owned. Creating just
-# `.../uv/tools` therefore produced a root-owned `.../uv`, and the first
-# `uv python install 3.11` as sandbox died with
-# "failed to create directory /home/sandbox/.local/share/uv/python: Permission denied".
-# Name every level explicitly, parents first, so each one is owned by sandbox.
 RUN install -d -o sandbox -g sandbox \
       /home/sandbox/.local \
       /home/sandbox/.local/share \
@@ -201,31 +137,21 @@ RUN install -d -o sandbox -g sandbox \
  && chown -R sandbox:sandbox /opt/uv 2>/dev/null || true \
  && if [ -d /usr/local/lib/hermes-agent ]; then chown -R sandbox:sandbox /usr/local/lib/hermes-agent; fi
 
-# Pi self-updates only when its package directory and parent are writable.
-# Install it under sandbox's npm prefix, and put that bin directory before
-# /usr/bin so `pi update` updates the active executable without sudo.
 RUN set -e; \
     install -d -o sandbox -g sandbox "$NPM_USER_PREFIX"; \
     if [[ ",${AGENTS}," == *",pi-coding-agent,"* ]]; then \
         su - sandbox -c 'npm --prefix "$HOME/.local" install -g --ignore-scripts @earendil-works/pi-coding-agent'; \
     fi
 
-# ─── oh-my-zsh + plugins ───────────────────────────────────────────
-# Install as sandbox so $HOME resolves and files land with correct ownership.
-# RUNZSH/CHSH=no keeps the installer from trying to exec zsh or re-run chsh.
 RUN su - sandbox -c "RUNZSH=no CHSH=no KEEP_ZSHRC=yes sh -c \"\$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)\" --unattended" \
  && su - sandbox -c "git clone --depth 1 https://github.com/zsh-users/zsh-autosuggestions         /home/sandbox/.oh-my-zsh/custom/plugins/zsh-autosuggestions" \
  && su - sandbox -c "git clone --depth 1 https://github.com/zsh-users/zsh-syntax-highlighting     /home/sandbox/.oh-my-zsh/custom/plugins/zsh-syntax-highlighting" \
  && su - sandbox -c "git clone --depth 1 https://github.com/zsh-users/zsh-history-substring-search /home/sandbox/.oh-my-zsh/custom/plugins/zsh-history-substring-search"
 
-# Default tmux config for sandbox user (real path — COPY ignores the install symlink)
 COPY --chown=sandbox:sandbox .oh/install/.tmux.conf /home/sandbox/.tmux.conf
 
-# Default .zshrc for sandbox user (overrides the oh-my-zsh template)
 COPY --chown=sandbox:sandbox .oh/install/.zshrc /home/sandbox/.zshrc
 
-# Ensure user npm bin + PNPM_HOME are on PATH for login shells (SSH, openharness shell).
-# bash reads .profile; zsh reads .zprofile — mirror the exports into both.
 RUN printf '%s\n' \
       'export NPM_USER_PREFIX="/home/sandbox/.local"' \
       'export PNPM_HOME="/usr/local/share/pnpm"' \
@@ -235,41 +161,24 @@ RUN printf '%s\n' \
       | tee -a /home/sandbox/.profile /home/sandbox/.zprofile \
  && chown sandbox:sandbox /home/sandbox/.profile /home/sandbox/.zprofile
 
-# Shell aliases for agent CLIs (bash fallback — .zshrc ships with these baked in)
 RUN echo "alias claude='claude --dangerously-skip-permissions'" >> /home/sandbox/.bashrc \
  && echo "alias codex='codex --dangerously-bypass-approvals-and-sandbox'" >> /home/sandbox/.bashrc
 
-# Git safe.directory for bind-mounted project
 RUN su - sandbox -c "git config --global --add safe.directory ${OH_PROJECT_ROOT}"
 
-# Default working directory for interactive shells (SSH + terminal attach, bash fallback)
 RUN echo "cd ${OH_PROJECT_ROOT} 2>/dev/null" >> /home/sandbox/.bashrc
 
-# Image-level devcontainer config — VS Code reads this on "Attach to Running Container"
 RUN mkdir -p /.devcontainer && echo '{"workspaceFolder":"/home/sandbox/harness","remoteUser":"sandbox"}' > /.devcontainer/devcontainer.json
 
-# Labels for VS Code "Attach to Running Container"
 LABEL devcontainer.metadata='[{"remoteUser":"sandbox","workspaceFolder":"/home/sandbox/harness"}]'
 LABEL org.opencontainers.image.licenses="Apache-2.0"
 
-# ─── Copy install scripts (for CI; bind mount overrides at runtime)
-# Real path .oh/install/ — COPY does not traverse the back-compat install symlink.
 COPY --chown=sandbox:sandbox .oh/install/ /home/sandbox/install/
 RUN chmod +x /home/sandbox/install/*.sh
 
-# Flavor B (#609): bake a non-shadowed seed copy of the repo/control-plane so
-# the image-only path can populate an empty named workspace volume on first
 # boot (entrypoint OH_IMAGE_ONLY / seed_workspace_volume, OH_IMAGE_SEED_SRC).
-# Scoped by .dockerignore (.git, node_modules, .oh/worktrees/*, .claude, .env* etc.).
-# Tradeoff: bakes the repo into the image (size cost) for the seeding path only;
-# the primary bind-mount build ignores /opt/oh-seed at runtime.
 COPY --chown=sandbox:sandbox . /opt/oh-seed/
 
-# ─── User-scoped Python provisioning ───────────────────────────────
-# Bake the managed interpreter + kernel venv into the image so a fresh boot
-# needs no network. Run as `sandbox` with HOME pinned: a root-run `uv python
-# install` would land under /root/.local, which the agent user cannot read.
-# The entrypoint re-runs the same idempotent script on every boot.
 ARG INSTALL_PYTHON_KERNEL=true
 ARG OH_PYTHON_VERSION=3.11
 RUN if [ "${INSTALL_PYTHON_KERNEL}" = "true" ]; then \
@@ -278,7 +187,6 @@ RUN if [ "${INSTALL_PYTHON_KERNEL}" = "true" ]; then \
       echo "Skipping Python kernel provisioning (INSTALL_PYTHON_KERNEL=false)"; \
     fi
 
-# ─── Entrypoint ────────────────────────────────────────────────────
 COPY .devcontainer/entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
 

--- a/.devcontainer/client-slack-supervise.sh
+++ b/.devcontainer/client-slack-supervise.sh
@@ -1,47 +1,6 @@
 #!/usr/bin/env bash
-# Self-healing supervisor for the gateway client sessions (client-slack-<backend>
-# tmux sessions).
-#
-# Launched by .devcontainer/entrypoint.sh (pi) or .oh/scripts/gateway.sh with
-# HARNESS / LOG exported, plus:
-#   pi (default):  PI_SLACK_* tokens, BRIDGE_ENTRY, RECOVERY_ENTRY.
-#   hermes:        GATEWAY_BACKEND=hermes and SUPERVISE_CMD=<the hermes launch
-#                  command> — a GENERIC crash-restart loop with NONE of the
-#                  pi-specific stale-ctx/lock/recovery logic below.
-#
-# Why this exists (pi): pi-messenger-bridge binds its long-lived Slack socket to a
-# session-scoped pi ctx. When pi replaces the session (compaction, fork, switch,
-# reload) that ctx goes stale and every subsequent Slack message throws
-# "extension ctx is stale after session replacement or reload" — the package has
-# no recovery hook, so the bridge silently stops responding while the process
-# keeps running. This loop restarts pi on that signature (and on any crash),
-# clearing the single-instance lock each time so the fresh process reconnects.
-#
-# pi runs INTERACTIVELY, attached to the tmux pane's real TTY (stdin + stdout are
 # the pane pty), with NO `| tee` pipe and NO `--mode rpc`. On a TTY pi resolves to
-# interactive mode, so the loaded UI extensions (prompt-suggester, pi-recap)
-# RENDER in the TUI instead of serializing every setStatus/setWidget call to
-# stdout as `extension_ui_request` JSON frames — that flood is an rpc-mode
-# artifact. Interactive pi also stays alive at idle (it is a REPL), so the
 # session no longer needs `--mode rpc` to avoid the idle exit.
-#
-# Logging is out-of-band (we lost `tee`): pi's stderr is redirected to $LOG, and
-# the entrypoint additionally mirrors the visible pane into $LOG (ANSI-stripped)
-# via `tmux pipe-pane`. Both feed the stale-ctx watchdog below.
-#
-# A 2nd --extension loads the standalone Codex retry-recovery extension
-# (.pi/bridge-recovery/index.ts), which re-injects a failed Slack-originated turn
-# once on `previous_response_not_found` — recovery the npm bridge lacks.
-#
-# Health/observability: each launch stamps a non-secret state file and a
-# background ticker refreshes a heartbeat (proving the session is actively
-# supervised, not merely "a tmux session exists") and caps $LOG in place so a
-# long-lived session cannot grow it without bound. `gateway status` reads these.
-#
-# A clean exit (rc=0) stops the loop; a crash or watchdog-kill (rc!=0) restarts it.
-#
-# NOTE: intentionally no `set -e` — pkill/kill return non-zero when there is
-# nothing to signal, which is normal control flow here, not an error.
 set -u
 
 BACKEND="${GATEWAY_BACKEND:-pi}"
@@ -52,13 +11,12 @@ RECOVERY_ENTRY="${RECOVERY_ENTRY:-$HARNESS/.pi/bridge-recovery/index.ts}"
 LOG="${LOG:-/tmp/client-slack-$BACKEND.log}"
 LOCK="$HOME/.pi/msg-bridge.lock"
 
-# Non-secret runtime state consumed by `gateway status` (see gateway.sh).
 STATE_DIR="${GATEWAY_STATE_DIR:-$HOME/.pi/gateway}"
 STATE="$STATE_DIR/$BACKEND.state"
 HEARTBEAT_FILE="$STATE_DIR/$BACKEND.heartbeat"
 STALE_FILE="$STATE_DIR/$BACKEND.stale"
 HEARTBEAT_INTERVAL="${GATEWAY_HEARTBEAT_INTERVAL:-20}"
-LOG_MAX_BYTES="${GATEWAY_LOG_MAX_BYTES:-5242880}"  # 5 MiB
+LOG_MAX_BYTES="${GATEWAY_LOG_MAX_BYTES:-5242880}"
 mkdir -p "$STATE_DIR" 2>/dev/null || true
 rm -f "$STALE_FILE" 2>/dev/null || true
 
@@ -69,9 +27,6 @@ else TOKEN_STATE="n/a"; fi
 STARTED_ISO="$(date -u +%FT%TZ)"
 LAUNCHES=0
 
-# Atomic single-line/kv writes (never carry secrets). Writers are disjoint per
-# file: the main loop owns $STATE, the ticker owns $HEARTBEAT_FILE, the watchdog
-# owns $STALE_FILE — so no locking is needed.
 write_state() {
   local tmp
   tmp=$(mktemp "$STATE_DIR/.state.XXXXXX" 2>/dev/null) || return 0
@@ -91,9 +46,6 @@ write_heartbeat() {
   date -u +%s >"$tmp" 2>/dev/null && mv -f "$tmp" "$HEARTBEAT_FILE" 2>/dev/null || rm -f "$tmp" 2>/dev/null || true
 }
 
-# Copytruncate cap: keep the last half, then rewrite the SAME inode in place so
-# the pipe-pane / pi-stderr append fds and the stale-ctx `tail -F` stay valid
-# (a rename/create would leave them writing to the rotated-away inode).
 cap_log() {
   [ -f "$LOG" ] || return 0
   local sz; sz=$(stat -c %s "$LOG" 2>/dev/null || echo 0)
@@ -111,19 +63,11 @@ while true; do
   echo "[bridge-supervisor] launching $BACKEND bridge ($(date -u +%FT%TZ))" >>"$LOG"
   write_state
 
-  # Heartbeat + in-place log cap ticker: refreshes while the process runs, torn
-  # down when it exits. Fully redirected so it never touches the pane pty.
   ( while true; do write_heartbeat; cap_log; sleep "$HEARTBEAT_INTERVAL"; done ) </dev/null >/dev/null 2>&1 &
   HB=$!
 
   WD=""
   if [ "$BACKEND" = pi ]; then
-    # Watchdog: tail $LOG from end-of-file (old stale-ctx lines never re-trigger),
-    # strip ANSI/CR so a TUI-rendered error is still greppable, record the recovery
-    # for `gateway status`, and kill the bridge pi — matched by its unique
-    # --extension path — on the first stale-ctx line so the loop relaunches a
-    # fresh, non-stale process. Fully redirected (incl. stdin from /dev/null) so it
-    # never reads the pane pty or holds a stdout pipe open.
     ( tail -Fn0 "$LOG" 2>/dev/null \
         | sed -u 's/\x1b\[[0-9;?]*[A-Za-z]//g; s/\r//g' \
         | grep -m1 'ctx is stale' >/dev/null 2>&1 \
@@ -132,15 +76,10 @@ while true; do
              pkill -f 'pi-messenger-bridge/dist/index.js'; } ) </dev/null >/dev/null 2>&1 &
     WD=$!
 
-    # Interactive TTY launch: stdin+stdout = pane pty (-> interactive mode, no JSON
     # flood, stays alive at idle), stderr -> $LOG. No pipe, no --mode rpc.
     pi --extension "$BRIDGE_ENTRY" --extension "$RECOVERY_ENTRY" --approve 2>>"$LOG"
     rc=$?
   else
-    # Generic backend (hermes): crash-restart-with-backoff only. SUPERVISE_CMD
-    # ends in `exec <bin> gateway run`, so it replaces this subshell and returns
-    # the backend's own exit code. No stale-ctx/lock/recovery — those are
-    # pi-bridge-specific.
     if [ -z "$SUPERVISE_CMD" ]; then
       echo "[bridge-supervisor] no SUPERVISE_CMD for backend '$BACKEND' — exiting" >>"$LOG"
       break

--- a/.devcontainer/entrypoint.sh
+++ b/.devcontainer/entrypoint.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 set -e
 
-# Match the container's docker group GID to the host socket's GID
-# so the sandbox user can use Docker without sudo.
 SOCK=/var/run/docker.sock
 if [ -S "$SOCK" ]; then
   HOST_GID=$(stat -c '%g' "$SOCK")
@@ -21,10 +19,6 @@ repair_home_mount_ownership() {
   owner="$(sandbox_ownership)"
   echo "[entrypoint] repairing sandbox auth mount ownership as $owner"
 
-  # Fix ownership of mounted volumes (created as root by Docker). Use the
-  # sandbox user's numeric uid:gid so this remains correct after UID/GID sync,
-  # even when the primary group is remapped to an existing host group whose
-  # name is not `sandbox`.
   for dir in .claude .codex .pi .prime .grok .deepagents .herdr .cloudflared .config .cc-safety-net .ssh; do
     if [ -d "/home/sandbox/$dir" ]; then
       chown -hR "$owner" "/home/sandbox/$dir" 2>/dev/null || true
@@ -34,16 +28,10 @@ repair_home_mount_ownership() {
 
   # Legacy Hermes home state may exist from earlier layouts. Do not recurse
   # into $HERMES_HOME when it points at the bind-mounted checkout; that
-  # project-local runtime is handled by the Hermes block after UID sync.
   if [ -d "/home/sandbox/.hermes" ]; then
     chown -hR "$owner" "/home/sandbox/.hermes" 2>/dev/null || true
   fi
 
-  # Fix ownership of parents Docker auto-creates as root to satisfy named-volume
-  # or bind-mount targets, which then block the sandbox user from creating
-  # sibling dirs (EACCES on first run). Non-recursive so the bind-mounted
-  # children (`.local/share/opencode`, `.config/gh`) stay under the explicit
-  # repairs below.
   for parent in /home/sandbox/.local /home/sandbox/.local/share /home/sandbox/.config; do
     if [ -d "$parent" ]; then
       chown -h "$owner" "$parent" 2>/dev/null || true
@@ -55,12 +43,6 @@ repair_home_mount_ownership() {
     chown -hR "$owner" "$OPENCODE_STATE" 2>/dev/null || true
   fi
 
-  # uv's user-scoped state. The UID-sync sweep below only rewrites paths owned
-  # by the OLD sandbox UID, so a root-owned dir here is never repaired by it —
-  # and a root-owned `.../share/uv` is exactly what made `uv python install`
-  # fail with "Permission denied" for the sandbox user. Create the whole chain
-  # explicitly (install -d only chowns its final component) and chown the uv
-  # subtrees recursively so a stray `sudo uv` run is self-healing on next boot.
   install -d -o sandbox -g sandbox \
     /home/sandbox/.local/share/uv \
     /home/sandbox/.local/share/uv/tools \
@@ -75,21 +57,11 @@ repair_home_mount_ownership() {
 }
 
 # >>> seed_workspace_volume >>>
-# First-boot seed for OH_IMAGE_ONLY (no-bind) mode: populate an empty named
-# workspace volume from the image's baked control plane (/opt/oh-seed by
-# default). Self-contained: uses only $1 (dest) + $OH_IMAGE_SEED_SRC so the
-# eval probe can source it in isolation. Sets OH_IMAGE_SEEDED_THIS_BOOT.
 seed_workspace_volume() {
   local dest="$1"
   local marker="$dest/.oh/.image-seeded"
   local src="${OH_IMAGE_SEED_SRC:-/opt/oh-seed}"
   OH_IMAGE_SEEDED_THIS_BOOT=0
-  # Self-heal: backfill tracked .claude control-plane config that a prior
-  # (pre-fix) image failed to seed. Copy ONLY when the dest file is absent and
-  # the seed carries it, so operator edits are never clobbered. Runs before the
-  # marker early-return so an already-marked-but-incomplete volume heals in
-  # place — no volume wipe. Idempotent. protected-paths.txt is boot-critical
-  # (link-providers.sh --init hard-requires it); settings.json wires hooks.
   if [ -n "$src" ] && [ -d "$src/.claude" ]; then
     local _rel
     for _rel in protected-paths.txt settings.json; do
@@ -102,7 +74,6 @@ seed_workspace_volume() {
   if [ -f "$marker" ]; then
     return 0
   fi
-  # Clobber guard: only seed when the control plane is absent (marker AND emptiness).
   if [ -n "$src" ] && [ -d "$src" ] && [ ! -d "$dest/.oh" ]; then
     cp -a "$src/." "$dest/" 2>/dev/null || true
   fi
@@ -117,14 +88,7 @@ seed_workspace_volume() {
 repair_home_mount_ownership
 
 # ─── Host UID reconciliation ────────────────────────────────────────
-# The repo is bind-mounted at /home/sandbox/harness with its host UID/GID.
-# To avoid permission drift between host and container (host edits files
-# created in-container and vice versa; git authorship stays consistent),
-# we sync the sandbox user's UID/GID to the host owner. After the sync,
-# anything sandbox creates inside the container is owned by the host
-# user on the host filesystem — no chown handoff needed.
 OH_PROJECT_ROOT="${OH_PROJECT_ROOT:-/home/sandbox/harness}"
-# DEPRECATED alias — prefer $OH_PROJECT_ROOT
 HARNESS="${HARNESS:-$OH_PROJECT_ROOT}"
 
 uid_reconcile_step() {
@@ -176,31 +140,15 @@ elif [ -d "$HARNESS_DIR" ]; then
   fi
 fi
 
-# Set the sandbox user's password. This is BOTH the remote login password
-# (e.g. `su sandbox` / SSH password auth) AND the sudo password: sudo now
-# requires it (/etc/sudoers.d/sandbox is `sandbox ALL=(ALL) ALL`, no NOPASSWD),
-# so an interactive operator who knows it can escalate, but a non-interactive
-# internal agent hits the password prompt and fails (`sudo -n` -> error). We
-# run as root here (before the gosu drop), so no sudo is needed to set it.
-# Unconditional — independent of whether the UID/GID reconcile above succeeded.
-# The trailing `|| echo ... >&2` (not a bare `|| true`) keeps a chpasswd
-# failure (e.g. read-only /etc on some hosts) from aborting boot under
-# `set -e`, while still surfacing it as a warning; never log $PW itself.
 PW="${SANDBOX_PASSWORD:-test1234}"
 echo "sandbox:${PW}" | chpasswd || echo "[entrypoint] WARNING: failed to set sandbox password" >&2
 unset PW
 
 # UID/GID reconciliation can change the numeric identity behind the sandbox
-# user after Docker-created auth volumes were repaired above. Repeat the
-# idempotent repair with the final uid:gid so persisted credentials remain
-# readable on hosts where UID 1000 is already occupied.
 repair_home_mount_ownership
 
 HARNESS="${HARNESS:-$OH_PROJECT_ROOT}"
 
-# How the skill pack is wired: the shared skills/agents/hooks are vendored
-# directly under .oh/ (no submodule). Create/repair the provider symlinks into
-# .oh/ before any provider symlink, hook, eval runner, or Hermes skill path reads it.
 if [ -x "$HARNESS/.oh/scripts/link-providers.sh" ]; then
   if ! gosu sandbox bash "$HARNESS/.oh/scripts/link-providers.sh" --init; then
     echo "[entrypoint] failed to link provider skills; run: bash .oh/scripts/link-providers.sh --init"
@@ -208,12 +156,6 @@ if [ -x "$HARNESS/.oh/scripts/link-providers.sh" ]; then
   fi
 fi
 
-# ─── User-scoped uv/Python provisioning ─────────────────────────────
-# Idempotent: a fully provisioned home is a no-op, so this runs on every boot
-# and repairs a container whose uv state predates the ownership fix. The script
-# drops to the sandbox user itself and pins HOME, so nothing lands under /root.
-# Non-fatal: a sandbox without Python must still boot, but the failure is
-# surfaced with the exact repair command rather than swallowed.
 if [ "${OH_PROVISION_PYTHON:-true}" = "true" ] \
    && [ -x "$HARNESS/.oh/scripts/provision-python.sh" ]; then
   if ! bash "$HARNESS/.oh/scripts/provision-python.sh"; then
@@ -222,20 +164,12 @@ if [ "${OH_PROVISION_PYTHON:-true}" = "true" ] \
 fi
 
 # Hermes keeps all runtime state — including auth.json — inside the
-# project-local HERMES_HOME directory. An earlier design symlinked
-# auth.json into the home-scoped ~/.hermes named volume, but that volume
-# is a different filesystem from the bind-mounted checkout, so hermes'
-# atomic_replace() (write-temp-then-os.replace) died with EXDEV on every
-# auth write. Keeping auth on the same device as its temp file fixes it;
-# HERMES_HOME is gitignored, so credentials stay out of version control.
 if [ "${INSTALL_HERMES:-false}" = "true" ]; then
   HERMES_RUNTIME="${HERMES_HOME:-$HARNESS/.hermes}"
   HERMES_LEGACY_AUTH="/home/sandbox/.hermes/auth.json"
 
   mkdir -p "$HERMES_RUNTIME"
 
-  # Heal the legacy cross-device symlink: drop it and restore any
-  # credentials that reached the old volume as a real file.
   if [ -L "$HERMES_RUNTIME/auth.json" ]; then
     rm -f "$HERMES_RUNTIME/auth.json"
     if [ -s "$HERMES_LEGACY_AUTH" ]; then
@@ -243,11 +177,6 @@ if [ "${INSTALL_HERMES:-false}" = "true" ]; then
     fi
   fi
 
-  # Share the harness' vendored skill pack with Hermes through its normal
-  # HERMES_HOME skills tree. Claude, Codex, and Pi point at the same neutral
-  # /home/sandbox/harness/.oh/skills directory; Hermes keeps its bundled/runtime
-  # skills under $HERMES_RUNTIME/skills and gets the harness collection as a
-  # symlinked child so one primitive is visible to every agent.
   HERMES_SHARED_SKILLS_DIR="$HARNESS/.oh/skills"
   HERMES_SHARED_SKILLS_LINK="$HERMES_RUNTIME/skills/openharness"
   mkdir -p "$HERMES_RUNTIME/skills"
@@ -267,22 +196,10 @@ if [ "${INSTALL_HERMES:-false}" = "true" ]; then
 
   chown -hR "$(sandbox_ownership)" "$HERMES_RUNTIME" 2>/dev/null || true
 
-  # The venv is a system path (outside /home/sandbox) that the Dockerfile
-  # chowned to the build-time sandbox UID. If the UID-sync above remapped
-  # sandbox to the host UID, the venv is left orphaned and ad-hoc
-  # `uv pip install --python .../venv 'hermes-agent[slack]'` fails EACCES.
-  # Re-chown the install dir + uv tools to the current sandbox UID.
   for d in /usr/local/lib/hermes-agent /opt/uv; do
     [ -d "$d" ] && chown -hR "$(sandbox_ownership)" "$d" 2>/dev/null || true
   done
 
-  # ─── Start Hermes dashboard in tmux session (opt-in) ────────────────
-  # Guard: HERMES_DASHBOARD=true AND hermes binary on PATH AND tmux on PATH.
-  # Idempotent: skip if the session already exists.
-  # Runs as sandbox user via gosu; logs tee to /tmp/app-hermes-dashboard.log.
-  # HERMES_DASHBOARD_HOST defaults to 127.0.0.1; set to 0.0.0.0 when the
-  # compose overlay publishes the port (Docker's published-port path requires
-  # the process to bind a non-loopback interface).
   if [ "${HERMES_DASHBOARD:-false}" = "true" ] && command -v hermes &>/dev/null \
      && command -v tmux &>/dev/null; then
     _dash_port="${HERMES_DASHBOARD_PORT:-9119}"
@@ -308,25 +225,13 @@ if [ "${INSTALL_HERMES:-false}" = "true" ]; then
   fi
 fi
 
-# ─── Optional: sshd for direct container SSH (opt-in via SANDBOX_SSH=true) ──
-# Publishes over the docker-compose.ssh.yml overlay. We start sshd as a
-# BACKGROUND daemon (no -D) so it runs alongside `sleep infinity` — PID 1 stays
-# the healthcheck-friendly sleep, matching how cron/hermes run as side services.
-# Auth is public-key by default; password auth (using SANDBOX_PASSWORD, applied
-# via chpasswd above) only when SANDBOX_SSH_PASSWORD_AUTH is truthy. Idempotent:
-# skip if sshd is already running. Runs as root (needed to bind port 22 + manage
-# host keys); never logs the password or key material.
 if [ "${SANDBOX_SSH:-false}" = "true" ] && [ -x /usr/sbin/sshd ]; then
   if pgrep -x sshd >/dev/null 2>&1; then
     echo "[entrypoint] sshd already running — skipping"
   else
     mkdir -p /run/sshd
-    ssh-keygen -A >/dev/null 2>&1 || true   # generate host keys if missing
+    ssh-keygen -A >/dev/null 2>&1 || true
 
-    # Seed the sandbox user's authorized_keys from env (public key material is
-    # not secret; it rides in .devcontainer/.env because it can be multi-line).
-    # Compose env files are single-line in practice, so also accept literal \n
-    # separators and normalize them into real authorized_keys lines.
     _ssh_dir=/home/sandbox/.ssh
     _have_keys=0
     if [ -n "${SANDBOX_SSH_AUTHORIZED_KEYS:-}" ]; then
@@ -339,16 +244,14 @@ if [ "${SANDBOX_SSH:-false}" = "true" ] && [ -x /usr/sbin/sshd ]; then
       chown -R "$(sandbox_ownership)" "$_ssh_dir"
       _have_keys=1
     elif [ -s "$_ssh_dir/authorized_keys" ]; then
-      _have_keys=1   # operator bind-mounted or pre-seeded keys
+      _have_keys=1
     fi
 
-    # Password auth: only when explicitly enabled.
     _pw_auth=no
     case "$(printf '%s' "${SANDBOX_SSH_PASSWORD_AUTH:-false}" | tr '[:upper:]' '[:lower:]')" in
       1|true|yes|on) _pw_auth=yes ;;
     esac
 
-    # Hardened drop-in — Debian's default sshd_config Includes sshd_config.d/*.conf.
     mkdir -p /etc/ssh/sshd_config.d
     cat > /etc/ssh/sshd_config.d/openharness.conf <<EOF
 # Managed by Open Harness entrypoint — regenerated every boot.
@@ -371,23 +274,12 @@ EOF
   fi
 fi
 
-# ─── Attach banner wiring (idempotent) ──────────────────────────────
-# Source .oh/install/banner.sh from the sandbox user's .bashrc so every
-# interactive shell (docker exec, VS Code) shows
-# sandbox + onboarding status. Safe to run on every boot.
 BASHRC="/home/sandbox/.bashrc"
 if [ -f "$BASHRC" ] && ! grep -q 'source.*\.oh/install/banner.sh' "$BASHRC"; then
   gosu sandbox bash -c "echo 'source ${OH_PROJECT_ROOT}/.oh/install/banner.sh 2>/dev/null' >> ~/.bashrc"
   echo "[entrypoint] attach banner wired into .bashrc"
 fi
 
-# ─── GitHub CLI auth via PAT (optional) ─────────────────────────────
-# When GH_TOKEN is provided, persist it into ~/.config/gh/hosts.yml on
-# disk (via the config-dir volume that backs ~/.config) so auth survives env changes and
-# `gh auth setup-git` has proper host config to reference. gh refuses
-# `--with-token` while GH_TOKEN is in env, so unset it in the subprocess.
-# Disk-auth check uses `env -u GH_TOKEN` so we don't mistake the env var
-# for a persisted login.
 if [ -n "${GH_TOKEN:-}" ]; then
   if ! gosu sandbox env -u GH_TOKEN -u GITHUB_TOKEN gh auth status &>/dev/null; then
     if echo "$GH_TOKEN" | gosu sandbox env -u GH_TOKEN -u GITHUB_TOKEN gh auth login --with-token 2>/dev/null; then
@@ -400,8 +292,6 @@ if [ -n "${GH_TOKEN:-}" ]; then
   fi
 fi
 
-# ─── Git identity + credential helper ───────────────────────────────
-# Set git user from env vars (fallback to gh-authenticated user)
 if [ -n "${GIT_USER_NAME:-}" ]; then
   gosu sandbox git config --global user.name "$GIT_USER_NAME"
 elif gosu sandbox gh auth status &>/dev/null; then
@@ -412,30 +302,18 @@ if [ -n "${GIT_USER_EMAIL:-}" ]; then
   gosu sandbox git config --global user.email "$GIT_USER_EMAIL"
 elif gosu sandbox gh auth status &>/dev/null; then
   GH_EMAIL=$(gosu sandbox gh api user --jq .email 2>/dev/null || true)
-  # GitHub may return null for private emails — use noreply fallback
   if [ -z "$GH_EMAIL" ] || [ "$GH_EMAIL" = "null" ]; then
     GH_LOGIN=$(gosu sandbox gh api user --jq .login 2>/dev/null || true)
     [ -n "$GH_LOGIN" ] && GH_EMAIL="${GH_LOGIN}@users.noreply.github.com"
   fi
   [ -n "$GH_EMAIL" ] && gosu sandbox git config --global user.email "$GH_EMAIL"
 fi
-# Register gh as git credential helper so `git push`/`git fetch` just work
-# over HTTPS on first attach — no SSH key setup required.
-# Must run with GH_TOKEN unset: gh refuses setup-git when env-var auth
-# would shadow the stored host config it's trying to wire up.
 if gosu sandbox env -u GH_TOKEN -u GITHUB_TOKEN gh auth status &>/dev/null; then
   if gosu sandbox env -u GH_TOKEN -u GITHUB_TOKEN gh auth setup-git 2>/dev/null; then
     echo "[entrypoint] git credential helper configured via gh auth setup-git"
   fi
 fi
 
-# ─── SSH key generation + GitHub upload ─────────────────────────────
-# Mirrors what the interactive `gh auth login` flow does when you pick
-# SSH as the git protocol: generate an ed25519 keypair and register the
-# public key with GitHub. `gh auth login --with-token` has no SSH path,
-# so we do it ourselves. Requires the PAT to carry `admin:public_key`
-# scope; without it the generation still runs but the upload is skipped
-# (HTTPS + credential helper continues to work).
 if [ -n "${GH_TOKEN:-}" ] && gosu sandbox env -u GH_TOKEN -u GITHUB_TOKEN gh auth status &>/dev/null; then
   SSH_DIR="/home/sandbox/.ssh"
   SSH_KEY="$SSH_DIR/id_ed25519"
@@ -465,17 +343,7 @@ if [ -n "${GH_TOKEN:-}" ] && gosu sandbox env -u GH_TOKEN -u GITHUB_TOKEN gh aut
   fi
 fi
 
-# ─── pnpm install at harness root ──────────────────────────────────
-# Root package.json declares deps that aren't bundled into Pi or any
-# global CLI: `croner` for .oh/scripts/cron-runtime.ts, plus dev tooling such
-# as `@sinclair/typebox` (kept as a devDep for tooling parity). The Slack
-# bridge no longer needs root npm deps — it is the `pi-messenger-bridge`
-# package, npm-installed into a gitignored `.pi/bridge/` dir and loaded only
-# in the dedicated client-slack-pi session (see the Slack restore block below).
-# The harness is bind-mounted, so a Dockerfile-time install gets shadowed
-# at runtime; we install when the root dependency manifest fingerprint differs
 # from the marker stored alongside node_modules. Set SKIP_PNPM_INSTALL=1 to opt
-# out (e.g. air-gapped envs managing deps externally).
 pnpm_workspace_package_patterns() {
   local workspace="$1/pnpm-workspace.yaml"
   [ -f "$workspace" ] || return 0
@@ -523,7 +391,6 @@ pnpm_workspace_package_patterns() {
 
 pnpm_manifest_rel_is_excluded() {
   case "$1" in
-    # Defensive: legacy root .worktrees/ may exist in old checkouts; never scan it.
     .git/*|.oh/worktrees/*|.worktrees/*|node_modules/*|*/node_modules/*)
       return 0
       ;;
@@ -612,47 +479,23 @@ if [ -f "$HARNESS/package.json" ] && [ "${SKIP_PNPM_INSTALL:-0}" != "1" ]; then
   fi
 fi
 
-# ─── Resolve + pre-create the worktrees directory ─────────────────
-# Single source of truth = WORKTREES_DIR (docker-compose passes
-# paths.worktrees through here; default .oh/worktrees). Cron worktree isolation
-# and the /worktrees skill use this root so ignored branch/project clones stay
-# under the .oh control-plane namespace.
 case "${WORKTREES_DIR:-.oh/worktrees}" in
   /*) WORKTREES_PATH="${WORKTREES_DIR}" ;;
   *)  WORKTREES_PATH="$HARNESS/${WORKTREES_DIR:-.oh/worktrees}" ;;
 esac
 mkdir -p "$WORKTREES_PATH"
 
-# ─── Start/supervise cron runtime in tmux sessions ────────────────
-# Per SPEC v0.7 §"Croner runtime" + .oh/skills/t3/references/sandbox-processes.md.
-# `cron-system` runs .oh/scripts/cron-runtime.ts. `cron-watchdog` is the outer
-# supervisor: if cron-system disappears after boot, it restarts the runtime
-# without requiring a container restart. Logs tee to /tmp/cron-system.log and
-# /tmp/cron-watchdog.log.
 case "${CRONS_DIR:-.oh/crons}" in
   /*) CRONS_PATH="${CRONS_DIR}" ;;
   *)  CRONS_PATH="$HARNESS/${CRONS_DIR:-.oh/crons}" ;;
 esac
 mkdir -p "$CRONS_PATH"
-# Bind-mounted; sandbox UID is synced to host UID above, so no chown.
 if [ -f "$HARNESS/.oh/scripts/cron-runtime.ts" ] && command -v tmux &>/dev/null; then
   if gosu sandbox tmux has-session -t system-cron 2>/dev/null; then
     echo "[entrypoint] legacy system-cron tmux session detected — stopping it before starting cron-watchdog"
     gosu sandbox tmux kill-session -t system-cron 2>/dev/null || true
   fi
 
-  # This helper must be REWRITABLE on a container RESTART (`docker start`). The
-  # entrypoint runs as root; the previous version chowned this file to the
-  # sandbox user (1000:1000, mode 755). On the second boot /tmp still holds it
-  # (container writable-layer, not tmpfs), so the root entrypoint's `cat >` had
-  # to overwrite a file it no longer owned — which fails with EACCES on node
-  # runtimes that drop CAP_DAC_OVERRIDE, and the global `set -e` then promoted
-  # that one failed redirect into a fatal boot abort (container crash-loop on
-  # restart). Fix: keep the file root-owned (root can always rewrite a file it
-  # owns via the owner mode bits — no CAP_DAC_OVERRIDE needed); the sandbox only
-  # needs to READ it, since it is launched via `bash <path>`. rm any stale
-  # sandbox-owned copy left by an older image, and never let this OPTIONAL
-  # supervisor kill the sandbox boot.
   rm -f /tmp/cron-watchdog.sh 2>/dev/null || true
   if cat > /tmp/cron-watchdog.sh <<'CRON_WATCHDOG'
 #!/usr/bin/env bash
@@ -687,22 +530,6 @@ CRON_WATCHDOG
   fi
 fi
 
-# ─── Restore client-slack-pi session if Slack is configured ───────────
-# The pi-messenger-bridge Slack client (the /msg-bridge config surface) is
-# intentionally NOT pinned in .pi/settings.json — it loads ONLY in the dedicated
-# client-slack-pi session. Boot and manual `gateway pi` share ONE launch path:
-# .oh/scripts/gateway.sh, which sources PI_SLACK_* from the sandbox-owned,
-# mode-600 .env, seeds the non-secret bridge config (preserving the operator's
-# runtime trust grants, bug #289), clears the single-instance lock, npm-installs
-# the fork-pinned bridge if missing, and runs the self-healing supervisor in the
-# client-slack-pi session. Here we only gate on Slack being configured (both
-# tokens present in .env) and pi being installed, then hand off as the sandbox
-# user. The sibling hermes gateway client (client-slack-hermes) is NOT
-# auto-started — bring it up manually with `gateway hermes`.
-#
-# Expose the launcher as a bare `gateway` command. Recreated every boot
-# (idempotent) pointing at the live bind-mounted script, so edits to gateway.sh
-# take effect without an image rebuild.
 ln -sf "$HARNESS/.oh/scripts/gateway.sh" /usr/local/bin/gateway 2>/dev/null || true
 SLACK_ENV="$HARNESS/.devcontainer/.env"
 if [ -f "$SLACK_ENV" ] \
@@ -719,7 +546,6 @@ else
   echo "[entrypoint] Slack not configured (or pi missing) — skipping client-slack-pi"
 fi
 
-# ─── Optional: agent-browser (opt-in via INSTALL_AGENT_BROWSER=true) ──
 if [ "${INSTALL_AGENT_BROWSER:-false}" = "true" ] && ! command -v agent-browser &>/dev/null; then
   echo "[entrypoint] Installing agent-browser (INSTALL_AGENT_BROWSER=true)..."
   pnpm add -g agent-browser@0.8.5 \
@@ -729,7 +555,6 @@ if [ "${INSTALL_AGENT_BROWSER:-false}" = "true" ] && ! command -v agent-browser 
     || echo "[entrypoint] agent-browser install failed — skipping"
 fi
 
-# Source any harness-pack entrypoint hooks (installed by `oh harness add`)
 for hook in /usr/local/bin/*-entrypoint-hook.sh; do
   [ -x "$hook" ] && "$hook"
 done

--- a/.devcontainer/seed-msg-bridge.sh
+++ b/.devcontainer/seed-msg-bridge.sh
@@ -1,29 +1,5 @@
 #!/usr/bin/env bash
-# Seed (or reboot-merge) the pi-messenger-bridge runtime config into ~/.pi.
-#
-# The bridge reads ~/.pi/msg-bridge.json and REWRITES it at runtime: the
-# operator's challenge-auth grants land in auth.trustedUsers / auth.channels.
-# The tracked repo seed (.pi/msg-bridge.json) ships those grant containers EMPTY
-# so personal Slack user/channel IDs never enter git.
-#
-# Behavior:
-#   First boot (no runtime file): install the tracked seed verbatim.
-#   Reboot   (runtime file present): keep the tracked seed's non-grant structure
 #            (autoConnect, showWidget, …) but PRESERVE the operator's runtime
-#            grants (auth.trustedUsers, auth.channels) so a container restart
-#            never silently wipes who/what they already trusted. The previous
-#            entrypoint unconditionally copied the empty seed over the runtime
-#            file, wiping grants on every restart (bug #289).
-#
-# Safety:
-#   - Never writes back to the tracked seed (the git-tracked file is read-only
-#     input here).
-#   - On any jq failure (missing jq, malformed runtime JSON) it leaves the
-#     existing runtime file untouched — grants are preserved by default, never
-#     clobbered.
-#
-# Usage: seed-msg-bridge.sh <tracked-seed-path>
-#   (destination is always $HOME/.pi/msg-bridge.json, the package's hard-coded path)
 set -u
 
 seed="${1:-}"
@@ -33,17 +9,13 @@ umask 077
 mkdir -p "$HOME/.pi" 2>/dev/null || true
 chmod 700 "$HOME/.pi" 2>/dev/null || true
 
-# No tracked seed → nothing to install.
 [ -n "$seed" ] && [ -f "$seed" ] || exit 0
 
-# First boot: install the tracked seed verbatim.
 if [ ! -f "$dest" ]; then
   cp "$seed" "$dest" && chmod 600 "$dest"
   exit 0
 fi
 
-# Reboot: merge. Without jq we cannot safely merge → leave the runtime file as-is
-# (preserving grants) rather than risk clobbering it.
 command -v jq >/dev/null 2>&1 || exit 0
 
 merged="$(mktemp)"

--- a/.oh/cli/build.mjs
+++ b/.oh/cli/build.mjs
@@ -1,6 +1,3 @@
-// Bundle .oh/cli/src/cli.ts → dist/oh.js with package.json version inlined.
-// `__OH_VERSION__` is replaced at build time so the runtime VERSION constant
-// can never drift from what npm/git tags say the package version is.
 
 import { build } from "esbuild";
 import { readFileSync, chmodSync } from "node:fs";
@@ -25,6 +22,4 @@ await build({
   logLevel: "info",
 });
 
-// The bundle has a shebang and is the `oh` bin target — make it executable so a
-// bare `oh` on PATH keeps working after every rebuild (esbuild writes 0o644).
 chmodSync(outfile, 0o755);

--- a/.oh/cli/src/__tests__/cli.property.test.ts
+++ b/.oh/cli/src/__tests__/cli.property.test.ts
@@ -1,15 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
 import fc from "fast-check";
 
-// cli.ts has a top-level side effect: main(process.argv.slice(2)).then(process.exit).
-// vi.mock hoisting ensures this mock is applied before the module executes,
-// preventing vitest's process.exit interception from surfacing as an unhandled error.
 vi.mock("../cli.js", async (importOriginal) => {
-  // Stub process.exit before the module body runs its top-level main() call
   const original = process.exit;
   process.exit = (() => {}) as never;
   const mod = await importOriginal<typeof import("../cli.js")>();
-  // Allow a microtask tick for main().then(process.exit) to complete with the stub
   await new Promise((r) => setTimeout(r, 0));
   process.exit = original;
   return mod;

--- a/.oh/cli/src/__tests__/cli.remote.test.ts
+++ b/.oh/cli/src/__tests__/cli.remote.test.ts
@@ -12,9 +12,6 @@ import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 
-// cli.ts has a top-level side effect: main(process.argv.slice(2)).then(process.exit).
-// Same guard as cli.property.test.ts: stub process.exit around the import so the
-// module body's main() call cannot terminate the vitest worker.
 vi.mock("../cli.js", async (importOriginal) => {
   const original = process.exit;
   process.exit = (() => {}) as never;
@@ -34,9 +31,6 @@ const {
 const { DEFAULT_REPO_URL } = await import("../lib/remote.js");
 const { runInit } = await import("../commands/init.js");
 
-// ---------------------------------------------------------------------------
-// Test infrastructure
-// ---------------------------------------------------------------------------
 
 const cleanups: string[] = [];
 
@@ -52,7 +46,6 @@ afterEach(() => {
   }
 });
 
-/** Run git in a fixture repo with a hermetic identity (argv-array form). */
 function git(cwd: string, args: string[]): void {
   execFileSync(
     "git",
@@ -67,12 +60,6 @@ function writeFile(root: string, rel: string, content: string): void {
   writeFileSync(full, content);
 }
 
-/**
- * Local git fixture shaped like an OpenHarness checkout: an `.oh/` payload
- * (cli/package.json carrying `version`, a README) plus `.oh/templates/` so a
- * remote-sourced runInit can use BOTH paths. file:// is the only transport —
- * no network I/O.
- */
 function makePayloadRepo(version = "9.9.9"): string {
   const repo = mkTmp("oh-cli-remote-fixture-");
   git(repo, ["-c", "init.defaultBranch=main", "init"]);
@@ -86,9 +73,6 @@ function makePayloadRepo(version = "9.9.9"): string {
 
 const BUNDLED = { sourceOhDir: "/bundled/.oh", templatesDir: "/bundled/.oh/templates" };
 
-// ---------------------------------------------------------------------------
-// parseInitArgs
-// ---------------------------------------------------------------------------
 
 describe("parseInitArgs", () => {
   it("parses --from-remote and --ref alongside the existing flags", () => {
@@ -160,9 +144,6 @@ describe("parseInitArgs", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// parseUpdateArgs
-// ---------------------------------------------------------------------------
 
 describe("parseUpdateArgs", () => {
   it("parses --from-remote [--ref] and keeps --from/--dry-run/--force behavior", () => {
@@ -206,7 +187,6 @@ describe("parseUpdateArgs", () => {
     if (!r.ok) {
       expect(r.error).toContain("--from <dir>");
       expect(r.error).toContain("--from-remote");
-      // Not a usage mistake → main must not dump the help text (parity with the old behavior).
       expect(r.showHelp).toBeUndefined();
     }
   });
@@ -225,9 +205,6 @@ describe("parseUpdateArgs", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// resolveInitSource — the bundled-payload seam + both-paths asymmetry
-// ---------------------------------------------------------------------------
 
 describe("resolveInitSource", () => {
   it("asymmetry: --from-remote sets BOTH paths from the checkout; --from sets only sourceOhDir", () => {
@@ -249,7 +226,6 @@ describe("resolveInitSource", () => {
     expect(local.kind).toBe("local");
     if (local.kind === "local") {
       expect(local.sourceOhDir).toBe(resolve(join("/somewhere/checkout", ".oh")));
-      // Templates stay at the bundled default — --from sets ONE path.
       expect(local.templatesDir).toBe(BUNDLED.templatesDir);
     }
   });
@@ -304,21 +280,16 @@ describe("bundledPayloadExists", () => {
       return true;
     };
     expect(bundledPayloadExists(BUNDLED, allThere)).toBe(true);
-    // The decision keys off the manifest marker, not the directory itself.
     expect(probed).toContain(join(BUNDLED.sourceOhDir, "manifest.json"));
     expect(probed).toContain(BUNDLED.templatesDir);
 
     expect(bundledPayloadExists(BUNDLED, () => false)).toBe(false);
-    // Parent dir exists (e.g. /usr for an installed binary) but no manifest → absent.
     expect(
       bundledPayloadExists(BUNDLED, (p) => !p.endsWith("manifest.json")),
     ).toBe(false);
   });
 });
 
-// ---------------------------------------------------------------------------
-// runWithRemoteSource — fetch → downstream run → guaranteed cleanup
-// ---------------------------------------------------------------------------
 
 describe("runWithRemoteSource", () => {
   it("happy path: a file:// fixture flows through a FULL runInit and prints the version-skew line", async () => {
@@ -332,7 +303,6 @@ describe("runWithRemoteSource", () => {
       { repoUrl, stdout: (s) => cliOut.push(s) },
       (checkoutDir) => {
         seenCheckout = checkoutDir;
-        // The exact both-paths wiring main() applies for --from-remote.
         return runInit(
           {
             targetDir: target,
@@ -347,15 +317,11 @@ describe("runWithRemoteSource", () => {
     );
 
     expect(code).toBe(0);
-    // Scaffolded from the FETCHED templates…
     expect(readFileSync(join(target, "AGENTS.md"), "utf8")).toBe(
       "remote-templates-payload\n",
     );
-    // …and vendored through the existing copyOhPayload path.
     expect(readFileSync(join(target, ".oh/README.md"), "utf8")).toBe("# payload\n");
-    // Version-skew line names the FETCHED payload version and the installed CLI's.
     expect(cliOut.join("")).toContain("fetched payload v9.9.9 (installed CLI v");
-    // Temp checkout removed after a successful run.
     expect(seenCheckout).not.toBe("");
     expect(existsSync(seenCheckout)).toBe(false);
   });
@@ -366,7 +332,6 @@ describe("runWithRemoteSource", () => {
     await expect(
       runWithRemoteSource({ repoUrl, stdout: () => {} }, (dir) => {
         checkout = dir;
-        // Prove the fetch really succeeded before the downstream failure.
         expect(existsSync(join(dir, ".oh", "README.md"))).toBe(true);
         throw new Error("downstream write exploded");
       }),

--- a/.oh/cli/src/__tests__/compose-verbs.test.ts
+++ b/.oh/cli/src/__tests__/compose-verbs.test.ts
@@ -10,7 +10,6 @@ import {
 } from "../commands/lifecycle.js";
 import type { LifecycleRunner, RunResult } from "../lib/execution/runner.js";
 
-// cli.ts has a top-level side effect: main(process.argv.slice(2)).then(process.exit).
 vi.mock("../cli.js", async (importOriginal) => {
   const original = process.exit;
   process.exit = (() => {}) as never;
@@ -31,7 +30,6 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-/** An equipped-repo fixture with the vendored compose script present. */
 function makeRepo(): string {
   const d = mkdtempSync(join(tmpdir(), "oh-compose-verb-"));
   cleanups.push(d);
@@ -59,14 +57,10 @@ function makeRunner(result: RunResult = { status: 0 }): {
 
 describe("compose verbs — the surface gap they close", () => {
   it("exposes exactly the four non-destructive verbs", () => {
-    // `destroy` and a `config` equivalent are deliberately absent — see
-    // .oh/docs/lifecycle-commands.md and the probe that keeps them documented.
     expect(composeVerbs()).toEqual(["stop", "restart", "logs", "ps"]);
   });
 
   it("does not expose destroy", () => {
-    // `down -v` wipes the volumes holding provider auth. It needs a
-    // confirmation policy, not a passthrough.
     expect(composeVerbs()).not.toContain("destroy" as ComposeVerb);
   });
 });
@@ -145,10 +139,6 @@ describe("help", () => {
   });
 });
 
-/**
- * The consolidation's real invariant: the two front doors must keep agreeing.
- * These read the repo's own Makefile, not a fixture.
- */
 describe("parity with the Makefile", () => {
   const MAKEFILE = read("Makefile");
 
@@ -159,15 +149,11 @@ describe("parity with the Makefile", () => {
   });
 
   it("keeps the Makefile free of direct `docker compose` calls", () => {
-    // Both doors run .oh/scripts/docker-compose.sh; a raw call in a recipe
-    // would fork overlay resolution and project naming.
     const recipes = MAKEFILE.split("\n").filter((l) => l.startsWith("\t"));
     for (const line of recipes) expect(line).not.toContain("docker compose");
   });
 
   it("leaves the pinned `make shell` line verbatim", () => {
-    // execution-target-contract.sh C5 asserts this too. Restated here so that
-    // changing it fails from both sides.
     expect(MAKEFILE).toContain("docker exec -it -u $(SHELL_USER) $(SHELL_CONTAINER) zsh");
   });
 

--- a/.oh/cli/src/__tests__/env-file.test.ts
+++ b/.oh/cli/src/__tests__/env-file.test.ts
@@ -16,20 +16,7 @@ import {
   setKeyInEnv,
 } from "../lib/env-file.js";
 
-/**
- * Tests for the `.devcontainer/.env` reader/writer — the module that replaced
- * `lib/harness-yaml.ts` when harness.yaml was removed in 0.4.0.
- *
- * mkdtemp fixtures only — NEVER the real worktree root, whose `.example.env`
- * would fire the seed and whose `.env` the writer would edit for real.
- *
- * The round-trip test is the ONLY place a real subprocess is acceptable: it runs
- * the vendored `.oh/scripts/migrate-harness-yaml.sh` (which carries its own
- * writer) against a temp fixture, proving the TS writer and the shell writer
- * agree on the grammar. It spawns no docker.
- */
 
-// src/__tests__ -> src -> .oh/cli -> .oh -> repo root
 const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "..", "..");
 const REAL_EXAMPLE = join(REPO_ROOT, ".devcontainer", ".example.env");
 const REAL_MIGRATOR = join(REPO_ROOT, ".oh", "scripts", "migrate-harness-yaml.sh");
@@ -39,7 +26,6 @@ afterEach(() => {
   while (cleanups.length > 0) rmSync(cleanups.pop()!, { recursive: true, force: true });
 });
 
-/** A repo fixture carrying the REAL tracked template. */
 function makeRepo(withEnv = true): string {
   const d = mkdtempSync(join(tmpdir(), "oh-env-file-"));
   cleanups.push(d);
@@ -51,9 +37,6 @@ function makeRepo(withEnv = true): string {
 
 const readEnv = (root: string): string => readFileSync(envFilePath(root), "utf8");
 
-// ---------------------------------------------------------------------------
-// setKeyInEnv — the pure line editor
-// ---------------------------------------------------------------------------
 
 describe("setKeyInEnv", () => {
   it("uncomments a template line IN PLACE, keeping the line count and the prose", () => {
@@ -69,7 +52,6 @@ describe("setKeyInEnv", () => {
     expect(outcome).toBe("uncommented");
     expect(content.split("\n")).toHaveLength(before.split("\n").length);
     expect(content.split("\n")[1]).toBe("SANDBOX_NAME=mine");
-    // The surrounding lines are untouched — the diff is exactly one line.
     expect(content.split("\n")[0]).toBe("# ─── Sandbox identity ───");
     expect(content.split("\n")[2]).toBe("# TZ=America/Los_Angeles");
   });
@@ -117,9 +99,6 @@ describe("setKeyInEnv", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// readEnvValue
-// ---------------------------------------------------------------------------
 
 describe("readEnvValue", () => {
   it("reads a live key and treats a commented one as unset", () => {
@@ -149,9 +128,6 @@ describe("readEnvValue", () => {
   });
 
   it("is anchored to the ROOT, never the process CWD", () => {
-    // The bug this pins: a CWD-relative lookup makes every value look unset
-    // from a nested directory, which is how `oh shell` silently fell back to
-    // the default container name when run from a subdirectory.
     const root = makeRepo(false);
     writeFileSync(envFilePath(root), "SANDBOX_NAME=anchored\n");
     const nested = join(root, "pkg", "web");
@@ -166,9 +142,6 @@ describe("readEnvValue", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// seedEnvFile / setEnvValue / setInstallFlag
-// ---------------------------------------------------------------------------
 
 describe("seedEnvFile", () => {
   it("copies the template when .env is missing, and reports that it wrote", () => {
@@ -222,7 +195,6 @@ describe("setInstallFlag", () => {
   it("seeds the file first when .env does not exist yet", () => {
     const root = makeRepo(false);
     expect(setInstallFlag(root, "hermes")).toBe("uncommented");
-    // Seeded from the template, so the prose came along with the key.
     expect(readEnv(root)).toContain("Open Harness");
     expect(readEnv(root)).toMatch(/^INSTALL_HERMES=true$/m);
   });
@@ -240,16 +212,9 @@ describe("assertInRoot", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// Round trip against the shell writer
-// ---------------------------------------------------------------------------
 
 describe("round trip with the vendored shell writer", () => {
   it("the migrator's awk writer and setEnvValue produce the same file", () => {
-    // TWO writers exist by design: this TS one for the CLI, and the awk one
-    // inside migrate-harness-yaml.sh (self-contained so the whole harness.yaml
-    // compatibility story is one deletable file). They MUST agree on
-    // uncomment-in-place, or a migrated install and a CLI-configured one drift.
     const viaTs = makeRepo();
     setEnvValue(viaTs, "SANDBOX_NAME", "roundtrip");
     setEnvValue(viaTs, "TZ", "America/Denver");

--- a/.oh/cli/src/__tests__/execution-target.test.ts
+++ b/.oh/cli/src/__tests__/execution-target.test.ts
@@ -10,16 +10,6 @@ import {
   type RunResult,
 } from "../lib/execution/index.js";
 
-/**
- * Unit tests for the `ExecutionTarget` contract's first implementation
- * (EPIC #731, issue #733).
- *
- * Every case runs against an INJECTED fake runner over an mkdtemp fixture — no
- * real subprocess is ever spawned, so the suite asserts the exact argv the
- * adapter WOULD run rather than what a live engine happens to do. The
- * behavioural compat oracle for the CLI verbs themselves lives in
- * `lifecycle.test.ts`, whose assertions are unchanged by this slice.
- */
 
 const cleanups: string[] = [];
 
@@ -29,7 +19,6 @@ afterEach(() => {
   }
 });
 
-/** An equipped-repo fixture: a root containing `.oh/scripts/`. */
 function makeRepo(): string {
   const d = mkdtempSync(join(tmpdir(), "oh-exec-target-"));
   cleanups.push(d);
@@ -37,7 +26,6 @@ function makeRepo(): string {
   return d;
 }
 
-/** Drop a stub script in place so `requireLifecycleScript` is satisfied. */
 function addScript(root: string, name: string): string {
   const p = join(root, ".oh", "scripts", name);
   writeFileSync(p, "#!/usr/bin/env bash\n");
@@ -50,7 +38,6 @@ interface RecordedCall {
   opts: { stdio: "inherit" | "capture"; env?: NodeJS.ProcessEnv; timeoutMs?: number };
 }
 
-/** Queue-backed fake runner: returns results[i] for call i (last one repeats). */
 function makeRunner(results: RunResult[] = [{ status: 0 }]): {
   calls: RecordedCall[];
   run: LifecycleRunner;
@@ -63,10 +50,6 @@ function makeRunner(results: RunResult[] = [{ status: 0 }]): {
   return { calls, run };
 }
 
-/**
- * A `--print-argv` dump, one argv entry per line — the script's own
- * non-executing oracle, which is how the adapter discovers the socket overlay.
- */
 function printArgvDump(root: string, opts: { socket: boolean }): string {
   const dc = join(root, ".devcontainer");
   const lines = ["docker", "compose", "-f", join(dc, "docker-compose.yml")];
@@ -75,9 +58,6 @@ function printArgvDump(root: string, opts: { socket: boolean }): string {
   return `${lines.join("\n")}\n`;
 }
 
-// ---------------------------------------------------------------------------
-// provision()
-// ---------------------------------------------------------------------------
 
 describe("DockerComposeExecutionTarget.provision", () => {
   it("delegates the EXACT vendored argv with inherited stdio, in exactly one child", async () => {
@@ -123,9 +103,6 @@ describe("DockerComposeExecutionTarget.provision", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// attach() — synchronous in contractVersion 1 (target.ts refinement 3)
-// ---------------------------------------------------------------------------
 
 describe("DockerComposeExecutionTarget.attach", () => {
   it("hands over the terminal with the EXACT argv, synchronously", () => {
@@ -135,9 +112,6 @@ describe("DockerComposeExecutionTarget.attach", () => {
 
     const code = target.attach({ argv: ["zsh"], user: "sandbox" });
 
-    // Synchronous by contract: a raw number, never a thenable. This is what
-    // keeps `runShell(): number` — and therefore lifecycle.test.ts's
-    // `expect(runShell(...)).toBe(0)` — valid.
     expect(typeof code).toBe("number");
     expect(code).toBe(0);
     expect(calls).toEqual([
@@ -174,9 +148,6 @@ describe("DockerComposeExecutionTarget.attach", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// capabilities() — discovered, not assumed, in BOTH socket states
-// ---------------------------------------------------------------------------
 
 describe("DockerComposeExecutionTarget.capabilities", () => {
   it('includes "docker" when the socket overlay is ON, and asks the script rather than reimplementing truthy()', async () => {
@@ -223,9 +194,6 @@ describe("DockerComposeExecutionTarget.capabilities", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// exec() — the minimal contract case: argv pass-through + REAL stderr
-// ---------------------------------------------------------------------------
 
 describe("DockerComposeExecutionTarget.exec", () => {
   it("resolves { exitCode, stdout, stderr } from the runner — stderr is plumbed, not stubbed", async () => {
@@ -276,15 +244,10 @@ describe("DockerComposeExecutionTarget.exec", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// stdio: "inherit" — the streaming path, not only "capture"
-// ---------------------------------------------------------------------------
 
 describe("stdio: inherit streaming", () => {
   it('exec({ stdio: "inherit" }) streams to the terminal and captures nothing', async () => {
     const root = makeRepo();
-    // A runner that "leaks" streams even on an inherit run: the adapter must
-    // still report "" for both, because inherited output went to the terminal.
     const { calls, run } = makeRunner([{ status: 0, stdout: undefined, stderr: undefined }]);
     const target = resolveExecutionTarget({ projectRoot: root, container: "my-box", run });
 
@@ -301,17 +264,12 @@ describe("stdio: inherit streaming", () => {
     const target = resolveExecutionTarget({ projectRoot: root, container: "my-box", run });
 
     await target.provision();
-    // `request.stdio` is deliberately NOT consulted by attach(): attaching IS
-    // inheriting, so an explicit "capture" cannot silently swallow the session.
     target.attach({ argv: ["zsh"], user: "sandbox", stdio: "capture" });
 
     expect(calls.map((c) => c.opts.stdio)).toEqual(["inherit", "inherit"]);
   });
 });
 
-// ---------------------------------------------------------------------------
-// status() — engine state mapped onto the contract's five states
-// ---------------------------------------------------------------------------
 
 describe("DockerComposeExecutionTarget.status", () => {
   it.each([

--- a/.oh/cli/src/__tests__/harness-catalog.test.ts
+++ b/.oh/cli/src/__tests__/harness-catalog.test.ts
@@ -9,19 +9,7 @@ import {
   HARNESS_CATALOG,
 } from "../lib/harnesses/catalog.js";
 
-/**
- * The DRIFT TEST for the harness catalog.
- *
- * `.devcontainer/Dockerfile` is the ground truth for how a harness is installed.
- * The catalog restates that so the CLI can install one WITHOUT a rebuild — which
- * means the two can silently diverge, and a divergence is invisible in review
- * (nobody diffs a TS table against a Dockerfile by eye). These assertions make
- * the divergence a failing command instead.
- *
- * Reads real repo files, spawns nothing.
- */
 
-// src/__tests__ -> src -> .oh/cli -> .oh -> repo root
 const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "..", "..");
 const read = (rel: string): string => readFileSync(join(REPO_ROOT, rel), "utf8");
 
@@ -29,7 +17,6 @@ const DOCKERFILE = read(".devcontainer/Dockerfile");
 const COMPOSE_YML = read(".devcontainer/docker-compose.yml");
 const EXAMPLE_ENV = read(".devcontainer/.example.env");
 
-/** Version-like tokens in an argv, e.g. the `0.2.39` grok-build pin. */
 function versionPins(argv: readonly string[]): string[] {
   const pins = new Set<string>();
   for (const part of argv) {
@@ -63,7 +50,6 @@ describe("harness catalog", () => {
 
   it("excludes agent_browser — it shares the INSTALL_* namespace but is not a harness", () => {
     expect(HARNESS_CATALOG.some((h) => h.harnessKey === "agent_browser")).toBe(false);
-    // Guard the premise: the key really is in the INSTALL_* namespace.
     expect(EXAMPLE_ENV).toMatch(/INSTALL_AGENT_BROWSER=/);
   });
 
@@ -96,13 +82,7 @@ describe("harness catalog", () => {
     it.each(flagged.map((h) => [h.id, h] as const))(
       "%s: the INSTALL_* key derived from harnessKey IS the build arg, and compose forwards it",
       (_id, h) => {
-        // Since harness.yaml was removed there is no envmap translating
-        // `install.<key>` into an env var: the key IS `INSTALL_<KEY>`, derived
-        // mechanically by installEnvKey(). Pin that derivation against the
-        // catalog's own buildArg so a rename of either half cannot drift past
-        // the other unnoticed.
         expect(`INSTALL_${(h.harnessKey as string).toUpperCase()}`).toBe(h.buildArg);
-        // ...and compose must actually forward it into the image build.
         expect(COMPOSE_YML).toContain(`${h.buildArg}: \${${h.buildArg}:-false}`);
       },
     );
@@ -124,16 +104,12 @@ describe("harness catalog", () => {
     );
 
     it("grok-build keeps the Dockerfile's exact pin", () => {
-      // The one hard-pinned installer — assert the pin explicitly so bumping it
-      // in the Dockerfile alone fails here rather than installing a stale CLI.
       const grok = findHarness("grok-build");
       expect(versionPins(grok!.installArgv)).toEqual(["0.2.39"]);
       expect(DOCKERFILE).toContain("bash -s 0.2.39");
     });
 
     it("installs deepagents and pi as the sandbox user, not root", () => {
-      // UV_TOOL_DIR/UV_TOOL_BIN_DIR live under /home/sandbox, and pi installs
-      // under the sandbox user's npm prefix so `pi update` needs no sudo.
       expect(findHarness("deepagents")!.installUser).toBe("sandbox");
       expect(findHarness("pi")!.installUser).toBe("sandbox");
       expect(DOCKERFILE).toContain("UV_TOOL_DIR=/home/sandbox");
@@ -144,8 +120,6 @@ describe("harness catalog", () => {
     for (const h of HARNESS_CATALOG) {
       if (h.installArgv[0] !== "bash") continue;
       expect(h.installArgv[1]).toBe("-lc");
-      // A shell string is only acceptable when it is a fixed literal. Nothing
-      // derived from user input may appear in it.
       expect(h.installArgv[2]).not.toContain("${");
       expect(h.installArgv).toHaveLength(3);
     }
@@ -153,7 +127,6 @@ describe("harness catalog", () => {
 
   it("findHarness resolves known ids and rejects unknown ones", () => {
     expect(findHarness("opencode")?.harnessKey).toBe("opencode");
-    // The slug/key mismatch that makes hand-editing .devcontainer/.env error-prone.
     expect(findHarness("grok-build")?.harnessKey).toBe("grok_build");
     expect(findHarness("nope")).toBeUndefined();
   });

--- a/.oh/cli/src/__tests__/harness.test.ts
+++ b/.oh/cli/src/__tests__/harness.test.ts
@@ -12,9 +12,6 @@ import {
 import type { LifecycleRunner, RunResult } from "../lib/execution/runner.js";
 import { HARNESS_CATALOG } from "../lib/harnesses/catalog.js";
 
-// cli.ts has a top-level side effect: main(process.argv.slice(2)).then(process.exit).
-// Same guard as lifecycle.test.ts: stub process.exit around the import so the
-// module body's main() call cannot terminate the vitest worker.
 vi.mock("../cli.js", async (importOriginal) => {
   const original = process.exit;
   process.exit = (() => {}) as never;
@@ -26,7 +23,6 @@ vi.mock("../cli.js", async (importOriginal) => {
 
 const { parseHarnessArgs, printHarnessHelp, printOhHelp } = await import("../cli.js");
 
-// src/__tests__ -> src -> .oh/cli -> .oh -> repo root
 const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "..", "..");
 const REAL_EXAMPLE = join(REPO_ROOT, ".devcontainer", ".example.env");
 
@@ -36,10 +32,6 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-/**
- * An equipped-repo fixture. mkdtemp only — NEVER the real worktree root, whose
- * .devcontainer/.env the installer would edit for real.
- */
 function makeRepo(): string {
   const d = mkdtempSync(join(tmpdir(), "oh-harness-cmd-"));
   cleanups.push(d);
@@ -55,11 +47,6 @@ interface RecordedCall {
   args: string[];
 }
 
-/**
- * Fake runner driven by a per-argv matcher, so a test states only the calls it
- * cares about. Every call is recorded; the default is exit 0 with empty stdout.
- * No real docker, bash, or sh ever runs here.
- */
 function makeRunner(
   reply: (cmd: string, args: string[]) => RunResult | undefined = () => undefined,
 ): { calls: RecordedCall[]; run: LifecycleRunner } {
@@ -71,19 +58,15 @@ function makeRunner(
   return { calls, run };
 }
 
-/** `docker inspect -f {{.State.Status}}` — the call `status()` makes. */
 function isInspect(cmd: string, args: string[]): boolean {
   return cmd === "docker" && args[0] === "inspect";
 }
 
-/** A `docker exec` whose in-container argv contains `token`. */
 function isExecOf(cmd: string, args: string[], token: string): boolean {
   return cmd === "docker" && args[0] === "exec" && args.includes(token);
 }
 
-/** Report the container as running. */
 const running: RunResult = { status: 0, stdout: "running\n", stderr: "" };
-/** Report the container as stopped. */
 const exited: RunResult = { status: 0, stdout: "exited\n", stderr: "" };
 
 function makeIo(): { out: string[]; err: string[]; io: HarnessIO } {
@@ -95,13 +78,9 @@ function makeIo(): { out: string[]; err: string[]; io: HarnessIO } {
 const text = (lines: string[]): string => lines.join("");
 const readEnv = (root: string): string =>
   readFileSync(join(root, ".devcontainer", ".env"), "utf8");
-/** Every `docker exec` in the recorded calls — the "did it touch the container" oracle. */
 const execCalls = (calls: RecordedCall[]): RecordedCall[] =>
   calls.filter((c) => c.cmd === "docker" && c.args[0] === "exec");
 
-// ---------------------------------------------------------------------------
-// parseHarnessArgs
-// ---------------------------------------------------------------------------
 
 describe("parseHarnessArgs", () => {
   it("treats a bare `oh harness` and a help flag as help", () => {
@@ -149,11 +128,7 @@ describe("parseHarnessArgs", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// help
-// ---------------------------------------------------------------------------
 
-/** Capture a help printer's output without letting it hit the real terminal. */
 function captureStdout(fn: () => void): string {
   const spy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
   fn();
@@ -185,9 +160,6 @@ describe("help", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// install — the persist half
-// ---------------------------------------------------------------------------
 
 describe("runHarnessInstall persists the flag", () => {
   it("sets INSTALL_OPENCODE and says so", async () => {
@@ -249,9 +221,6 @@ describe("runHarnessInstall persists the flag", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// install — the live half
-// ---------------------------------------------------------------------------
 
 describe("runHarnessInstall against the container", () => {
   it("on a stopped sandbox: exits 0, sets the flag, hints, and runs zero docker exec", async () => {
@@ -281,7 +250,6 @@ describe("runHarnessInstall against the container", () => {
     const root = makeRepo();
     const { calls, run } = makeRunner((c, a) => {
       if (isInspect(c, a)) return running;
-      // The verify probe must FAIL, or nothing would be installed.
       if (isExecOf(c, a, "--version")) return { status: 1, stdout: "", stderr: "not found" };
       return undefined;
     });
@@ -316,10 +284,8 @@ describe("runHarnessInstall against the container", () => {
     const { out, io } = makeIo();
 
     expect(await runHarnessInstall("opencode", { cwd: root, run }, io)).toBe(0);
-    // The verify probe ran; the installer did not.
     expect(execCalls(calls).some((c) => c.args.includes("opencode-ai"))).toBe(false);
     expect(text(out)).toContain("already installed");
-    // The durable half still landed.
     expect(readEnv(root)).toMatch(/^INSTALL_OPENCODE=true$/m);
   });
 
@@ -376,9 +342,6 @@ describe("runHarnessInstall against the container", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// list / status
-// ---------------------------------------------------------------------------
 
 describe("runHarnessList", () => {
   it("renders one row per catalog entry with the state columns", async () => {
@@ -401,7 +364,6 @@ describe("runHarnessList", () => {
 
     await runHarnessList({ cwd: root, run }, io);
     expect(text(out)).toContain("not running");
-    // "Unknown" must not cost a single probe.
     expect(execCalls(calls)).toEqual([]);
   });
 
@@ -410,9 +372,6 @@ describe("runHarnessList", () => {
     writeFileSync(join(root, ".devcontainer", ".env"), "INSTALL_HERMES=true\n");
     const { run } = makeRunner((c, a) => {
       if (isInspect(c, a)) return exited;
-      // The flag read goes through the vendored parser; the fake stands in for
-      // it here so this test stays a pure unit (env-file.test.ts drives the
-      // real script).
       if (c === "sh" && a.includes("INSTALL_HERMES")) {
         return { status: 0, stdout: "true\n", stderr: "" };
       }
@@ -422,11 +381,8 @@ describe("runHarnessList", () => {
 
     await runHarnessList({ cwd: root, run, json: true }, io);
     const parsed = JSON.parse(text(out));
-    // Every catalog entry is listed. Keyed off the catalog rather than a literal
-    // so adding a harness does not require editing an unrelated assertion.
     expect(parsed).toHaveLength(HARNESS_CATALOG.length);
     expect(parsed.find((h: { id: string }) => h.id === "hermes").enabled).toBe(true);
-    // A harness with no flag reports null, not false — the two differ.
     expect(parsed.find((h: { id: string }) => h.id === "codex").enabled).toBeNull();
   });
 

--- a/.oh/cli/src/__tests__/init.test.ts
+++ b/.oh/cli/src/__tests__/init.test.ts
@@ -18,7 +18,6 @@ import { fileURLToPath } from "node:url";
 
 import { runInit, type InitOptions, type InitIO } from "../commands/init.js";
 
-/** Sorted POSIX relpaths of every file under `<root>/.oh/`. */
 function listOh(root: string): string[] {
   const ohRoot = join(root, ".oh");
   const acc: string[] = [];
@@ -33,14 +32,11 @@ function listOh(root: string): string[] {
   return acc.sort();
 }
 
-// THREE levels up from src/__tests__/ to reach .oh/, then into templates.
-// (Two levels would wrongly resolve .oh/cli/templates.)
 const TEMPLATES = resolve(
   dirname(fileURLToPath(import.meta.url)),
   "../../../templates",
 );
 
-// The repo's own `.oh/` — the vendor source. THREE levels up from src/__tests__/.
 const SOURCE_OH = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
 
 function makeIO(): { io: InitIO; out: string[]; err: string[] } {
@@ -84,7 +80,6 @@ describe("runInit", () => {
     expect(existsSync(join(t, ".devcontainer/.example.env"))).toBe(true);
     expect(existsSync(join(t, "AGENTS.md"))).toBe(true);
     expect(existsSync(join(t, ".gitignore"))).toBe(true);
-    // The top-level README.md must NOT be copied.
     expect(existsSync(join(t, "README.md"))).toBe(false);
     expect(out.some((l) => l.includes("create .devcontainer/.example.env"))).toBe(true);
   });
@@ -101,7 +96,6 @@ describe("runInit", () => {
     const code = await runInit(opts(t), second.io);
 
     expect(code).toBe(0);
-    // Every per-file action is a skip (gitignore reports its own skip phrasing).
     for (const line of second.out) {
       const trimmed = line.trim();
       expect(trimmed.startsWith("skip ")).toBe(true);
@@ -171,14 +165,12 @@ describe("runInit", () => {
     expect(afterSecond).toBe(afterFirst);
     expect(afterSecond.endsWith("\n")).toBe(true);
 
-    // No duplicate non-empty lines.
     const lines = afterSecond.split("\n").filter((l) => l.trim() !== "");
     expect(new Set(lines).size).toBe(lines.length);
   });
 
   it("partial-existing .gitignore: appends only the missing entries", async () => {
     const t = freshTmp();
-    // Pre-seed with one of the template's entries.
     writeFileSync(join(t, ".gitignore"), ".devcontainer/.env\n");
 
     const templateLines = readFileSync(join(TEMPLATES, "gitignore"), "utf8")
@@ -198,7 +190,6 @@ describe("runInit", () => {
 
     const result = readFileSync(join(t, ".gitignore"), "utf8");
     const resultLines = result.split("\n").filter((l) => l.trim() !== "");
-    // All template entries present, exactly once each, no dupes.
     expect(new Set(resultLines).size).toBe(resultLines.length);
     for (const l of templateLines) {
       expect(resultLines).toContain(l.trimEnd());
@@ -217,7 +208,6 @@ describe("runInit", () => {
     );
 
     expect(code).toBe(0);
-    // Template scaffold writes nothing (only README.md, which is skipped).
     expect(existsSync(join(t, ".gitignore"))).toBe(false);
     expect(existsSync(join(t, "README.md"))).toBe(false);
     expect(statSync(t).isDirectory()).toBe(true);
@@ -233,7 +223,6 @@ describe("runInit", () => {
 
     expect(code).toBe(1);
     expect(err.join("")).not.toBe("");
-    // No scaffolding occurred next to the file.
     expect(existsSync(join(parent, ".gitignore"))).toBe(false);
   });
 
@@ -264,7 +253,6 @@ describe("runInit", () => {
     expect(parsed.workspaceFolder).toBe("/home/sandbox/harness");
   });
 
-  // --- US-001 vendor ---------------------------------------------------------
 
   it("vendor: init --yes populates .oh/ with manifest-shipped files, excludes volatile", async () => {
     const t = freshTmp();
@@ -277,10 +265,8 @@ describe("runInit", () => {
     expect(existsSync(join(t, ".oh/cli/package.json"))).toBe(true);
     expect(existsSync(join(t, ".oh/cli/src/cli.ts"))).toBe(true);
     expect(existsSync(join(t, ".oh/templates/.devcontainer/.example.env"))).toBe(true);
-    // Volatile build artifacts are never shipped.
     expect(existsSync(join(t, ".oh/cli/node_modules"))).toBe(false);
     expect(existsSync(join(t, ".oh/cli/dist"))).toBe(false);
-    // The devcontainer lives at .devcontainer/, never vendored under .oh/.
     expect(existsSync(join(t, ".oh/devcontainer"))).toBe(false);
   });
 
@@ -364,7 +350,6 @@ describe("runInit", () => {
     const msg = err.join("");
     expect(msg).toContain(resolve(bogus));
     expect(msg).toContain("--from-remote");
-    // Nothing vendored on the precondition failure.
     expect(existsSync(join(t, ".oh"))).toBe(false);
   });
 
@@ -395,7 +380,6 @@ describe("runInit", () => {
     expect(listOh(t)).toEqual(ohBefore);
   });
 
-  // --- US-002 wizard ---------------------------------------------------------
 
   it("wizard: every answer lands in ONE .devcontainer/.env write; untouched lines byte-identical", async () => {
     const t = freshTmp();
@@ -405,7 +389,7 @@ describe("runInit", () => {
       if (q.includes("Git user name")) return "Ada Lovelace";
       if (q.includes("Git user email")) return "ada@example.com";
       if (q.includes("agent_browser")) return "y";
-      return ""; // decline other installs / accept blank text defaults
+      return "";
     };
     const askSecret = async (q: string): Promise<string> =>
       q.includes("GH_TOKEN") ? "ghp_supersecrettoken12345" : "";
@@ -418,29 +402,21 @@ describe("runInit", () => {
       askSecret,
     };
 
-    // yes:false + injected reader → wizard runs even without a TTY.
     const code = await runInit(opts(t, { yes: false }), io);
     expect(code).toBe(0);
 
     const env = readFileSync(join(t, ".devcontainer/.env"), "utf8");
-    // Set keys are uncommented AND given the answer value.
     expect(env).toMatch(/^SANDBOX_NAME=my-cool-sandbox$/m);
     expect(env).toMatch(/^TZ=America\/New_York$/m);
     expect(env).toMatch(/^GIT_USER_NAME=Ada Lovelace$/m);
     expect(env).toMatch(/^GIT_USER_EMAIL=ada@example.com$/m);
     expect(env).toMatch(/^INSTALL_AGENT_BROWSER=true$/m);
-    // A declined install stays commented (the compose default applies).
     expect(env).toMatch(/^#\s*INSTALL_HERMES=false/m);
-    // The secret lands in the SAME file — there is no second surface any more.
     expect(env).toContain("GH_TOKEN=ghp_supersecrettoken12345");
 
-    // ONE write, reported once: the operation log names .env exactly once for
-    // the whole wizard, not once per key and not once per surface.
     const envWrites = out.filter((l) => l.includes("update .devcontainer/.env"));
     expect(envWrites).toHaveLength(1);
 
-    // Every line whose key the user did NOT set is byte-identical to the
-    // template — the uncomment-in-place discipline, measured.
     const tmpl = readFileSync(
       join(TEMPLATES, ".devcontainer", ".example.env"),
       "utf8",
@@ -479,21 +455,17 @@ describe("runInit", () => {
 
     expect(code).toBe(0);
     expect(asked).toBe(0);
-    // Template defaults left commented (nothing uncommented), and with no
-    // answers to record there is no .env at all.
     const example = readFileSync(join(t, ".devcontainer/.example.env"), "utf8");
     expect(example).toMatch(/^#\s*SANDBOX_NAME=/m);
     expect(existsSync(join(t, ".devcontainer/.env"))).toBe(false);
   });
 
-  // --- Full scaffold (P2: vendor content + empty seeds + full devcontainer) ---
 
   it("full (default): vendors context/crons/evals as content", async () => {
     const t = freshTmp();
     expect(await runInit(opts(t, { yes: true }), makeIO().io)).toBe(0);
     expect(existsSync(join(t, ".oh/context/REPO_MAP.md"))).toBe(true);
     expect(existsSync(join(t, ".oh/crons/heartbeat.md"))).toBe(true);
-    // evals/ ships its probe suite as content.
     expect(readdirSync(join(t, ".oh/evals")).length).toBeGreaterThan(0);
   });
 
@@ -501,7 +473,6 @@ describe("runInit", () => {
     const t = freshTmp();
     expect(await runInit(opts(t, { yes: true }), makeIO().io)).toBe(0);
     expect(readdirSync(join(t, ".oh/tasks"))).toEqual(["README.md"]);
-    // This harness's own PRDs are never shipped.
     expect(existsSync(join(t, ".oh/memory"))).toBe(false);
   });
 
@@ -518,31 +489,23 @@ describe("runInit", () => {
     expect(dc.dockerComposeFile).toBe("docker-compose.yml");
     expect(dc.service).toBe("sandbox");
     expect(dc.workspaceFolder).toBe("/home/sandbox/harness");
-    // The ghcr image is present ONLY as a documented fallback key, never active.
     expect(dc.image).toBeUndefined();
     expect(dc["// image"]).toContain("ghcr.io/mifunedev/openharness");
 
-    // The relocated compose build context targets the repo root (one level up).
     const compose = readFileSync(join(t, ".devcontainer/docker-compose.yml"), "utf8");
     expect(compose).toContain("context: ..");
     expect(compose).not.toContain("context: ../..");
 
-    // The compose file is copied VERBATIM: its workspace path stays the
-    // parameterized `${OH_PROJECT_ROOT:-/home/sandbox/harness}` default, which
-    // resolves to the harness path — no per-target rewrite is applied.
     expect(compose).toContain("/home/sandbox/harness");
   });
 
   it("--minimal: thin scaffold only (no full devcontainer, no empty seeds, no workspace)", async () => {
     const t = freshTmp();
     expect(await runInit(opts(t, { yes: true, minimal: true }), makeIO().io)).toBe(0);
-    // Thin compat files + vendored .oh/ are still present.
     expect(existsSync(join(t, ".oh/manifest.json"))).toBe(true);
     expect(existsSync(join(t, "AGENTS.md"))).toBe(true);
-    // Full-scaffold-only artifacts are absent.
     expect(existsSync(join(t, ".devcontainer/Dockerfile"))).toBe(false);
     expect(existsSync(join(t, ".oh/tasks/README.md"))).toBe(false);
-    // The thin devcontainer.json stub is image-based (no dockerComposeFile).
     const dc = JSON.parse(
       readFileSync(join(t, ".devcontainer/devcontainer.json"), "utf8"),
     );
@@ -583,7 +546,6 @@ describe("runInit", () => {
     );
   });
 
-  // --- Full scaffold (P3: AGENTS-lite + CLAUDE + vendored skill pack + providers) -
 
   it("full (default): writes the project AGENTS.md-lite", async () => {
     const t = freshTmp();
@@ -600,7 +562,6 @@ describe("runInit", () => {
     const claude = join(t, "CLAUDE.md");
     expect(lstatSync(claude).isSymbolicLink()).toBe(true);
     expect(readlinkSync(claude)).toBe("AGENTS.md");
-    // Resolves to the same content as AGENTS.md.
     expect(readFileSync(claude, "utf8")).toBe(readFileSync(join(t, "AGENTS.md"), "utf8"));
   });
 
@@ -615,7 +576,6 @@ describe("runInit", () => {
   it("full (default): vendors the skill pack into .oh/ and writes NO submodule", async () => {
     const t = freshTmp();
     expect(await runInit(opts(t, { yes: true }), makeIO().io)).toBe(0);
-    // The skills/agents/hooks pack is vendored directly — no submodule, no .gitmodules.
     expect(existsSync(join(t, ".gitmodules"))).toBe(false);
     expect(existsSync(join(t, ".mifune"))).toBe(false);
     expect(existsSync(join(t, ".oh/skills/git/SKILL.md"))).toBe(true);
@@ -641,10 +601,8 @@ describe("runInit", () => {
     ]) {
       expect(existsSync(join(t, rel))).toBe(true);
     }
-    // settings.json is valid JSON and is the trimmed project default (no MCP / Slack).
     const cs = JSON.parse(readFileSync(join(t, ".claude/settings.json"), "utf8"));
     expect(cs.enabledMcpjsonServers).toBeUndefined();
-    // The codex hook keeps its +x bit.
     expect(statSync(join(t, ".codex/hooks/deny-env-dump.sh")).mode & 0o111).not.toBe(0);
     expect(statSync(join(t, ".codex/hooks/deny-local-settings.sh")).mode & 0o111).not.toBe(0);
   });
@@ -670,8 +628,6 @@ describe("runInit", () => {
   it("provider symlinks resolve into the vendored .oh/skills pack", async () => {
     const t = freshTmp();
     expect(await runInit(opts(t, { yes: true }), makeIO().io)).toBe(0);
-    // No DI/fake needed: the skill pack is vendored with .oh/, so the provider
-    // symlinks resolve immediately — no submodule materialization step.
     expect(existsSync(join(t, ".claude/skills/git/SKILL.md"))).toBe(true);
     expect(existsSync(join(t, ".codex/skills/git/SKILL.md"))).toBe(true);
     expect(existsSync(join(t, ".pi/skills/git/SKILL.md"))).toBe(true);
@@ -687,7 +643,6 @@ describe("runInit", () => {
     expect(existsSync(join(t, ".pi/settings.json"))).toBe(false);
   });
 
-  // --- Full scaffold (P4: dry-run plan, verbose, gitignore union, idempotency)-
 
   it("--dry-run previews the WHOLE full plan and writes nothing", async () => {
     const t = freshTmp();
@@ -696,17 +651,14 @@ describe("runInit", () => {
 
     expect(code).toBe(0);
     for (const line of out) expect(line.startsWith("[dry-run] ")).toBe(true);
-    // The plan covers every full-scaffold surface.
     const joined = out.join("");
     expect(joined).toContain("create .devcontainer/Dockerfile");
     expect(joined).toContain("create .devcontainer/devcontainer.json");
     expect(joined).toContain("create CLAUDE.md");
     expect(joined).toContain("create .claude/settings.json");
     expect(joined).toContain("create .claude/skills");
-    // The vendored skill pack ships with the .oh/ payload (no submodule).
     expect(joined).toContain("create .oh/skills/git/SKILL.md");
     expect(joined).toContain("create .oh/tasks/README.md");
-    // Nothing was written.
     expect(existsSync(join(t, ".oh"))).toBe(false);
     expect(existsSync(join(t, ".devcontainer"))).toBe(false);
     expect(existsSync(join(t, ".gitmodules"))).toBe(false);
@@ -753,7 +705,6 @@ describe("runInit", () => {
 
     const { io, out } = makeIO();
     expect(await runInit(opts(t, { yes: true }), io)).toBe(0);
-    // Every per-file action is a skip.
     for (const line of out) expect(line.trim().startsWith("skip ")).toBe(true);
     expect(listOh(t)).toEqual(ohBefore);
     expect(readFileSync(join(t, ".gitignore"), "utf8")).toBe(giBefore);

--- a/.oh/cli/src/__tests__/lifecycle.test.ts
+++ b/.oh/cli/src/__tests__/lifecycle.test.ts
@@ -13,9 +13,6 @@ import {
   type RunResult,
 } from "../commands/lifecycle.js";
 
-// cli.ts has a top-level side effect: main(process.argv.slice(2)).then(process.exit).
-// Same guard as cli.property.test.ts: stub process.exit around the import so the
-// module body's main() call cannot terminate the vitest worker.
 vi.mock("../cli.js", async (importOriginal) => {
   const original = process.exit;
   process.exit = (() => {}) as never;
@@ -35,11 +32,6 @@ const {
   printShellHelp,
 } = await import("../cli.js");
 
-// ---------------------------------------------------------------------------
-// Test infrastructure — mkdtemp fixtures only, injected runners only. Never the
-// real worktree root (its .devcontainer/.example.env would fire the sandbox
-// seed) and never a real docker/bash subprocess.
-// ---------------------------------------------------------------------------
 
 const cleanups: string[] = [];
 
@@ -50,7 +42,6 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-/** An equipped-repo fixture: a root containing `.oh/scripts/`. */
 function makeRepo(): string {
   const d = mkdtempSync(join(tmpdir(), "oh-lifecycle-"));
   cleanups.push(d);
@@ -70,7 +61,6 @@ interface RecordedCall {
   opts: { stdio: "inherit" | "capture"; env?: NodeJS.ProcessEnv };
 }
 
-/** Queue-backed fake runner: returns results[i] for call i (last one repeats). */
 function makeRunner(results: RunResult[] = [{ status: 0 }]): {
   calls: RecordedCall[];
   run: LifecycleRunner;
@@ -89,7 +79,6 @@ function makeIo(): { out: string[]; err: string[]; io: LifecycleIO } {
   return { out, err, io: { stdout: (s) => out.push(s), stderr: (s) => err.push(s) } };
 }
 
-/** Capture a help printer's output without letting it hit the real terminal. */
 function captureStdout(fn: () => void): string {
   const spy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
   fn();
@@ -98,9 +87,6 @@ function captureStdout(fn: () => void): string {
   return text;
 }
 
-// ---------------------------------------------------------------------------
-// runSandbox
-// ---------------------------------------------------------------------------
 
 describe("runSandbox", () => {
   it("delegates the EXACT vendored argv with inherited stdio and returns the child's exit code", async () => {
@@ -119,8 +105,6 @@ describe("runSandbox", () => {
         opts: { stdio: "inherit" },
       },
     ]);
-    // .devcontainer/.env already existed → no seed, no operation-log line.
-    // DOCKER_SOCKET already set → the Docker-socket prompt never fires either.
     expect(out).toEqual([]);
   });
 
@@ -170,15 +154,14 @@ describe("runSandbox", () => {
     expect(await runSandbox({ cwd: root, run }, io)).toBe(0);
     expect(existsSync(join(root, ".devcontainer", ".env"))).toBe(false);
     expect(out).toEqual([]);
-    expect(calls).toHaveLength(1); // compose still runs
+    expect(calls).toHaveLength(1);
   });
 
   it("errors naming the missing docker-compose.sh path (no oh: prefix) without spawning", async () => {
-    const root = makeRepo(); // .oh/scripts exists but the script does not
+    const root = makeRepo();
     const { calls, run } = makeRunner();
     const expected = join(root, ".oh", "scripts", "docker-compose.sh");
 
-    // Now async → a thrown error surfaces as a rejected promise, not a sync throw.
     await expect(runSandbox({ cwd: root, run }, makeIo().io)).rejects.toThrow(expected);
     await expect(runSandbox({ cwd: root, run }, makeIo().io)).rejects.not.toThrow(/oh:/);
     expect(calls).toEqual([]);
@@ -203,7 +186,6 @@ describe("runSandbox", () => {
     );
   });
 
-  // ── Docker-socket opt-in (default OFF; prompt only when interactive) ──────
   it("prompts and writes DOCKER_SOCKET=true to .devcontainer/.env on yes", async () => {
     const root = makeRepo();
     addScript(root, "docker-compose.sh");
@@ -253,14 +235,10 @@ describe("runSandbox", () => {
 
     expect(await runSandbox({ cwd: root, run }, io)).toBe(0);
     expect(asked).toBe(0);
-    // Standing choice untouched.
     expect(readFileSync(join(root, ".devcontainer", ".env"), "utf8")).toBe("DOCKER_SOCKET=false\n");
   });
 
   it("treats a COMMENTED template line as unconfigured and still prompts", async () => {
-    // The seeded .env ships `# DOCKER_SOCKET=false`. A commented line is
-    // documentation, not a standing choice — reading it as one would silence
-    // the security prompt for every fresh install.
     const root = makeRepo();
     addScript(root, "docker-compose.sh");
     mkdirSync(join(root, ".devcontainer"), { recursive: true });
@@ -278,14 +256,10 @@ describe("runSandbox", () => {
 
     expect(await runSandbox({ cwd: root, run }, io)).toBe(0);
     expect(asked).toBe(1);
-    // Uncommented IN PLACE, not appended: one line in, one line out.
     expect(readFileSync(join(root, ".devcontainer", ".env"), "utf8")).toBe("DOCKER_SOCKET=true\n");
   });
 
   it("reads config with ZERO subprocesses — only compose is spawned", async () => {
-    // harness.yaml needed a vendored parser, so every config read was a
-    // subprocess. `.env` is read in-process, so the ONLY spawn left is compose
-    // itself. This is the assertion that the parser shell-out is gone.
     const root = makeRepo();
     const composeScript = addScript(root, "docker-compose.sh");
     mkdirSync(join(root, ".devcontainer"), { recursive: true });
@@ -310,7 +284,6 @@ describe("runSandbox", () => {
     expect(calls[0].args).toEqual([composeScript, "--repo-dir", root, "up", "-d", "--build"]);
   });
 
-  // ── Prebuilt-image mode (--image / --no-build) ───────────────────────────
   it("--image (bare, no OH_SANDBOX_IMAGE) → up -d --no-build + OH_SANDBOX_IMAGE=<default>", async () => {
     const root = makeRepo();
     const script = addScript(root, "docker-compose.sh");
@@ -372,9 +345,6 @@ describe("runSandbox", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// runShell
-// ---------------------------------------------------------------------------
 
 describe("runShell", () => {
   it("positional container wins — the .env value is not consulted", () => {
@@ -394,9 +364,6 @@ describe("runShell", () => {
   });
 
   it("reads SANDBOX_NAME from <root>/.devcontainer/.env, from a nested cwd", () => {
-    // The read is anchored to the resolved project ROOT, never the caller's
-    // CWD. A CWD-relative lookup would make every value look unset from a
-    // subdirectory — the contract `readEnvValue` documents.
     const root = makeRepo();
     mkdirSync(join(root, ".devcontainer"), { recursive: true });
     writeFileSync(join(root, ".devcontainer", ".env"), "SANDBOX_NAME=my-sandbox\n");
@@ -405,7 +372,6 @@ describe("runShell", () => {
     const { calls, run } = makeRunner([{ status: 0 }]);
 
     expect(runShell({ cwd: nested, run }, makeIo().io)).toBe(0);
-    // No parser subprocess: the docker exec is the ONLY call.
     expect(calls).toHaveLength(1);
     expect(calls[0].cmd).toBe("docker");
     expect(calls[0].args).toEqual(["exec", "-it", "-u", "sandbox", "my-sandbox", "zsh"]);
@@ -437,7 +403,6 @@ describe("runShell", () => {
     const { err, io } = makeIo();
 
     expect(runShell({ cwd: root, run, container: "openharness" }, io)).toBe(126);
-    // docker's raw error already went to the INHERITED stderr; ours follows it.
     expect(err).toEqual(["container `openharness` not running? start it with `oh sandbox`\n"]);
   });
 
@@ -465,9 +430,6 @@ describe("runShell", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// runGateway
-// ---------------------------------------------------------------------------
 
 describe("runGateway", () => {
   it("passes args through VERBATIM with OH_PROJECT_ROOT set and inherited stdio", () => {
@@ -521,9 +483,6 @@ describe("runGateway", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// Arg parsing (the cli.ts parse<Cmd>Args convention)
-// ---------------------------------------------------------------------------
 
 describe("parseSandboxArgs", () => {
   it("accepts no arguments and recognizes the help flags", () => {
@@ -621,9 +580,6 @@ describe("parseGatewayArgs", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// Help surfaces
-// ---------------------------------------------------------------------------
 
 describe("help surfaces", () => {
   it("oh --help lists all three lifecycle verbs", () => {

--- a/.oh/cli/src/__tests__/manifest.test.ts
+++ b/.oh/cli/src/__tests__/manifest.test.ts
@@ -5,11 +5,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 
-// ---------------------------------------------------------------------------
-// Test infrastructure
-// ---------------------------------------------------------------------------
 
-// Track every tmpdir created so afterEach can remove them all.
 let tmpdirs: string[] = [];
 
 function mkTmp(): string {
@@ -51,9 +47,6 @@ afterEach(() => {
   tmpdirs = [];
 });
 
-// ---------------------------------------------------------------------------
-// globToRegExp — matcher semantics
-// ---------------------------------------------------------------------------
 
 describe("globToRegExp", () => {
   it("1. `cli/**` matches nested + shallow under cli/ but not siblings/prefix/bare", () => {
@@ -89,9 +82,6 @@ describe("globToRegExp", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// shouldShip — include/exclude with exclude-wins
-// ---------------------------------------------------------------------------
 
 describe("shouldShip", () => {
   it("5. exclude wins over include; non-included paths are dropped", () => {
@@ -125,9 +115,6 @@ describe("shouldShip", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// loadManifest — parsing + the hollow-out guard
-// ---------------------------------------------------------------------------
 
 describe("loadManifest", () => {
   it("present + valid → returns parsed {include, exclude}", () => {
@@ -184,20 +171,15 @@ describe("loadManifest", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// runUpdate — manifest-honoring integration (the headline contract)
-// ---------------------------------------------------------------------------
 
 describe("runUpdate — manifest payload filtering", () => {
   it("INTEGRATION: overlays allow-listed docs; patches/dist excluded; project untouched", async () => {
-    // Use ONE dedicated base dir so the project-untouched assertion owns its parent.
     const base = mkTmp();
     const src = path.join(base, "src-checkout");
     const tgt = path.join(base, "target-repo");
     fs.mkdirSync(src, { recursive: true });
     fs.mkdirSync(tgt, { recursive: true });
 
-    // Fake NEWER source checkout: version 9.9.9 + manifest + a mix of files.
     writeFile(
       src,
       ".oh/cli/package.json",
@@ -222,7 +204,6 @@ describe("runUpdate — manifest payload filtering", () => {
     );
     writeFile(src, ".oh/patches/p.diff", "--- a\n+++ b\n");
 
-    // Fake equipped target: older version + a PROJECT file outside .oh/.
     writeFile(
       tgt,
       ".oh/cli/package.json",
@@ -240,12 +221,10 @@ describe("runUpdate — manifest payload filtering", () => {
 
     expect(rc).toBe(0);
 
-    // Allow-listed payload landed.
     expect(fs.existsSync(path.join(tgt, ".oh/cli/cli.ts"))).toBe(true);
     expect(fs.existsSync(path.join(tgt, ".oh/README.md"))).toBe(true);
     expect(fs.existsSync(path.join(tgt, ".oh/manifest.json"))).toBe(true);
 
-    // The copier ships docs/ and skips patches/ and dist/.
     expect(fs.existsSync(path.join(tgt, ".oh/docs/site.md"))).toBe(true);
     expect(
       fs.existsSync(
@@ -255,12 +234,10 @@ describe("runUpdate — manifest payload filtering", () => {
     expect(fs.existsSync(path.join(tgt, ".oh/patches/p.diff"))).toBe(false);
     expect(fs.existsSync(path.join(tgt, ".oh/cli/dist/oh.js"))).toBe(false);
 
-    // Project file outside .oh/ is byte-identical (untouched).
     expect(fs.readFileSync(path.join(tgt, ".devcontainer/.env"), "utf8")).toBe(
       envBefore,
     );
 
-    // The copier emits the skip line for a non-payload file.
     expect(
       out.some((l) => l.includes("skip patches/p.diff (not in payload)")),
     ).toBe(true);
@@ -273,7 +250,6 @@ describe("runUpdate — manifest payload filtering", () => {
     fs.mkdirSync(src, { recursive: true });
     fs.mkdirSync(tgt, { recursive: true });
 
-    // Same fixture but WITHOUT a manifest.json in the source .oh/.
     writeFile(
       src,
       ".oh/cli/package.json",
@@ -295,10 +271,8 @@ describe("runUpdate — manifest payload filtering", () => {
     const rc = await runUpdate({ targetDir: tgt, fromDir: src }, io);
 
     expect(rc).toBe(0);
-    // Legacy mode copies docs/ and patches/ when the source has no manifest.
     expect(fs.existsSync(path.join(tgt, ".oh/docs/site.md"))).toBe(true);
     expect(fs.existsSync(path.join(tgt, ".oh/patches/p.diff"))).toBe(true);
-    // The update command emits the legacy-mode warning.
     expect(out.some((l) => l.includes("legacy mode"))).toBe(true);
   });
 });

--- a/.oh/cli/src/__tests__/project.test.ts
+++ b/.oh/cli/src/__tests__/project.test.ts
@@ -4,8 +4,6 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { resolveProjectRoot } from "../lib/project.js";
 
-// All fixtures are mkdtemp dirs — never the real repo (whose root contains a
-// real .oh/ and would satisfy the walk from any cwd inside it).
 
 const cleanups: string[] = [];
 

--- a/.oh/cli/src/__tests__/remote.test.ts
+++ b/.oh/cli/src/__tests__/remote.test.ts
@@ -13,9 +13,6 @@ import {
   type RunResult,
 } from "../lib/remote.js";
 
-// ---------------------------------------------------------------------------
-// Test infrastructure
-// ---------------------------------------------------------------------------
 
 const cleanups: string[] = [];
 
@@ -31,7 +28,6 @@ afterEach(() => {
   }
 });
 
-/** Run git in a fixture repo with a hermetic identity (argv-array form). */
 function git(cwd: string, args: string[]): void {
   execFileSync(
     "git",
@@ -40,11 +36,6 @@ function git(cwd: string, args: string[]): void {
   );
 }
 
-/**
- * Build a local git fixture repo (pinned default branch `main`) with a
- * `marker.txt` commit, plus a `feature-x` branch whose marker differs.
- * Returns its file:// URL — the ONLY transport tests clone over (no network).
- */
 function makeFixtureRepo(): string {
   const repo = mkTmp("oh-remote-fixture-");
   git(repo, ["-c", "init.defaultBranch=main", "init"]);
@@ -58,7 +49,6 @@ function makeFixtureRepo(): string {
   return pathToFileURL(repo).href;
 }
 
-/** Fake runner capturing every invocation and returning a canned result. */
 function makeFakeRunner(result: RunResult): {
   run: RemoteRunner;
   calls: { cmd: string; args: string[]; env: NodeJS.ProcessEnv; timeoutMs: number }[];
@@ -71,9 +61,6 @@ function makeFakeRunner(result: RunResult): {
   return { run, calls };
 }
 
-// ---------------------------------------------------------------------------
-// fetchRemoteSource — behavior contract
-// ---------------------------------------------------------------------------
 
 describe("fetchRemoteSource", () => {
   it("clones a file:// fixture into the caller-supplied dir and returns its path", () => {
@@ -84,7 +71,6 @@ describe("fetchRemoteSource", () => {
 
     expect(got).toBe(dest);
     expect(readFileSync(join(dest, "marker.txt"), "utf8")).toBe("main-payload\n");
-    // Pristine git checkout, not a bare copy.
     expect(existsSync(join(dest, ".git"))).toBe(true);
   });
 
@@ -136,7 +122,6 @@ describe("fetchRemoteSource", () => {
   });
 
   it("clone failure surfaces git's stderr, the URL tried, and the --from fallback", () => {
-    // Nonexistent file:// path — real git, non-zero exit, zero network I/O.
     const missing = pathToFileURL(join(mkTmp("oh-remote-missing-"), "no-such-repo")).href;
     const dest = mkTmp("oh-remote-dest-");
 

--- a/.oh/cli/src/__tests__/runtime-catalog.test.ts
+++ b/.oh/cli/src/__tests__/runtime-catalog.test.ts
@@ -11,18 +11,9 @@ import {
   RUNTIME_CATALOG,
 } from "../lib/runtimes/catalog.js";
 
-// src/__tests__ -> src -> .oh/cli -> .oh -> repo root
 const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "..", "..");
 const read = (p: string): string => readFileSync(join(REPO_ROOT, p), "utf8");
 
-/**
- * Remove TypeScript comments so an assertion can be about code alone.
- *
- * Deliberately simple: block comments, then line comments whose `//` is not
- * preceded by `:` (which would eat a `https://` URL out of a string literal).
- * It is not a parser and does not need to be — it runs over two files whose
- * shape this repo controls.
- */
 function stripComments(src: string): string {
   return src
     .replace(/\/\*[\s\S]*?\*\//g, "")
@@ -53,7 +44,6 @@ describe("runtime catalog shape", () => {
 
   it("gives every entry with open work a tracking issue", () => {
     for (const r of RUNTIME_CATALOG) {
-      // `docker` has none, and that is the point: it is in use, not pending.
       if (r.state === "active") expect(r.tracking, r.id).toBeUndefined();
       else expect(r.tracking, r.id).toMatch(/^#\d+$/);
     }
@@ -75,14 +65,6 @@ describe("runtime catalog shape", () => {
   });
 });
 
-/**
- * The load-bearing assertion of this PR: `oh runtime` writes NO config key.
- *
- * #806 § B1 records `sandbox.substrate` vs `sandbox.runtime` as an OPEN
- * decision owned by #731, and says deciding it elsewhere forks the
- * ExecutionTarget seam. If a later change quietly adds a key here, this test
- * and `.oh/evals/probes/runtime-preflight-gate.sh` both go red.
- */
 describe("no runtime selector is introduced", () => {
   const sources = [
     ".oh/cli/src/lib/runtimes/catalog.ts",
@@ -91,9 +73,6 @@ describe("no runtime selector is introduced", () => {
 
   it("names neither candidate config key in the implementation", () => {
     for (const path of sources) {
-      // Comments explaining WHY the key is absent are the whole point of this
-      // PR, so they must survive — the assertion is about CODE. Strip comments
-      // first, then look for either key in what actually executes.
       const body = stripComments(read(path));
       expect(body, path).not.toContain("sandbox.substrate");
       expect(body, path).not.toContain("sandbox.runtime");
@@ -114,11 +93,6 @@ describe("no runtime selector is introduced", () => {
   });
 });
 
-/**
- * Drift test against the measurement record. These two numbers are the whole
- * reason `install` refuses on this host; if the catalog and #805 disagree, the
- * command lies to the operator.
- */
 describe("microsandbox preflight matches the measured blockers (#805)", () => {
   const msb = findRuntime("microsandbox")!;
 
@@ -137,9 +111,6 @@ describe("microsandbox preflight matches the measured blockers (#805)", () => {
   });
 
   it("still describes the base image the Dockerfile actually pins", () => {
-    // The remediation text names debian:bookworm-slim. If the base image is
-    // upgraded (#807) the blocker may clear, and this message must not keep
-    // blaming a base that is no longer there.
     const glibc = msb.preflight.find((c) => c.id === "glibc")!;
     const dockerfile = read(".devcontainer/Dockerfile");
     const claimsBookworm = glibc.remediation.includes("debian:bookworm-slim");
@@ -148,9 +119,6 @@ describe("microsandbox preflight matches the measured blockers (#805)", () => {
   });
 
   it("uses the installer command recorded by the P0 spike, not an invented one", () => {
-    // Provenance: `.oh/tasks/microsandbox-substrate/next-tasks.md` on PR #803.
-    // msb has never produced a binary in this harness, so the spike is the only
-    // ground truth that exists.
     expect(msb.installArgv).toEqual([
       "bash",
       "-lc",
@@ -180,8 +148,6 @@ describe("docker is the active runtime and is checked, not assumed", () => {
   });
 
   it("declares a real check rather than assuming the daemon answers", () => {
-    // The point of listing docker at all: `oh runtime status` must be able to
-    // say "your daemon is down" instead of silently implying it is fine.
     expect(docker.preflight.length).toBeGreaterThan(0);
     const check = docker.preflight[0];
     expect(check.id).toBe("command");
@@ -194,8 +160,6 @@ describe("docker is the active runtime and is checked, not assumed", () => {
   });
 
   it("probes the HOST, not the container", () => {
-    // The daemon lives on the machine holding the `oh` binary. Asking inside
-    // the sandbox would answer about the wrong kernel.
     for (const check of docker.preflight) expect(check.scope).toBe("host");
   });
 
@@ -231,8 +195,6 @@ describe("gvisor is present but not installable", () => {
 
 describe("compareVersions", () => {
   it("compares numerically, not lexically", () => {
-    // The bug this guards: "2.9" > "2.39" under a string compare, which would
-    // pass the glibc floor on a host that does not meet it.
     expect(compareVersions("2.9", "2.39")).toBeLessThan(0);
     expect(compareVersions("2.39", "2.39")).toBe(0);
     expect(compareVersions("2.41", "2.39")).toBeGreaterThan(0);
@@ -248,7 +210,6 @@ describe("compareVersions", () => {
 
 describe("parseGlibcVersion", () => {
   it("takes the trailing version, not the packaging string", () => {
-    // Both real forms measured in #805.
     expect(parseGlibcVersion("ldd (Ubuntu GLIBC 2.35-0ubuntu3.11) 2.35")).toBe("2.35");
     expect(parseGlibcVersion("ldd (Debian GLIBC 2.36-9+deb12u7) 2.36")).toBe("2.36");
     expect(parseGlibcVersion("ldd (GNU libc) 2.39")).toBe("2.39");

--- a/.oh/cli/src/__tests__/runtime.test.ts
+++ b/.oh/cli/src/__tests__/runtime.test.ts
@@ -11,9 +11,6 @@ import {
 } from "../commands/runtime.js";
 import type { LifecycleRunner, RunResult } from "../lib/execution/runner.js";
 
-// cli.ts has a top-level side effect: main(process.argv.slice(2)).then(process.exit).
-// Same guard as harness.test.ts: stub process.exit around the import so the
-// module body's main() call cannot terminate the vitest worker.
 vi.mock("../cli.js", async (importOriginal) => {
   const original = process.exit;
   process.exit = (() => {}) as never;
@@ -34,7 +31,6 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-/** An equipped-repo fixture. mkdtemp only — never the real worktree root. */
 function makeRepo(): string {
   const d = mkdtempSync(join(tmpdir(), "oh-runtime-"));
   cleanups.push(d);
@@ -75,7 +71,6 @@ const isExecOf = (cmd: string, args: string[], token: string): boolean =>
 const running: RunResult = { status: 0, stdout: "running\n", stderr: "" };
 const exited: RunResult = { status: 0, stdout: "exited\n", stderr: "" };
 
-/** A container that reports `running`, with msb absent and both blockers present. */
 function blockedHost(extra: (cmd: string, args: string[]) => RunResult | undefined = () => undefined) {
   return makeRunner((cmd, args) => {
     const custom = extra(cmd, args);
@@ -90,7 +85,6 @@ function blockedHost(extra: (cmd: string, args: string[]) => RunResult | undefin
   });
 }
 
-/** A host that clears both blockers. */
 function readyHost(extra: (cmd: string, args: string[]) => RunResult | undefined = () => undefined) {
   return makeRunner((cmd, args) => {
     const custom = extra(cmd, args);
@@ -227,7 +221,6 @@ describe("oh runtime — docker, the runtime in use", () => {
     const docker = rows.find((r: { id: string }) => r.id === "docker");
     expect(docker.active).toBe(true);
     expect(docker.state).toBe("active");
-    // Nothing else is in use — the sandbox runs on one thing.
     expect(rows.filter((r: { active: boolean }) => r.active).length).toBe(1);
   });
 
@@ -247,7 +240,6 @@ describe("oh runtime — docker, the runtime in use", () => {
     await runRuntimeList({ cwd: root, run }, io);
     const probe = calls.find(isDaemonProbe);
     expect(probe).toBeDefined();
-    // `docker version …`, never `docker exec … docker version …`.
     expect(probe!.args).toEqual(["version", "--format", "{{.Server.Version}}"]);
   });
 
@@ -265,7 +257,6 @@ describe("oh runtime — docker, the runtime in use", () => {
 
   it("says the daemon is down instead of implying it is fine", async () => {
     const root = makeRepo();
-    // The whole reason docker is in the table: a dead daemon must be visible.
     const { run } = blockedHost((cmd, args) =>
       cmd === "docker" && args[0] === "version"
         ? { status: 1, stdout: "", stderr: "Cannot connect to the Docker daemon\n" }
@@ -280,9 +271,6 @@ describe("oh runtime — docker, the runtime in use", () => {
 
   it("still probes the daemon when the container is unreachable", async () => {
     const root = makeRepo();
-    // A host-scoped check does not depend on the sandbox running — that is the
-    // point of the scope field, and it is what makes `status` useful when the
-    // container will not start.
     const { calls, run } = makeRunner((cmd, args) => (isInspect(cmd, args) ? exited : undefined));
     const { io } = makeIo();
     await runRuntimeList({ cwd: root, run }, io);
@@ -305,7 +293,6 @@ describe("oh runtime status", () => {
     const { io, out } = makeIo();
     expect(await runRuntimeStatus("microsandbox", { cwd: root, run }, io)).toBe(0);
     const text = out.join("");
-    // The whole point of `status` over `list`: the numbers, not just a verdict.
     expect(text).toContain("2.36");
     expect(text).toContain(">= 2.39");
     expect(text).toContain("/dev/kvm");
@@ -323,7 +310,6 @@ describe("oh runtime status", () => {
 
   it("reports unknown, not unsupported, when the probe cannot run", async () => {
     const root = makeRepo();
-    // glibc probe fails to produce a parseable line.
     const { run } = blockedHost((cmd, args) =>
       isExecOf(cmd, args, "ldd --version")
         ? { status: 127, stdout: "", stderr: "not found\n" }
@@ -388,7 +374,6 @@ describe("oh runtime install — the preflight gate", () => {
 
   it("refuses when only one blocker clears", async () => {
     const root = makeRepo();
-    // glibc fine, KVM still absent.
     const { calls, run } = readyHost((cmd, args) =>
       isExecOf(cmd, args, "/dev/kvm") ? { status: 1, stdout: "", stderr: "" } : undefined,
     );
@@ -425,7 +410,6 @@ describe("oh runtime install — the other exits", () => {
     const { io, err } = makeIo();
     expect(await runRuntimeInstall("gvisor", { cwd: root, run }, io)).toBe(1);
     expect(err.join("")).toContain("#806");
-    // Not installable means not even reachable — no container work at all.
     expect(calls.length).toBe(0);
   });
 
@@ -445,7 +429,6 @@ describe("oh runtime install — the other exits", () => {
       isExecOf(cmd, args, "doctor") ? { status: 1, stdout: "", stderr: "" } : undefined,
     );
     const { io, out } = makeIo();
-    // The install itself succeeded; the doctor is diagnosing the host.
     expect(await runRuntimeInstall("microsandbox", { cwd: root, run }, io)).toBe(0);
     expect(out.join("")).toContain("msb self doctor");
   });

--- a/.oh/cli/src/__tests__/tool-catalog.test.ts
+++ b/.oh/cli/src/__tests__/tool-catalog.test.ts
@@ -11,7 +11,6 @@ import {
 import { HARNESS_CATALOG } from "../lib/harnesses/catalog.js";
 import { RUNTIME_CATALOG } from "../lib/runtimes/catalog.js";
 
-// src/__tests__ -> src -> .oh/cli -> .oh -> repo root
 const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "..", "..");
 const read = (p: string): string => readFileSync(join(REPO_ROOT, p), "utf8");
 
@@ -27,9 +26,6 @@ describe("tool catalog shape", () => {
   });
 
   it("has exactly one installable tool", () => {
-    // The rest are baked into the image. This is the same shape as the runtime
-    // catalog (3 entries, 1 installable): reporting on something you cannot
-    // install is the point, not filler.
     expect(installableToolIds()).toEqual(["agent-browser"]);
   });
 
@@ -46,17 +42,12 @@ describe("tool catalog shape", () => {
   });
 
   it("checks presence with `command -v`, never a version flag", () => {
-    // Presence and version are different questions, and the shell cannot be
-    // wrong about PATH.
     for (const t of TOOL_CATALOG) {
       expect(t.verifyArgv.join(" "), t.id).toContain(`command -v ${t.binary}`);
     }
   });
 
   it("declares a version probe only where the flag is a safe standard", () => {
-    // herdr and agent-browser are omitted deliberately: neither binary was
-    // available to confirm its flag, and the repo's rule (set by `msb`) is to
-    // cite a verified source or omit, never guess.
     const withVersion = TOOL_CATALOG.filter((t) => t.versionArgv !== undefined).map((t) => t.id);
     expect(withVersion).toEqual(["cloudflared", "docker-cli", "gh"]);
     for (const t of TOOL_CATALOG) {
@@ -68,18 +59,12 @@ describe("tool catalog shape", () => {
     for (const t of TOOL_CATALOG) {
       for (const argv of [t.installArgv, t.verifyArgv, t.versionArgv]) {
         if (!argv) continue;
-        // `${` would be a template hole. `$PNPM_HOME` is fine — the container's
-        // own login shell expands it, and nothing user-supplied reaches it.
         for (const token of argv) expect(token, `${t.id}: ${token}`).not.toContain("${");
       }
     }
   });
 });
 
-/**
- * The three catalogs must stay disjoint. A tool appearing in two tables means
- * two commands claim it and two drift tests assert different ground truths.
- */
 describe("the three catalogs are disjoint", () => {
   it("shares no id with the harness or runtime catalog", () => {
     const harness = new Set(HARNESS_CATALOG.map((h) => h.id));
@@ -95,24 +80,16 @@ describe("the three catalogs are disjoint", () => {
   });
 
   it("keeps docker-cli distinct from the docker RUNTIME", () => {
-    // Not a duplicate: one is the client binary in the image, the other is the
-    // isolation boundary and its daemon. The ids differ on purpose.
     expect(findTool("docker-cli")).toBeDefined();
     expect(findTool("docker")).toBeUndefined();
     expect(RUNTIME_CATALOG.some((r) => r.id === "docker")).toBe(true);
   });
 
   it("leaves agent_browser excluded from the harness catalog", () => {
-    // harness-catalog.test.ts asserts this too. Restated here so that moving it
-    // INTO the harness table fails from both sides.
     expect(HARNESS_CATALOG.some((h) => h.harnessKey === "agent_browser")).toBe(false);
   });
 });
 
-/**
- * Drift test for agent-browser. Its ground truth is `entrypoint.sh` — NOT the
- * Dockerfile — and the inverse assertion is what keeps this catalog honest.
- */
 describe("agent-browser matches the entrypoint that really installs it", () => {
   const ab = findTool("agent-browser")!;
   const ENTRYPOINT = read(".devcontainer/entrypoint.sh");
@@ -124,8 +101,6 @@ describe("agent-browser matches the entrypoint that really installs it", () => {
   });
 
   it("is installed by the entrypoint and is ABSENT from the Dockerfile", () => {
-    // This absence is the whole reason `entrypointGuard` exists as a separate
-    // field. An unasserted premise is how these tables drift.
     expect(ENTRYPOINT).toContain("INSTALL_AGENT_BROWSER");
     expect(read(".devcontainer/Dockerfile")).not.toContain("INSTALL_AGENT_BROWSER");
   });
@@ -160,8 +135,6 @@ describe("agent-browser matches the entrypoint that really installs it", () => {
 
   it("keeps the env plumbing wired end to end", () => {
     expect(read(".devcontainer/docker-compose.yml")).toContain("INSTALL_AGENT_BROWSER");
-    // One surface, one key: `.devcontainer/.env` documents it and compose
-    // interpolates it. There is no envmap in between any more.
     expect(read(".devcontainer/.example.env")).toMatch(/^#\s*INSTALL_AGENT_BROWSER=/m);
   });
 });

--- a/.oh/cli/src/__tests__/tool.test.ts
+++ b/.oh/cli/src/__tests__/tool.test.ts
@@ -11,9 +11,6 @@ import {
 } from "../commands/tool.js";
 import type { LifecycleRunner, RunResult } from "../lib/execution/runner.js";
 
-// cli.ts has a top-level side effect: main(process.argv.slice(2)).then(process.exit).
-// Same guard as harness.test.ts: stub process.exit around the import so the
-// module body's main() call cannot terminate the vitest worker.
 vi.mock("../cli.js", async (importOriginal) => {
   const original = process.exit;
   process.exit = (() => {}) as never;
@@ -34,7 +31,6 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-/** An equipped-repo fixture. mkdtemp only — never the real worktree root. */
 function makeRepo(): string {
   const d = mkdtempSync(join(tmpdir(), "oh-tool-"));
   cleanups.push(d);
@@ -88,7 +84,6 @@ const isExecOf = (cmd: string, args: string[], token: string): boolean =>
 const running: RunResult = { status: 0, stdout: "running\n", stderr: "" };
 const exited: RunResult = { status: 0, stdout: "exited\n", stderr: "" };
 
-/** Container running; agent-browser absent. */
 function liveHost(extra: (cmd: string, args: string[]) => RunResult | undefined = () => undefined) {
   return makeRunner((cmd, args) => {
     const custom = extra(cmd, args);
@@ -101,17 +96,9 @@ function liveHost(extra: (cmd: string, args: string[]) => RunResult | undefined 
   });
 }
 
-/** The `docker exec` that actually runs the installer. */
 const isInstallCall = (c: RecordedCall): boolean =>
   c.cmd === "docker" && c.args[0] === "exec" && c.args.some((a) => a.includes("--with-deps"));
 
-/**
- * The `INSTALL_AGENT_BROWSER` KEY line, not the prose above it.
- *
- * The optional-installs block carries a comment mentioning `agent_browser`, so
- * a plain substring search finds the comment first and every assertion below
- * would test the wrong line.
- */
 const flagLine = (root: string): string | undefined =>
   readFileSync(join(root, ".devcontainer", ".env"), "utf8")
     .split("\n")
@@ -125,8 +112,6 @@ describe("oh tool — argument parsing", () => {
   });
 
   it("requires a name for install — there is no obvious default", () => {
-    // Unlike `oh runtime install`, most tools are baked in, so no single tool
-    // is the sensible implicit target.
     const r = parseToolArgs(["install"]);
     expect(r.ok).toBe(false);
     expect(!r.ok && r.showHelp).toBe(true);
@@ -164,7 +149,6 @@ describe("oh tool — help", () => {
     const text = w.mock.calls.map((c) => String(c[0])).join("");
     expect(text).toContain("oh harness");
     expect(text).toContain("oh runtime");
-    // Distinguishes "known" from "installable" — most tools are report-only.
     expect(text).toContain("agent-browser");
     expect(text).toContain("gh");
   });
@@ -233,7 +217,6 @@ describe("oh tool install — the ~1 GB download gate", () => {
   it("fails closed when non-interactive without --yes", async () => {
     const root = makeRepo();
     const { calls, run } = liveHost();
-    // No injected confirm and no TTY in vitest → the fail-closed path.
     const { io, err } = makeIo();
     expect(await runToolInstall("agent-browser", { cwd: root, run }, io)).toBe(1);
     expect(calls.some(isInstallCall)).toBe(false);
@@ -246,7 +229,6 @@ describe("oh tool install — the ~1 GB download gate", () => {
     const root = makeRepo();
     const { io, out } = makeIo(false);
     await runToolInstall("agent-browser", { cwd: root, run: liveHost().run }, io);
-    // The durable half is the whole reason persist runs first.
     expect(flagLine(root)).toMatch(/^INSTALL_AGENT_BROWSER=true$/);
     expect(out.join("")).toContain("next container start");
   });
@@ -269,7 +251,7 @@ describe("oh tool install — the ~1 GB download gate", () => {
   it("--yes bypasses the prompt entirely", async () => {
     const root = makeRepo();
     const { calls, run } = liveHost();
-    const { io, asked } = makeIo(false); // would decline if consulted
+    const { io, asked } = makeIo(false);
     expect(await runToolInstall("agent-browser", { cwd: root, run, yes: true }, io)).toBe(0);
     expect(asked).toEqual([]);
     expect(calls.some(isInstallCall)).toBe(true);
@@ -294,7 +276,6 @@ describe("oh tool install — the ~1 GB download gate", () => {
     );
     const { io, asked, out } = makeIo(true);
     expect(await runToolInstall("agent-browser", { cwd: root, run }, io)).toBe(0);
-    // Nobody should approve a download that would not have happened.
     expect(asked).toEqual([]);
     expect(calls.some(isInstallCall)).toBe(false);
     expect(out.join("")).toContain("already installed");

--- a/.oh/cli/src/__tests__/update.test.ts
+++ b/.oh/cli/src/__tests__/update.test.ts
@@ -4,11 +4,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 
-// ---------------------------------------------------------------------------
-// Test infrastructure
-// ---------------------------------------------------------------------------
 
-// Track every tmpdir created so afterEach can remove them all.
 let tmpdirs: string[] = [];
 
 function mkTmp(): string {
@@ -43,13 +39,6 @@ function readFile(root: string, rel: string): string {
   return fs.readFileSync(path.join(root, rel), "utf8");
 }
 
-/**
- * Build a fake OpenHarness-equipped repo at `root`.
- * Creates an `.oh/` control plane (cli/package.json with `version`, plus a
- * couple of control-plane files) AND project files OUTSIDE `.oh/` used to
- * assert non-mutation. Everything is written by explicit writeFileSync —
- * nothing is read from the real repo `.oh/`.
- */
 function buildEquippedRepo(
   root: string,
   opts: {
@@ -58,7 +47,6 @@ function buildEquippedRepo(
     project?: Record<string, string>;
   },
 ): void {
-  // The version package.json that gates the update.
   writeFile(
     root,
     ".oh/cli/package.json",
@@ -93,16 +81,12 @@ afterEach(() => {
   tmpdirs = [];
 });
 
-// ---------------------------------------------------------------------------
-// runUpdate — behavior contract
-// ---------------------------------------------------------------------------
 
 describe("runUpdate", () => {
   it("1. UPGRADE: newer source version overlays changed + new files (rc 0)", async () => {
     const from = mkTmp();
     const target = mkTmp();
 
-    // Source is newer (0.2.0) and carries a CHANGED control-plane file plus a NEW file.
     buildEquippedRepo(from, {
       version: "0.2.0",
       controlPlane: {
@@ -123,11 +107,9 @@ describe("runUpdate", () => {
     const rc = await runUpdate({ targetDir: target, fromDir: from }, io);
 
     expect(rc).toBe(0);
-    // Changed file now matches source content.
     expect(readFile(target, ".oh/scripts/foo.sh")).toBe(
       "#!/bin/sh\necho foo-NEW\n",
     );
-    // New file now exists with source content.
     expect(fs.existsSync(path.join(target, ".oh/scripts/brand-new.sh"))).toBe(
       true,
     );
@@ -137,10 +119,6 @@ describe("runUpdate", () => {
   });
 
   it("2. PROJECT UNTOUCHED: nothing outside <target>/.oh/ is mutated or created", async () => {
-    // Put `from` and `target` under ONE dedicated base dir so the "nothing
-    // created outside <target>/.oh/" backstop can assert on a parent we own —
-    // os.tmpdir() itself is a shared namespace concurrent vitest workers write
-    // to, so snapshotting it would be flaky.
     const base = mkTmp();
     const from = path.join(base, "from");
     const target = path.join(base, "target");
@@ -161,26 +139,19 @@ describe("runUpdate", () => {
       },
     });
 
-    // Capture project files + top-level dir listing before.
     const envBefore = readFile(target, ".devcontainer/.env");
     const appBefore = readFile(target, "src/app.ts");
     const topBefore = fs.readdirSync(target).sort();
-    // Snapshot the dedicated base dir (parent of <target>) so we can prove
-    // nothing new appears alongside <target> — runUpdate writes ONLY under
-    // <target>/.oh/, so `base` must still list exactly [from, target].
     const baseBefore = fs.readdirSync(base).sort();
 
     const { io } = mkIo();
     const rc = await runUpdate({ targetDir: target, fromDir: from }, io);
     expect(rc).toBe(0);
 
-    // Project files byte-identical.
     expect(readFile(target, ".devcontainer/.env")).toBe(envBefore);
     expect(readFile(target, "src/app.ts")).toBe(appBefore);
 
-    // No NEW top-level entry in <target> (only .oh/ contents should change).
     expect(fs.readdirSync(target).sort()).toEqual(topBefore);
-    // No new entries alongside <target> in the dedicated base dir.
     expect(fs.readdirSync(base).sort()).toEqual(baseBefore);
   });
 
@@ -207,7 +178,6 @@ describe("runUpdate", () => {
 
     expect(rc).toBe(0);
     expect(out.join("")).toContain("already up to date");
-    // No target file changed (content + mtime unchanged).
     expect(readFile(target, ".oh/scripts/foo.sh")).toBe(ctlBefore);
     expect(fs.statSync(path.join(target, ".oh/scripts/foo.sh")).mtimeMs).toBe(
       mtimeBefore,
@@ -232,12 +202,10 @@ describe("runUpdate", () => {
     const rc = await runUpdate({ ...opts, force: true }, io);
 
     expect(rc).toBe(0);
-    // Force overlay overwrote the local edit back to source content.
     expect(readFile(target, ".oh/scripts/foo.sh")).toBe("#!/bin/sh\necho SOURCE\n");
   });
 
   it("5. DOWNGRADE REFUSE: older source refused (rc 1, 'downgrade'); --force overrides; pre-release suffix treated equal", async () => {
-    // (a) downgrade refused.
     {
       const from = mkTmp();
       const target = mkTmp();
@@ -250,7 +218,6 @@ describe("runUpdate", () => {
       expect(err.join("")).toContain("downgrade");
     }
 
-    // (b) downgrade with --force succeeds.
     {
       const from = mkTmp();
       const target = mkTmp();
@@ -265,8 +232,6 @@ describe("runUpdate", () => {
       expect(rc).toBe(0);
     }
 
-    // (c) pre-release suffix-strip: 0.1.0 (source) vs 0.1.0-dev (target) are EQUAL → no-op.
-    // A naive parseInt would mis-rank these; the suffix must be stripped per segment.
     {
       const from = mkTmp();
       const target = mkTmp();
@@ -281,7 +246,6 @@ describe("runUpdate", () => {
   });
 
   it("6. DRY-RUN: every line prefixed [dry-run], no writes (even with force on a downgrade)", async () => {
-    // (a) upgrade dry-run: rc 0, all lines prefixed, target unchanged on disk.
     {
       const from = mkTmp();
       const target = mkTmp();
@@ -306,19 +270,15 @@ describe("runUpdate", () => {
       );
 
       expect(rc).toBe(0);
-      // Each pushed string is one line; every one must carry the prefix.
       expect(out.length).toBeGreaterThan(0);
       expect(out.every((l) => l.startsWith("[dry-run] "))).toBe(true);
 
-      // A file that would be overwritten still has its OLD content.
       expect(readFile(target, ".oh/scripts/foo.sh")).toBe(overwriteBefore);
-      // A file that would be created does NOT exist.
       expect(fs.existsSync(path.join(target, ".oh/scripts/brand-new.sh"))).toBe(
         false,
       );
     }
 
-    // (b) force + dryRun on a DOWNGRADE: writes NOTHING, rc 0.
     {
       const from = mkTmp();
       const target = mkTmp();
@@ -340,7 +300,6 @@ describe("runUpdate", () => {
       );
 
       expect(rc).toBe(0);
-      // Target untouched despite force, because dryRun suppresses writes.
       expect(readFile(target, ".oh/scripts/foo.sh")).toBe(before);
     }
   });
@@ -353,7 +312,6 @@ describe("runUpdate", () => {
       version: "0.2.0",
       controlPlane: {
         ".oh/scripts/foo.sh": "#!/bin/sh\necho from\n",
-        // Nested volatile segments (NOT top-level) — proves per-segment skip.
         ".oh/cli/node_modules/pkg/index.js": "module.exports = {};\n",
         ".oh/cli/dist/oh.js": "console.log('built');\n",
       },
@@ -364,23 +322,17 @@ describe("runUpdate", () => {
     const rc = await runUpdate({ targetDir: target, fromDir: from }, io);
     expect(rc).toBe(0);
 
-    // Neither volatile path was copied into the target .oh/.
     expect(
       fs.existsSync(path.join(target, ".oh/cli/node_modules/pkg/index.js")),
     ).toBe(false);
     expect(fs.existsSync(path.join(target, ".oh/cli/dist/oh.js"))).toBe(false);
-    // A normal control-plane file still copied.
     expect(fs.existsSync(path.join(target, ".oh/scripts/foo.sh"))).toBe(true);
   });
 });
 
-// ---------------------------------------------------------------------------
-// runUpdate — preconditions
-// ---------------------------------------------------------------------------
 
 describe("runUpdate — preconditions", () => {
   it("8a. missing source .oh/ → rc 1, 'update source not found'", async () => {
-    // fromDir has no .oh/ at all.
     const from = mkTmp();
     const target = mkTmp();
     buildEquippedRepo(target, { version: "0.1.0" });
@@ -395,7 +347,6 @@ describe("runUpdate — preconditions", () => {
     const from = mkTmp();
     const target = mkTmp();
     buildEquippedRepo(from, { version: "0.1.0" });
-    // target is just an empty dir (no .oh/).
 
     const { err, io } = mkIo();
     const rc = await runUpdate({ targetDir: target, fromDir: from }, io);
@@ -414,16 +365,12 @@ describe("runUpdate — preconditions", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// assertDestInTarget — exported path-escape guard
-// ---------------------------------------------------------------------------
 
 describe("assertDestInTarget", () => {
   it("7. throws on escape outside target .oh, allows paths inside", () => {
     const someTarget = mkTmp();
     const targetOh = path.resolve(someTarget, ".oh");
 
-    // Escaping the target .oh/ must throw.
     expect(() =>
       assertDestInTarget(
         path.resolve(targetOh, "../outside.ts"),
@@ -432,12 +379,10 @@ describe("assertDestInTarget", () => {
       ),
     ).toThrow("refusing to write outside target .oh");
 
-    // A path properly nested inside target .oh/ must NOT throw.
     expect(() =>
       assertDestInTarget(path.join(targetOh, "cli/x.ts"), targetOh, path.sep),
     ).not.toThrow();
 
-    // The target .oh/ itself must NOT throw (dest === targetOh).
     expect(() =>
       assertDestInTarget(targetOh, targetOh, path.sep),
     ).not.toThrow();

--- a/.oh/cli/src/__tests__/vendor.test.ts
+++ b/.oh/cli/src/__tests__/vendor.test.ts
@@ -59,7 +59,6 @@ describe("copyOhPayload — manifest filtering", () => {
 
     expect(fs.existsSync(path.join(targetOh, "cli/src/cli.ts"))).toBe(true);
     expect(fs.existsSync(path.join(targetOh, "manifest.json"))).toBe(true);
-    // Volatile files and the non-payload patch are absent.
     expect(fs.existsSync(path.join(targetOh, "cli/node_modules/pkg/index.js"))).toBe(false);
     expect(fs.existsSync(path.join(targetOh, "cli/dist/oh.js"))).toBe(false);
     expect(fs.existsSync(path.join(targetOh, "docs/readme.md"))).toBe(true);
@@ -125,7 +124,7 @@ describe("copyOhPayload — skipExisting vs force vs dryRun", () => {
 
     const target = mkTmp();
     const targetOh = path.join(target, ".oh");
-    write(targetOh, "scripts/foo.sh", "LOCAL"); // pre-existing local edit
+    write(targetOh, "scripts/foo.sh", "LOCAL");
 
     const manifest = loadManifest(from);
 

--- a/.oh/cli/src/cli.ts
+++ b/.oh/cli/src/cli.ts
@@ -42,26 +42,14 @@ import {
   type FetchRemoteSourceOptions,
 } from "./lib/remote.js";
 
-// Injected at build time from package.json#version (see build.mjs).
 declare const __OH_VERSION__: string;
 const VERSION: string = typeof __OH_VERSION__ === "string" ? __OH_VERSION__ : "0.0.0-dev";
 
-// Resolved once at module load. Correct from BOTH `src/cli.ts` and the bundled
-// `dist/oh.js` — both live two levels under `.oh/cli`, so `../../templates`
-// lands on `.oh/templates`. esbuild (bundle:true, format:esm) preserves
-// `import.meta.url` as a live ref to the output file, so this holds at runtime.
 const DEFAULT_TEMPLATES_DIR = resolve(
   dirname(fileURLToPath(import.meta.url)),
   "../../templates",
 );
 
-// The CLI's own bundled `.oh/` — the default source `oh init` vendors FROM. From
-// both `src/cli.ts` and `dist/oh.js` (each two levels under `.oh/cli`), `../..`
-// resolves to `.oh` (verified empirically; `DEFAULT_TEMPLATES_DIR` is `.oh/templates`,
-// one level deeper). For an installed binary this parent dir is some unrelated
-// real directory (e.g. `/usr`), NOT a payload — `resolveInitSource` detects that
-// via the manifest marker and auto-falls back to a remote fetch (`--from-remote`).
-// Bundling the payload into a published binary is gated on publishing (#564).
 const DEFAULT_SOURCE_OH_DIR = resolve(
   dirname(fileURLToPath(import.meta.url)),
   "../..",
@@ -72,10 +60,6 @@ interface Integration {
   runner: () => Promise<number>;
 }
 
-// No interactive wizards remain — Slack is configured natively by editing
-// `.devcontainer/.env` + `.pi/msg-bridge.json` (see .oh/docs/integrations/slack.md).
-// The framework stays for future integrations; `integrationLines()` renders
-// "(none)" while this record is empty.
 const INTEGRATIONS: Record<string, Integration> = {};
 
 export function isHelpFlag(arg: string | undefined): boolean {
@@ -95,7 +79,6 @@ function integrationLines(): string {
     .join("\n");
 }
 
-/** Exported for tests (asserting the Usage block lists every subcommand). */
 export function printOhHelp(): void {
   process.stdout.write(`oh — Open Harness CLI (v${VERSION})
 
@@ -196,7 +179,6 @@ Flags:
 `);
 }
 
-/** Exported for tests. */
 export function printSandboxHelp(): void {
   process.stdout.write(`oh sandbox — Provision and start the sandbox
 
@@ -224,7 +206,6 @@ Build/pull output streams live; oh sandbox exits with docker compose's exit code
 `);
 }
 
-/** Exported for tests. */
 export function printShellHelp(): void {
   process.stdout.write(`oh shell — Open a shell in the running sandbox container
 
@@ -238,7 +219,6 @@ exits with docker's exit code.
 `);
 }
 
-/** Exported for tests. */
 export function printHarnessHelp(): void {
   process.stdout.write(`oh harness — Install and inspect agent CLI harnesses
 
@@ -263,7 +243,6 @@ ${harnessIds().map((h) => `  ${h}`).join("\n")}
 `);
 }
 
-/** Exported for tests. */
 export function printGatewayHelp(): void {
   process.stdout.write(`oh gateway — Manage a messaging client session (Slack bridge)
 
@@ -289,19 +268,13 @@ This launches an interactive wizard. It takes no flags.
 `);
 }
 
-// ---------------------------------------------------------------------------
-// Arg parsing (exported so flag handling is unit-testable; main() stays
-// dispatch-only per the cli.property.test.ts process.exit-stub pattern)
-// ---------------------------------------------------------------------------
 
 export type ParseResult<T> =
   | { ok: true; args: T }
   | { ok: false; error: string; showHelp?: boolean };
 
-/** Parsed `oh init` flags. */
 export interface InitArgs {
   targetDir?: string;
-  /** Set only when `--templates <dir>` was passed (default applied later). */
   templatesDir?: string;
   fromDir?: string;
   fromRemote: boolean;
@@ -374,11 +347,6 @@ ${toolIds().map((t) => `  ${t}`).join("\n")}
 `);
 }
 
-/**
- * One help block for all four compose verbs — they differ only in the word.
- * `oh destroy` and a `make config` equivalent are deliberately absent; see
- * `.oh/docs/lifecycle-commands.md` for why.
- */
 export function printComposeVerbHelp(verb: ComposeVerb): void {
   const what: Record<ComposeVerb, string> = {
     stop: "Stop the sandbox, preserving volumes for a later restart",
@@ -474,7 +442,6 @@ export function parseInitArgs(rest: string[]): ParseResult<InitArgs> {
   return { ok: true, args };
 }
 
-/** Parsed `oh update` flags. */
 export interface UpdateArgs {
   help: boolean;
   fromDir?: string;
@@ -543,14 +510,10 @@ export function parseUpdateArgs(rest: string[]): ParseResult<UpdateArgs> {
   return { ok: true, args };
 }
 
-/** Parsed `oh sandbox` flags — the prebuilt-image / no-build knobs. */
 export interface SandboxArgs {
   help: boolean;
-  /** `--image` (bare) or `--image=<ref>` was passed — run the prebuilt image. */
   image: boolean;
-  /** Explicit ref from `--image=<ref>` (undefined for a bare `--image`). */
   imageRef?: string;
-  /** `--no-build` was passed — suppress the local build. */
   noBuild: boolean;
 }
 
@@ -581,7 +544,6 @@ export function parseSandboxArgs(rest: string[]): ParseResult<SandboxArgs> {
   return { ok: true, args };
 }
 
-/** Parsed `oh shell` args. */
 export interface ShellArgs {
   help: boolean;
   container?: string;
@@ -602,12 +564,9 @@ export function parseShellArgs(rest: string[]): ParseResult<ShellArgs> {
   return { ok: true, args };
 }
 
-/** Parsed `oh harness` args. */
 export interface HarnessArgs {
   help: boolean;
-  /** `list` | `install` | `status`; undefined when only `--help` was given. */
   subcommand?: "list" | "install" | "status";
-  /** The `<name>` positional — required by `install`, optional for `status`. */
   name?: string;
   persistOnly: boolean;
   noPersist: boolean;
@@ -652,8 +611,6 @@ export function parseHarnessArgs(rest: string[]): ParseResult<HarnessArgs> {
   if (sub === "list" && name !== undefined) {
     return { ok: false, error: `oh harness list: unexpected argument "${name}"` };
   }
-  // The two escape hatches are opposites — persisting only while also refusing
-  // to persist would leave the command with nothing to do.
   if (args.persistOnly && args.noPersist) {
     return {
       ok: false,
@@ -666,7 +623,6 @@ export function parseHarnessArgs(rest: string[]): ParseResult<HarnessArgs> {
   return { ok: true, args };
 }
 
-/** Parsed `oh runtime` args. */
 interface RuntimeArgs {
   help: boolean;
   force: boolean;
@@ -710,15 +666,11 @@ export function parseRuntimeArgs(rest: string[]): ParseResult<RuntimeArgs> {
   }
 
   args.subcommand = sub;
-  // `install` with no name is the documented default, NOT an error — the
-  // operator asked for one obvious runtime, and naming it every time would
-  // be ceremony. `list`/`status` keep undefined meaning "all".
   if (name !== undefined) args.name = name;
   else if (sub === "install") args.name = DEFAULT_RUNTIME;
   return { ok: true, args };
 }
 
-/** Parsed `oh tool` args. */
 interface ToolArgs {
   help: boolean;
   persistOnly: boolean;
@@ -759,8 +711,6 @@ export function parseToolArgs(rest: string[]): ParseResult<ToolArgs> {
   if (extra.length > 0) {
     return { ok: false, error: `oh tool: unexpected argument "${extra[0]}"` };
   }
-  // No default name: most tools are baked in, so there is no one obvious
-  // thing to install. `oh runtime install` can default; this cannot.
   if (sub === "install" && name === undefined) {
     return { ok: false, error: "oh tool install: a tool name is required", showHelp: true };
   }
@@ -781,42 +731,25 @@ export function parseToolArgs(rest: string[]): ParseResult<ToolArgs> {
 
 
 
-/** Parsed `oh gateway` args — everything after a leading help flag is verbatim. */
 export interface GatewayArgs {
   help: boolean;
-  /** Arguments handed to gateway.sh untouched (never re-interpreted). */
   passthrough: string[];
 }
 
 export function parseGatewayArgs(rest: string[]): ParseResult<GatewayArgs> {
-  // Intercept ONLY a leading --help/-h; a later --help belongs to the script.
   if (rest[0] === "--help" || rest[0] === "-h") {
     return { ok: true, args: { help: true, passthrough: [] } };
   }
   return { ok: true, args: { help: false, passthrough: [...rest] } };
 }
 
-// ---------------------------------------------------------------------------
-// Payload-source decision (the bundled-payload seam)
-// ---------------------------------------------------------------------------
 
-/** The CLI's own bundled payload paths + an injectable existence predicate. */
 export interface BundledPayloadPaths {
-  /** The bundled `.oh/` (production: module-level DEFAULT_SOURCE_OH_DIR). */
   sourceOhDir: string;
-  /** The bundled `.oh/templates` (production: DEFAULT_TEMPLATES_DIR). */
   templatesDir: string;
-  /** Injectable so tests can simulate an installed binary with no payload. */
   exists?: (path: string) => boolean;
 }
 
-/**
- * "Does the CLI's own bundled payload exist?" — the auto-fallback decision.
- * Checks for the payload manifest rather than the bare directory: an installed
- * binary's `../..` resolves to some real directory (e.g. `/usr`) that is NOT an
- * OpenHarness payload, so `manifest.json` is the marker distinguishing a real
- * bundled `.oh/` from an unrelated parent dir.
- */
 export function bundledPayloadExists(
   bundled: { sourceOhDir: string; templatesDir: string },
   exists: (path: string) => boolean = existsSync,
@@ -829,28 +762,10 @@ export type InitSource =
   | {
       kind: "remote";
       ref?: string;
-      /** One-line auto-fallback notice — set ONLY when no source flag was given. */
       notice?: string;
-      /**
-       * Both payload paths inside a fetched checkout. `--from-remote` sets BOTH
-       * `sourceOhDir` AND `templatesDir` (a fetched checkout is complete, so its
-       * templates always match its payload) — deliberately unlike `--from`,
-       * which sets only `sourceOhDir`.
-       */
       paths: (checkoutDir: string) => { sourceOhDir: string; templatesDir: string };
     };
 
-/**
- * Decide where `oh init` sources its payload from.
- *
- * Precedence: `--from-remote` > `--from <dir>` (the flags conflict, so at most
- * one is set) > the CLI's own bundled payload > auto-fallback to a remote fetch
- * when the bundled payload is absent (the installed-binary case — payload
- * bundling into a published binary is gated on publishing, #564).
- *
- * An explicit `--templates <dir>` pins the local path (never silently ignored
- * by the auto-fallback); `runInit`'s preconditions surface any missing source.
- */
 export function resolveInitSource(
   args: Pick<InitArgs, "fromDir" | "fromRemote" | "ref" | "templatesDir">,
   bundled: BundledPayloadPaths,
@@ -865,8 +780,6 @@ export function resolveInitSource(
     return { kind: "remote", ref: args.ref, paths: remotePaths };
   }
   if (args.fromDir !== undefined) {
-    // `--from <checkout>` mirrors `oh update --from`: vendor from `<checkout>/.oh`.
-    // Templates stay at the bundled default unless --templates overrides them.
     return {
       kind: "local",
       sourceOhDir: resolve(join(args.fromDir, ".oh")),
@@ -880,7 +793,6 @@ export function resolveInitSource(
       templatesDir: args.templatesDir ?? bundled.templatesDir,
     };
   }
-  // Auto-fallback: no source flags and no bundled payload (installed binary).
   return {
     kind: "remote",
     ref: args.ref,
@@ -889,27 +801,16 @@ export function resolveInitSource(
   };
 }
 
-// ---------------------------------------------------------------------------
-// Remote-sourced run wrapper
-// ---------------------------------------------------------------------------
 
-/** DI hooks for `runWithRemoteSource` — production callers pass `{ ref }` only. */
 export interface RemoteSourceHooks {
-  /** Branch/tag to fetch (`--ref`). */
   ref?: string;
-  /** Test override: clone URL (a `file://` fixture; default: the public repo). */
   repoUrl?: string;
-  /** Test override: the fetch itself. */
   fetch?: (opts: FetchRemoteSourceOptions) => string;
-  /** Test override: temp-dir factory (default: mkdtempSync under os.tmpdir()). */
   mkdtemp?: () => string;
-  /** Test override: recursive remover for the temp checkout. */
   rm?: (dir: string) => void;
-  /** Where the version-skew line goes (default: process.stdout). */
   stdout?: (s: string) => void;
 }
 
-/** Version of the FETCHED payload — a file read of `<checkout>/.oh/cli/package.json`. */
 function readPayloadVersion(checkoutDir: string): string {
   try {
     const parsed = JSON.parse(
@@ -917,19 +818,10 @@ function readPayloadVersion(checkoutDir: string): string {
     );
     if (parsed && typeof parsed.version === "string") return parsed.version;
   } catch {
-    // absent / unparseable → "unknown"
   }
   return "unknown";
 }
 
-/**
- * Fetch a remote checkout into a fresh temp dir, run `fn` against it, and ALWAYS
- * remove the temp dir afterwards — the try/finally wraps the ENTIRE downstream
- * runInit/runUpdate call, not just the clone. After a successful fetch, prints
- * `fetched payload v<X> (installed CLI v<Y>)` so version skew is visible (X is
- * read from the FETCHED checkout; Y comes from `__OH_VERSION__` — the CLI never
- * reads its own package.json at runtime).
- */
 export async function runWithRemoteSource(
   hooks: RemoteSourceHooks,
   fn: (checkoutDir: string) => Promise<number> | number,
@@ -1066,7 +958,6 @@ async function main(argv: string[]): Promise<number> {
         runUpdate({ targetDir, fromDir: checkoutDir, force, dryRun }, io),
       );
     }
-    // parseUpdateArgs guarantees fromDir is set when --from-remote is absent.
     return await runUpdate({ targetDir, fromDir: fromDir as string, force, dryRun }, io);
   }
 
@@ -1103,8 +994,6 @@ async function main(argv: string[]): Promise<number> {
     return runShell({ container: parsed.args.container }, lifecycleIo());
   }
 
-  // The compose lifecycle verbs. `--`-separated extras pass straight through to
-  // docker compose; anything else is rejected rather than silently forwarded.
   if ((composeVerbs() as string[]).includes(first)) {
     const verb = first as ComposeVerb;
     const rest = argv.slice(1);
@@ -1144,7 +1033,6 @@ async function main(argv: string[]): Promise<number> {
     if (a.subcommand === "status") {
       return await runHarnessStatus(a.name, { json: a.json }, io);
     }
-    // parseHarnessArgs guarantees `name` is set for `install`.
     return await runHarnessInstall(
       a.name as string,
       { persistOnly: a.persistOnly, noPersist: a.noPersist },
@@ -1174,7 +1062,6 @@ async function main(argv: string[]): Promise<number> {
     if (a.subcommand === "status") {
       return await runRuntimeStatus(a.name, { json: a.json }, io);
     }
-    // parseRuntimeArgs defaults `name` for `install`.
     return await runRuntimeInstall(a.name as string, { force: a.force }, io);
   }
 
@@ -1200,7 +1087,6 @@ async function main(argv: string[]): Promise<number> {
     if (a.subcommand === "status") {
       return await runToolStatus(a.name, { json: a.json }, io);
     }
-    // parseToolArgs guarantees `name` is set for `install`.
     return await runToolInstall(
       a.name as string,
       { persistOnly: a.persistOnly, noPersist: a.noPersist, yes: a.yes },

--- a/.oh/cli/src/commands/harness.ts
+++ b/.oh/cli/src/commands/harness.ts
@@ -21,92 +21,41 @@ import {
 } from "../lib/harnesses/catalog.js";
 import { configuredContainerName, DEFAULT_CONTAINER_NAME } from "./lifecycle.js";
 
-/**
- * `oh harness <list|install|status>` — install and inspect agent CLI harnesses.
- *
- * THE PROBLEM THIS SOLVES: adding an optional harness used to mean knowing that
- * `.devcontainer/.env` carries `INSTALL_*` keys, knowing the key is
- * `INSTALL_GROK_BUILD` while the doc slug is `grok-build`, uncommenting a line
- * by hand in a gitignored file, and then running
- * `make destroy && make sandbox` — a full image rebuild that throws the container
- * away for what is a one-package operation.
- *
- * THE INSTALL IS BOTH HALVES, deliberately (PRD decision D2):
- *
- *   1. persist `INSTALL_<KEY>=true` in `.devcontainer/.env` — cheap, always possible,
- *      and the reason the choice survives the next rebuild;
- *   2. install into the ALREADY-RUNNING container, so it is usable now.
- *
- * Live-only would be a trap: a container recreate silently loses the CLI.
- * Flag-only is exactly the rebuild pain being removed. `--persist-only` and
- * `--no-persist` are the escape hatches, and they conflict with each other.
- *
- * WHAT THIS COMMAND NEVER DOES: rebuild or restart the sandbox. A stopped or
- * absent container is the normal "not started yet" case, so it persists the flag,
- * prints the `oh sandbox` hint, and exits 0 rather than punishing the user for it.
- *
- * All container work goes through the `ExecutionTarget` contract — `status()` and
- * `exec()` — never a direct `docker exec` spawn, and never a `kind` check. See
- * `../lib/execution/target.ts` and `.oh/docs/rfcs/rfc-brain-hands-boundary.md`.
- */
 
-/** Output channels — mirrors `LifecycleIO` so tests capture the log and hints. */
 export interface HarnessIO {
   stdout: (s: string) => void;
   stderr: (s: string) => void;
 }
 
-/** Options shared by every `oh harness` verb. */
 export interface HarnessOptions {
-  /** Where the equipped-project-root walk starts (default: process.cwd()). */
   cwd?: string;
-  /** Subprocess runner. Default: real `spawnSync`. Tests inject a fake. */
   run?: LifecycleRunner;
-  /** Emit machine-readable JSON (list/status). */
   json?: boolean;
 }
 
 export interface HarnessInstallOptions extends HarnessOptions {
-  /** Only set the `.devcontainer/.env` flag; do no container work. */
   persistOnly?: boolean;
-  /** Live-install only; leave `.devcontainer/.env` untouched. */
   noPersist?: boolean;
 }
 
-/** Per-harness state as reported by `list` / `status`. */
 interface HarnessState {
   id: string;
   title: string;
   kind: string;
-  /** `INSTALL_<KEY>` reads `true` in `.devcontainer/.env`. `null` when it has no key. */
   enabled: boolean | null;
-  /** Binary present in the container, or `null` when the container is unreachable. */
   installed: boolean | null;
   docs: string;
 }
 
-/** The container-unreachable states — the ones that skip live work entirely. */
 function isReachable(status: string): boolean {
   return status === "ready" || status === "starting";
 }
 
-/**
- * Resolve the sandbox `ExecutionTarget`, reusing `oh shell`'s container-name
- * precedence (`.env` `SANDBOX_NAME` > the default) instead of forking it.
- */
 function targetFor(root: string, run: LifecycleRunner): ExecutionTarget {
   const name = configuredContainerName(root) ?? DEFAULT_CONTAINER_NAME;
   return resolveExecutionTarget({ projectRoot: root, container: name, run });
 }
 
-/**
- * Is the harness's binary present inside the container? `verifyArgv` exiting 0
- * is the oracle. Captured stdio — this is a probe, not user-facing output.
- *
- * Returns `null` when the probe could not run at all (no docker binary), which
- * the callers render as "unknown" rather than "not installed" — claiming a
- * harness is missing because we could not look is worse than saying so.
- */
 async function probeInstalled(
   target: ExecutionTarget,
   entry: HarnessEntry,
@@ -124,7 +73,6 @@ async function probeInstalled(
   }
 }
 
-/** Gather the state of every catalog entry (or one, when `only` is given). */
 async function collectStates(
   root: string,
   run: LifecycleRunner,
@@ -158,7 +106,6 @@ async function collectStates(
   return states;
 }
 
-/** Render one state cell: yes / no / n/a (no flag) / ? (container unreachable). */
 function cell(value: boolean | null, absent: string): string {
   if (value === null) return absent;
   return value ? "yes" : "no";
@@ -184,7 +131,6 @@ function renderTable(states: HarnessState[], io: HarnessIO): void {
   }
 }
 
-/** `oh harness list` — every known harness and its state. */
 export async function runHarnessList(opts: HarnessOptions, io: HarnessIO): Promise<number> {
   const run = opts.run ?? spawnRunner;
   const root = resolveProjectRoot(opts.cwd);
@@ -197,14 +143,12 @@ export async function runHarnessList(opts: HarnessOptions, io: HarnessIO): Promi
   return 0;
 }
 
-/** The unknown-name error, shaped like `oh config`'s unknown-integration path. */
 function unknownHarness(name: string, io: HarnessIO): number {
   io.stderr(`oh harness: unknown harness "${name}"\n\n`);
   io.stderr(`Known harnesses:\n${harnessIds().map((h) => `  ${h}`).join("\n")}\n`);
   return 1;
 }
 
-/** `oh harness status [name]` — the same data as `list`, optionally for one. */
 export async function runHarnessStatus(
   name: string | undefined,
   opts: HarnessOptions,
@@ -228,15 +172,6 @@ export async function runHarnessStatus(
   return 0;
 }
 
-/**
- * `oh harness install <name>` — persist the flag, then install into the running
- * container.
- *
- * ORDER MATTERS: persist FIRST. The write is cheap and always possible, and it
- * stays correct even when the live install then fails — the next rebuild will
- * pick the harness up either way, and the failure message says so. Doing it the
- * other way round would lose the durable half whenever the network did.
- */
 export async function runHarnessInstall(
   name: string,
   opts: HarnessInstallOptions,
@@ -248,12 +183,8 @@ export async function runHarnessInstall(
   const entry = findHarness(name);
   if (!entry) return unknownHarness(name, io);
 
-  // ---- 1. persist -------------------------------------------------------
   if (!opts.noPersist) {
     if (entry.harnessKey === undefined) {
-      // `default` and `on-demand` harnesses have no `INSTALL_*` key. Say so
-      // rather than inventing one — a fabricated key would be interpolated by
-      // nothing in docker-compose.yml and mislead the next reader.
       io.stdout(
         `${entry.id}: ${entry.kind} harness — no .devcontainer/.env install key, nothing to persist\n`,
       );
@@ -273,7 +204,6 @@ export async function runHarnessInstall(
 
   if (opts.persistOnly) return 0;
 
-  // ---- 2. live install --------------------------------------------------
   const target = targetFor(root, run);
   let status: string;
   try {
@@ -287,8 +217,6 @@ export async function runHarnessInstall(
   }
 
   if (!isReachable(status)) {
-    // The normal "not started yet" case. The durable half already landed, so
-    // this is success, not failure.
     io.stdout(
       `sandbox not running (${status}) — skipping the live install.\n` +
         "Start it with `oh sandbox`, then re-run this command; or the next build picks it up.\n",

--- a/.oh/cli/src/commands/init.ts
+++ b/.oh/cli/src/commands/init.ts
@@ -22,61 +22,28 @@ import * as prompt from "../lib/prompt.js";
 export interface InitIO {
   stdout: (s: string) => void;
   stderr: (s: string) => void;
-  /**
-   * Reader for the config wizard. Defaults to `prompt.ask` (real stdin) when
-   * omitted. Tests inject a fake so they never touch real stdin. Providing it
-   * ALSO flips the wizard on without a TTY (the DI seam) — production cli.ts
-   * leaves it unset, so the wizard there gates purely on `process.stdin.isTTY`.
-   */
   ask?: (q: string) => Promise<string>;
-  /** Secret reader for the wizard. Defaults to `prompt.askSecret`. */
   askSecret?: (q: string) => Promise<string>;
 }
 
 export interface InitOptions {
-  targetDir: string; // dir to scaffold into (resolved by caller; default cwd)
-  templatesDir: string; // absolute path to .oh/templates
-  /**
-   * Absolute path to the source `.oh/` directory to vendor FROM (already
-   * resolved by cli.ts: `--from <checkout>` → `<checkout>/.oh`, a fetched
-   * `--from-remote` checkout's `.oh`, or the CLI's own bundled `.oh/` via
-   * DEFAULT_SOURCE_OH_DIR).
-   */
+  targetDir: string;
+  templatesDir: string;
   sourceOhDir?: string;
-  yes?: boolean; // non-interactive: skip the wizard
+  yes?: boolean;
   force?: boolean;
   dryRun?: boolean;
-  /**
-   * FULL scaffold is the DEFAULT. `minimal: true` reverts to the old thin
-   * scaffold (the compat template files + vendored `.oh/` only) — no full
-   * devcontainer, empty seeds, or provider surfaces.
-   */
   minimal?: boolean;
-  /**
-   * Write `CLAUDE.md` as a COPY of `AGENTS.md` instead of a symlink — for
-   * filesystems without symlink support. Default: symlink.
-   */
   copyClaude?: boolean;
-  /**
-   * Show every per-file action, including the `skip … (not in payload/volatile)`
-   * vendor noise that is summarized away by default.
-   */
   verbose?: boolean;
 }
 
-/**
- * Recursively enumerate FILE relpaths (POSIX-style separators) under `root`,
- * skipping directory entries themselves. Used for the trusted, repo-shipped
- * template payload (the user-supplied `.oh/` source uses the stricter
- * symlink-skipping walk in lib/vendor.ts).
- */
 function walkFiles(root: string, dir: string, acc: string[]): void {
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
     const abs = path.join(dir, entry.name);
     if (entry.isDirectory()) {
       walkFiles(root, abs, acc);
     } else if (entry.isFile()) {
-      // path.relative gives platform separators; normalize to POSIX for relpaths.
       const rel = path.relative(root, abs).split(path.sep).join("/");
       acc.push(rel);
     }
@@ -96,10 +63,8 @@ export async function runInit(
   const verbose = opts.verbose === true;
   const prefix = dryRun ? "[dry-run] " : "";
   const report = (line: string): void => io.stdout(`${prefix}${line}\n`);
-  // Aggregate tallies for the legible end-of-run summary (UX channel).
   const stats = { created: 0, overwritten: 0, skipped: 0 };
 
-  // Precondition: templates dir must exist and be a directory.
   if (!existsSync(templatesDir) || !statSync(templatesDir).isDirectory()) {
     io.stderr(
       `oh init: scaffold templates not found at ${templatesDir}. Pass --templates <dir>, run from a built OpenHarness checkout, or use --from-remote to fetch one.\n`,
@@ -107,13 +72,11 @@ export async function runInit(
     return 1;
   }
 
-  // Precondition: target, if it exists, must not be a plain file (applies even under dryRun).
   if (existsSync(t) && !statSync(t).isDirectory()) {
     io.stderr(`oh init: target path is a file, not a directory: ${t}\n`);
     return 1;
   }
 
-  // Precondition: a vendor source `.oh/` must exist (checked before any write).
   const sourceOh = opts.sourceOhDir ? path.resolve(opts.sourceOhDir) : "";
   if (!sourceOh || !existsSync(sourceOh) || !statSync(sourceOh).isDirectory()) {
     io.stderr(
@@ -124,17 +87,10 @@ export async function runInit(
     return 1;
   }
 
-  // Create the target dir if missing (real runs only).
   if (!existsSync(t) && !dryRun) {
     mkdirSync(t, { recursive: true });
   }
 
-  // --- Thin compat scaffold (templates) ---------------------------------------
-  // Enumerate template files, skip the top-level README.md, sort for determinism.
-  // The `full/` subtree holds full-scaffold-only payloads (provider configs)
-  // copied explicitly by the full-mode phases — never by this generic walk.
-  // In full mode the local-build `.devcontainer/devcontainer.json` is written by
-  // the devcontainer phase, so the thin stub template is skipped there.
   const relpaths: string[] = [];
   walkFiles(templatesDir, templatesDir, relpaths);
   const files = relpaths
@@ -151,7 +107,6 @@ export async function runInit(
       continue;
     }
 
-    // Path-escape guard (PIN): the resolved target must stay inside `t`.
     const resolved = path.resolve(t, R);
     if (!(resolved === t || resolved.startsWith(t + path.sep))) {
       throw new Error(
@@ -178,7 +133,6 @@ export async function runInit(
     }
   }
 
-  // --- Vendor the .oh/ control plane (US-001) ---------------------------------
   const targetOh = path.join(t, ".oh");
   const manifest = loadManifest(sourceOh);
   if (manifest === null) {
@@ -187,7 +141,7 @@ export async function runInit(
 
   let vCreated = 0;
   let vOverwritten = 0;
-  let vFiltered = 0; // not-in-payload + volatile (the noise we summarize away)
+  let vFiltered = 0;
   const vReport: CopyReport = (action, rel) => {
     const r = `.oh/${rel}`;
     switch (action) {
@@ -204,8 +158,6 @@ export async function runInit(
         stats.skipped++;
         break;
       case "skip-not-in-payload":
-        // Noise: dozens of source files outside the manifest. Summarized away
-        // by default; surfaced per-file only under --verbose.
         if (verbose) report(`skip ${r} (not in payload)`);
         vFiltered++;
         break;
@@ -223,12 +175,9 @@ export async function runInit(
     vReport,
   );
 
-  // --- Full scaffold phases (default; skipped under --minimal) -----------------
   if (!minimal) {
     const wr: WriteCtx = { t, dryRun, force, report, stats };
 
-    // Phase 2a: seed tasks/ as an EMPTY dir (README stub). This harness's own
-    // PRDs are NEVER shipped — init creates the directory fresh.
     writeGenerated(
       wr,
       ".oh/tasks/README.md",
@@ -236,10 +185,6 @@ export async function runInit(
         "prd.json) produced by `/spec plan` and consumed by `/spec execute`.\n",
     );
 
-    // Phase 2b: full .devcontainer/ (Dockerfile, compose, entrypoint, *.sh) +
-    // a local-build devcontainer.json. The published image is a documented
-    // fallback only. The harness keeps these assets under its own conventional
-    // .devcontainer/ (a sibling of .oh/), so they copy across near-verbatim.
     const sourceDevcontainer = path.join(sourceOh, "..", ".devcontainer");
     if (existsSync(sourceDevcontainer) && statSync(sourceDevcontainer).isDirectory()) {
       copyDevcontainer(sourceDevcontainer, wr);
@@ -250,12 +195,8 @@ export async function runInit(
       );
     }
 
-    // Phase 3a: CLAUDE.md alias of AGENTS.md (AGENTS.md itself comes from the
-    // template scaffold above). Symlink by default; copy under --copy-claude.
     writeClaudeAlias(wr, copyClaude);
 
-    // Phase 3b: curated, secret-free provider config surfaces (.claude/.codex/
-    // .pi/.hermes). Authored project defaults — NOT the harness's live files.
     const fullTemplates = path.join(templatesDir, "full");
     if (existsSync(fullTemplates) && statSync(fullTemplates).isDirectory()) {
       const rels: string[] = [];
@@ -266,18 +207,11 @@ export async function runInit(
       }
     }
 
-    // Phase 3c: provider skill/agent/hook symlinks into the vendored `.oh/`
-    // pack. The skills/agents/hooks live in `.oh/` (vendored above with the rest
-    // of the control plane), so these links resolve immediately — no submodule
-    // materialization, no network step. link-providers.sh repairs them later.
     for (const [linkRel, linkTarget] of PROVIDER_LINKS) {
       linkReport(wr, linkRel, linkTarget);
     }
   }
 
-  // --- Interactive config wizard (US-002/003) ---------------------------------
-  // Gate: only in a real TTY (or when a reader is injected for tests), and never
-  // under --yes. Production cli.ts never injects io.ask → pure isTTY gate.
   const interactive =
     opts.yes !== true && (process.stdin.isTTY === true || io.ask !== undefined);
 
@@ -285,13 +219,6 @@ export async function runInit(
     ? await runWizard(io)
     : { env: {}, secrets: {} };
 
-  // --- Config writes (vendor → wizard → config) -------------------------------
-  // ONE write, to ONE file. Non-secret answers and secrets both land in
-  // `.devcontainer/.env`: since harness.yaml was removed, there is no second
-  // surface to split them across, and `.env` is the only one the VS Code
-  // "Reopen in Container" path can read. Non-secret keys go through
-  // `setKeyInEnv` so a commented template line is uncommented in place rather
-  // than shadowed by an appended duplicate.
   const configVars: Record<string, string> = { ...answers.env, ...answers.secrets };
   const configKeys = Object.keys(configVars);
   if (configKeys.length > 0) {
@@ -306,9 +233,6 @@ export async function runInit(
       const envDir = path.join(t, ".devcontainer");
       mkdirSync(envDir, { recursive: true });
       const envPath = path.join(envDir, ".env");
-      // Seed from the template that was just scaffolded, so the operator's
-      // answers land as UNCOMMENTED lines inside the documented file rather
-      // than as a bare list of keys with none of the prose explaining them.
       const examplePath = path.join(envDir, ".example.env");
       if (!existsSync(envPath) && existsSync(examplePath)) {
         copyFileSync(examplePath, envPath);
@@ -332,9 +256,6 @@ export async function runInit(
     }
   }
 
-  // --- Post-init guidance (UX channel; not the io operation log) ---------------
-  // Routed through prompt.* (process.stdout) so it never pollutes the testable
-  // io.stdout operation log. Suppressed under --dry-run.
   if (dryRun) {
     prompt.info("");
     prompt.ok(`Dry run complete — previewed the ${minimal ? "minimal" : "full"} plan, wrote nothing.`);
@@ -342,7 +263,6 @@ export async function runInit(
     return 0;
   }
 
-  // --- Legible summary -------------------------------------------------------
   const totalOverwritten = vOverwritten + stats.overwritten;
   prompt.header(`OpenHarness ${minimal ? "minimal" : "full"} scaffold — done`);
   prompt.ok(`Vendored .oh/ (${vCreated + vOverwritten} files)`);
@@ -360,7 +280,6 @@ export async function runInit(
     prompt.warn(`--force overwrote ${totalOverwritten} existing file(s).`);
   }
 
-  // --- Next steps ------------------------------------------------------------
   prompt.header("Next steps");
   if (!minimal) {
     prompt.ok("Provider skills are live — symlinks resolve into the vendored .oh/skills.");
@@ -379,11 +298,7 @@ export async function runInit(
   return 0;
 }
 
-// ---------------------------------------------------------------------------
-// Full-scaffold helpers
-// ---------------------------------------------------------------------------
 
-/** Shared context for the generated-file writers (create/skip/overwrite). */
 interface WriteCtx {
   t: string;
   dryRun: boolean;
@@ -392,21 +307,12 @@ interface WriteCtx {
   stats: { created: number; overwritten: number; skipped: number };
 }
 
-/**
- * Path-escape guard shared by every full-scaffold writer: the resolved dest
- * MUST be `t` itself or strictly inside it. Mirrors the vendor invariant.
- */
 function assertInTarget(dest: string, t: string): void {
   if (!(dest === t || dest.startsWith(t + path.sep))) {
     throw new Error(`oh init: refusing to write outside target dir: ${dest}`);
   }
 }
 
-/**
- * Write generated `content` to `<t>/<rel>` with create/skip/overwrite semantics
- * identical to the thin-scaffold loop: skip an existing file unless `force`,
- * honor `dryRun`, and report exactly one operation-log line.
- */
 function writeGenerated(ctx: WriteCtx, rel: string, content: string): void {
   const dest = path.resolve(ctx.t, rel);
   assertInTarget(dest, ctx.t);
@@ -432,7 +338,6 @@ function writeGenerated(ctx: WriteCtx, rel: string, content: string): void {
   }
 }
 
-/** Copy a real file (preserving the +x bit for `*.sh`) with create/skip/overwrite. */
 function copyFileReport(ctx: WriteCtx, src: string, rel: string): void {
   const dest = path.resolve(ctx.t, rel);
   assertInTarget(dest, ctx.t);
@@ -452,17 +357,6 @@ function copyFileReport(ctx: WriteCtx, src: string, rel: string): void {
   else ctx.stats.created++;
 }
 
-/**
- * Copy the harness's own `.devcontainer/` build assets into `<t>/.devcontainer/`.
- * Source and target share the conventional `.devcontainer/` layout (build context
- * = repo root, one level up), so every asset — `docker-compose.yml`, the
- * Dockerfile, and the client scripts — copies verbatim. The workspace path in
- * `docker-compose.yml` is already parameterized as
- * `${OH_PROJECT_ROOT:-/home/sandbox/harness}`, so no per-target rewrite is
- * needed. The source `devcontainer.json` (the consumer's is written separately)
- * and any env files (never ship secrets) are skipped. Real files only
- * (symlinks/volatile dirs skipped).
- */
 function copyDevcontainer(srcDir: string, ctx: WriteCtx): void {
   const skip = new Set([
     "devcontainer.json",
@@ -481,7 +375,6 @@ function copyDevcontainer(srcDir: string, ctx: WriteCtx): void {
   }
 }
 
-/** POSIX relpaths of every REAL file under `dir` (skip symlinks + volatile dirs). */
 function collectRealFiles(root: string, dir: string, acc: string[]): void {
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
     const abs = path.join(dir, entry.name);
@@ -495,10 +388,6 @@ function collectRealFiles(root: string, dir: string, acc: string[]): void {
   }
 }
 
-// devcontainer.json for LOCAL BUILD (default). Valid JSON (JSON.parse-able): the
-// `// image` key is a documented fallback, not a real comment. To use the
-// published image instead, drop dockerComposeFile/service/shutdownAction and add
-// `"image": "ghcr.io/mifunedev/openharness:latest"`.
 const DEVCONTAINER_JSON = `${JSON.stringify(
   {
     name: "openharness-project",
@@ -515,10 +404,6 @@ const DEVCONTAINER_JSON = `${JSON.stringify(
   2,
 )}\n`;
 
-// Provider skill/agent/hook symlinks into the vendored `.oh/` pack. init creates
-// them for the target; link-providers.sh repairs them. `.codex` reuses
-// `.claude`'s agents/specs. `.prime` nests its surface one level deeper, so its
-// target climbs two directories rather than one.
 const PROVIDER_LINKS: [string, string][] = [
   [".pi/skills", "../.oh/skills"],
   [".claude/skills", "../.oh/skills"],
@@ -530,7 +415,6 @@ const PROVIDER_LINKS: [string, string][] = [
   [".prime/agent/skills", "../../.oh/skills"],
 ];
 
-/** Create/refresh a symlink at `<t>/<linkRel>` → `linkTarget` (create/skip/overwrite). */
 function linkReport(ctx: WriteCtx, linkRel: string, linkTarget: string): void {
   const dest = path.resolve(ctx.t, linkRel);
   assertInTarget(dest, ctx.t);
@@ -539,14 +423,12 @@ function linkReport(ctx: WriteCtx, linkRel: string, linkTarget: string): void {
     lstatSync(dest);
     exists = true;
   } catch {
-    /* absent */
   }
   if (exists) {
     let current: string | null = null;
     try {
       current = readlinkSync(dest);
     } catch {
-      /* not a symlink */
     }
     if (current === linkTarget) {
       ctx.report(`skip ${linkRel} (exists)`);
@@ -575,7 +457,6 @@ function linkReport(ctx: WriteCtx, linkRel: string, linkTarget: string): void {
   ctx.stats.created++;
 }
 
-/** CLAUDE.md alias of AGENTS.md — a symlink by default, a copy under --copy-claude. */
 function writeClaudeAlias(ctx: WriteCtx, copyClaude: boolean): void {
   if (!copyClaude) {
     linkReport(ctx, "CLAUDE.md", "AGENTS.md");
@@ -599,23 +480,12 @@ function writeClaudeAlias(ctx: WriteCtx, copyClaude: boolean): void {
   else ctx.stats.created++;
 }
 
-// ---------------------------------------------------------------------------
-// Wizard
-// ---------------------------------------------------------------------------
 
 interface WizardAnswers {
-  /**
-   * Non-secret `.devcontainer/.env` keys to activate: each uncomments the
-   * template line in place and substitutes a value. Env keys are flat and
-   * globally unique, so the section coordinate the harness.yaml writer needed
-   * is gone with it.
-   */
   env: Record<string, string>;
-  /** Secret env vars. Same file — kept separate only so the log can count them. */
   secrets: Record<string, string>;
 }
 
-/** A y/N confirm built over the injected reader (so it is test-controllable). */
 async function confirmWith(
   askFn: (q: string) => Promise<string>,
   question: string,
@@ -661,11 +531,6 @@ async function runWizard(io: InitIO): Promise<WizardAnswers> {
     if (yes) env[`INSTALL_${inst.key.toUpperCase()}`] = "true";
   }
 
-  // Step 3 covers the two settings that most often bite a new user and are not
-  // reachable any other way short of hand-editing the file. Deliberately NOT a
-  // push toward full key coverage: the remaining keys are advanced and every one
-  // of them is documented in `.devcontainer/.example.env`, which is now the
-  // schema document — a reader who needs one edits it there.
   prompt.step(3, 4, "Access (off by default)");
   const sshOn = await confirmWith(askFn, "Enable sshd for direct container SSH?", false);
   if (sshOn) {
@@ -680,9 +545,6 @@ async function runWizard(io: InitIO): Promise<WizardAnswers> {
   prompt.info("privileged container that mounts the host filesystem. Enable only if needed.");
   const sockOn = await confirmWith(askFn, "Mount host Docker socket into the sandbox?", false);
   if (sockOn) {
-    // The same key `oh sandbox`'s opt-in prompt writes, in the same file — the
-    // VS Code "Reopen in Container" path reads it too, which is the whole point
-    // of collapsing configuration onto `.env`.
     env.DOCKER_SOCKET = "true";
   }
 
@@ -709,11 +571,6 @@ async function runWizard(io: InitIO): Promise<WizardAnswers> {
   return { env, secrets };
 }
 
-/**
- * `.gitignore` append rule: union the candidate lines from the `gitignore`
- * template into the target's `.gitignore`, deduped by `trimEnd()`, with the
- * resulting file ending in exactly one `\n`.
- */
 function appendGitignore(
   src: string,
   t: string,
@@ -722,7 +579,6 @@ function appendGitignore(
 ): void {
   const target = path.join(t, ".gitignore");
 
-  // Candidate lines from the template: non-empty (after trim).
   const candidates = readFileSync(src, "utf8")
     .split("\n")
     .filter((line) => line.trim() !== "");
@@ -749,7 +605,6 @@ function appendGitignore(
   report(`update .gitignore (+${newLines.length})`);
   if (dryRun) return;
 
-  // Trailing-newline care (PIN): mirror upsertEnvFile's approach in lib/env.ts.
   let output = existing;
   if (output.length > 0 && !output.endsWith("\n")) output += "\n";
   output += newLines.join("\n") + "\n";

--- a/.oh/cli/src/commands/lifecycle.ts
+++ b/.oh/cli/src/commands/lifecycle.ts
@@ -21,64 +21,24 @@ import {
 } from "../lib/env-file.js";
 import * as prompt from "../lib/prompt.js";
 
-/**
- * Lifecycle verbs for equipped repos (issue #564): `oh sandbox`, `oh shell`,
- * `oh gateway`.
- *
- * These are deliberately THIN wrappers over the vendored `.oh/scripts/`
- * lifecycle scripts (the same ones the source repo's Makefile drives) — no
- * compose-argv building or env-file parsing is re-implemented in
- * TypeScript. All subprocess invocations use argv-array form (never a shell
- * string, mirroring lib/tmux.ts) behind an injectable runner (DI seam in the
- * style of lib/remote.ts's RemoteRunner) so unit tests never spawn real
- * docker/bash. Thrown errors carry no `oh:` prefix — cli.ts's main() adds it
- * and maps throws to exit code 2.
- *
- * Since issue #733 the two HANDS-side verbs reach their environment through the
- * provider-neutral `ExecutionTarget` contract (`../lib/execution/`) instead of
- * naming a substrate themselves: `oh sandbox` calls `provision()`, `oh shell`
- * calls `attach()`. The brain-side decisions stay here — the `.env` seed,
- * the Docker-socket opt-in prompt, image-ref resolution, and container-name
- * precedence — so the contract is told what to run and never decides policy.
- * `.oh/docs/rfcs/rfc-brain-hands-boundary.md` is the authority for that split;
- * it is cited here, not restated.
- */
 
-/** Output channels (mirrors InitIO) — injectable so tests capture the log/hints. */
 export interface LifecycleIO {
   stdout: (s: string) => void;
   stderr: (s: string) => void;
-  /**
-   * Reader for the one interactive prompt (`oh sandbox`'s Docker-socket
-   * opt-in). Defaults to `prompt.ask` (real stdin). Injecting it also FORCES
-   * the prompt on in tests regardless of isTTY — mirrors init.ts's `io.ask`
-   * gate. Production cli.ts never injects it → pure isTTY gate.
-   */
   ask?: (q: string) => Promise<string>;
 }
 
-/**
- * The subprocess seam lives in `lib/execution/runner.ts` (issue #733) so the
- * lifecycle verbs and the execution targets share one runner. Re-exported here
- * for back-compat: `LifecycleRunner`/`RunResult` keep resolving from this
- * module's original import path.
- */
 export type { LifecycleRunner, RunResult };
 
-/** Options shared by every lifecycle verb. */
 export interface LifecycleOptions {
-  /** Where the equipped-project-root walk starts (default: process.cwd()). */
   cwd?: string;
-  /** Subprocess runner. Default: real `spawnSync`. Tests inject a fake. */
   run?: LifecycleRunner;
 }
 
 export interface ShellOptions extends LifecycleOptions {
-  /** Positional container-name argument — highest precedence when set. */
   container?: string;
 }
 
-/** `oh sandbox` options — the prebuilt-image / no-build knobs on top of the base. */
 export interface SandboxOptions extends LifecycleOptions {
   /** `--image` was passed (run the prebuilt image; implies `--no-build`). */
   image?: boolean;
@@ -88,70 +48,32 @@ export interface SandboxOptions extends LifecycleOptions {
   noBuild?: boolean;
 }
 
-/** The fallback container name (parity with the Makefile's SANDBOX_NAME). */
 export const DEFAULT_CONTAINER_NAME = "openharness";
 
-/**
- * The image `oh sandbox --image` (bare, no ref) resolves to when `.env`
- * carries no `sandbox.image`. `latest` is safe because the bind-mounted repo
- * shadows the image's baked `.oh/` — the image supplies only the toolchain, so
- * its version is a toolchain concern, not a correctness one. Override precedence
- * (last wins): this default -> `.env` `OH_SANDBOX_IMAGE` -> `--image=<ref>`.
- */
 export const DEFAULT_SANDBOX_IMAGE = "ghcr.io/mifunedev/openharness:latest";
 
-/**
- * Defensive config seed (FR-11's one writer): copy `.devcontainer/.example.env`
- * → `.devcontainer/.env` when the example exists and the target is missing —
- * parity with what `.oh/scripts/install.sh` does for source-repo-style
- * checkouts. `oh init`-equipped repos already have a `.env`, so this is a no-op
- * there. Reports exactly one operation-log line when (and only when) it writes.
- *
- * The copy itself, and the `assertInRoot` path-escape invariant that guards it,
- * live in `../lib/env-file.ts` so `oh harness` shares them instead of forking
- * them. This wrapper keeps the IO side (the one log line) here.
- */
 function seedConfig(root: string, io: LifecycleIO): void {
   if (seedEnvFile(root)) {
     io.stdout("create .devcontainer/.env (from .devcontainer/.example.env)\n");
   }
 }
 
-/**
- * Whether the DOCKER_SOCKET toggle already has an explicit value in
- * `.devcontainer/.env`. When configured, `oh sandbox` respects the standing
- * choice and does NOT re-prompt.
- *
- * This is a SET-NESS test, not a truthiness one, so it matches a bare
- * `DOCKER_SOCKET=` too — an operator who deliberately blanked the value has
- * still made a choice. A COMMENTED template line is not a choice and does not
- * match, which is why the regex anchors on whitespace only.
- */
 function dockerSocketConfigured(root: string): boolean {
   const envFile = envFilePath(root);
   if (!existsSync(envFile)) return false;
   try {
     return /^\s*DOCKER_SOCKET=/m.test(readFileSync(envFile, "utf8"));
   } catch {
-    /* unreadable .env → treat as unconfigured */
     return false;
   }
 }
 
-/**
- * The Docker-socket opt-in for `oh sandbox` (the get-oh.sh / CLI provisioning
- * path). Mounting /var/run/docker.sock is effectively HOST ROOT, so it is OFF
- * by default: we only prompt on a TTY (or when a test injects `io.ask`) and
- * only when no standing choice exists. The answer is persisted to
- * `.devcontainer/.env` (`DOCKER_SOCKET=true|false`) so the choice sticks and
- * docker-compose.sh applies the docker-compose.docker-sock.yml overlay when true.
- */
 async function maybePromptDockerSocket(root: string, io: LifecycleIO): Promise<void> {
   if (dockerSocketConfigured(root)) return;
   const interactive = process.stdin.isTTY === true || io.ask !== undefined;
-  if (!interactive) return; // non-TTY → leave it OFF, don't persist
+  if (!interactive) return;
   const envDir = join(root, ".devcontainer");
-  if (!existsSync(envDir)) return; // nowhere durable to record the choice
+  if (!existsSync(envDir)) return;
   const askFn = io.ask ?? prompt.ask;
   const answer = (
     await askFn(
@@ -169,41 +91,15 @@ async function maybePromptDockerSocket(root: string, io: LifecycleIO): Promise<v
   );
 }
 
-/**
- * `OH_SANDBOX_IMAGE` from `<root>/.devcontainer/.env`, or undefined when
- * unconfigured — the middle layer of the `--image` ref resolution (below the
- * `--image=<ref>` flag, above DEFAULT_SANDBOX_IMAGE). Same root-anchored,
- * never-CWD-relative contract as `configuredContainerName`.
- */
 function configuredImage(root: string): string | undefined {
   return readEnvValue(root, "OH_SANDBOX_IMAGE");
 }
 
-/**
- * `oh sandbox` — provision and start the sandbox: seed `.env` if needed,
- * prompt once for the (default-off) Docker-socket opt-in, then hand ONE
- * provisioning call to the execution target (`provision()`), which delegates to
- * the vendored wrapper that owns ALL compose-argv building.
- *
- * Prebuilt-image mode (`--image[=<ref>]` / `--no-build`) suppresses the local
- * build and — when an image is requested — threads the resolved ref through
- * `OH_SANDBOX_IMAGE` in the child env (the compose file interpolates it at
- * `image:`). The ref resolves last-wins: `--image=<ref>` > `.env`
- * `OH_SANDBOX_IMAGE` > DEFAULT_SANDBOX_IMAGE. Resolving it is a brain-side policy
- * decision and stays HERE; the ref travels to the target as child env, so this
- * remains a thin pass-through with no compose-argv building in TS.
- *
- * Runs with inherited stdio (live build/pull output) and returns the child's exit code.
- */
 export async function runSandbox(opts: SandboxOptions, io: LifecycleIO): Promise<number> {
   const run = opts.run ?? spawnRunner;
   const root = resolveProjectRoot(opts.cwd);
   seedConfig(root, io);
   await maybePromptDockerSocket(root, io);
-  // Preflight the vendored payload BEFORE the image-mode log line, so an
-  // incomplete `.oh/` still fails with the same message in the same order as it
-  // did before this verb routed through the target. `provision()` re-checks it
-  // internally; the check is idempotent and spawns nothing.
   requireLifecycleScript(root, "docker-compose.sh");
 
   // `--image` implies `--no-build` (skipping the build is the whole point);
@@ -230,41 +126,15 @@ export async function runSandbox(opts: SandboxOptions, io: LifecycleIO): Promise
     await target.provision();
     return 0;
   } catch (err) {
-    // `provision(): Promise<void>` has nowhere to return a child's exit status,
-    // so the target throws it; propagating it here reproduces the previous
-    // `return r.status ?? 1` exactly. Spawn-level failures still throw.
     if (err instanceof ExecutionExitError) return err.exitCode;
     throw err;
   }
 }
 
-/**
- * `SANDBOX_NAME` from `<root>/.devcontainer/.env`, or undefined when
- * unconfigured. The root-anchored contract that makes this correct from a
- * nested cwd lives on `readEnvValue` in `../lib/env-file.ts` — see its doc
- * comment.
- *
- * Exported so `oh harness` resolves the container the same way `oh shell` does
- * rather than forking the precedence rule.
- */
 export function configuredContainerName(root: string): string | undefined {
   return readEnvValue(root, "SANDBOX_NAME");
 }
 
-/**
- * `oh shell [container]` — open an interactive `zsh` as the `sandbox` user in
- * the already-running environment by handing the terminal to the execution
- * target's `attach()`. The target owns the substrate argv; this verb names no
- * engine. Container-name precedence stays a brain-side decision made HERE:
- * positional arg > `SANDBOX_NAME` in `<root>/.devcontainer/.env` > "openharness".
- *
- * Stays SYNCHRONOUS: `attach()` is `(request) => number` in `contractVersion: 1`
- * (see `../lib/execution/target.ts` and `rfc-brain-hands-boundary.md` § 6), so
- * this signature is unchanged. On a non-zero exit it prints an actionable hint
- * AFTER the child's own (inherited) error output, then propagates the code. A
- * missing engine binary surfaces as a spawn-level `ENOENT`, re-thrown here with
- * the same operator-facing message as before.
- */
 export function runShell(opts: ShellOptions, io: LifecycleIO): number {
   const run = opts.run ?? spawnRunner;
   const root = resolveProjectRoot(opts.cwd);
@@ -285,30 +155,6 @@ export function runShell(opts: ShellOptions, io: LifecycleIO): number {
   return code;
 }
 
-/**
- * `oh gateway <args…>` — pass every argument through VERBATIM to the vendored
- * `bash .oh/scripts/gateway.sh <args…>` with `OH_PROJECT_ROOT` set to the
- * resolved project root (gateway.sh:29 reads it) and inherited stdio; returns
- * the child's exit code. A leading `--help`/`-h` is intercepted in cli.ts
- * BEFORE this runs — nothing else is interpreted here.
- *
- * DELIBERATELY NOT routed through an `ExecutionTarget` (issue #733): the gateway
- * is BRAIN-side — orchestration and policy that runs on the host beside the
- * agent, not work executed inside a provisioned environment. Routing it through
- * the execution contract would put a brain responsibility on the hands side of
- * the boundary. See `.oh/docs/rfcs/rfc-brain-hands-boundary.md`.
- */
-/**
- * The compose verbs `oh` exposes 1:1 with the Makefile's targets.
- *
- * WHY THESE FOUR AND NOT SIX. `make destroy` runs `down -v`, which wipes the
- * named volumes holding provider auth — a passthrough with no confirmation
- * policy would make data loss one typo away, so it stays make-only until that
- * policy is designed. `make config` has no entry either: `oh config` already
- * means "configure an integration", and overloading it would be worse than the
- * gap. Both exceptions are recorded in `.oh/docs/lifecycle-commands.md`, and a
- * probe asserts they stay recorded rather than silently growing.
- */
 const COMPOSE_VERBS = Object.freeze({
   stop: Object.freeze(["stop"]),
   restart: Object.freeze(["restart"]),
@@ -316,34 +162,12 @@ const COMPOSE_VERBS = Object.freeze({
   ps: Object.freeze(["ps"]),
 });
 
-/** The verbs `runComposeVerb` accepts — the keys of `COMPOSE_VERBS`. */
 export type ComposeVerb = keyof typeof COMPOSE_VERBS;
 
-/** Every compose verb name, for help text and the dispatcher. */
 export function composeVerbs(): ComposeVerb[] {
   return Object.keys(COMPOSE_VERBS) as ComposeVerb[];
 }
 
-/**
- * `oh stop | restart | logs | ps` — the compose lifecycle verbs the Makefile
- * already had and the CLI did not.
- *
- * THIS CLOSES A SURFACE GAP, NOT A LOGIC GAP. `make stop` and this verb run the
- * same `.oh/scripts/docker-compose.sh`; the script has always been the single
- * implementation, and `oh sandbox` reaches it too (via the compose target's
- * `provision()`). What was missing was only that a user who had `oh` still had
- * to switch tools mid-lifecycle — and an `oh init` repo has no Makefile at all.
- *
- * BRAIN-SIDE, deliberately NOT routed through `ExecutionTarget`. These manage
- * the environment from outside rather than executing work inside a provisioned
- * one, which is the same reasoning that keeps `runGateway` off the contract.
- * `contractVersion: 1` has exactly `provision()` and `attach()`; adding methods
- * for them would widen a versioned interface to no benefit.
- *
- * No compose argv is assembled here beyond the constant verb — the script owns
- * overlay resolution, project naming, and env plumbing, and duplicating any of
- * that in TypeScript is how the two front doors would start to drift.
- */
 export function runComposeVerb(
   verb: ComposeVerb,
   opts: LifecycleOptions,

--- a/.oh/cli/src/commands/runtime.ts
+++ b/.oh/cli/src/commands/runtime.ts
@@ -16,87 +16,39 @@ import {
 } from "../lib/runtimes/catalog.js";
 import { configuredContainerName, DEFAULT_CONTAINER_NAME } from "./lifecycle.js";
 
-/**
- * `oh runtime <list|install|status>` — report which isolation runtime the
- * sandbox is on, measure what the others would need, and install MicroSandbox.
- *
- * WHAT THIS SOLVES: the runtime work is spread across four issues, two draft
- * PRs, and a task folder. Finding out whether this machine can run MicroSandbox
- * meant reading #805, then checking `.devcontainer/Dockerfile`'s base for its
- * glibc, then checking `docker-compose.yml` for a `devices:` key — three files
- * and two issues to answer one yes/no question. And nothing at all reported the
- * runtime you are *currently* on. `oh runtime status` answers both by
- * measuring, in one command.
- *
- * THIS COMMAND CHANGES NO RUNTIME. It reports, and it installs a tool. The
- * sandbox keeps booting exactly as it does today — nothing is selected, no
- * config key is written, and `resolveExecutionTarget` is untouched. Selecting a
- * runtime is EPIC #731's decision (#806 § B1 records the open
- * `sandbox.substrate` vs `sandbox.runtime` split); see the catalog's header for
- * why this command deliberately stays out of it, and why naming the command
- * `runtime` does not decide the key.
- *
- * THE PREFLIGHT FAILS CLOSED. MicroSandbox has two measured blockers here and
- * has never produced a binary in this harness. Running the installer anyway
- * would spend a network round trip to reproduce an error #805 already
- * documents. So `install` measures first, reports both facts with their
- * remediation, and attempts nothing — unless `--force`, which is where the
- * operator's own decision lives.
- *
- * Container work goes through the `ExecutionTarget` contract — `status()` and
- * `exec()` — never a direct `docker exec` spawn, and never a `kind` check. The
- * one deliberate exception is a `scope: "host"` preflight check, which asks the
- * machine holding the `oh` binary rather than the sandbox; that is the whole
- * point of the scope field, and `ExecutionTarget` cannot answer it.
- */
 
-/** Output channels — mirrors `HarnessIO` so tests capture the log and hints. */
 export interface RuntimeIO {
   stdout: (s: string) => void;
   stderr: (s: string) => void;
 }
 
-/** Options shared by every `oh runtime` verb. */
 export interface RuntimeOptions {
-  /** Where the equipped-project-root walk starts (default: process.cwd()). */
   cwd?: string;
-  /** Subprocess runner. Default: real `spawnSync`. Tests inject a fake. */
   run?: LifecycleRunner;
-  /** Emit machine-readable JSON (list/status). */
   json?: boolean;
 }
 
 export interface RuntimeInstallOptions extends RuntimeOptions {
-  /** Attempt the install even when the preflight says the host cannot run it. */
   force?: boolean;
 }
 
-/** One measured requirement. */
 interface CheckResult {
   id: string;
   label: string;
-  /** Where it was measured — the sandbox, or the machine running `oh`. */
   scope: "host" | "target";
-  /** What was actually read, e.g. `2.36`, `absent`, or a daemon version. */
   found: string;
-  /** What the runtime needs, e.g. `>= 2.39`. */
   required: string;
-  /** `null` when the probe could not run — unknown, NOT failed. */
   ok: boolean | null;
   remediation: string;
 }
 
-/** Per-runtime state as reported by `list` / `status`. */
 interface RuntimeRow {
   id: string;
   title: string;
   tier: string;
   state: string;
-  /** All preflight checks pass. `null` when unmeasured or when there are none. */
   supported: boolean | null;
-  /** Is the sandbox running on this runtime right now? */
   active: boolean;
-  /** Binary present in the container. `null` for non-installable runtimes. */
   installed: boolean | null;
   installable: boolean;
   checks: CheckResult[];
@@ -104,15 +56,10 @@ interface RuntimeRow {
   tracking?: string;
 }
 
-/** The container-unreachable states — the ones that skip live work entirely. */
 function isReachable(status: string): boolean {
   return status === "ready" || status === "starting";
 }
 
-/**
- * Resolve the sandbox `ExecutionTarget`, reusing `oh shell`'s container-name
- * precedence (`.env` `SANDBOX_NAME` > the default) instead of forking it.
- */
 function targetFor(root: string, run: LifecycleRunner): ExecutionTarget {
   const name = configuredContainerName(root) ?? DEFAULT_CONTAINER_NAME;
   return resolveExecutionTarget({ projectRoot: root, container: name, run });
@@ -124,7 +71,6 @@ function requiredOf(check: PreflightCheck): string {
   return "exit 0";
 }
 
-/** An unmeasured check — rendered `?`, never as a failure. */
 function unmeasured(check: PreflightCheck): CheckResult {
   return {
     id: check.id,
@@ -137,18 +83,6 @@ function unmeasured(check: PreflightCheck): CheckResult {
   };
 }
 
-/**
- * Run one preflight check.
- *
- * `scope: "host"` runs on the machine holding the `oh` binary, via the injected
- * runner. `scope: "target"` runs inside the sandbox, through `ExecutionTarget`.
- * They are different machines and the distinction is load-bearing: asking the
- * container about the Docker daemon would answer about the wrong kernel.
- *
- * Returns `ok: null` when the probe itself could not run, which renders as `?`.
- * Reporting "unsupported" because we failed to look would be a false negative
- * that sends the operator to fix a blocker they may not have.
- */
 async function runCheck(
   target: ExecutionTarget,
   check: PreflightCheck,
@@ -169,7 +103,6 @@ async function runCheck(
   if (check.scope === "host") {
     const argv = [...check.probeArgv];
     const r = run(argv[0], argv.slice(1), { stdio: "capture" });
-    // A runner that could not spawn reports a null status; that is "unknown".
     if (r.status === null || r.status === undefined) return { ...base, found: "?", ok: null };
     exitCode = r.status;
     stdout = r.stdout ?? "";
@@ -200,12 +133,9 @@ async function runCheck(
   }
 
   if (check.id === "device") {
-    // The probe is `test -e <path>`, so the exit code IS the answer.
     return { ...base, found: exitCode === 0 ? "present" : "absent", ok: exitCode === 0 };
   }
 
-  // `command`: report the first line of stdout, which for a version probe is
-  // the version itself — more useful than a bare "ok".
   const first = stdout.trim().split("\n")[0] ?? "";
   return {
     ...base,
@@ -214,7 +144,6 @@ async function runCheck(
   };
 }
 
-/** Is the runtime's binary present inside the container? */
 async function probeInstalled(
   target: ExecutionTarget,
   entry: RuntimeEntry,
@@ -233,13 +162,6 @@ async function probeInstalled(
   }
 }
 
-/**
- * Roll the individual checks into one verdict.
- *
- * An unknown check makes the whole verdict unknown. Any failing check makes it
- * false. A runtime with no checks is `null` — "not applicable", never a bare
- * `true`.
- */
 function verdict(checks: CheckResult[]): boolean | null {
   if (checks.length === 0) return null;
   if (checks.some((c) => c.ok === false)) return false;
@@ -247,7 +169,6 @@ function verdict(checks: CheckResult[]): boolean | null {
   return true;
 }
 
-/** Gather the state of every catalog entry (or one, when `only` is given). */
 async function collectRows(
   root: string,
   run: LifecycleRunner,
@@ -275,10 +196,6 @@ async function collectRows(
       tier: entry.tier,
       state: entry.state,
       supported: verdict(checks),
-      // The sandbox runs on exactly one runtime, and today that is always the
-      // container one. This is a FACT about the running sandbox, not a config
-      // read — there is no selector to read (#806 B1), so deriving it from
-      // `state: "active"` plus a live container is the honest answer.
       active: entry.state === "active" && reachable,
       installed: reachable ? await probeInstalled(target, entry) : null,
       installable: entry.installable,
@@ -290,7 +207,6 @@ async function collectRows(
   return rows;
 }
 
-/** Render one cell: yes / no / n/a / ? (unmeasured). */
 function cell(value: boolean | null, absent: string): string {
   if (value === null) return absent;
   return value ? "yes" : "no";
@@ -319,7 +235,6 @@ function renderTable(rows: RuntimeRow[], io: RuntimeIO): void {
   }
 }
 
-/** `status` adds the measured detail behind each verdict. */
 function renderDetail(rows: RuntimeRow[], io: RuntimeIO): void {
   renderTable(rows, io);
   for (const r of rows) {
@@ -338,7 +253,6 @@ function renderDetail(rows: RuntimeRow[], io: RuntimeIO): void {
   }
 }
 
-/** `oh runtime list` — every known runtime and its state. */
 export async function runRuntimeList(
   opts: RuntimeOptions,
   io: RuntimeIO,
@@ -354,14 +268,12 @@ export async function runRuntimeList(
   return 0;
 }
 
-/** The unknown-name error, shaped like `oh harness`'s. */
 function unknownRuntime(name: string, io: RuntimeIO): number {
   io.stderr(`oh runtime: unknown runtime "${name}"\n\n`);
   io.stderr(`Known runtimes:\n${runtimeIds().map((r) => `  ${r}`).join("\n")}\n`);
   return 1;
 }
 
-/** `oh runtime status [name]` — the same data as `list`, plus the measurements. */
 export async function runRuntimeStatus(
   name: string | undefined,
   opts: RuntimeOptions,
@@ -385,15 +297,6 @@ export async function runRuntimeStatus(
   return 0;
 }
 
-/**
- * `oh runtime install [name]` — preflight, then install into the running
- * container.
- *
- * ORDER MATTERS, and it is the OPPOSITE of `oh harness install`. That command
- * persists a flag first because the flag is cheap and survives failure. This
- * one has no flag to persist (see the catalog header), so the first action is
- * the measurement — and the measurement is a gate, not a warning.
- */
 export async function runRuntimeInstall(
   name: string,
   opts: RuntimeInstallOptions,
@@ -429,8 +332,6 @@ export async function runRuntimeInstall(
   }
 
   if (!isReachable(status)) {
-    // Nothing durable to write, so there is genuinely nothing to do — but this
-    // is the normal "not started yet" case, not an error the user caused.
     io.stdout(
       `sandbox not running (${status}) — nothing was installed.\n` +
         "Start it with `oh sandbox`, then re-run this command.\n",
@@ -448,7 +349,6 @@ export async function runRuntimeInstall(
     return 1;
   }
 
-  // ---- preflight --------------------------------------------------------
   const checks: CheckResult[] = [];
   for (const check of entry.preflight) {
     checks.push(await runCheck(target, check, run, true));
@@ -472,7 +372,6 @@ export async function runRuntimeInstall(
     io.stderr("\n--force given — attempting the install despite the preflight.\n");
   }
 
-  // ---- install ----------------------------------------------------------
   io.stdout(`installing ${entry.title} into the sandbox…\n`);
   const r = await target.exec({
     argv: [...(entry.installArgv ?? [])],
@@ -485,9 +384,6 @@ export async function runRuntimeInstall(
     return r.exitCode;
   }
 
-  // The doctor DIAGNOSES; it does not gate. The install already succeeded, and
-  // a failing doctor on a host that only just cleared its blockers is
-  // information, not a reason to report the install as failed.
   if (entry.doctorArgv !== undefined) {
     const doctor = await target.exec({
       argv: [...entry.doctorArgv],

--- a/.oh/cli/src/commands/tool.ts
+++ b/.oh/cli/src/commands/tool.ts
@@ -23,56 +23,13 @@ import {
 } from "../lib/tools/catalog.js";
 import { configuredContainerName, DEFAULT_CONTAINER_NAME } from "./lifecycle.js";
 
-/**
- * `oh tool <list|install|status>` — the sandbox tooling that is neither an
- * agent CLI (`oh harness`) nor an isolation runtime (`oh runtime`).
- *
- * WHAT THIS SOLVES: `agent-browser` shares the `INSTALL_*` namespace in
- * `.devcontainer/.env` with the optional harnesses but is not one, so
- * `oh harness` deliberately refuses it — leaving the only way to add it a
- * hand-edit of `.env` followed by a full container recreate, because the entrypoint installs it at
- * boot. And nothing could answer "is `gh` actually in this image, and what
- * version" without opening a shell.
- *
- * INSTALL IS PERSIST-FIRST, like `oh harness` and unlike `oh runtime`:
- *
- *   1. persist `INSTALL_AGENT_BROWSER=true` in `.devcontainer/.env` — cheap, always
- *      possible, and the reason the choice survives the next container recreate;
- *   2. install into the ALREADY-RUNNING container, so it is usable now.
- *
- * `oh runtime`'s refusal to persist anything is specific to the unmade #731
- * selector decision and does NOT transfer here: `INSTALL_AGENT_BROWSER` is
- * already interpolated by `.devcontainer/docker-compose.yml` and documented in
- * `.devcontainer/.example.env`, so this command writes a key the schema already
- * defines and changes no schema.
- *
- * THE DOWNLOAD GATE. agent-browser pulls Chromium, roughly 1 GB. No harness
- * install downloads anything comparable, so this is the one place the CLI asks
- * before spending the operator's bandwidth. It FAILS CLOSED: a non-interactive
- * run without `--yes` installs nothing and says which flag it wanted. The
- * durable half still lands, so the next container recreate picks it up.
- *
- * WHAT THIS COMMAND NEVER DOES: rebuild or restart the sandbox. A stopped or
- * absent container is the normal "not started yet" case, so it persists the
- * flag, prints the hint, and exits 0.
- *
- * All container work goes through the `ExecutionTarget` contract — `status()`
- * and `exec()` — never a direct `docker exec` spawn, and never a `kind` check.
- */
 
-/** Output channels, plus the injectable confirmation seam. */
 export interface ToolIO {
   stdout: (s: string) => void;
   stderr: (s: string) => void;
-  /**
-   * Confirmation prompt. Tests inject a fake; production leaves it undefined
-   * and the real `confirm()` is used behind an `isTTY` gate. Mirrors the
-   * `io.ask` seam in `init.ts`.
-   */
   confirm?: (question: string) => Promise<boolean>;
 }
 
-/** Options shared by every `oh tool` verb. */
 export interface ToolOptions {
   cwd?: string;
   run?: LifecycleRunner;
@@ -80,24 +37,17 @@ export interface ToolOptions {
 }
 
 export interface ToolInstallOptions extends ToolOptions {
-  /** Only set the `.devcontainer/.env` flag; do no container work. */
   persistOnly?: boolean;
-  /** Live-install only; leave `.devcontainer/.env` untouched. */
   noPersist?: boolean;
-  /** Skip the large-download confirmation. */
   yes?: boolean;
 }
 
-/** Per-tool state as reported by `list` / `status`. */
 interface ToolRow {
   id: string;
   title: string;
   kind: string;
-  /** `INSTALL_<KEY>` reads `true` in `.devcontainer/.env`. `null` when it has no key. */
   enabled: boolean | null;
-  /** Binary present in the container, or `null` when unreachable. */
   installed: boolean | null;
-  /** First line of `versionArgv` output, or `null` when not declared/readable. */
   version: string | null;
   installable: boolean;
   docs: string;
@@ -112,7 +62,6 @@ function targetFor(root: string, run: LifecycleRunner): ExecutionTarget {
   return resolveExecutionTarget({ projectRoot: root, container: name, run });
 }
 
-/** Run an argv in the container, returning `null` if it could not spawn. */
 async function tryExec(
   target: ExecutionTarget,
   argv: readonly string[],
@@ -127,7 +76,6 @@ async function tryExec(
   }
 }
 
-/** Is the tool's binary present? `null` when the probe could not run at all. */
 async function probeInstalled(
   target: ExecutionTarget,
   entry: ToolEntry,
@@ -136,13 +84,6 @@ async function probeInstalled(
   return r === null ? null : r.exitCode === 0;
 }
 
-/**
- * Read the tool's version, when it declares a probe.
- *
- * Returns `null` for a tool with no `versionArgv` — the catalog omits it rather
- * than guess an unverified flag — and `null` when the probe fails, because a
- * failed read is not a version.
- */
 async function probeVersion(
   target: ExecutionTarget,
   entry: ToolEntry,
@@ -182,7 +123,6 @@ async function collectRows(
           ? null
           : configured && isInstallFlagEnabled(root, entry.toolKey),
       installed,
-      // Only ask a present binary for its version.
       version: reachable && installed === true ? await probeVersion(target, entry) : null,
       installable: entry.installArgv !== undefined,
       docs: entry.docsPath,
@@ -191,7 +131,6 @@ async function collectRows(
   return rows;
 }
 
-/** Render one cell: yes / no / n/a (no flag) / ? (container unreachable). */
 function cell(value: boolean | null, absent: string): string {
   if (value === null) return absent;
   return value ? "yes" : "no";
@@ -217,20 +156,16 @@ function renderTable(rows: ToolRow[], io: ToolIO): void {
   }
 }
 
-/** `status` adds the version, where the catalog declares a probe for it. */
 function renderDetail(rows: ToolRow[], io: ToolIO): void {
   renderTable(rows, io);
   for (const r of rows) {
     io.stdout(`\n${r.id} — ${r.title}\n`);
-    // `—` distinguishes "no probe declared" from a failed read; the catalog
-    // omits unverified flags rather than guessing them.
     io.stdout(`  version:    ${r.version ?? "—"}\n`);
     io.stdout(`  installable: ${r.installable ? "yes" : "no"}\n`);
     io.stdout(`  see ${r.docs}\n`);
   }
 }
 
-/** `oh tool list` — every known tool and its state. */
 export async function runToolList(opts: ToolOptions, io: ToolIO): Promise<number> {
   const run = opts.run ?? spawnRunner;
   const root = resolveProjectRoot(opts.cwd);
@@ -249,7 +184,6 @@ function unknownTool(name: string, io: ToolIO): number {
   return 1;
 }
 
-/** `oh tool status [name]` — the same data as `list`, plus versions. */
 export async function runToolStatus(
   name: string | undefined,
   opts: ToolOptions,
@@ -273,14 +207,6 @@ export async function runToolStatus(
   return 0;
 }
 
-/**
- * Ask before a large download.
- *
- * Precedence: `--yes` wins; then an injected confirm (tests); then the real
- * prompt, but ONLY on a TTY. A non-interactive run with no `--yes` returns
- * false — fail closed. Silently proceeding would spend a gigabyte of someone's
- * bandwidth in CI.
- */
 async function confirmDownload(
   entry: ToolEntry,
   opts: ToolInstallOptions,
@@ -301,15 +227,6 @@ async function confirmDownload(
   return false;
 }
 
-/**
- * `oh tool install <name>` — persist the flag, then install into the running
- * container.
- *
- * ORDER MATTERS: persist FIRST, exactly as `oh harness install` does. The write
- * is cheap and always possible, and it stays correct even when the download is
- * then declined or fails — the next container start picks the tool up either
- * way, and the message says so.
- */
 export async function runToolInstall(
   name: string,
   opts: ToolInstallOptions,
@@ -328,7 +245,6 @@ export async function runToolInstall(
     return 1;
   }
 
-  // ---- 1. persist -------------------------------------------------------
   if (!opts.noPersist && entry.toolKey !== undefined) {
     if (seedEnvFile(root)) {
       io.stdout("create .devcontainer/.env (from .devcontainer/.example.env)\n");
@@ -344,7 +260,6 @@ export async function runToolInstall(
 
   if (opts.persistOnly) return 0;
 
-  // ---- 2. live install --------------------------------------------------
   const target = targetFor(root, run);
   let status: string;
   try {
@@ -375,9 +290,6 @@ export async function runToolInstall(
     return 1;
   }
 
-  // The gate sits AFTER the persist and AFTER the already-installed check, so
-  // declining costs nothing that was already done and nobody is asked to
-  // approve a download that would not have happened.
   if (!(await confirmDownload(entry, opts, io))) {
     if (!opts.noPersist && entry.toolKey !== undefined) {
       io.stdout(

--- a/.oh/cli/src/commands/update.ts
+++ b/.oh/cli/src/commands/update.ts
@@ -7,9 +7,6 @@ import path from 'node:path';
 import { loadManifest } from '../lib/manifest.js';
 import { copyOhPayload, assertDestInTarget, type CopyReport } from '../lib/vendor.js';
 
-// `assertDestInTarget` now lives in lib/vendor.ts (shared by init + update); it
-// is re-exported here so existing importers (src/__tests__/update.test.ts) keep
-// working unchanged.
 export { assertDestInTarget };
 
 export interface UpdateIO {
@@ -24,7 +21,6 @@ export interface UpdateOptions {
   dryRun?: boolean;
 }
 
-/** Parse a semver-ish string into a 3-segment numeric tuple (pre-release/build stripped). */
 function parseVersion(v: string): [number, number, number] {
   const parts = v.split('.');
   while (parts.length < 3) {
@@ -38,7 +34,6 @@ function parseVersion(v: string): [number, number, number] {
   return [seg(parts[0]), seg(parts[1]), seg(parts[2])];
 }
 
-/** -1 if a<b, 0 if equal, 1 if a>b — segment-by-segment numeric compare. */
 function compareVersions(a: string, b: string): number {
   const av = parseVersion(a);
   const bv = parseVersion(b);
@@ -49,7 +44,6 @@ function compareVersions(a: string, b: string): number {
   return 0;
 }
 
-/** Read the `version` string from a cli/package.json, defaulting to '0.0.0'. */
 function readCliVersion(ohDir: string): string {
   const pkgPath = path.resolve(ohDir, 'cli', 'package.json');
   try {
@@ -58,7 +52,6 @@ function readCliVersion(ohDir: string): string {
       return parsed.version;
     }
   } catch {
-    // missing / unparseable → fall through
   }
   return '0.0.0';
 }
@@ -67,7 +60,6 @@ export async function runUpdate(opts: UpdateOptions, io: UpdateIO): Promise<numb
   const { targetDir, fromDir, force, dryRun } = opts;
   const dryPrefix = dryRun ? '[dry-run] ' : '';
 
-  // AC-2(a): source preconditions
   const fromOh = path.resolve(fromDir, '.oh');
   if (!existsSync(fromOh) || !statSync(fromOh).isDirectory()) {
     io.stderr(
@@ -78,7 +70,6 @@ export async function runUpdate(opts: UpdateOptions, io: UpdateIO): Promise<numb
     return 1;
   }
 
-  // AC-2(b): target preconditions
   const targetOh = path.resolve(targetDir, '.oh');
   if (!existsSync(targetOh) || !statSync(targetOh).isDirectory()) {
     io.stderr(
@@ -89,13 +80,11 @@ export async function runUpdate(opts: UpdateOptions, io: UpdateIO): Promise<numb
     return 1;
   }
 
-  // AC-2(c): same .oh
   if (fromOh === targetOh) {
     io.stderr('oh update: source and target are the same .oh; nothing to update.\n');
     return 1;
   }
 
-  // AC-3: version gate
   const available = readCliVersion(fromOh);
   const current = readCliVersion(targetOh);
   const cmp = compareVersions(available, current);
@@ -109,7 +98,6 @@ export async function runUpdate(opts: UpdateOptions, io: UpdateIO): Promise<numb
     }
     io.stdout(dryPrefix + 'oh update: re-overlay (v' + current + ', --force)\n');
   } else {
-    // available < current
     if (!force) {
       io.stderr(
         'oh update: refusing downgrade (current v' +
@@ -125,8 +113,6 @@ export async function runUpdate(opts: UpdateOptions, io: UpdateIO): Promise<numb
     );
   }
 
-  // AC-4 / AC-6: overlay via the shared copier. update preserves its
-  // always-overwrite behavior by NOT passing `skipExisting`.
   const manifest = loadManifest(fromOh);
   if (manifest === null) {
     io.stdout(
@@ -155,8 +141,6 @@ export async function runUpdate(opts: UpdateOptions, io: UpdateIO): Promise<numb
         io.stdout(dryPrefix + 'skip ' + rel + ' (not in payload)\n');
         break;
       case 'skip-exists':
-        // update never passes skipExisting, so this is unreachable; handled for
-        // exhaustiveness.
         io.stdout(dryPrefix + 'skip ' + rel + ' (exists)\n');
         break;
     }

--- a/.oh/cli/src/lib/cloud-config.ts
+++ b/.oh/cli/src/lib/cloud-config.ts
@@ -62,7 +62,5 @@ export async function writeCloudConfig(path: string, config: CloudConfig): Promi
     ...(config.provisionKey ? { provisionKey: config.provisionKey } : {}),
   };
   await writeFile(path, `${JSON.stringify(stored, null, 2)}\n`, { mode: 0o600 });
-  // writeFile preserves an existing file's mode, so enforce the secret-file
-  // contract after every update as well as on first creation.
   await chmod(path, 0o600);
 }

--- a/.oh/cli/src/lib/env-file.ts
+++ b/.oh/cli/src/lib/env-file.ts
@@ -2,63 +2,20 @@ import { copyFileSync, existsSync, readFileSync, writeFileSync } from "node:fs";
 import { resolve, sep } from "node:path";
 import { loadEnvInto } from "./env.js";
 
-/**
- * `.devcontainer/.env` access for the CLI — the ONE place that reads a config
- * value, seeds the file, or edits an `INSTALL_*` flag.
- *
- * Replaces `lib/harness-yaml.ts`. `harness.yaml` was removed because every key
- * it mapped already existed as a compose env var with a default, and because it
- * was invisible on the VS Code "Reopen in Container" path — that path names
- * `.devcontainer/docker-compose.yml` directly, so compose auto-loads
- * `.devcontainer/.env` and nothing in `harness.yaml` ever applied. `.env` is now
- * the one surface, on EVERY path, and this module is the one writer.
- *
- * READS DO NOT ADD A PARSER. `readEnvValue` goes through `loadEnvInto`
- * (`./env.ts`), the existing reader compose-argv construction already uses, so
- * the CLI and the shell wrapper agree on the grammar by construction.
- *
- * THE GRAMMAR THE WRITER MUST RESPECT (Docker Compose env-file format):
- *   - a key is `KEY=value` at column 0, no `export`,
- *   - a full-line comment (first non-space char `#`) is ignored,
- *   - the value runs to end of line; `#` in a value is NOT a comment.
- *
- * Every optional key ships COMMENTED in `.devcontainer/.example.env`:
- *
- *     # INSTALL_OPENCODE=false        # OpenCode CLI (build arg)
- *
- * so enabling one means UNCOMMENTING THAT LINE IN PLACE — not appending a
- * second `INSTALL_OPENCODE=`, which would leave two keys the parser reads
- * first-wins and a diff no reviewer can follow.
- */
 
-/** The env file, relative to the project root. */
 const ENV_FILE = ".devcontainer/.env";
-/** The tracked template the env file is seeded from. */
 const ENV_EXAMPLE = ".devcontainer/.example.env";
 
-/**
- * Path-escape guard for every writer in this module: the resolved destination
- * MUST be inside the project root. Moved verbatim from `harness-yaml.ts`, where
- * it guarded the harness.yaml seed; `setInstallFlag` reuses the same invariant.
- */
 export function assertInRoot(dest: string, root: string): void {
   if (!(dest === root || dest.startsWith(root + sep))) {
     throw new Error(`refusing to write outside the project root: ${dest}`);
   }
 }
 
-/** Absolute path to `<root>/.devcontainer/.env`. */
 export function envFilePath(root: string): string {
   return resolve(root, ENV_FILE);
 }
 
-/**
- * Copy `.devcontainer/.example.env` → `.devcontainer/.env` when the example
- * exists and the target is missing.
- *
- * Returns `true` only when it wrote, so the caller emits exactly one
- * operation-log line and stays silent otherwise.
- */
 export function seedEnvFile(root: string): boolean {
   const dest = envFilePath(root);
   const example = resolve(root, ENV_EXAMPLE);
@@ -68,14 +25,6 @@ export function seedEnvFile(root: string): boolean {
   return true;
 }
 
-/**
- * Read one key from `.devcontainer/.env`, or `undefined` when it is unset,
- * empty, or the file is absent.
- *
- * The env-file path is derived from `root`, never from the CWD — the same
- * invariant `readConfigValue` documented in `harness-yaml.ts`. A CWD-relative
- * lookup would make every value look unset from a nested directory.
- */
 export function readEnvValue(root: string, key: string): string | undefined {
   const file = envFilePath(root);
   if (!existsSync(file)) return undefined;
@@ -85,7 +34,6 @@ export function readEnvValue(root: string, key: string): string | undefined {
   return value === undefined || value === "" ? undefined : stripQuotes(value);
 }
 
-/** Strip one layer of matching enclosing quotes, as compose does. */
 function stripQuotes(s: string): string {
   if (s.length >= 2 && ((s[0] === '"' && s.endsWith('"')) || (s[0] === "'" && s.endsWith("'")))) {
     return s.slice(1, -1);
@@ -93,49 +41,24 @@ function stripQuotes(s: string): string {
   return s;
 }
 
-/** The `INSTALL_*` env var an install key maps to (`grok_build` → `INSTALL_GROK_BUILD`). */
 export function installEnvKey(key: string): string {
   return `INSTALL_${key.toUpperCase()}`;
 }
 
-/** Whether `INSTALL_<KEY>` currently reads as truthy. */
 export function isInstallFlagEnabled(root: string, key: string): boolean {
   return readEnvValue(root, installEnvKey(key)) === "true";
 }
 
-/** What a write did, so the caller can report it precisely. */
 export type InstallFlagOutcome =
-  /** The key already held the value; the file was not touched. */
   | "already-set"
-  /** A commented template line was uncommented in place. */
   | "uncommented"
-  /** An existing key's value was changed. */
   | "updated"
-  /** A new key line was appended. */
   | "added";
 
-/**
- * Enable `INSTALL_<KEY>=true` in `<root>/.devcontainer/.env` with the smallest
- * possible diff, and report which of the four cases applied.
- *
- * Idempotent: calling it on an already-`true` key returns `already-set` and
- * writes nothing.
- */
 export function setInstallFlag(root: string, key: string): InstallFlagOutcome {
   return setEnvValue(root, installEnvKey(key), "true");
 }
 
-/**
- * Set one key in `<root>/.devcontainer/.env`, seeding the file from the
- * template first when it does not exist yet.
- *
- * Resolution order:
- *
- *   1. a live `KEY=<value>` line       → rewrite the value (or `already-set`)
- *   2. a commented `# KEY=<value>` line → UNCOMMENT IN PLACE, keeping the line
- *      index and any trailing prose, so the diff is one character class
- *   3. neither                          → append the key
- */
 export function setEnvValue(root: string, key: string, value: string): InstallFlagOutcome {
   const file = envFilePath(root);
   assertInRoot(file, root);
@@ -146,25 +69,14 @@ export function setEnvValue(root: string, key: string, value: string): InstallFl
   return outcome;
 }
 
-/** The result of a content-level write: the new text and what happened. */
 export interface SetKeyResult {
   content: string;
   outcome: InstallFlagOutcome;
 }
 
-/**
- * THE ONE `.env` LINE EDITOR. Pure — takes file text, returns file text — so
- * both the file-level writer (`setEnvValue`) and `oh init`'s wizard, which
- * batches several keys through one read/write pair and must also support
- * `--dry-run`, share exactly one implementation of the grammar.
- *
- * Idempotent: a key already holding `value` returns `already-set` with the
- * content unchanged.
- */
 export function setKeyInEnv(content: string, key: string, value: string): SetKeyResult {
   const lines = content.split("\n");
   const live = new RegExp(`^${escapeRegExp(key)}=(.*)$`);
-  // The commented template form: `# INSTALL_OPENCODE=false   # OpenCode CLI`.
   const commented = new RegExp(`^[ \\t]*#[ \\t]*${escapeRegExp(key)}=(.*)$`);
 
   for (let i = 0; i < lines.length; i++) {
@@ -178,14 +90,11 @@ export function setKeyInEnv(content: string, key: string, value: string): SetKey
 
   for (let i = 0; i < lines.length; i++) {
     if (commented.test(lines[i])) {
-      // Uncomment in place: same line index, so the file keeps its line count
-      // and the surrounding prose still reads correctly.
       lines[i] = `${key}=${value}`;
       return { content: lines.join("\n"), outcome: "uncommented" };
     }
   }
 
-  // Named nowhere — append, keeping exactly one trailing newline on the file.
   const body = content.replace(/\n+$/, "");
   return {
     content: body === "" ? `${key}=${value}\n` : `${body}\n${key}=${value}\n`,
@@ -193,7 +102,6 @@ export function setKeyInEnv(content: string, key: string, value: string): SetKey
   };
 }
 
-/** Escape a literal for embedding in a RegExp — keys are `[A-Z_]`, but do not assume. */
 function escapeRegExp(s: string): string {
   return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }

--- a/.oh/cli/src/lib/env.ts
+++ b/.oh/cli/src/lib/env.ts
@@ -68,13 +68,6 @@ export function upsertEnvFile(
   writeEnvFile(envPath, output);
 }
 
-/**
- * Atomic 0600 write of a whole env file: temp file in the same directory,
- * fsync, then rename. Exported because `oh init`'s wizard composes its content
- * in memory (through the `setKeyInEnv` line editor, so template lines are
- * uncommented in place) and must land it with the same durability and mode as
- * `upsertEnvFile` — the file can hold secrets on either path.
- */
 export function writeEnvFile(envPath: string, content: string): void {
   const tmpPath = `${envPath}.tmp.${process.pid}`;
   let fd: number | undefined;
@@ -87,9 +80,9 @@ export function writeEnvFile(envPath: string, content: string): void {
     renameSync(tmpPath, envPath);
   } catch (err) {
     if (fd !== undefined) {
-      try { closeSync(fd); } catch { /* ignore */ }
+      try { closeSync(fd); } catch { }
     }
-    try { unlinkSync(tmpPath); } catch { /* ignore */ }
+    try { unlinkSync(tmpPath); } catch { }
     throw err;
   }
 }

--- a/.oh/cli/src/lib/execution/docker-compose-target.ts
+++ b/.oh/cli/src/lib/execution/docker-compose-target.ts
@@ -13,67 +13,20 @@ import type {
   ExecutionTarget,
 } from "./target.js";
 
-/**
- * The Docker Compose execution target — the first `ExecutionTarget`
- * implementation (EPIC #731, issue #733).
- *
- * It WRAPS the proven lifecycle machinery instead of reimplementing it: every
- * compose operation delegates to `.oh/scripts/docker-compose.sh`, which stays
- * the single source of truth for env-file wiring, compose overrides,
- * the docker-socket opt-in, the SSH overlay and its port-collision preflight,
- * the Hermes overlay, sandbox naming, and project-root behavior. No compose
- * `-f <overlay>` argv is assembled here, so today's behavior is preserved by
- * construction rather than by luck.
- *
- * Brain-side decisions stay brain-side: the `.env` seed, the interactive
- * Docker-socket opt-in prompt, sandbox image resolution, and container-name
- * precedence all remain in `../../commands/lifecycle.ts`. This adapter is told
- * what to run; it does not decide policy.
- *
- * FAILURE SEMANTICS (the callers depend on these, so they are contract, not
- * detail):
- *   - a child that never ran         → throws `ExecutionSpawnError` (all ops)
- *   - `attach()` / `exec()` non-zero → returned as the exit code, never thrown
- *   - `provision()` non-zero         → throws `ExecutionExitError` carrying the
- *     exit code, because `provision(): Promise<void>` has nowhere to return it.
- *     A CLI verb that propagates the child's status catches it and returns
- *     `err.exitCode`, which is exactly today's `return r.status ?? 1`.
- */
 
-/** The overlay file the script appends when the socket opt-in is truthy. */
 const DOCKER_SOCK_OVERLAY = "docker-compose.docker-sock.yml";
 
 export interface DockerComposeTargetOptions {
-  /** Equipped-project root — `--repo-dir` for the script, and the workspace root. */
   projectRoot: string;
-  /**
-   * Container name for `attach()`, `exec()`, and `status()`. Resolution
-   * (positional arg > `.env` `SANDBOX_NAME` > the default) is a
-   * brain-side decision and stays with the caller; this adapter never guesses.
-   */
   container?: string;
-  /** Subprocess runner. Default: the real `spawnRunner`. Tests inject a fake. */
   run?: LifecycleRunner;
-  /** `false` → `provision()` passes `--no-build`. Default: `true` (`--build`). */
   build?: boolean;
-  /**
-   * Host-side child env for compose runs (e.g. `OH_SANDBOX_IMAGE`, which the
-   * compose file interpolates). Distinct from `ExecRequest.env`, which sets
-   * variables INSIDE the target.
-   */
   env?: NodeJS.ProcessEnv;
 }
 
 export class DockerComposeExecutionTarget implements ExecutionTarget {
   readonly kind = "docker-compose";
   readonly contractVersion = 1;
-  /**
-   * Phase-0 supports the identical mapping only (`hostRoot === targetRoot`):
-   * nothing above this seam translates paths, so one resolved project root
-   * serves both file reads and delegation. See
-   * `.oh/docs/rfcs/rfc-brain-hands-boundary.md` § 5 / § 5.1 — that RFC is the
-   * authority for the stance and it is cited here, not restated.
-   */
   readonly workspace: { hostRoot: string; targetRoot: string };
 
   private readonly projectRoot: string;
@@ -91,11 +44,6 @@ export class DockerComposeExecutionTarget implements ExecutionTarget {
     this.workspace = { hostRoot: opts.projectRoot, targetRoot: opts.projectRoot };
   }
 
-  /**
-   * Bring the environment up: `bash <script> --repo-dir <root> up -d
-   * --build|--no-build` with inherited stdio (live build/pull output). Exactly
-   * one child process — the script owns everything else.
-   */
   async provision(): Promise<void> {
     const script = this.composeScript();
     const argv = [script, "--repo-dir", this.projectRoot, "up", "-d", this.build ? "--build" : "--no-build"];
@@ -107,11 +55,6 @@ export class DockerComposeExecutionTarget implements ExecutionTarget {
     }
   }
 
-  /**
-   * Lifecycle state, read from the container itself. `docker inspect` exits
-   * non-zero when no such container exists — that is the `"absent"` case, not
-   * an error.
-   */
   async status(): Promise<ExecutionStatus> {
     const name = this.requireContainer();
     const r = this.run("docker", ["inspect", "-f", "{{.State.Status}}", name], { stdio: "capture" });
@@ -128,26 +71,10 @@ export class DockerComposeExecutionTarget implements ExecutionTarget {
       case "exited":
         return "stopped";
       default:
-        // "dead", and anything a future engine reports that we do not model.
         return "failed";
     }
   }
 
-  /**
-   * Capabilities, discovered at runtime rather than assumed.
-   *
-   * `"exec"` and `"pty"` are unconditional — this target always runs argv and
-   * always hands over a terminal. `"docker"` is conditional on the host-socket
-   * opt-in, whose truthiness logic lives entirely in the script. Rather than
-   * reimplement it, this asks the script's own non-executing oracle:
-   * `--print-argv` emits the compose argv it WOULD run, one entry per line, and
-   * the socket overlay is present in the `-f` list exactly when the opt-in is
-   * on. No `truthy()` port, no env-file parsing, no `DOCKER_SOCKET` read.
-   *
-   * `"files"` and `"ports"` are deliberately NOT advertised: this contract
-   * declares no method for moving files or forwarding ports, so claiming them
-   * would be a capability a caller cannot use.
-   */
   async capabilities(): Promise<ReadonlySet<ExecutionCapability>> {
     const caps = new Set<ExecutionCapability>(["exec", "pty"]);
     const script = this.composeScript();
@@ -161,15 +88,6 @@ export class DockerComposeExecutionTarget implements ExecutionTarget {
     return caps;
   }
 
-  /**
-   * Run one argv to completion inside the environment. Defaults to
-   * `stdio: "capture"` — the caller asked for a result, not a terminal.
-   *
-   * A non-zero exit is data, not an exception: it comes back as `exitCode`.
-   * `stdout`/`stderr` carry the REAL captured streams; they are `""` only for
-   * `stdio: "inherit"` runs, where both streams went straight to the terminal
-   * and were never captured.
-   */
   async exec(request: ExecRequest): Promise<ExecResult> {
     const name = this.requireContainer();
     const inherit = request.stdio === "inherit";
@@ -185,12 +103,6 @@ export class DockerComposeExecutionTarget implements ExecutionTarget {
     };
   }
 
-  /**
-   * Hand the terminal to an interactive child and return its exit code.
-   * Synchronous in `contractVersion: 1` — see `target.ts`'s header and
-   * `rfc-brain-hands-boundary.md` § 6. Always inherits stdio (that is what
-   * attaching means), so `request.stdio` is not consulted.
-   */
   attach(request: ExecRequest): number {
     const name = this.requireContainer();
     const r = this.run("docker", this.execArgv(request, true), { stdio: "inherit" });
@@ -202,7 +114,6 @@ export class DockerComposeExecutionTarget implements ExecutionTarget {
     return `docker compose target at ${this.projectRoot}${this.container ? ` (container ${this.container})` : ""}`;
   }
 
-  /** `docker exec [-it] [-u user] [-w cwd] [-e K=V …] <container> <argv…>`. */
   private execArgv(request: ExecRequest, interactive: boolean): string[] {
     const argv = ["exec"];
     if (interactive) argv.push("-it");
@@ -213,12 +124,10 @@ export class DockerComposeExecutionTarget implements ExecutionTarget {
     return argv;
   }
 
-  /** The vendored compose wrapper every compose operation delegates to. */
   private composeScript(): string {
     return requireLifecycleScript(this.projectRoot, "docker-compose.sh");
   }
 
-  /** Operations that address the running environment need its name. */
   private requireContainer(): string {
     if (this.container === undefined || this.container === "") {
       throw new Error("no container name was supplied to the execution target");
@@ -227,11 +136,6 @@ export class DockerComposeExecutionTarget implements ExecutionTarget {
   }
 }
 
-/**
- * The `-f <file>` pairs out of a `--print-argv` dump (one argv entry per line).
- * Reads the value that FOLLOWS each `-f`, so a filename can never be mistaken
- * for a flag or vice versa.
- */
 function composeFileList(printed: string): string[] {
   const lines = printed.split("\n");
   const files: string[] = [];

--- a/.oh/cli/src/lib/execution/index.ts
+++ b/.oh/cli/src/lib/execution/index.ts
@@ -4,29 +4,12 @@ import {
 } from "./docker-compose-target.js";
 import type { ExecutionTarget } from "./target.js";
 
-/**
- * The execution-target entry point (EPIC #731, issue #733).
- *
- * `resolveExecutionTarget()` is INTERNAL: it is the CLI's own seam, not a user
- * surface. There is deliberately no `.env` key, CLI flag, or env var that
- * selects a target — Docker Compose is the only implementation in Phase-0, and
- * a selector would be configuration for a choice that does not exist yet. The
- * next substrate arrives by adding an implementation here, not by asking the
- * operator to pick one.
- */
 
-/** Options for the resolved target (currently the compose target's options). */
 export type ResolveExecutionTargetOptions = DockerComposeTargetOptions;
 
-/**
- * An `ExecutionTarget` whose optional `provision()`/`attach()` members are
- * known to be present. Callers get the interface's guarantees without an
- * `attach?.()` optional-call dance, and still never name a concrete class.
- */
 export type ResolvedExecutionTarget = ExecutionTarget &
   Required<Pick<ExecutionTarget, "provision" | "attach">>;
 
-/** The execution target for this harness. Always the Docker Compose target. */
 export function resolveExecutionTarget(
   opts: ResolveExecutionTargetOptions,
 ): ResolvedExecutionTarget {

--- a/.oh/cli/src/lib/execution/runner.ts
+++ b/.oh/cli/src/lib/execution/runner.ts
@@ -2,57 +2,24 @@ import { spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 
-/**
- * The subprocess seam shared by the lifecycle verbs and the execution targets
- * (EPIC #731, issue #733).
- *
- * Extracted out of `../../commands/lifecycle.ts` so an `ExecutionTarget`
- * implementation and the CLI verbs run through the SAME injectable runner —
- * one process boundary, one fake in tests. `commands/lifecycle.ts` re-exports
- * `LifecycleRunner` and `RunResult`, so every existing import path still
- * resolves.
- *
- * All subprocess invocations stay argv-array form (never a shell string).
- */
 
-/**
- * Outcome of one subprocess run — the shape a fake runner returns in tests.
- * Mirrors the useful subset of `spawnSync`'s return value; fakes branch on
- * `error.code` ("ENOENT") vs a non-zero `status`, never a real subprocess.
- */
 export interface RunResult {
-  /** Exit status; null when the process never ran. */
   status: number | null;
-  /** Spawn-level failure, e.g. `code: "ENOENT"` (binary not on PATH). */
   error?: { code?: string; message?: string };
-  /** Captured stdout — only populated by `stdio: "capture"` runs. */
   stdout?: string;
-  /**
-   * Captured stderr — only populated by `stdio: "capture"` runs, under exactly
-   * the same rule as `stdout`. `"inherit"` runs send stderr straight to the
-   * terminal, so there is nothing to capture. Optional so pre-existing fake
-   * runners that only set `status`/`stdout` keep typechecking.
-   */
   stderr?: string;
 }
 
-/** Injectable subprocess runner (DI seam in the style of `RemoteRunner`). */
 export type LifecycleRunner = (
   cmd: string,
   args: string[],
   opts: {
     stdio: "inherit" | "capture";
     env?: NodeJS.ProcessEnv;
-    /** Bounded wall-clock timeout; omitted → no timeout is imposed. */
     timeoutMs?: number;
   },
 ) => RunResult;
 
-/**
- * Real runner. `"inherit"` hands the terminal to the child (live docker build
- * output, interactive shells); `"capture"` collects stdout and stderr for
- * config lookups and `exec()` results.
- */
 export const spawnRunner: LifecycleRunner = (cmd, args, opts) => {
   const common = { env: opts.env, ...(opts.timeoutMs !== undefined ? { timeout: opts.timeoutMs } : {}) };
   const r =
@@ -68,9 +35,7 @@ export const spawnRunner: LifecycleRunner = (cmd, args, opts) => {
   };
 };
 
-/** The child never ran at all — a spawn-level failure, not a bad exit code. */
 export class ExecutionSpawnError extends Error {
-  /** `spawnSync`'s error code, e.g. "ENOENT" (binary not on PATH). */
   readonly code?: string;
 
   constructor(what: string, error?: { code?: string; message?: string }) {
@@ -80,12 +45,6 @@ export class ExecutionSpawnError extends Error {
   }
 }
 
-/**
- * The child ran and exited non-zero. Thrown only by operations whose contract
- * return type has nowhere to put an exit code (`provision(): Promise<void>`);
- * `attach()` and `exec()` return the code instead of throwing. Callers that
- * propagate a child's exit status translate this back into their own exit code.
- */
 export class ExecutionExitError extends Error {
   readonly exitCode: number;
 
@@ -96,14 +55,12 @@ export class ExecutionExitError extends Error {
   }
 }
 
-/** Throw when the child never ran at all (spawn-level failure, not a bad exit). */
 export function assertSpawned(r: RunResult, what: string): void {
   if (r.error) {
     throw new ExecutionSpawnError(what, r.error);
   }
 }
 
-/** A vendored lifecycle script the caller is about to delegate to must exist. */
 export function requireLifecycleScript(root: string, rel: string): string {
   const script = join(root, ".oh", "scripts", rel);
   if (!existsSync(script)) {

--- a/.oh/cli/src/lib/execution/target.ts
+++ b/.oh/cli/src/lib/execution/target.ts
@@ -1,143 +1,45 @@
-/**
- * The provider-neutral execution contract (EPIC #731, issue #733).
- *
- * `ExecutionTarget` is the seam between the harness's brain (planning, memory,
- * scheduling) and its hands (whatever actually runs a process on its behalf).
- * Callers provision, inspect, and execute through this interface without
- * knowing which substrate is on the other side; capability discovery — not a
- * `kind` string check — is how a caller asks what an environment can do.
- *
- * Types and interface ONLY: no implementation, no runtime imports. The
- * boundary decisions this file encodes are recorded once, in
- * `.oh/docs/rfcs/rfc-brain-hands-boundary.md`. That RFC is the sole authority
- * for them and is cited here, never restated.
- *
- * THREE deliberate refinements to the sketch in issue #733:
- *
- * 1. `ExecRequest.argv: string[]`, not `command: string`. The codebase bans
- *    shell strings — every subprocess invocation is argv-array form. A
- *    `command: string` field would reintroduce shell-injection surface at the
- *    exact seam this file creates.
- *
- * 2. `ExecutionStatus` gains `"absent"`. The sketch's four states cannot
- *    express "this target has never been provisioned", which `status()` must
- *    be able to report before `provision()` has ever run.
- *
- * 3. `attach?()` is SYNCHRONOUS — `attach?(request: ExecRequest): number`, not
- *    `Promise<number>`. It wraps the existing synchronous process-runner seam
- *    (`../../commands/lifecycle.ts:49-53`, over `spawnSync` at `:59`) and is a
- *    blocking terminal handoff: it gives stdio to the child, blocks until the
- *    child exits, and returns its exit code. There is nothing to await. Every
- *    other method — `provision?()`, `status()`, `capabilities()`, `exec()`,
- *    `destroy?()` — is async; the asymmetry is deliberate.
- *
- *    MIGRATION PATH: this is a versioned decision, not a closed door. If a
- *    later substrate, or durable/remote sessions (#732), need a non-blocking
- *    attach, the contract bumps to `contractVersion: 2` with
- *    `attach(): Promise<number>` (or a sibling async method) and migrates its
- *    callers AND their assertions at that point, as a separately-reviewed
- *    change. Full rationale: `rfc-brain-hands-boundary.md` § 6.
- */
 
-/**
- * Lifecycle state of an execution target, as reported by `status()`.
- *
- * `"absent"` is the pre-provision state — the target has never been created.
- * It is distinct from `"stopped"`, which means the target exists but is not
- * currently running.
- */
 export type ExecutionStatus = "absent" | "starting" | "ready" | "stopped" | "failed";
 
-/**
- * What an execution target can do. Callers branch on these, never on `kind`,
- * so a new substrate becomes usable without editing its callers.
- */
 export type ExecutionCapability =
-  /** Run one argv to completion inside the environment. */
   | "exec"
-  /** Hand an interactive terminal to a child process. */
   | "pty"
-  /** Move files in and out of the environment from the outside. */
   | "files"
-  /** Publish or forward network ports out of the environment. */
   | "ports"
-  /** A Docker daemon is reachable from inside the environment. */
   | "docker"
-  /** Capture and restore environment state. Capability literal only — this contract declares no method for it. */
   | "snapshot";
 
-/** One execution request. */
 export type ExecRequest = {
-  /** Program and arguments in argv-array form. Never a shell string. */
   argv: string[];
-  /** Working directory inside the target. Omitted → the target's own default. */
   cwd?: string;
-  /** Extra environment variables for the child process. */
   env?: Record<string, string>;
-  /** Bounded wall-clock timeout in ms. Omitted → no timeout is imposed. */
   timeoutMs?: number;
-  /**
-   * `"inherit"` gives this process's stdio to the child (live output,
-   * interactive sessions); `"capture"` collects stdout/stderr into the
-   * `ExecResult`. Omitted → the implementation's documented default.
-   */
   stdio?: "inherit" | "capture";
-  /** User to run as inside the target. Omitted → the target's default user. */
   user?: string;
 };
 
-/** Outcome of one `exec()` call. */
 export type ExecResult = {
-  /** Child exit code. */
   exitCode: number;
-  /**
-   * Captured stdout. Empty for `stdio: "inherit"` runs — inherited output went
-   * straight to the terminal and was never captured.
-   */
   stdout: string;
-  /** Captured stderr, under the same capture rule as `stdout`. Required. */
   stderr: string;
 };
 
-/**
- * A place the harness can run work. Implementations wrap a substrate; nothing
- * above this seam knows which one.
- */
 export interface ExecutionTarget {
-  /** Stable implementation identifier, e.g. for logs and `describe()`. */
   readonly kind: string;
-  /** Contract version this implementation satisfies. */
   readonly contractVersion: 1;
-  /**
-   * The workspace mapping: where the project tree lives on the host, and the
-   * path the same tree is reachable at inside the target. Phase-0 supports the
-   * identical mapping (`hostRoot === targetRoot`) only, and the two-field shape
-   * is explicitly speculative — see `rfc-brain-hands-boundary.md` § 5 / § 5.1.
-   */
   readonly workspace: { hostRoot: string; targetRoot: string };
 
-  /** Create/start the environment. Optional: some targets always exist. */
   provision?(): Promise<void>;
 
-  /** Current lifecycle state. */
   status(): Promise<ExecutionStatus>;
 
-  /** What this target can do, discovered at runtime. */
   capabilities(): Promise<ReadonlySet<ExecutionCapability>>;
 
-  /** Run one argv to completion and report its outcome. */
   exec(request: ExecRequest): Promise<ExecResult>;
 
-  /**
-   * Give the terminal to an interactive child and return its exit code.
-   * SYNCHRONOUS in `contractVersion: 1` — see refinement 3 in the file header.
-   * Optional: only targets advertising `"pty"` implement it.
-   */
   attach?(request: ExecRequest): number;
 
-  /** Tear the environment down. Optional. */
   destroy?(): Promise<void>;
 
-  /** One-line human-readable description, for logs and diagnostics. */
   describe(): string;
 }

--- a/.oh/cli/src/lib/harnesses/catalog.ts
+++ b/.oh/cli/src/lib/harnesses/catalog.ts
@@ -1,74 +1,22 @@
-/**
- * The agent-harness catalog — the single source of truth `oh harness` reads.
- *
- * WHY A BUNDLED TS MODULE, not a data file under `.oh/` and not the docs:
- *
- *  - An installed `oh` binary has no readable `.oh/` payload. That is exactly
- *    why `resolveInitSource` / `bundledPayloadExists` exist in `../../cli.ts`.
- *    A data file would need the same remote-fallback dance for a static table.
- *  - The docs are already drifted: `.oh/docs/harnesses/claude-code.md` says
- *    `pnpm add -g @anthropic-ai/claude-code` while `.devcontainer/Dockerfile`
- *    runs `npm install -g`. Docs are prose, not a source of truth.
- *
- * `.devcontainer/Dockerfile` IS the ground truth for every `installArgv`,
- * including version pins. `__tests__/harness-catalog.test.ts` enforces that as a
- * drift test, so this table cannot silently diverge from the image build.
- *
- * SHELL-STRING RULE: this repo passes argv arrays, never shell command strings
- * built at runtime. Two upstream installers are genuinely pipelines
- * (`curl … | bash`), so their argv is `["bash", "-lc", "<constant>"]`. That
- * string is a LITERAL in this file with zero interpolation — nothing derived
- * from a user-supplied harness name ever reaches a shell.
- */
 
-/** How a harness reaches the sandbox image. */
 export type HarnessKind =
-  /** In the default image build (the `AGENTS` build-arg list). */
   | "default"
-  /** Behind an `INSTALL_*` build arg / `.devcontainer/.env` key. */
   | "optional"
-  /** Never baked in; fetched at use time (`npx`). */
   | "on-demand";
 
-/** One harness the CLI knows how to inspect and install. */
 export interface HarnessEntry {
-  /** Doc slug — the name the user types. Matches `.oh/docs/harnesses/<id>.md`. */
   readonly id: string;
-  /** Human-readable name for list/status output. */
   readonly title: string;
-  /** Executable this harness puts on PATH. */
   readonly binary: string;
-  /**
-   * `INSTALL_*` key in lower snake_case WITHOUT the prefix, e.g. `grok_build`.
-   * NOTE the underscore — the key is `install.grok_build` while the slug is
-   * `grok-build`. `undefined` for `default` and `on-demand` harnesses, which
-   * have no flag; the installer must never invent one for them.
-   */
   readonly harnessKey?: string;
-  /** Dockerfile build arg this key maps to. Absent when `harnessKey` is. */
   readonly buildArg?: string;
-  /** Install command, argv form. Copied verbatim from the Dockerfile. */
   readonly installArgv: readonly string[];
-  /**
-   * User the install runs as inside the container. This is NOT cosmetic:
-   * `UV_TOOL_DIR`/`UV_TOOL_BIN_DIR` point under `/home/sandbox`, and pi installs
-   * under the sandbox user's npm prefix so `pi update` works without sudo.
-   */
   readonly installUser: "root" | "sandbox";
-  /** Presence check. Exit 0 → already installed. */
   readonly verifyArgv: readonly string[];
-  /** Repo-relative doc path, printed in list/status output. */
   readonly docsPath: string;
   readonly kind: HarnessKind;
 }
 
-/**
- * Every harness documented under `.oh/docs/harnesses/`, and only those.
- *
- * `INSTALL_AGENT_BROWSER` lives in the same `.devcontainer/.env` namespace but
- * is a browser tool, not a harness — it is deliberately absent, and `oh harness`
- * must never write it.
- */
 export const HARNESS_CATALOG: readonly HarnessEntry[] = [
   {
     id: "claude-code",
@@ -91,9 +39,6 @@ export const HARNESS_CATALOG: readonly HarnessEntry[] = [
     kind: "default",
   },
   {
-    // Installed under the sandbox user's npm prefix so `pi update` can
-    // self-update the active executable without sudo (Dockerfile: the
-    // `su - sandbox -c 'npm --prefix "$HOME/.local" …'` step).
     id: "pi",
     title: "Pi",
     binary: "pi",
@@ -124,10 +69,6 @@ export const HARNESS_CATALOG: readonly HarnessEntry[] = [
     kind: "optional",
   },
   {
-    // Pipeline installer. The version pin (0.2.39) is asserted against the
-    // Dockerfile by the drift test. The two post-install steps mirror the image
-    // build: symlink the launcher onto PATH, and drop the `agent` alias the
-    // installer leaves behind (it collides with other tooling).
     id: "grok-build",
     title: "Grok Build",
     binary: "grok",
@@ -144,9 +85,6 @@ export const HARNESS_CATALOG: readonly HarnessEntry[] = [
     kind: "optional",
   },
   {
-    // Runs as `sandbox`, NOT root: UV_TOOL_DIR/UV_TOOL_BIN_DIR are set to paths
-    // under /home/sandbox, so a root-run `uv tool install` would write
-    // root-owned files into the sandbox user's tool dirs.
     id: "deepagents",
     title: "DeepAgents",
     binary: "deepagents",
@@ -159,8 +97,6 @@ export const HARNESS_CATALOG: readonly HarnessEntry[] = [
     kind: "optional",
   },
   {
-    // Pipeline installer plus the messaging extras the gateway adapters need,
-    // so the Slack/Teams bridges work with no post-install step.
     id: "hermes",
     title: "Hermes",
     binary: "hermes",
@@ -177,9 +113,6 @@ export const HARNESS_CATALOG: readonly HarnessEntry[] = [
     kind: "optional",
   },
   {
-    // Never baked into the image. `npx --yes t3` fetches it at use time, which
-    // is also what the `/t3` skill does — so "installing" it is a no-op fetch
-    // that warms the npx cache. It has no `INSTALL_*` key by design.
     id: "t3code",
     title: "T3 Code",
     binary: "t3",
@@ -190,22 +123,6 @@ export const HARNESS_CATALOG: readonly HarnessEntry[] = [
     kind: "on-demand",
   },
   {
-    // Never baked into the image, so it has no `INSTALL_*` key: the upstream
-    // installer resolves the latest release at run time, and pinning it in the
-    // Dockerfile would make this catalog the second place a version lives.
-    //
-    // Three details in the argv are load-bearing:
-    //   - `npm_config_prefix` puts the global install under the sandbox user's
-    //     own prefix (the same one pi uses), so the default root-owned
-    //     /usr/lib/node_modules is never written and `prime-agent update`
-    //     needs no sudo.
-    //   - `setsid --wait` drops the controlling terminal. The installer's two
-    //     confirmation prompts read /dev/tty directly, so redirecting stdin
-    //     does not silence them; with no controlling terminal they report
-    //     "No terminal detected" and proceed.
-    //   - `PRIME_AGENT_BOOTSTRAP_KERNEL_ON_INSTALL=0` skips the IPython
-    //     runtime (uv + Python 3.11 + ipykernel). The agent prepares it on
-    //     first ipython use, which keeps the on-demand install light.
     id: "prime-agent",
     title: "Prime Agent",
     binary: "prime-agent",
@@ -221,12 +138,10 @@ export const HARNESS_CATALOG: readonly HarnessEntry[] = [
   },
 ];
 
-/** Catalog lookup by doc slug. `undefined` when the name is unknown. */
 export function findHarness(id: string): HarnessEntry | undefined {
   return HARNESS_CATALOG.find((h) => h.id === id);
 }
 
-/** Every valid `<name>`, for the unknown-name error and the help text. */
 export function harnessIds(): string[] {
   return HARNESS_CATALOG.map((h) => h.id);
 }

--- a/.oh/cli/src/lib/manifest.ts
+++ b/.oh/cli/src/lib/manifest.ts
@@ -1,39 +1,13 @@
 import { readFileSync } from 'node:fs';
 import path from 'node:path';
 
-/**
- * The declared `.oh/` payload contract: an allowlist of glob patterns to ship
- * (`include`) minus an explicit denylist (`exclude`). All patterns are POSIX
- * `/`-separated and relative to `.oh/`. `exclude` always wins over `include`.
- */
 export interface Manifest {
   include: string[];
   exclude: string[];
 }
 
-/** Regex-special characters that must be backslash-escaped to match literally. */
 const REGEX_SPECIAL = new Set(['.', '+', '?', '^', '$', '{', '}', '(', ')', '|', '[', ']', '\\']);
 
-/**
- * Translate a POSIX glob into an anchored (`^...$`) RegExp with these EXACT,
- * documented semantics (US-003 unit-tests them directly):
- *
- *  - a `**\/` token translates to `(?:.*\/)?` — matches zero-or-more leading
- *    segments, so a leading `**\/` ALSO matches zero leading segments
- *    (`**\/node_modules\/**` matches BOTH `node_modules/x` and `cli/node_modules/x`);
- *  - a standalone `**` (not followed by `/`) translates to `.*` (cross-segment,
- *    includes `/`);
- *  - a single `*` translates to `[^/]*` (within one segment, excludes `/`);
- *  - every regex-special char among `.+?^${}()|[]\` is backslash-escaped;
- *  - a literal `/` stays `/`.
- *
- * A pattern with NO wildcard is therefore an EXACT match
- * (e.g. `README.md` -> /^README\.md$/, matching 'README.md' but NOT 'cli/README.md').
- *
- * The glob is processed left-to-right via an index walk so the two-char `**`
- * token is detected before the one-char `*` (a sequential String.replace could
- * double-translate `**` -> `.*` -> ...).
- */
 export function globToRegExp(glob: string): RegExp {
   let out = '';
   let i = 0;
@@ -56,11 +30,6 @@ export function globToRegExp(glob: string): RegExp {
   return new RegExp('^' + out + '$');
 }
 
-/**
- * True IFF `relpath` matches at least one `manifest.include` pattern AND zero
- * `manifest.exclude` patterns (exclude WINS over include). `relpath` is a POSIX
- * `/`-separated path relative to `.oh/` (e.g. 'cli/src/cli.ts', 'manifest.json').
- */
 export function shouldShip(relpath: string, manifest: Manifest): boolean {
   const included = manifest.include.some((pattern) => globToRegExp(pattern).test(relpath));
   if (!included) {
@@ -70,18 +39,6 @@ export function shouldShip(relpath: string, manifest: Manifest): boolean {
   return !excluded;
 }
 
-/**
- * Read `<fromOh>/manifest.json` (via readFileSync + JSON.parse inside try/catch).
- *
- * Returns `null` (-> caller back-compat legacy-mode) when the file is ABSENT,
- * unparseable, its parsed value lacks an array `include`, OR `include` is an
- * EMPTY array. (An empty allowlist would make `shouldShip` return false for
- * everything and silently ship NOTHING — a hollow-out footgun; treating it as
- * 'no manifest' instead surfaces the caller's legacy-mode warning.)
- *
- * On success returns `{ include, exclude: Array.isArray(parsed.exclude) ? parsed.exclude : [] }`
- * (a missing `exclude` is tolerated as `[]`). NEVER throws.
- */
 export function loadManifest(fromOh: string): Manifest | null {
   try {
     const manifestPath = path.resolve(fromOh, 'manifest.json');

--- a/.oh/cli/src/lib/project.ts
+++ b/.oh/cli/src/lib/project.ts
@@ -1,26 +1,10 @@
 import { statSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 
-/**
- * Equipped-project-root resolution (issue #564).
- *
- * The lifecycle verbs (`oh sandbox` / `oh shell` / `oh gateway`) all operate on
- * an `oh init`-equipped repo and must work from any subdirectory of it, so they
- * share this one resolver: walk up from the starting directory to the first
- * ancestor containing a `.oh/` directory.
- */
 
-/**
- * Walk up from `startDir` (default: cwd) to the first directory containing a
- * `.oh/` directory and return that directory — the equipped project root.
- *
- * Throws a plain `Error` (no `oh:` prefix — cli.ts's main() adds it and maps
- * thrown errors to exit code 2) when no ancestor is equipped.
- */
 export function resolveProjectRoot(startDir: string = process.cwd()): string {
   let dir = resolve(startDir);
   for (;;) {
-    // `.oh` must be a directory — a stray file of that name does not equip a repo.
     const marker = statSync(join(dir, ".oh"), { throwIfNoEntry: false });
     if (marker?.isDirectory()) return dir;
     const parent = dirname(dir);

--- a/.oh/cli/src/lib/prompt.ts
+++ b/.oh/cli/src/lib/prompt.ts
@@ -40,9 +40,6 @@ export function bold(s: string): string {
 }
 
 export function link(url: string, label: string): string {
-  // OSC 8 hyperlink — supported by VS Code, iTerm2, GNOME Terminal, Windows
-  // Terminal. Unsupported terminals show only the label, so fall back to
-  // "label (url)" so the URL is still copy-pasteable.
   if (!process.stdout.isTTY) return `${label} (${url})`;
   return `\x1b]8;;${url}\x1b\\${label}\x1b]8;;\x1b\\`;
 }
@@ -64,8 +61,6 @@ export async function ask(question: string): Promise<string> {
 }
 
 export async function askSecret(question: string): Promise<string> {
-  // Non-TTY (piped stdin, tests): the raw-mode path can't be used — fall back
-  // to the readline-based echo-suppressed implementation.
   if (!process.stdin.isTTY) return askSecretPiped(question);
 
   process.stdout.write(`  ${question} `);
@@ -75,36 +70,35 @@ export async function askSecret(question: string): Promise<string> {
   const bytes: number[] = [];
   return await new Promise<string>((resolve) => {
     const cleanup = (): void => {
-      try { process.stdin.setRawMode(false); } catch { /* ignore */ }
+      try { process.stdin.setRawMode(false); } catch { }
       process.stdin.pause();
       process.stdin.removeListener("data", onData);
     };
     const onData = (data: Buffer): void => {
       for (const byte of data) {
-        if (byte === 0x03) {                            // Ctrl-C
+        if (byte === 0x03) {
           cleanup();
           process.stdout.write("\n");
-          process.exit(130);                             // 128 + SIGINT(2)
-        } else if (byte === 0x0d || byte === 0x0a) {    // Enter
+          process.exit(130);
+        } else if (byte === 0x0d || byte === 0x0a) {
           cleanup();
           process.stdout.write("\n");
           resolve(Buffer.from(bytes).toString("utf8").trim());
           return;
-        } else if (byte === 0x7f || byte === 0x08) {    // Backspace / DEL
+        } else if (byte === 0x7f || byte === 0x08) {
           if (bytes.length > 0) {
             bytes.pop();
             process.stdout.write("\b \b");
           }
-        } else if (byte === 0x15) {                     // Ctrl-U → clear line
+        } else if (byte === 0x15) {
           while (bytes.length > 0) {
             bytes.pop();
             process.stdout.write("\b \b");
           }
-        } else if (byte >= 0x20) {                      // printable + UTF-8 cont.
+        } else if (byte >= 0x20) {
           bytes.push(byte);
           process.stdout.write("●");
         }
-        // Silently drop other control bytes (Tab, Esc sequences, etc.).
       }
     };
     process.stdin.on("data", onData);
@@ -114,9 +108,6 @@ export async function askSecret(question: string): Promise<string> {
 async function askSecretPiped(question: string): Promise<string> {
   const rl = createInterface({ input: process.stdin, output: process.stdout });
 
-  // Suppress echo by intercepting the output writer. Without this, every
-  // keystroke would be echoed to the terminal and the token would be
-  // visible mid-entry.
   const stdoutWrite = process.stdout.write.bind(process.stdout);
   let prompted = false;
   const patched = (chunk: string | Uint8Array): boolean => {
@@ -124,7 +115,7 @@ async function askSecretPiped(question: string): Promise<string> {
       prompted = true;
       return stdoutWrite(chunk);
     }
-    return true; // swallow keystroke echoes
+    return true;
   };
   type WritableHole = { write: (chunk: string | Uint8Array) => boolean };
   (process.stdout as unknown as WritableHole).write = patched;
@@ -134,7 +125,7 @@ async function askSecretPiped(question: string): Promise<string> {
     if (restored) return;
     restored = true;
     (process.stdout as unknown as WritableHole).write = stdoutWrite;
-    try { rl.close(); } catch { /* ignore */ }
+    try { rl.close(); } catch { }
   };
 
   const onSigint = (): void => {

--- a/.oh/cli/src/lib/remote.ts
+++ b/.oh/cli/src/lib/remote.ts
@@ -1,35 +1,15 @@
 import { spawnSync } from "node:child_process";
 
-/**
- * Remote payload sourcing for `oh init` / `oh update` (issue #564).
- *
- * Materializes a pristine OpenHarness checkout by shallow-cloning the public
- * repo into a caller-supplied temp directory. The caller owns the directory's
- * lifecycle (mkdtemp before, rm in a try/finally after) — this module only
- * fills it. All subprocess invocations use argv-array form (never a shell
- * string, mirroring lib/tmux.ts) and the CLI stays dependency-free.
- */
 
 export const DEFAULT_REPO_URL = "https://github.com/mifunedev/openharness";
 export const DEFAULT_CLONE_TIMEOUT_MS = 120_000;
 
-/**
- * Outcome of one subprocess run — the shape a fake runner returns in tests.
- * Mirrors the useful subset of `spawnSync`'s return value.
- */
 export interface RunResult {
-  /** Exit status; null when the process never ran or was killed (timeout). */
   status: number | null;
-  /**
-   * Spawn-level failure, e.g. `code: "ENOENT"` (git not on PATH) or
-   * `code: "ETIMEDOUT"` (bounded timeout exceeded).
-   */
   error?: { code?: string; message?: string };
-  /** Captured stderr — surfaces git's own failure reason in thrown errors. */
   stderr?: string;
 }
 
-/** Injectable subprocess runner (DI seam in the style of `InitIO`). */
 export type RemoteRunner = (
   cmd: string,
   args: string[],
@@ -37,22 +17,13 @@ export type RemoteRunner = (
 ) => RunResult;
 
 export interface FetchRemoteSourceOptions {
-  /**
-   * Caller-supplied temp directory to clone into (empty or nonexistent;
-   * `git clone` refuses a non-empty one). Returned on success.
-   */
   destDir: string;
-  /** Clone URL. Default: the public OpenHarness repo. Tests use `file://` fixtures. */
   repoUrl?: string;
-  /** Branch/tag to clone (`--branch <ref>`). Omitted → the clone's default branch. */
   ref?: string;
-  /** Bounded clone timeout in ms. Default 120000; overridable for tests. */
   timeoutMs?: number;
-  /** Subprocess runner. Default: real `spawnSync`. Tests inject a fake. */
   run?: RemoteRunner;
 }
 
-/** Real runner: argv-array spawnSync, stderr captured for error surfacing. */
 const spawnRunner: RemoteRunner = (cmd, args, opts) => {
   const r = spawnSync(cmd, args, {
     env: opts.env,
@@ -68,29 +39,16 @@ const spawnRunner: RemoteRunner = (cmd, args, opts) => {
   };
 };
 
-/** The offline-fallback suffix every fetch failure suggests. */
 function fallbackHint(): string {
   return "use --from <dir> to point at a local OpenHarness checkout instead";
 }
 
-/**
- * Shallow-clone the OpenHarness repo into `opts.destDir` and return that path.
- *
- * Runs `git clone --depth 1 [--branch <ref>] -- <repoUrl> <destDir>` with
- * `GIT_TERMINAL_PROMPT=0` (auth failures fail fast instead of blocking on a
- * credential prompt) and a bounded timeout. Every failure throws a plain
- * `Error` naming the URL tried and suggesting the `--from <dir>` offline
- * fallback; cli.ts's main() maps thrown errors to exit code 2.
- */
 export function fetchRemoteSource(opts: FetchRemoteSourceOptions): string {
   const repoUrl = opts.repoUrl ?? DEFAULT_REPO_URL;
   const ref = opts.ref;
   const timeoutMs = opts.timeoutMs ?? DEFAULT_CLONE_TIMEOUT_MS;
   const run = opts.run ?? spawnRunner;
 
-  // Flag-injection guard: user-supplied values must never be parseable as
-  // git options. Rejected BEFORE any spawn (the `--` separator below is
-  // defense-in-depth, not the primary guard).
   if (repoUrl.startsWith("-")) {
     throw new Error(`invalid repo URL "${repoUrl}" (must not start with "-")`);
   }
@@ -126,8 +84,6 @@ export function fetchRemoteSource(opts: FetchRemoteSourceOptions): string {
     );
   }
   if (r.status !== 0) {
-    // Covers auth failures too: with GIT_TERMINAL_PROMPT=0 git exits non-zero
-    // ("terminal prompts disabled") instead of hanging on a credential prompt.
     const detail = (r.stderr ?? "").trim();
     throw new Error(
       `git clone of ${repoUrl} failed (exit ${r.status})` +

--- a/.oh/cli/src/lib/runtimes/catalog.ts
+++ b/.oh/cli/src/lib/runtimes/catalog.ts
@@ -1,85 +1,19 @@
-/**
- * The isolation-runtime catalog — the single source of truth `oh runtime` reads.
- *
- * A RUNTIME IS NOT A HARNESS. `../harnesses/catalog.ts` lists agent CLIs that
- * run *inside* the sandbox; this file lists the isolation boundaries the sandbox
- * itself runs *on*. They are deliberately separate tables: a harness is a
- * package, a runtime is a kernel boundary, and conflating them would put `msb`
- * in the same list as `claude`.
- *
- * "runtime" is the word Docker already uses (`docker run --runtime=runsc`) and
- * the word this repo already uses (`.oh/docs/rfcs/rfc-runtime-support.md`).
- * NAMING THE COMMAND DOES NOT SETTLE THE CONFIG KEY: #806 § B1 records
- * `sandbox.substrate` vs `sandbox.runtime` as an open decision owned by #731,
- * and this file writes neither — see below.
- *
- * WHY THIS TABLE DECLARES NO `INSTALL_*` KEY, AND NO DOCKERFILE BUILD ARG:
- *
- *  - No config key. #806 § B1 states that settling the selector outside #731
- *    forks the `ExecutionTarget` seam at `../execution/index.ts`. So
- *    `oh runtime` writes NOTHING. It reports which runtime is in use, measures
- *    what the others would need, and installs a tool; it does not select a
- *    runtime. Selection is #731's, and this command stays correct whichever
- *    name wins.
- *
- *  - No build arg. `.devcontainer/Dockerfile` pins `debian:bookworm-slim`
- *    (glibc 2.36) and the MicroSandbox installer floors at glibc 2.39 (#805).
- *    A build arg would bake a guaranteed-failing install into every image.
- *
- * Consequently `oh runtime install` is LIVE-ONLY by construction. The
- * persist-first ordering that `oh harness install` uses does not apply here,
- * because there is nothing durable to persist.
- *
- * SHELL-STRING RULE, inherited from the harness catalog: argv arrays only.
- * The MicroSandbox installer is genuinely a two-step pipeline, so its argv is
- * `["bash", "-lc", "<constant>"]` where the string is a LITERAL in this file
- * with zero interpolation. Nothing derived from a user-supplied name ever
- * reaches a shell.
- *
- * PROVENANCE: every MicroSandbox command below is copied from
- * `.oh/tasks/microsandbox-substrate/next-tasks.md` on PR #803 — the P0 spike
- * record. None is invented. MicroSandbox has never produced a binary in this
- * harness, so there is no local round trip to derive them from, and guessing an
- * installer flag would be worse than citing the spike.
- */
 
-/** Isolation depth. Not a ranking — a description of the boundary. */
 export type RuntimeTier =
-  /** A shared host kernel with namespaces and cgroups. What runs today. */
   | "container"
-  /** One real kernel per sandbox, KVM-backed. */
   | "microvm"
-  /** A userspace kernel intercepts syscalls. No KVM needed. */
   | "syscall-interposition";
 
-/** How far a runtime has got in this harness. */
 export type RuntimeState =
-  /** In use right now. The sandbox runs on this. */
   | "active"
-  /** Measured, and measured to NOT work here yet. Blockers are known. */
   | "blocked"
-  /** Measured green elsewhere. Not implemented here, and no adoption decision. */
   | "planned";
 
-/**
- * One requirement, probed and reported.
- *
- * `scope` decides WHERE it runs, and the two are genuinely different machines:
- * `"target"` runs inside the sandbox through `ExecutionTarget.exec` (that is
- * where glibc and `/dev/kvm` must be right), while `"host"` runs on the machine
- * holding the `oh` binary (that is where the Docker daemon lives). A host check
- * asked inside the container would answer about the wrong kernel.
- *
- * A discriminated union rather than a free-form predicate so the catalog stays
- * data: `__tests__/runtime-catalog.test.ts` asserts the declared floor, and a
- * probe asserts the checks exist at all.
- */
 export type PreflightCheck =
   | {
       readonly id: "glibc";
       readonly scope: "target";
       readonly label: string;
-      /** Minimum acceptable `major.minor`. */
       readonly minVersion: string;
       readonly probeArgv: readonly string[];
       readonly remediation: string;
@@ -88,13 +22,11 @@ export type PreflightCheck =
       readonly id: "device";
       readonly scope: "target";
       readonly label: string;
-      /** Device path that must exist. */
       readonly path: string;
       readonly probeArgv: readonly string[];
       readonly remediation: string;
     }
   | {
-      /** A command that must exit 0. Its stdout is reported as the found value. */
       readonly id: "command";
       readonly scope: "host" | "target";
       readonly label: string;
@@ -102,57 +34,23 @@ export type PreflightCheck =
       readonly remediation: string;
     };
 
-/** One isolation runtime the CLI knows how to inspect and (maybe) install. */
 export interface RuntimeEntry {
-  /** The name the user types. Matches `.oh/docs/runtimes/<id>.md` when one exists. */
   readonly id: string;
   readonly title: string;
   readonly tier: RuntimeTier;
   readonly state: RuntimeState;
-  /**
-   * Can `oh runtime install <id>` do anything at all? `false` means either
-   * "already in use" or "the adoption decision is unmade" — never "this runtime
-   * is bad". `notInstallableReason` says which.
-   */
   readonly installable: boolean;
-  /** Why `install` refuses. Required when `installable` is false. */
   readonly notInstallableReason?: string;
-  /** Executable this runtime puts on PATH. Absent when not installable. */
   readonly binary?: string;
-  /** Install command, argv form. Absent when not installable. */
   readonly installArgv?: readonly string[];
-  /** User the install runs as inside the container. */
   readonly installUser?: "root" | "sandbox";
-  /** Presence check, run inside the container. Absent when not installable. */
   readonly verifyArgv?: readonly string[];
-  /**
-   * Post-install self-check. `msb self doctor` per #805's acceptance list.
-   * Run for its exit code only; a non-zero result downgrades the success
-   * message rather than failing the install, because the install itself
-   * succeeded and the doctor is diagnosing the host.
-   */
   readonly doctorArgv?: readonly string[];
-  /** Requirements, all of which must pass before an install is attempted. */
   readonly preflight: readonly PreflightCheck[];
-  /** Repo-relative doc path, printed in list/status output. */
   readonly docsPath: string;
-  /** Where this runtime's open work is tracked. Absent when there is none. */
   readonly tracking?: string;
 }
 
-/**
- * Every runtime the harness has measured, in tier order.
- *
- * DOCKER IS LISTED FIRST AND IS NOT A PLACEHOLDER. It is what the sandbox runs
- * on right now, and it is checked exactly like the others — `oh runtime status`
- * measures whether the daemon answers rather than assuming it does. A table
- * that showed only the runtimes you cannot use would answer "what could I move
- * to" while silently skipping "what am I on, and is it healthy".
- *
- * THREE ENTRIES ON PURPOSE, though only one is installable. A one-entry table
- * would encode a false singleton and force a schema change the moment gVisor's
- * adoption decision lands (#806).
- */
 export const RUNTIME_CATALOG: readonly RuntimeEntry[] = Object.freeze([
   Object.freeze({
     id: "docker",
@@ -162,8 +60,6 @@ export const RUNTIME_CATALOG: readonly RuntimeEntry[] = Object.freeze([
     installable: false,
     notInstallableReason:
       "Docker is the runtime the sandbox already runs on — there is nothing to install. `oh sandbox` starts the container; `oh runtime status docker` checks the daemon.",
-    // Host-scope: the daemon lives on the machine holding the `oh` binary, not
-    // inside the container. Asking inside would answer about the wrong kernel.
     preflight: Object.freeze([
       Object.freeze({
         id: "command",
@@ -188,22 +84,12 @@ export const RUNTIME_CATALOG: readonly RuntimeEntry[] = Object.freeze([
     state: "blocked",
     installable: true,
     binary: "msb",
-    // Two steps, from `next-tasks.md` on #803. Kept as one `bash -lc` literal
-    // because the second step consumes the first step's file.
     installArgv: Object.freeze([
       "bash",
       "-lc",
       "curl -sSL https://get.microsandbox.dev -o /tmp/get-msb.sh && sh /tmp/get-msb.sh",
     ]),
-    // The installer places `msb` under the invoking user's home, so this runs
-    // as `sandbox` — the user every interactive session is. See the CAVEAT in
-    // `.oh/docs/runtimes/microsandbox.md`: whether the container or the host is
-    // the intended target is NOT settled by #805, and container-side is chosen
-    // here because it is the only side `ExecutionTarget` can reach.
     installUser: "sandbox",
-    // Presence only. `msb --version` is unverified in this harness — no binary
-    // has ever existed here to confirm the flag — so the check asks the shell,
-    // which cannot be wrong about PATH.
     verifyArgv: Object.freeze(["bash", "-lc", "command -v msb >/dev/null"]),
     doctorArgv: Object.freeze(["msb", "self", "doctor"]),
     preflight: Object.freeze([
@@ -237,40 +123,22 @@ export const RUNTIME_CATALOG: readonly RuntimeEntry[] = Object.freeze([
     installable: false,
     notInstallableReason:
       "gVisor is planned and not yet implemented here. It is a host-side Docker runtime, not a package installed inside the sandbox, so `oh runtime` cannot install it. It measured GREEN (#806, draft PR #804) but the adoption decision is unmade.",
-    // No preflight, deliberately: nothing is implemented to probe. Declaring a
-    // check for an unimplemented runtime would report a readiness the harness
-    // cannot act on. An empty list is the honest answer, not a missing one.
     preflight: Object.freeze([]),
     docsPath: ".oh/docs/runtimes/overview.md",
     tracking: "#806",
   }),
 ]);
 
-/** Look up one runtime by the name the user typed. */
 export function findRuntime(id: string): RuntimeEntry | undefined {
   return RUNTIME_CATALOG.find((r) => r.id === id);
 }
 
-/** Every known runtime id, in catalog order. */
 export function runtimeIds(): string[] {
   return RUNTIME_CATALOG.map((r) => r.id);
 }
 
-/**
- * The runtime `oh runtime install` picks when given no name.
- *
- * NOT `docker`, even though docker is the active one: `install` means "add a
- * runtime this harness does not have", and docker is already here. The only
- * installable entry is the sensible default.
- */
 export const DEFAULT_RUNTIME = "microsandbox";
 
-/**
- * Compare two `major.minor` version strings. Returns <0, 0, or >0.
- *
- * Deliberately numeric per component: a lexical compare puts "2.9" above
- * "2.39", which is exactly the floor this file cares about.
- */
 export function compareVersions(a: string, b: string): number {
   const pa = a.split(".").map((n) => Number.parseInt(n, 10));
   const pb = b.split(".").map((n) => Number.parseInt(n, 10));
@@ -282,19 +150,6 @@ export function compareVersions(a: string, b: string): number {
   return 0;
 }
 
-/**
- * Pull the glibc version out of `ldd --version`'s first line.
- *
- * The line varies by distribution:
- *   `ldd (Ubuntu GLIBC 2.35-0ubuntu3.11) 2.35`
- *   `ldd (Debian GLIBC 2.36-9+deb12u7) 2.36`
- * The trailing bare `major.minor` is the stable part, so the LAST match wins —
- * taking the first would read the packaging string inside the parentheses.
- *
- * Returns `undefined` when nothing matches, which callers must render as
- * "unknown" rather than "too old": failing to read a version is not evidence
- * that the version is bad.
- */
 export function parseGlibcVersion(output: string): string | undefined {
   const matches = output.match(/\d+\.\d+/g);
   return matches ? matches[matches.length - 1] : undefined;

--- a/.oh/cli/src/lib/tools/catalog.ts
+++ b/.oh/cli/src/lib/tools/catalog.ts
@@ -1,108 +1,24 @@
-/**
- * The sandbox-tooling catalog — the single source of truth `oh tool` reads.
- *
- * THE THREE CATALOGS, AND THE LINE BETWEEN THEM:
- *
- *   ../harnesses/catalog.ts  agent CLIs you drive       (claude, codex, pi …)
- *   ../runtimes/catalog.ts   the isolation boundary     (docker, microsandbox …)
- *   this file                everything else the sandbox ships
- *
- * `agent-browser` is the entry that forced the third table. It lives in the
- * same `INSTALL_*` namespace in `.devcontainer/.env` as the optional harnesses, so it looks
- * like one — but it is a headless browser, not an agent, and
- * `__tests__/harness-catalog.test.ts` asserts its exclusion from that catalog.
- * The exclusion was always correct; until now it had no destination.
- *
- * WHY FIVE ENTRIES WHEN ONLY ONE IS INSTALLABLE:
- *
- * A table containing only `agent-browser` WOULD be the false singleton the
- * runtime catalog's header argues against — one row, no shape, a schema change
- * waiting to happen. The fix is not to pad it. The fix is that the category is
- * "sandbox tooling that is neither an agent CLI nor an isolation runtime", and
- * that category already has five real members, four of which are baked into the
- * image and therefore report-only.
- *
- * This is structurally the same table as `../runtimes/catalog.ts`: three
- * entries, exactly one installable. Reporting on a tool you cannot install is
- * the point, not filler — "is `gh` actually here, and what version" is a real
- * question the harness could not answer before.
- *
- * SHELL-STRING RULE, inherited from the harness catalog: argv arrays only. The
- * agent-browser installer is genuinely a three-step pipeline, so its argv is
- * `["bash", "-lc", "<constant>"]` where the string is a LITERAL in this file
- * with zero interpolation. `$PNPM_HOME` inside it is expanded by the container's
- * own login shell, not by this process, and nothing user-supplied reaches it.
- */
 
-/** How a tool reaches the sandbox. */
 export type ToolKind =
-  /** In the base image, unconditionally. Nothing to install. */
   | "baked-in"
-  /** Behind an `install:` key, installed by the entrypoint at container start. */
   | "opt-in";
 
-/** One tool the CLI knows how to inspect and (maybe) install. */
 export interface ToolEntry {
-  /** The name the user types. */
   readonly id: string;
   readonly title: string;
   readonly kind: ToolKind;
-  /** Executable this tool puts on PATH. */
   readonly binary: string;
-  /**
-   * Presence check. Exit 0 → installed.
-   *
-   * ALWAYS `command -v`, never `<binary> --version`. Presence and version are
-   * different questions, and the shell cannot be wrong about PATH — see
-   * `versionArgv` for why that distinction is load-bearing here.
-   */
   readonly verifyArgv: readonly string[];
-  /**
-   * Optional version probe, reported by `status`.
-   *
-   * DECLARED ONLY WHERE `--version` IS AN INDUSTRY-STANDARD FLAG ON A
-   * UBIQUITOUS TOOL (docker, gh, cloudflared). It is deliberately ABSENT for
-   * `herdr` and `agent-browser`: neither binary exists on the machine this
-   * catalog was written on, so their flags could not be confirmed, and the
-   * repo's rule — set by `msb` in the runtime catalog — is to cite a verified
-   * source or omit, never to guess a flag. `status` renders the absence as `—`.
-   */
   readonly versionArgv?: readonly string[];
-  /**
-   * `INSTALL_*` key in lower snake_case WITHOUT the prefix. Only `opt-in` tools have
-   * one; the installer must never invent a key for a baked-in tool.
-   */
   readonly toolKey?: string;
-  /**
-   * Environment variable the ENTRYPOINT reads to decide whether to install.
-   *
-   * NOT `buildArg`. The harness catalog's `buildArg` carries an invariant —
-   * "this name appears in .devcontainer/Dockerfile" — that its drift test
-   * enforces. agent-browser has no Dockerfile presence at all; it is installed
-   * at container start by `.devcontainer/entrypoint.sh`. Reusing `buildArg`
-   * would quietly falsify the harness invariant, so this is a distinct field
-   * with a distinct ground truth, and the drift test asserts BOTH that the name
-   * is in entrypoint.sh/compose/harness-config.sh AND that it is absent from
-   * the Dockerfile.
-   */
   readonly entrypointGuard?: string;
-  /** Install command, argv form. Absent for baked-in tools. */
   readonly installArgv?: readonly string[];
-  /** User the install runs as inside the container. */
   readonly installUser?: "root" | "sandbox";
-  /**
-   * Approximate download size, when it is large enough that the operator
-   * should be asked first. Presence of this field is what arms the
-   * confirmation gate in `../../commands/tool.ts`.
-   */
   readonly downloadSize?: string;
-  /** Why `install` refuses. Required when there is no `installArgv`. */
   readonly notInstallableReason?: string;
-  /** Repo-relative doc path, printed in list/status output. */
   readonly docsPath: string;
 }
 
-/** Docs live in one shared table; there is no per-tool page. */
 const TOOLS_DOC = ".oh/docs/installation.md";
 
 export const TOOL_CATALOG: readonly ToolEntry[] = Object.freeze([
@@ -114,17 +30,12 @@ export const TOOL_CATALOG: readonly ToolEntry[] = Object.freeze([
     verifyArgv: Object.freeze(["bash", "-lc", "command -v agent-browser >/dev/null"]),
     toolKey: "agent_browser",
     entrypointGuard: "INSTALL_AGENT_BROWSER",
-    // Copied from `.devcontainer/entrypoint.sh`. The `2>&1 | tail -5` and the
-    // echo/|| cosmetics are dropped: they shape the entrypoint's boot log, and
-    // here they would swallow the installer's own output and its exit code.
     installArgv: Object.freeze([
       "bash",
       "-lc",
       "pnpm add -g agent-browser@0.8.5 && find \"$PNPM_HOME\" -name \"agent-browser-linux-*\" -exec chmod +x {} \\; && agent-browser install --with-deps",
     ]),
     installUser: "sandbox",
-    // Chromium. No harness install downloads anything close to this, which is
-    // why this tool gets a confirmation the harness installs never needed.
     downloadSize: "~1 GB",
     docsPath: TOOLS_DOC,
   }),
@@ -173,17 +84,14 @@ export const TOOL_CATALOG: readonly ToolEntry[] = Object.freeze([
   }),
 ]);
 
-/** Look up one tool by the name the user typed. */
 export function findTool(id: string): ToolEntry | undefined {
   return TOOL_CATALOG.find((t) => t.id === id);
 }
 
-/** Every known tool id, in catalog order. */
 export function toolIds(): string[] {
   return TOOL_CATALOG.map((t) => t.id);
 }
 
-/** The tools `oh tool install` can actually act on. */
 export function installableToolIds(): string[] {
   return TOOL_CATALOG.filter((t) => t.installArgv !== undefined).map((t) => t.id);
 }

--- a/.oh/cli/src/lib/vendor.ts
+++ b/.oh/cli/src/lib/vendor.ts
@@ -8,12 +8,6 @@ import {
 import path from "node:path";
 import { shouldShip, type Manifest } from "./manifest.js";
 
-/**
- * Throws unless `dest` is `targetOh` itself or strictly inside it.
- * This is the path-escape safety invariant shared by `oh init` (vendor) and
- * `oh update` (overlay) — never weaken it. `commands/update.ts` re-exports this
- * so its existing import keeps working.
- */
 export function assertDestInTarget(dest: string, targetOh: string, sep: string): void {
   if (dest === targetOh || dest.startsWith(targetOh + sep)) {
     return;
@@ -21,16 +15,6 @@ export function assertDestInTarget(dest: string, targetOh: string, sep: string):
   throw new Error("oh: refusing to write outside target .oh: " + dest);
 }
 
-/**
- * Recurse `dir` (anchored at `root`), pushing POSIX relpaths of every REAL file.
- *
- * Symlinks (file AND dir) are skipped via `lstatSync` and never followed, so a
- * malicious source `.oh/` symlink can never pull external content into the
- * target (the stricter invariant that `oh update` always enforced). The
- * volatile `node_modules/` and `dist/` directories are pruned during the walk —
- * they are never shipped, and pruning avoids descending into a
- * multi-thousand-file `node_modules` when vendoring a built checkout.
- */
 function walkFiles(root: string, dir: string, acc: string[]): void {
   const entries = readdirSync(dir, { withFileTypes: true });
   for (const entry of entries) {
@@ -60,11 +44,8 @@ export type CopyAction =
 export type CopyReport = (action: CopyAction, rel: string) => void;
 
 export interface CopyOptions {
-  /** Overwrite existing destinations even when `skipExisting` is set. */
   force?: boolean;
-  /** Report the plan but write nothing. */
   dryRun?: boolean;
-  /** Leave an already-present destination untouched (reported `skip-exists`). */
   skipExisting?: boolean;
 }
 
@@ -73,16 +54,6 @@ export interface CopyResult {
   skipped: number;
 }
 
-/**
- * Copy the manifest-shipped `.oh/` payload from `fromOh` into `targetOh`.
- * Shared by `oh init` (initial vendor) and `oh update` (overlay). Every
- * destination is guarded by `assertDestInTarget` so nothing is ever written
- * outside `targetOh`. A `null` manifest means legacy mode — ship everything the
- * walk yields (minus the pruned volatile dirs).
- *
- * `init` passes `skipExisting: !force` (non-destructive default); `update` omits
- * it (always overwrites). `dryRun` reports the plan and writes nothing.
- */
 export function copyOhPayload(
   fromOh: string,
   targetOh: string,
@@ -103,8 +74,6 @@ export function copyOhPayload(
 
   for (const rel of relpaths) {
     const segments = rel.split("/");
-    // Defense-in-depth: the walk already prunes node_modules/dist dirs, but a
-    // stray volatile segment must never be shipped.
     if (segments.includes("node_modules") || segments.includes("dist")) {
       report?.("skip-volatile", rel);
       skipped++;

--- a/.oh/evals/capability/run.sh
+++ b/.oh/evals/capability/run.sh
@@ -1,20 +1,6 @@
 #!/usr/bin/env bash
-# Capability benchmark runner — score ONE CB-<id> task on the three axes
-# (success · cost-time · unattended) from operator-supplied, validated values,
-# compute a baseline delta, classify capability-improved vs machinery-added, and
-# atomically overwrite that task's row in RESULTS.md (overwrite-per-id).
-#
-# This is the executable substrate the `/benchmark` verdict skill consults; it is
-# NOT a skill and NOT a scorer of judgment axes — values are supplied by the
-# operator and validated, never fabricated. Idiom mirrors .oh/skills/eval/run.sh:
-# ${BASH_SOURCE[0]} root-resolution, arg parse, atomic temp-sibling + `mv -f`.
-#
-# Exit codes: 0 ok · 1 schema/validation failure · 64 usage error.
 set -euo pipefail
 
-# --- path resolution from ${BASH_SOURCE[0]}, never cwd ---
-# run.sh lives at .oh/evals/capability/run.sh, so its own directory IS the
-# capability instrument dir; derive everything else relative to it.
 CAP="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT="$(cd "$CAP/../../.." && pwd)"
 TASKS="$CAP/tasks"
@@ -61,10 +47,6 @@ Score + overwrite a task's row:
 EOF
 }
 
-# --- --validate: assert RESULTS.md still matches the canonical schema ---
-# Canonical header tokens + exactly one row per CB task id (discovered from the
-# tasks/CB-*.md specs). Exactly-one-row catches appended duplicates — the
-# overwrite-per-id house style that a naive append would silently break.
 validate_schema() {
   local fails=()
 
@@ -73,7 +55,6 @@ validate_schema() {
     return 1
   fi
 
-  # (a) canonical header row with all expected column tokens.
   local header
   header="$(grep -E '^\|[[:space:]]*task[[:space:]]*\|' "$RESULTS" | head -1 || true)"
   if [[ -z "$header" ]]; then
@@ -85,7 +66,6 @@ validate_schema() {
     done
   fi
 
-  # (b) exactly one scoreboard row per CB task id.
   shopt -s nullglob
   local task_files=("$TASKS"/CB-*.md)
   shopt -u nullglob
@@ -113,16 +93,7 @@ validate_schema() {
   return 0
 }
 
-# --- axis validation + task-score computation ---
-# Axis values are operator-supplied and validated against the closed enum
-# {PASS,PARTIAL,FAIL}. A missing or out-of-enum value exits non-zero and writes
-# NO score — the runner never fabricates a judgment axis (this is why the
-# benchmark is *semi*-automated). The task score is the mean of the three axes
-# with PASS=2 PARTIAL=1 FAIL=0, and is fully task-agnostic: there is ZERO
-# per-task-id branching, so a held-out task cannot be special-cased (anti-Goodhart).
 
-# Map a validated axis label to its point value. The caller MUST have validated
-# the value first (validate_axis); an unvalidated value here is a programming bug.
 axis_points() {
   case "$1" in
     PASS)    echo 2 ;;
@@ -132,8 +103,6 @@ axis_points() {
   esac
 }
 
-# Validate one axis value against the closed enum. $1 = flag name (for the
-# message), $2 = supplied value. Empty (missing) is a fabrication-guard failure.
 validate_axis() {
   local name="$1" val="$2"
   if [[ -z "$val" ]]; then
@@ -148,9 +117,6 @@ validate_axis() {
   esac
 }
 
-# Mean of the three axis point values (PASS=2 PARTIAL=1 FAIL=0), formatted to two
-# decimals to match the committed RESULTS.md rounding. Pure integer arithmetic in
-# awk => deterministic: identical inputs yield a byte-identical score.
 compute_score() {
   local a b c
   a="$(axis_points "$1")"
@@ -159,10 +125,6 @@ compute_score() {
   awk -v x="$a" -v y="$b" -v z="$c" 'BEGIN{ printf "%.2f\n", (x + y + z) / 3 }'
 }
 
-# Validate the full triad. Collect ALL axis failures before returning (so a
-# missing/invalid axis message names every offender, not just the first) — the
-# fabrication guard: an unvalidated triad never reaches a score or a write. The
-# `|| bad=1` list and the `if (( bad ))` are both set -e exempt.
 validate_triad() {
   local bad=0
   validate_axis --success    "$SUCCESS"    || bad=1
@@ -174,14 +136,6 @@ validate_triad() {
   return 0
 }
 
-# Optionally run a task's success-signal check (e.g. its runnable probe) and map
-# the exit code to a PASS/SKIPPED/FAIL label — recorded as EVIDENCE only. The
-# runner NEVER lets this result set or override a judgment axis: the operator
-# still supplies the validated triad (this is why the benchmark is *semi*-
-# automated). Runs from $ROOT so a relative probe path resolves independently of
-# cwd; a pure-oracle probe writes nothing. A non-zero exit is recorded honestly,
-# it does NOT abort the write. Exit oracle mirrors the probes: 0=PASS 2=SKIPPED
-# else=FAIL. Emits the command's own output to stderr; only the label to stdout.
 run_check() {
   local cmd="$1" code
   set +e
@@ -195,10 +149,6 @@ run_check() {
   esac
 }
 
-# Validate the triad and print the deterministic task score to stdout WITHOUT
-# writing the scoreboard (score-preview mode). Any missing/invalid axis returns
-# non-zero WITHOUT printing a score. The score never depends on the task id. An
-# optional --check is run and its label appended as evidence (never a judgment axis).
 score_task() {
   validate_triad || return 1
   local score check_suffix=""
@@ -209,24 +159,11 @@ score_task() {
   return 0
 }
 
-# --- baseline delta + machinery-vs-capability + atomic row overwrite (US-003) ---
-# Overwrite-per-id: the runner replaces exactly ONE scoreboard row (the named CB
-# task) and recomputes the suite-score comment, leaving every other line byte-for-
-# byte intact. It never appends a row (git history is the time series; an appended
-# row also breaks capability-benchmark-schema.sh). The whole file is rebuilt into a
-# temp sibling and swapped in with a single `mv -f` so an interrupted write can
-# never leave a partial scoreboard.
 
-# Trim leading/trailing whitespace from field $2 (awk -F'|' index) of a table row
-# line $1. Field 2 = task id, 7 = score, 8 = basis (rows are `| id | date | s | c
-# | u | score | basis |`).
 row_field() {
   awk -F'|' -v f="$2" '{ gsub(/^[[:space:]]+|[[:space:]]+$/, "", $f); print $f }' <<<"$1"
 }
 
-# Read the prior score for a task id. Default source is the current working-tree
-# RESULTS.md; --base <ref> reads the scoreboard at that git ref instead (the
-# counterfactual). Prints the score (e.g. 1.33) or empty if the id has no prior row.
 prior_score_for() {
   local id="$1" content row
   if [[ -n "$BASE" ]]; then
@@ -239,9 +176,6 @@ prior_score_for() {
   row_field "$row" 7
 }
 
-# Classify the transition. Mirrors the /benchmark verdict (keys on the score, never
-# inverts it): a risen task score = capability-improved; flat = machinery-added; a
-# fallen score = capability-regressed. Pure numeric delta => no per-task branching.
 classify_delta() {
   awk -v n="$1" -v p="$2" 'BEGIN{
     d = n - p
@@ -251,10 +185,6 @@ classify_delta() {
   }'
 }
 
-# Recompute the suite-score comment from every CB row's score, substituting the
-# NEW score for the target id ($1=id, $2=new score). Deterministic: a pure function
-# of the row scores in file order. The literal number is placed IMMEDIATELY after
-# `suite score = ` so /benchmark's `grep -oE 'suite score = [0-9.]+'` reads it.
 recompute_suite() {
   local tid="$1" tscore="$2" line id sc mean list=""
   local -a scores=()
@@ -270,15 +200,9 @@ recompute_suite() {
     "$mean" "$list"
 }
 
-# Score the named CB task and atomically overwrite its row. Requires a validated
-# triad (validate_triad runs first — fabrication guard). Refuses to write if the id
-# has no existing row (never append/renumber). --dry-run prints the row + suite
-# comment instead of writing.
 write_row() {
   local id="$TASK"
 
-  # overwrite-per-id: the row must already exist exactly once (never append; do not
-  # add or renumber CB tasks — that is the task-spec authors' job, not the runner's).
   local nrows
   nrows="$(grep -cE "^\|[[:space:]]*${id}[[:space:]]*\|" "$RESULTS" || true)"
   if (( nrows == 0 )); then
@@ -295,9 +219,6 @@ write_row() {
 
   existing_row="$(grep -E "^\|[[:space:]]*${id}[[:space:]]*\|" "$RESULTS" | head -1 || true)"
   prior_basis="$(row_field "$existing_row" 8)"
-  # drop any prior runner-appended delta note so re-writes don't accumulate them
-  # (keeps the write idempotent for a fixed baseline). The ` · check=` evidence is
-  # folded INSIDE the ` · Δ ` annotation below, so this one strip removes both.
   prior_basis="${prior_basis% · Δ *}"
 
   if [[ -n "$BASIS" ]]; then basis="$BASIS"; else basis="$prior_basis"; fi
@@ -309,16 +230,12 @@ write_row() {
   else
     note="Δ baseline established (no prior score in ${BASE:-RESULTS.md})"
   fi
-  # optional success-signal check, recorded as EVIDENCE only (never a judgment
-  # axis). Folded into the Δ annotation so the single ` · Δ *` strip above stays
-  # idempotent across re-writes.
   if [[ -n "$CHECK" ]]; then
     check_result="$(run_check "$CHECK")"
     note="${note} · check=${check_result}"
   fi
   basis="${basis} · ${note}"
 
-  # a literal pipe in the basis would corrupt the markdown table row.
   if [[ "$basis" == *"|"* ]]; then
     echo "run.sh: basis must not contain '|' (breaks the RESULTS.md table row)" >&2
     return 1
@@ -335,10 +252,6 @@ write_row() {
     return 0
   fi
 
-  # atomic rewrite: pass every line through verbatim, substituting ONLY the target
-  # row and the suite-score COMMENT line (the `<!--` guards against the prose line
-  # that also contains "suite score ="). Build into a temp sibling on the same
-  # filesystem, then swap in with one mv -f. TMP is cleaned up by the EXIT trap.
   TMP="$RESULTS.tmp.$$"
   {
     while IFS= read -r line || [[ -n "$line" ]]; do
@@ -359,9 +272,6 @@ write_row() {
   return 0
 }
 
-# --- arg parse ---
-# TMP holds the in-flight scoreboard temp file; the EXIT trap removes it so an
-# interrupted write leaves no partial sibling. Empty on every non-write path.
 TMP=""
 trap '[[ -n "${TMP:-}" ]] && rm -f "$TMP"' EXIT
 
@@ -414,16 +324,12 @@ case "$MODE" in
   validate)
     if validate_schema; then exit 0; else exit 1; fi ;;
   "")
-    # Scoring path. The full validated triad is always required first; a missing or
-    # out-of-enum axis exits non-zero and writes/prints no score (no fabrication).
     if [[ -n "$TASK" ]]; then
-      # Write mode: a named CB target => score it and overwrite ITS row.
       [[ "$TASK" =~ ^CB-[0-9]+$ ]] \
         || { echo "run.sh: --task must be a CB-<id> (matching CB-[0-9]+); got '$TASK'" >&2; exit 64; }
       validate_triad || exit 1
       if write_row; then exit 0; else exit 1; fi
     elif [[ -n "$SUCCESS$COST_TIME$UNATTENDED$BASIS" ]]; then
-      # Preview mode: a triad with no target => print the score, touch nothing.
       if score_task; then exit 0; else exit 1; fi
     else
       usage >&2

--- a/.oh/evals/datasets/retro-cycles/DS-020-lens-diversity/verify.sh
+++ b/.oh/evals/datasets/retro-cycles/DS-020-lens-diversity/verify.sh
@@ -1,8 +1,4 @@
 #!/usr/bin/env bash
-# verify.sh — dual-mode verifier for one dataset example (Repo2RLEnv-style).
-#   self-check (no args):  validate manifest.json + referenced oracle files; exit 0 iff well-formed.
-#   score (verify.sh DIFF): print score=<0..1> = changed-file overlap of DIFF vs this example's oracle.
-# DIFF may be a unified diff (parsed via '+++ b/<path>' lines) or a plain newline list of repo paths.
 set -euo pipefail
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -13,7 +9,6 @@ command -v jq >/dev/null 2>&1 || fail "jq not on PATH"
 [ -f "$MANIFEST" ] || fail "manifest.json missing in $HERE"
 [ -f "$HERE/prompt.md" ] || fail "prompt.md missing in $HERE"
 
-# Required manifest fields (jq -e is false/err if any is null/absent).
 jq -e '.id and .slug and .dataset and .title
        and (.source | type == "object") and (.reward_kind | type == "array")
        and (.oracle | type == "object")' "$MANIFEST" >/dev/null 2>&1 \
@@ -25,13 +20,11 @@ case "$id" in
   *) fail "id '$id' is not DS-<n>" ;;
 esac
 
-# Every string-valued oracle entry must reference a file that exists.
 while IFS= read -r rel; do
   [ -n "$rel" ] || continue
   [ -f "$HERE/$rel" ] || fail "oracle file referenced but missing: $rel"
 done < <(jq -r '.oracle | to_entries[] | .value | select(type == "string")' "$MANIFEST")
 
-# Resolve the oracle's changed-file set to stdout (one repo-relative path per line).
 oracle_changed_files() {
   local cf
   cf="$(jq -r '.oracle.changed_files // empty' "$MANIFEST")"
@@ -43,13 +36,11 @@ oracle_changed_files() {
 }
 
 if [ "$#" -eq 0 ]; then
-  # self-check: oracle set is resolvable (may be empty for artifact-only examples).
   oracle_changed_files >/dev/null || true
   echo "ok: $id self-check passed ($HERE)" >&2
   exit 0
 fi
 
-# score mode: diff_similarity = |candidate ∩ oracle| / |oracle changed files|.
 cand="$1"
 [ -f "$cand" ] || fail "candidate diff not found: $cand"
 tmp="$(mktemp -d)"

--- a/.oh/evals/datasets/ship-spec-prs/DS-001-pi-monitor-support/verify.sh
+++ b/.oh/evals/datasets/ship-spec-prs/DS-001-pi-monitor-support/verify.sh
@@ -1,8 +1,4 @@
 #!/usr/bin/env bash
-# verify.sh — dual-mode verifier for one dataset example (Repo2RLEnv-style).
-#   self-check (no args):  validate manifest.json + referenced oracle files; exit 0 iff well-formed.
-#   score (verify.sh DIFF): print score=<0..1> = changed-file overlap of DIFF vs this example's oracle.
-# DIFF may be a unified diff (parsed via '+++ b/<path>' lines) or a plain newline list of repo paths.
 set -euo pipefail
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -13,7 +9,6 @@ command -v jq >/dev/null 2>&1 || fail "jq not on PATH"
 [ -f "$MANIFEST" ] || fail "manifest.json missing in $HERE"
 [ -f "$HERE/prompt.md" ] || fail "prompt.md missing in $HERE"
 
-# Required manifest fields (jq -e is false/err if any is null/absent).
 jq -e '.id and .slug and .dataset and .title
        and (.source | type == "object") and (.reward_kind | type == "array")
        and (.oracle | type == "object")' "$MANIFEST" >/dev/null 2>&1 \
@@ -25,13 +20,11 @@ case "$id" in
   *) fail "id '$id' is not DS-<n>" ;;
 esac
 
-# Every string-valued oracle entry must reference a file that exists.
 while IFS= read -r rel; do
   [ -n "$rel" ] || continue
   [ -f "$HERE/$rel" ] || fail "oracle file referenced but missing: $rel"
 done < <(jq -r '.oracle | to_entries[] | .value | select(type == "string")' "$MANIFEST")
 
-# Resolve the oracle's changed-file set to stdout (one repo-relative path per line).
 oracle_changed_files() {
   local cf
   cf="$(jq -r '.oracle.changed_files // empty' "$MANIFEST")"
@@ -43,13 +36,11 @@ oracle_changed_files() {
 }
 
 if [ "$#" -eq 0 ]; then
-  # self-check: oracle set is resolvable (may be empty for artifact-only examples).
   oracle_changed_files >/dev/null || true
   echo "ok: $id self-check passed ($HERE)" >&2
   exit 0
 fi
 
-# score mode: diff_similarity = |candidate ∩ oracle| / |oracle changed files|.
 cand="$1"
 [ -f "$cand" ] || fail "candidate diff not found: $cand"
 tmp="$(mktemp -d)"

--- a/.oh/evals/datasets/ship-spec-prs/DS-002-pnpm-audit-ci/verify.sh
+++ b/.oh/evals/datasets/ship-spec-prs/DS-002-pnpm-audit-ci/verify.sh
@@ -1,8 +1,4 @@
 #!/usr/bin/env bash
-# verify.sh — dual-mode verifier for one dataset example (Repo2RLEnv-style).
-#   self-check (no args):  validate manifest.json + referenced oracle files; exit 0 iff well-formed.
-#   score (verify.sh DIFF): print score=<0..1> = changed-file overlap of DIFF vs this example's oracle.
-# DIFF may be a unified diff (parsed via '+++ b/<path>' lines) or a plain newline list of repo paths.
 set -euo pipefail
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -13,7 +9,6 @@ command -v jq >/dev/null 2>&1 || fail "jq not on PATH"
 [ -f "$MANIFEST" ] || fail "manifest.json missing in $HERE"
 [ -f "$HERE/prompt.md" ] || fail "prompt.md missing in $HERE"
 
-# Required manifest fields (jq -e is false/err if any is null/absent).
 jq -e '.id and .slug and .dataset and .title
        and (.source | type == "object") and (.reward_kind | type == "array")
        and (.oracle | type == "object")' "$MANIFEST" >/dev/null 2>&1 \
@@ -25,13 +20,11 @@ case "$id" in
   *) fail "id '$id' is not DS-<n>" ;;
 esac
 
-# Every string-valued oracle entry must reference a file that exists.
 while IFS= read -r rel; do
   [ -n "$rel" ] || continue
   [ -f "$HERE/$rel" ] || fail "oracle file referenced but missing: $rel"
 done < <(jq -r '.oracle | to_entries[] | .value | select(type == "string")' "$MANIFEST")
 
-# Resolve the oracle's changed-file set to stdout (one repo-relative path per line).
 oracle_changed_files() {
   local cf
   cf="$(jq -r '.oracle.changed_files // empty' "$MANIFEST")"
@@ -43,13 +36,11 @@ oracle_changed_files() {
 }
 
 if [ "$#" -eq 0 ]; then
-  # self-check: oracle set is resolvable (may be empty for artifact-only examples).
   oracle_changed_files >/dev/null || true
   echo "ok: $id self-check passed ($HERE)" >&2
   exit 0
 fi
 
-# score mode: diff_similarity = |candidate ∩ oracle| / |oracle changed files|.
 cand="$1"
 [ -f "$cand" ] || fail "candidate diff not found: $cand"
 tmp="$(mktemp -d)"

--- a/.oh/evals/probes/ablate-state-machine.sh
+++ b/.oh/evals/probes/ablate-state-machine.sh
@@ -23,54 +23,41 @@ if AUDIT_ROOT="$ROOT" bash "$A" "$ROOT/CLAUDE.md" "$probe" >/dev/null 2>&1; then
 ln -s "$target" "$ROOT/.oh/evals/link"
 if AUDIT_ROOT="$ROOT" bash "$A" "$ROOT/.oh/evals/link" "$probe" >/dev/null 2>&1; then fail 'symlink target accepted'; fi
 rm "$ROOT/.oh/evals/link"
-# The state directory itself must never be followed through a symlink.
 rm -rf "$state"; mkdir "$ROOT/external-state"; ln -s "$ROOT/external-state" "$state"
 if AUDIT_ROOT="$ROOT" bash "$A" "$target" "$probe" >/dev/null 2>&1; then fail 'symlinked state directory accepted'; fi
 [[ -z $(find "$ROOT/external-state" -mindepth 1 -print -quit) ]] || fail 'symlink state directory was written'
-# Global recovery must reject the symlink even when its destination is empty.
 if AUDIT_ROOT="$ROOT" A="$A" bash -c 'source "$A"; ablate_recover' >/dev/null 2>&1; then fail 'global recovery accepted empty symlinked state directory'; fi
 rm "$state"
-# Every ablatable target resolves against AUDIT_ROOT alone: the `.oh/memory` tier
-# that the second root existed to reach was deleted, and AUDIT_LOG_ROOT with it.
-# A context file under some OTHER root must be rejected, not silently ablated.
 SHARED=$(mktemp -d); mkdir -p "$SHARED/.oh/context"; printf forbidden >"$SHARED/.oh/context/USER.md"
 if AUDIT_ROOT="$ROOT" A="$A" T="$SHARED/.oh/context/USER.md" bash -c 'source "$A"; _ablate_canonical "$T"' >/dev/null 2>&1; then fail 'out-of-root target escaped source-root constraint'; fi
 [[ $(<"$SHARED/.oh/context/USER.md") == forbidden ]] || fail 'rejected out-of-root target was mutated'
 rm -rf "$SHARED"; assert_clean
-# SIGKILL cannot trap: the next startup recovery restores exact bytes.
 set +e
 AUDIT_ROOT="$ROOT" A="$A" T="$target" bash -c 'source "$A"; ablate_swap_out "$T"; kill -KILL $$' >/dev/null 2>&1
 set -e
 [[ ! -e $target ]] || fail 'crash fixture did not swap target'
 AUDIT_ROOT="$ROOT" A="$A" T="$target" bash -c 'source "$A"; ablate_recover "$T"'
 [[ $(<"$target") == original ]] || fail 'crash recovery bytes differ'; assert_clean
-# PREPARED can be durable while target removal already happened (crash before SWAPPED).
 AUDIT_ROOT="$ROOT" A="$A" T="$target" bash -c 'source "$A"; _ablate_paths "$T"; _ablate_lock; cp -p "$T" "$ABLATE_BACKUP"; _ablate_record PREPARED; rm "$T"; _ablate_unlock'
 AUDIT_ROOT="$ROOT" A="$A" T="$target" bash -c 'source "$A"; ablate_recover "$T"'
 [[ $(<"$target") == original ]] || fail 'PREPARED missing-target recovery failed'; assert_clean
-# Same-target lock contention fails; different targets remain independent.
 AUDIT_ROOT="$ROOT" A="$A" T="$target" bash -c 'source "$A"; ablate_swap_out "$T"; sleep 1; ablate_restore "$T"' & p1=$!
 sleep 0.2
 if AUDIT_ROOT="$ROOT" A="$A" T="$target" bash -c 'source "$A"; ablate_swap_out "$T"' >/dev/null 2>&1; then fail 'same target lock contention accepted'; fi
 AUDIT_ROOT="$ROOT" A="$A" T="$target2" bash -c 'source "$A"; ablate_swap_out "$T"; ablate_restore "$T"' & p2=$!
 wait "$p1"; wait "$p2"
 [[ $(<"$target") == original && $(<"$target2") == second ]] || fail 'concurrent target bytes differ'; assert_clean
-# Existing EXIT trap is composed rather than clobbered.
 marker="$ROOT/prior-trap"
 AUDIT_ROOT="$ROOT" A="$A" T="$target" M="$marker" bash -c 'source "$A"; trap '\''printf prior >"$M"'\'' EXIT; ablate_swap_out "$T"; exit 0'
 [[ $(<"$target") == original && $(<"$marker") == prior ]] || fail 'EXIT trap composition failed'; assert_clean
-# Explicit restore reinstates prior traps instead of clearing them.
 marker2="$ROOT/prior-after-restore"
 AUDIT_ROOT="$ROOT" A="$A" T="$target" M="$marker2" bash -c 'source "$A"; trap '\''printf restored >"$M"'\'' EXIT; ablate_swap_out "$T"; ablate_restore "$T"; [[ $(trap -p EXIT) == *"printf restored"* ]]'
 [[ $(<"$marker2") == restored ]] || fail 'prior trap not preserved after explicit restore'; assert_clean
-# Contradictory PREPARED state fails closed without overwriting either copy.
 AUDIT_ROOT="$ROOT" A="$A" T="$target" bash -c 'source "$A"; _ablate_paths "$T"; mkdir -p "$ABLATE_STATE_ROOT"; cp "$T" "$ABLATE_BACKUP"; _ablate_record PREPARED; printf changed >"$T"'
 if AUDIT_ROOT="$ROOT" A="$A" T="$target" bash -c 'source "$A"; ablate_recover "$T"' >/dev/null 2>&1; then fail 'contradictory PREPARED recovered'; fi
 [[ $(<"$target") == changed ]] || fail 'contradictory recovery overwrote target'
 backup=$(find "$state" -name '*.backup' -print -quit); [[ -n $backup && $(<"$backup") == original ]] || fail 'contradictory recovery overwrote backup'
 rm -rf "$state"
-# A recovery record whose filename hash does not match its declared target is an
-# orphan mismatch, not a reason to silently recover a different path.
 AUDIT_ROOT="$ROOT" A="$A" T="$target" bash -c 'source "$A"; _ablate_paths "$T"; mkdir -p "$ABLATE_STATE_ROOT"; cp "$T" "$ABLATE_BACKUP"; _ablate_record PREPARED; mv "$ABLATE_RECORD" "$ABLATE_STATE_ROOT/not-the-target-key.json"'
 if AUDIT_ROOT="$ROOT" A="$A" bash -c 'source "$A"; ablate_recover' >/dev/null 2>&1; then fail 'mismatched recovery record accepted'; fi
 [[ $(<"$target") == changed ]] || fail 'mismatched recovery overwrote target'

--- a/.oh/evals/probes/advisor-monitored-loop.sh
+++ b/.oh/evals/probes/advisor-monitored-loop.sh
@@ -17,7 +17,6 @@ if [[ ! -f "$RULE" ]]; then
   exit 2
 fi
 
-# Extract the "## Pipeline variants" section: from its heading to the next "## " heading.
 section=$(awk '
   tolower($0) ~ /^## pipeline variants/ {f=1; print; next}
   f && /^## / {f=0}
@@ -31,19 +30,14 @@ fi
 
 missing=()
 
-# Positive assertions (AND-logic): the variant + its three load-bearing rules.
 grep -qiF 'Monitored async build session'          <<<"$section" || missing+=("Monitored async build session variant name")
 grep -qiF 'owns the sentinel watch'                <<<"$section" || missing+=("caller-owns-the-watch rule")
 grep -qiF 'surfaces blocks'                        <<<"$section" || missing+=("session-surfaces-blocks property")
 grep -qiF 'finalizes through the promotable gate'  <<<"$section" || missing+=("finalize-via-promotable-gate rule")
 
-# The variant must name the ACTUAL launch contract, not a generic "build" word that
-# would stay green after the executor was renamed or removed underneath it.
 grep -qF '.oh/scripts/firstmate.sh'                <<<"$section" || missing+=("the launch contract .oh/scripts/firstmate.sh is not named in the variant")
 grep -qF 'STATUS: COMPLETE'                        <<<"$section" || missing+=("the STATUS: COMPLETE terminal interface is not named in the variant")
 
-# Negative assertion: the retired arm must not come back as a variant. Checked over the
-# WHOLE file, not just the section — a stale mention anywhere re-opens the arm question.
 if grep -qF 'ralph' "$RULE"; then
   echo "REGRESSION: $RULE still names the retired 'ralph' build arm — there is one executor" >&2
   exit 1

--- a/.oh/evals/probes/artifact-contract-audit.sh
+++ b/.oh/evals/probes/artifact-contract-audit.sh
@@ -10,7 +10,6 @@ tmp=$(mktemp -d); trap 'rm -rf "$tmp"' EXIT
 mkdir -p "$tmp/.oh/tasks/fixture" "$tmp/.oh/skills/audit/fixtures"
 cp "$FIX" "$tmp/.oh/tasks/fixture/prd.json"; cp "$FIX" "$tmp/.oh/skills/audit/fixtures/artifact-contract.prd.json"
 fail(){ echo "REGRESSION: $*" >&2; exit 1; }
-# Resolve the documentation link from its containing references directory.
 doc_link=$(grep -o '](\.\./\.\./\.\./docs/artifact-contract-schema.md)' "$REPO/.oh/skills/audit/references/implementation.md" | head -1)
 doc_rel=${doc_link#](}; doc_rel=${doc_rel%)}
 [[ -n $doc_rel && -f "$REPO/.oh/skills/audit/references/$doc_rel" ]] || fail 'artifact schema documentation link is broken'
@@ -27,13 +26,10 @@ if AUDIT_ROOT="$tmp" bash "$GATE" gate1 fixture >/dev/null 2>&1; then fail 'non-
 mkdir -p "$tmp/outside"; printf outside >"$tmp/outside/value"; ln -s "$tmp/outside" "$tmp/.oh/linked-artifacts"
 jq '.artifact_contract.required_artifacts=[".oh/linked-artifacts/value"]' "$tmp/.oh/tasks/fixture/prd.json" >"$tmp/prd.tmp"; mv "$tmp/prd.tmp" "$tmp/.oh/tasks/fixture/prd.json"
 if AUDIT_ROOT="$tmp" bash "$GATE" gate1 fixture >/dev/null 2>&1; then fail 'symlinked artifact component accepted'; fi
-# Contract containers must be arrays; jq iteration must not accidentally coerce
-# malformed strings/objects into a passing graph.
 jq '.artifact_contract.required_artifacts=".oh/skills/audit/fixtures/MISSING-ON-PURPOSE.md"' "$FIX" >"$tmp/.oh/tasks/fixture/prd.json"
 if AUDIT_ROOT="$tmp" bash "$GATE" gate1 fixture >/dev/null 2>&1; then fail 'non-array artifact contract accepted'; fi
 jq '.userStories={passes:true}' "$FIX" >"$tmp/.oh/tasks/fixture/prd.json"
 if AUDIT_ROOT="$tmp" bash "$GATE" gate1 fixture >/dev/null 2>&1; then fail 'non-array userStories contract accepted'; fi
-# A regular prd.json reached through a symlinked task directory is still unsafe.
 mkdir -p "$tmp/external-task"; cp "$FIX" "$tmp/external-task/prd.json"
 ln -s "$tmp/external-task" "$tmp/.oh/tasks/symlink-task"
 if AUDIT_ROOT="$tmp" bash "$GATE" gate1 symlink-task >/dev/null 2>&1; then fail 'symlinked task directory accepted'; fi

--- a/.oh/evals/probes/audit-dispatcher-contract.sh
+++ b/.oh/evals/probes/audit-dispatcher-contract.sh
@@ -26,8 +26,6 @@ done
 for kept in eval benchmark ci-status health-check wiki; do
   [[ -f "$ROOT/.oh/skills/$kept/SKILL.md" ]] || fail "retained instrument missing: $kept"
 done
-# critique/approve were NOT absorbed into /audit — they were retired outright with the
-# critique gate (spec-simplification US-001). They must not reappear as standalone skills.
 for retired in critique approve; do
   [[ ! -e "$ROOT/.oh/skills/$retired" ]] || fail "retired gate skill remains: $retired"
 done

--- a/.oh/evals/probes/audit-implementation-behavior.sh
+++ b/.oh/evals/probes/audit-implementation-behavior.sh
@@ -28,14 +28,11 @@ after=$(git -C "$root" status --porcelain=v1 --untracked-files=all)
 [[ $(grep -c '^--version$' "$calls") -eq 1 && $(grep -c '^open about:blank --session audit-audit-20260717T120000Z-fixture$' "$calls") -eq 1 ]] || fail 'preflight command sequence'
 ! grep -Eqi 'install|npm|pnpm|https?://' "$calls" || fail 'preflight installed or navigated externally'
 [[ -z $(find "$runtime" -mindepth 1 -print -quit) ]] || fail 'browser profile not cleaned'
-# A porcelain-only comparison misses edits to a file that was already dirty.
 printf preexisting-change >>"$root/.oh/tasks/ui/prd.json"
 if AUDIT_ROOT="$root" AUDIT_RUN_ID='audit-20260717T120001Z-fixture' AUDIT_TMP_ROOT="$runtime" \
   MUTATE_FILE="$root/.oh/tasks/ui/prd.json" PATH="$bin:$PATH" bash "$GATE" browser-preflight >/dev/null 2>&1; then
   fail 'content mutation of already-dirty file was not detected'
 fi
-# Git status and ls-files --others both omit ignored files; the content detector
-# must still see browser writes to them.
 printf 'ignored-profile\n' >"$root/.gitignore"; printf original >"$root/ignored-profile"; git -C "$root" add .gitignore; git -C "$root" commit -qm ignore
 if AUDIT_ROOT="$root" AUDIT_RUN_ID='audit-20260717T120002Z-fixture' AUDIT_TMP_ROOT="$runtime" \
   MUTATE_FILE="$root/ignored-profile" PATH="$bin:$PATH" bash "$GATE" browser-preflight >/dev/null 2>&1; then

--- a/.oh/evals/probes/audit-pr-classifier.sh
+++ b/.oh/evals/probes/audit-pr-classifier.sh
@@ -13,7 +13,6 @@ check_ci(){ local raw=$1 expect=$2 field=${3:-conclusion}; p=$(jq -c --arg f "$f
 for x in ACTION_REQUIRED CANCELLED ERROR FAILURE STARTUP_FAILURE STALE TIMED_OUT; do check_ci "$x" FAIL; done
 for x in EXPECTED IN_PROGRESS PENDING QUEUED REQUESTED WAITING; do check_ci "$x" PENDING status; done
 for x in SUCCESS NEUTRAL SKIPPED; do check_ci "$x" PASS; done
-# Real gh statusCheckRollup shapes carry COMPLETED status together with a conclusion.
 for case_expect in checkRunSuccess:PASS checkRunFailure:FAIL checkRunPending:PENDING statusContextSuccess:PASS failurePrecedesPending:FAIL unknownConclusion:UNKNOWN; do
   key=${case_expect%:*}; expect=${case_expect#*:}
   item=$(jq -c --arg key "$key" '.[$key]' "$REAL")
@@ -21,13 +20,10 @@ for case_expect in checkRunSuccess:PASS checkRunFailure:FAIL checkRunPending:PEN
   out=$(env pr "[$p]"|bash "$C")
   [[ $(jq -r .ci<<<"$out") == "$expect" ]] || fail "real GitHub shape $key"
 done
-# Contradictory CheckRun state may retain a priority CI value, but evidence is incomplete.
 for item in '{"__typename":"CheckRun","name":"ci","status":"IN_PROGRESS","conclusion":"SUCCESS"}' '{"__typename":"CheckRun","name":"ci","status":"COMPLETED","conclusion":null}'; do
   p=$(jq -c --argjson item "$item" '.+{statusCheckRollup:[$item]}'<<<"$base"); out=$(env pr "[$p]"|bash "$C")
   [[ $(jq -r .evidenceComplete<<<"$out") == false ]] || fail 'contradictory CheckRun evidence accepted as complete'
 done
-# StatusContext has a distinct contract: nonempty context + state only. A
-# conclusion/status field, missing context, or unknown typename is malformed.
 for item in \
   '{"__typename":"StatusContext","context":"ci","state":"SUCCESS","conclusion":"SUCCESS"}' \
   '{"__typename":"StatusContext","state":"SUCCESS"}' \
@@ -42,7 +38,6 @@ p=$(jq -c '.+{statusCheckRollup:[null]}'<<<"$base"); out=$(env pr "[$p]"|bash "$
 for review in APPROVED '' null; do p=$(jq -c --arg r "$review" '.+{statusCheckRollup:[{conclusion:"SUCCESS"}],reviewDecision:(if $r=="null" then null else $r end)}'<<<"$base"); out=$(env pr "[$p]"|bash "$C"); [[ $(jq -r '[.readyForReview,.readyToMerge,.promotable]|join(":")'<<<"$out") == false:true:true ]]||fail "solo readiness $review"; done
 p=$(jq -c '.+{isDraft:true,statusCheckRollup:[{conclusion:"SUCCESS"}],updatedAt:"2026-06-01T00:00:00Z"}'<<<"$base"); out=$(env pr "[$p]"|bash "$C"); [[ $(jq -r '[.draftStatus,.draftLimbo,.readyForReview,.readyToMerge]|join(":")'<<<"$out") == promotable:true:true:false ]]||fail limbo
 p=$(jq -c '.+{isDraft:true,statusCheckRollup:[{conclusion:"SUCCESS"}],updatedAt:"2026-07-17T10:00:00Z"}'<<<"$base"); out=$(env pr "[$p]"|bash "$C"); [[ $(jq -r '.ageSeconds|tostring'<<<"$out") == 7200 ]] || fail 'exact 2h ageSecondsatchdog ageSeconds missing'
-# Focused stacked PRs classify against their explicit parent base, not development.
 p=$(jq -c '.+{baseRefName:"skill/parent",statusCheckRollup:[{conclusion:"SUCCESS"}]}'<<<"$base")
 stack=$(env pr "[$p]" | jq '.options.expectedBase="skill/parent"' | bash "$C")
 [[ $(jq -r '[.promotable,(.flags|index("base-convention")==null)]|join(":")'<<<"$stack") == true:true ]] || fail 'focused stacked base override'

--- a/.oh/evals/probes/audit-run-root-contract.sh
+++ b/.oh/evals/probes/audit-run-root-contract.sh
@@ -3,14 +3,6 @@
 # source: issue #645 — executable immutable audit root/run correlation
 # desc: production lifecycle validates before state, preserves child identity, cleans temp, and reports one run record
 set -euo pipefail
-# This probe drives audit-run.sh from a TOP-LEVEL position: it asserts what a fresh
-# lifecycle does, and sets AUDIT_RUN_ID/AUDIT_ROOT itself for the one child-mode case
-# it tests. When the suite is run from INSIDE an audit (`/audit
-# implementation` -> Gate 2 -> run.sh), those variables are already exported, audit-run.sh
-# reads them as a half-configured child ("inherited run requires AUDIT_ROOT"), and the
-# probe reports a green->red that describes the caller's environment rather than the repo.
-# Clearing the inherited identity is not weakening the check -- every binding the probe
-# actually asserts is set explicitly below.
 unset AUDIT_RUN_ID AUDIT_ROOT AUDIT_TMP_ROOT AUDIT_EVIDENCE_PATH \
       AUDIT_ROUTE AUDIT_TARGET AUDIT_TARGET_ARGS_JSON AUDIT_AGENT_COMMAND_JSON
 REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"; RUN="$REPO/.oh/skills/audit/scripts/audit-run.sh"
@@ -38,7 +30,6 @@ still_running(){
   [[ -n $st && ${st#Z} == "$st" ]]
 }
 export TMPDIR="$tmpdir"
-# Invalid usage creates neither temp state nor log.
 set +e; usage_out=$(CRON_WORKTREE="$tmp" CRON_LOG_ROOT="$tmp" bash "$RUN" nope 2>&1); usage_rc=$?; set -e
 [[ $usage_rc -eq 64 ]] || fail 'unknown target accepted/wrong usage rc'
 [[ ${usage_out%%$'\n'*} == 'usage: /audit <implementation|pr|prs|harness|context|skills|eval-quality|drift|full> [target options]' ]] || fail 'usage first line is not exact'
@@ -49,8 +40,6 @@ if CRON_WORKTREE="$tmp" CRON_LOG_ROOT="$tmp" bash "$RUN" harness --wiki-ingest -
 if CRON_WORKTREE="$tmp" CRON_LOG_ROOT="$tmp" bash "$RUN" implementation -- true >/dev/null 2>&1; then fail 'missing implementation slug accepted'; fi
 if CRON_WORKTREE="$tmp" CRON_LOG_ROOT="$tmp" bash "$RUN" pr 7 --repo bad -- true >/dev/null 2>&1; then fail 'invalid focused repo accepted'; fi
 if CRON_WORKTREE="$tmp" CRON_LOG_ROOT="$tmp" bash "$RUN" drift >/dev/null 2>&1; then fail 'missing route driver accepted'; fi
-# Focused/queue repositories are optional; focused --base supports stacked PRs.
-# A no-op route can never certify completion, even when it exits zero.
 if CRON_WORKTREE="$tmp" CRON_LOG_ROOT="$tmp" bash "$RUN" drift -- true >/dev/null 2>&1; then fail 'true callback certified completion'; fi
 cat >"$tmp/fake-agent" <<'AGENT'
 #!/usr/bin/env bash
@@ -73,7 +62,6 @@ CRON_WORKTREE="$tmp" CRON_LOG_ROOT="$tmp" bash "$RUN" pr 7 --base stack-parent -
 CRON_WORKTREE="$tmp" CRON_LOG_ROOT="$tmp" bash "$RUN" prs --mine -- "$tmp/complete-driver" >/dev/null
 CRON_WORKTREE="$tmp" CRON_LOG_ROOT="$tmp" bash "$RUN" full --repo owner/name -- "$tmp/complete-driver" >/dev/null
 [[ ! -e "$tmp/.oh/logs" ]] || fail 'a run wrote the deleted .oh/logs tier'
-# Lifecycle remains active around the actual driver and exposes the selected route.
 CRON_WORKTREE="$tmp" CRON_LOG_ROOT="$tmp" bash "$RUN" drift -- bash -c '
   [[ $AUDIT_ROUTE == "$AUDIT_ROOT/.oh/skills/audit/references/drift.md" ]]
   [[ ! -e "$AUDIT_ROOT/.oh/logs" ]]
@@ -84,11 +72,9 @@ CRON_WORKTREE="$tmp" CRON_LOG_ROOT="$tmp" bash "$RUN" drift -- bash -c '
 '
 [[ $(<"$tmp/driver-marker") == route-ran ]] || fail 'selected route driver did not run/chdir or receive bindings'
 rm "$tmp/driver-marker"
-# The run record is REPORTED on stderr and never written to a file.
 rec=$(CRON_WORKTREE="$tmp" CRON_LOG_ROOT="$tmp" bash "$RUN" drift -- "$tmp/complete-driver" 2>&1 >/dev/null)
 [[ $(grep -c '^audit -- run-id=' <<<"$rec") -eq 1 ]] || fail 'terminal run record did not follow driver'
 [[ ! -e "$tmp/.oh/logs" ]] || fail 'run record was written to the deleted .oh/logs tier'
-# Two concurrent outer invocations get unique IDs and each reports exactly one record.
 for n in 1 2; do
   CRON_WORKTREE="$tmp" CRON_LOG_ROOT="$tmp" bash "$RUN" drift -- \
     bash -c 'printf "%s|%s" "$AUDIT_RUN_ID" "$AUDIT_ROOT" >"$AUDIT_TMP_ROOT/seen"; "$AUDIT_ROOT/.oh/skills/audit/scripts/audit-evidence.sh" complete DRIFT-OK' 2>"$tmp/rec.$n" & pids[n]=$!
@@ -99,13 +85,11 @@ mapfile -t ids < <(cat "$tmp/rec.1" "$tmp/rec.2" | sed -n 's/^audit -- run-id=\(
 [[ ${#ids[@]} -eq 2 && ${ids[0]} != "${ids[1]}" ]] || fail 'run IDs not unique'
 [[ ${ids[0]} =~ ^audit-[0-9]{8}T[0-9]{6}Z-[A-Za-z0-9._-]+$ ]] || fail 'run ID shape'
 [[ -z $(find "$tmpdir" -mindepth 1 -maxdepth 1 ! -name openharness-locked-append -print -quit) ]] || fail 'invocation temp not cleaned'
-# Child mode preserves the immutable root/ID and reports no record of its own.
 id=${ids[0]}
 child_rec=$(AUDIT_RUN_ID="$id" AUDIT_ROOT="$tmp" TMPDIR="$tmpdir" bash "$RUN" drift -- \
   bash -c '[[ "$AUDIT_RUN_ID" == "$1" && "$AUDIT_ROOT" == "$2" ]]; "$AUDIT_ROOT/.oh/skills/audit/scripts/audit-evidence.sh" complete DRIFT-OK' _ "$id" "$tmp" 2>&1 >/dev/null)
 [[ $(grep -c '^audit -- run-id=' <<<"$child_rec") -eq 0 ]] || fail 'child reported its own run record'
 [[ -z $(find "$tmpdir" -mindepth 1 -maxdepth 1 ! -name openharness-locked-append -print -quit) ]] || fail 'child temp not cleaned'
-# The bridge appends validated arguments verbatim after driver options.
 cat >"$tmp/args-driver" <<'DRIVER'
 #!/usr/bin/env bash
 printf '%s\n' "$PWD" "$AUDIT_TARGET" "$AUDIT_TARGET_ARGS_JSON" "$@" >"$AUDIT_ROOT/args-seen"
@@ -116,7 +100,6 @@ CRON_WORKTREE="$tmp" CRON_LOG_ROOT="$tmp" bash "$RUN" prs --label 'needs review'
 mapfile -t seen <"$tmp/args-seen"
 [[ ${seen[0]} == "$tmp" && ${seen[1]} == prs && ${seen[2]} == '["--label","needs review","--base","development"]' ]] || fail 'named argument bindings differ'
 [[ ${seen[3]} == prs && ${seen[4]} == --label && ${seen[5]} == 'needs review' && ${seen[6]} == --base && ${seen[7]} == development ]] || fail 'driver argv not exact'
-# Failed real work stays inside lifecycle and records its nonzero exit.
 set +e
 failed_rec=$(CRON_WORKTREE="$tmp" CRON_LOG_ROOT="$tmp" bash "$RUN" drift -- bash -c 'exit 23' 2>&1 >/dev/null)
 failed_rc=$?
@@ -124,7 +107,6 @@ set -e
 [[ $failed_rc -eq 23 ]] || fail 'driver failure rc was not propagated'
 grep -q 'state=failed' <<<"$failed_rec" || fail 'failed lifecycle not reported'
 grep -q 'exit=23' <<<"$failed_rec" || fail 'failed exit not reported'
-# INT/TERM/HUP reach the complete route process group and leave no descendants.
 cat >"$tmp/signal-driver" <<'DRIVER'
 #!/usr/bin/env bash
 sigfile="$AUDIT_ROOT/${SIGNAL_NAME,,}-seen"
@@ -152,7 +134,6 @@ for sig in INT TERM HUP; do
   rec_line=$(grep '^audit -- run-id=' "$tmp/sig-rec" | tail -1)
   [[ $rec_line == *state=interrupted* && $rec_line == *"exit=$expected"* ]] || fail "$sig interrupted lifecycle not reported nonzero"
 done
-# The direct fallback also resets inherited SIGINT and fails nonzero.
 cat >"$tmp/direct-driver" <<'DRIVER'
 #!/usr/bin/env bash
 trap 'printf INT >"$AUDIT_ROOT/int-seen"; exit 77' INT

--- a/.oh/evals/probes/audit-stale-references.sh
+++ b/.oh/evals/probes/audit-stale-references.sh
@@ -6,10 +6,6 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"; cd "$ROOT"
 pat='(^|[^A-Za-z0-9-])(pr-audit|harness-audit|context-audit|skill-lint|eval-lint|drift-check)([^A-Za-z0-9-]|$)|\.oh/skills/(pr-audit|harness-audit|context-audit|skill-lint|eval-lint|drift-check)(/|$)|auditor\.md'
 set +e
-# `preserved-changelog-rationale.md` is verbatim CHANGELOG.md history, quoted
-# under a header that says so — the same reason CHANGELOG.md itself is excluded.
-# It is a record of what shipped, not an active surface, so a skill named in a
-# 2026-05 entry is a historical fact rather than a stale reference to repair.
 hits=$(git grep -n -E "$pat" -- ':!CHANGELOG.md' ':!.oh/docs/rfcs/preserved-changelog-rationale.md' ':!.oh/evals/RESULTS.md' ':!.oh/evals/datasets/**' ':!.oh/tasks/archive/**')
 rc=$?; set -e
 [[ $rc -eq 0 || $rc -eq 1 ]] || { echo 'REGRESSION: stale-reference inventory failed' >&2; exit 1; }
@@ -28,8 +24,6 @@ while IFS= read -r hit; do
   bad+=("$hit")
 done <<<"$hits"
 if ((${#bad[@]})); then printf '%s\n' "${bad[@]}" >&2; echo 'REGRESSION: active legacy audit reference' >&2; exit 1; fi
-# Workflow callers that mean the per-unit gate must name the implementation
-# route. A bare namespace token is not executable and silently revives /audit <slug>.
 # shellcheck disable=SC2016 # literal Markdown route token
 bare_audit='`/audit`'
 for caller in \
@@ -48,12 +42,10 @@ done
 if grep -nF 'mechanics + `/audit`' AGENTS.md; then
   echo 'REGRESSION: workflow summary uses bare implementation audit route' >&2; exit 1
 fi
-# Canonical skill discovery must not regress to provider symlink scans.
 # shellcheck disable=SC2016 # literal documented environment variable
 canonical_skills='$AUDIT_ROOT/.oh/skills/'
 grep -qF "$canonical_skills" .oh/skills/audit/references/skills.md \
   || { echo 'REGRESSION: skills audit does not scan canonical .oh/skills' >&2; exit 1; }
-# Assert breadth explicitly so future pathspec narrowing cannot silently drop active classes.
 for path in AGENTS.md .oh/docs/README.md .oh/docs/artifact-contract-schema.md .oh/templates/AGENTS.md .oh/crons/heartbeat.md .github/workflows/ci-harness.yml .oh/evals/capability/tasks/CB-001-ship-harness-change.md .oh/skills/benchmark/SKILL.md .oh/skills/spec/references/retro.md .oh/tasks/archive/2026-07-27/audit-consolidation/progress.txt; do
   git ls-files --error-unmatch "$path" >/dev/null || { echo "REGRESSION: stale-reference coverage path missing: $path" >&2; exit 1; }
 done

--- a/.oh/evals/probes/boot-lint-glob.sh
+++ b/.oh/evals/probes/boot-lint-glob.sh
@@ -16,12 +16,8 @@ for workflow in "${WORKFLOWS[@]}"; do
     exit 2
   fi
 
-  # Unanchored match: the invocation is indented inside a `run: |` block, so a
-  # `^shellcheck` anchor would match nothing. Grab the first matching line.
   line=$(grep 'shellcheck -S warning' "$workflow" | head -1 || true)
 
-  # No false PASS on zero-match: workflow present but the lint line is gone is a
-  # regression, not a pass.
   if [[ -z "$line" ]]; then
     echo "REGRESSION: no 'shellcheck -S warning' invocation found in $workflow" >&2
     exit 1

--- a/.oh/evals/probes/builder-skill-consolidation.sh
+++ b/.oh/evals/probes/builder-skill-consolidation.sh
@@ -54,8 +54,6 @@ done
 grep -qF 'Usage: /builder <agent|skill|command|rule> <name-or-request>' "$SKILL" || fail "missing exact invalid-argument usage"
 grep -qF 'remaining request is empty or only' "$SKILL" || fail "dispatcher does not reject an empty request after a valid type"
 grep -qF 'stop without reading' "$SKILL" || fail "missing fail-closed invalid-type behavior"
-# The `.oh/memory` tier was deleted; /builder logs nothing. A reintroduced write
-# target here is the defect this replaces the old Memory-Protocol assertions with.
 if grep -qF '.oh/memory' "$SKILL"; then fail "builder references the deleted .oh/memory tier"; fi
 if grep -qF 'MEMORY_DIR' "$SKILL"; then fail "builder reintroduced the MEMORY_DIR override"; fi
 

--- a/.oh/evals/probes/capability-benchmark-schema.sh
+++ b/.oh/evals/probes/capability-benchmark-schema.sh
@@ -9,7 +9,6 @@ CAP="$ROOT/.oh/evals/capability"
 TASKS="$CAP/tasks"
 RESULTS="$CAP/RESULTS.md"
 
-# Assertion 1 — instrument not present on this branch => SKIPPED (not a regression).
 if [[ ! -f "$CAP/README.md" ]]; then
   echo "SKIPPED: capability-benchmark instrument absent: $CAP/README.md" >&2
   exit 2
@@ -17,7 +16,6 @@ fi
 
 fails=()
 
-# Assertion 2 — >=3 task specs matching CB-*.md.
 shopt -s nullglob
 task_files=("$TASKS"/CB-*.md)
 shopt -u nullglob
@@ -25,7 +23,6 @@ if (( ${#task_files[@]} < 3 )); then
   fails+=("expected >=3 CB-*.md task specs in $TASKS, found ${#task_files[@]}")
 fi
 
-# Assertion 3 — each CB-*.md carries a frontmatter `id:` line and the three sections.
 for f in "${task_files[@]}"; do
   grep -qE '^id:[[:space:]]*CB-[0-9]+' "$f" || fails+=("$f: missing frontmatter '^id: CB-<n>' line")
   grep -qE '^## Task[[:space:]]*$' "$f" || fails+=("$f: missing '## Task' section")
@@ -33,7 +30,6 @@ for f in "${task_files[@]}"; do
   grep -qE '^## Rubric[[:space:]]*$' "$f" || fails+=("$f: missing '## Rubric' section")
 done
 
-# Assertion 4 — scoreboard exists with the canonical header tokens.
 if [[ ! -f "$RESULTS" ]]; then
   fails+=("scoreboard absent: $RESULTS")
 else
@@ -47,7 +43,6 @@ else
   fi
 fi
 
-# Assertion 5 — drift guard: every task id has a scoreboard row.
 if [[ -f "$RESULTS" ]]; then
   while read -r id; do
     [[ -n "$id" ]] || continue

--- a/.oh/evals/probes/cc-safety-net-wiring.sh
+++ b/.oh/evals/probes/cc-safety-net-wiring.sh
@@ -4,9 +4,6 @@
 # desc: cc-safety-net@1.0.6 destructive-command guard stays wired across claude/codex/pi + image/compose; live binary denies 'git reset --hard'
 set -euo pipefail
 
-# Resolve the repo root the way sibling probes do (worktree-aware): prefer the
-# git toplevel resolved from the probe's own directory, fall back to the fixed
-# .oh/evals/probes/<id>.sh -> root climb when git is unavailable.
 PROBE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT="$(cd "$PROBE_DIR" && git rev-parse --show-toplevel 2>/dev/null)" \
   || ROOT="$(cd "$PROBE_DIR/../../.." && pwd)"
@@ -14,8 +11,6 @@ ROOT="$(cd "$PROBE_DIR" && git rev-parse --show-toplevel 2>/dev/null)" \
 PIN="1.0.6"
 fail=()
 
-# ── REPO-STATIC assertions (never SKIP — a missing wiring is a REGRESSION) ──
-# Each config edit is committed source; absence means a provider lost the guard.
 
 CLAUDE_SETTINGS="$ROOT/.claude/settings.json"
 CODEX_HOOKS="$ROOT/.codex/hooks.json"
@@ -24,37 +19,24 @@ PI_NPM="${CC_SAFETY_NET_PROBE_PI_NPM:-$ROOT/.pi/npm}"
 DOCKERFILE="$ROOT/.devcontainer/Dockerfile"
 COMPOSE="$ROOT/.devcontainer/docker-compose.yml"
 
-# (a) claude PreToolUse/Bash guard-wrapped command (kill-switch + hook invocation on one line)
 if [[ ! -f "$CLAUDE_SETTINGS" ]]; then
   fail+=("(a) .claude/settings.json absent")
 elif ! grep -F 'cc-safety-net hook --claude-code' "$CLAUDE_SETTINGS" | grep -Fq 'CC_SAFETY_NET_OFF'; then
   fail+=("(a) .claude/settings.json Bash hook missing CC_SAFETY_NET_OFF-guarded 'cc-safety-net hook --claude-code'")
 fi
 
-# (b) codex the same guard-wrapped command
 if [[ ! -f "$CODEX_HOOKS" ]]; then
   fail+=("(b) .codex/hooks.json absent")
 elif ! grep -F 'cc-safety-net hook --claude-code' "$CODEX_HOOKS" | grep -Fq 'CC_SAFETY_NET_OFF'; then
   fail+=("(b) .codex/hooks.json Bash hook missing CC_SAFETY_NET_OFF-guarded 'cc-safety-net hook --claude-code'")
 fi
 
-# (c) pi package pin in .pi/settings.json packages[]
 if [[ ! -f "$PI_SETTINGS" ]]; then
   fail+=("(c) .pi/settings.json absent")
 elif ! grep -Fq "npm:cc-safety-net@${PIN}" "$PI_SETTINGS"; then
   fail+=("(c) .pi/settings.json packages[] missing 'npm:cc-safety-net@${PIN}'")
 fi
 
-# (d) pi runtime tree .pi/npm/ is gitignored, boot-generated state — NOT asserted
-# statically (a fresh clone legitimately lacks it). Where it exists, the RESOLVED
-# cc-safety-net version must equal the pin: both the lockfile entry and the
-# installed package's own manifest are read, because the DECLARED range npm
-# writes ("^1.0.6") permits the very runtime drift this assertion exists to
-# catch. A tree that declares cc-safety-net but resolves nothing is a gap, not a
-# pass. Every gap here becomes a (d) line like any other — this assertion never
-# exits early, so it can never disarm (a),(b),(c),(e),(f).
-# CC_SAFETY_NET_PROBE_PI_NPM points tests at a fixture tree; a set override must
-# resolve a real version, so it cannot be used to silence the assertion.
 PI_LOCK="$PI_NPM/package-lock.json"
 PI_INSTALLED="$PI_NPM/node_modules/cc-safety-net/package.json"
 PI_MANIFEST="$PI_NPM/package.json"
@@ -63,9 +45,6 @@ D_FIX="reinstall .pi/npm, or bump the pin in .pi/settings.json + .devcontainer/D
 d_found=0
 d_lines=${#fail[@]}
 
-# Read one version string out of a JSON file with node (jq is image-only; the CI
-# eval job provisions node explicitly). Prints the version, prints nothing when
-# the key is absent, and exits non-zero ONLY when the file cannot be read/parsed.
 d_json_read() {
   "$D_NODE" -e '
 const fs = require("fs");
@@ -88,8 +67,6 @@ if (typeof v === "string" && v) process.stdout.write(v);
 ' "$1" "$2"
 }
 
-# One source file: absent → nothing; unreadable → a named (d) line; resolved →
-# compared against the pin. Never aborts the probe under `set -euo pipefail`.
 d_check() {
   local file="$1" kind="$2" label ver
   [[ -f "$file" ]] || return 0
@@ -119,9 +96,6 @@ if [[ -n "${CC_SAFETY_NET_PROBE_PI_NPM:-}" && ! -d "$PI_NPM" ]]; then
 elif [[ -d "$PI_NPM" ]]; then
   d_check "$PI_LOCK" lock
   d_check "$PI_INSTALLED" installed
-  # Nothing resolved and nothing reported yet: a manifest that declares the
-  # package is "declared but unresolved", and a set override that resolves
-  # nothing is a disarmed check. A silent pass is the fresh-clone case only.
   if (( d_found == 0 && ${#fail[@]} == d_lines )); then
     d_check "$PI_MANIFEST" declared
   fi
@@ -130,14 +104,12 @@ elif [[ -d "$PI_NPM" ]]; then
   fi
 fi
 
-# (e) Dockerfile bakes the pinned global install
 if [[ ! -f "$DOCKERFILE" ]]; then
   fail+=("(e) .devcontainer/Dockerfile absent")
 elif ! grep -Fq "npm install -g cc-safety-net@${PIN}" "$DOCKERFILE"; then
   fail+=("(e) .devcontainer/Dockerfile missing 'npm install -g cc-safety-net@${PIN}'")
 fi
 
-# (f) compose sets both mode env vars
 if [[ ! -f "$COMPOSE" ]]; then
   fail+=("(f) .devcontainer/docker-compose.yml absent")
 else
@@ -153,9 +125,6 @@ if (( ${#fail[@]} )); then
   exit 1
 fi
 
-# ── LIVE assertion (may SKIP only when no binary is reachable) ──
-# CC_SAFETY_NET_PROBE_BIN lets CI/tests point at a local install; otherwise
-# fall back to whatever cc-safety-net is on PATH inside the built image.
 BIN="${CC_SAFETY_NET_PROBE_BIN:-}"
 if [[ -z "$BIN" ]]; then
   BIN="$(command -v cc-safety-net 2>/dev/null || true)"
@@ -171,7 +140,6 @@ if [[ ! -x "$BIN" ]]; then
   exit 1
 fi
 
-# Pipe a known-destructive command and require a deny verdict.
 out="$(printf '{"tool_name":"Bash","tool_input":{"command":"git reset --hard HEAD"}}' \
   | "$BIN" hook --claude-code 2>/dev/null || true)"
 

--- a/.oh/evals/probes/cleanup-tasks-scoped-guard.sh
+++ b/.oh/evals/probes/cleanup-tasks-scoped-guard.sh
@@ -10,9 +10,6 @@
 #       add`/`git worktree remove` lifecycle — the old shared-checkout
 #       `git switch -c "archive/` is gone. So foreign WIP elsewhere neither aborts
 #       the sweep nor leaks into the archive commit.
-# NOTE: this is a STATIC grep oracle over markdown (.oh/crons/cleanup-tasks.md), NOT a
-#       runtime execution test of the cron — same limitation as owned-surface-guard.sh.
-#       It guards the documented procedure against silent revert, not its behavior.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
@@ -23,17 +20,11 @@ if [[ ! -f "$CRON" ]]; then
   exit 2
 fi
 
-# --- (a) the pre-flight is path-scoped to .oh/tasks/ --------------------------------------
-# On an UNMODIFIED cron the pre-flight is tree-wide, so this scoped form is absent → exit 1
-# (the symmetric-oracle anchor). `grep -F` keeps the `--porcelain` / `--` literal.
 if ! grep -Fq 'git status --porcelain -- .oh/tasks/' "$CRON"; then
   echo "REGRESSION: pre-flight is not scoped to .oh/tasks/ (missing 'git status --porcelain -- .oh/tasks/')" >&2
   exit 1
 fi
 
-# --- (b) no bare unscoped `git status --porcelain` survives ---------------------------
-# List every `git status --porcelain` line, then drop the pathspec-scoped `-- .oh/tasks/`
-# lines. Anything left is a bare tree-wide check that would abort the sweep on foreign WIP.
 unscoped="$(grep -n 'git status --porcelain' "$CRON" \
   | grep -v -- '-- .oh/tasks/' \
   || true)"
@@ -43,26 +34,20 @@ if [[ -n "$unscoped" ]]; then
   exit 1
 fi
 
-# --- (c) a dirty .oh/tasks/ emits the distinct BLOCKED-TASKS-WIP liveness token -----------
 if ! grep -q 'BLOCKED-TASKS-WIP' "$CRON"; then
   echo "REGRESSION: BLOCKED-TASKS-WIP token missing from .oh/crons/cleanup-tasks.md" >&2
   exit 1
 fi
 
-# --- (d) the archive work is isolated in a worktree (add + remove lifecycle) -----------
 if ! grep -q 'git worktree add' "$CRON"; then
   echo "REGRESSION: 'git worktree add' missing — archive work is not isolated in a worktree" >&2
   exit 1
 fi
-# Teardown may be inline `git worktree remove` or (post cc-safety-net) the
-# guard-compatible shim `git-maintenance.sh worktree-remove` — either satisfies
-# the crash-safe-teardown lesson this probe encodes.
 if ! grep -Eq 'git worktree remove|git-maintenance\.sh worktree-remove' "$CRON"; then
   echo "REGRESSION: worktree teardown missing ('git worktree remove' or git-maintenance.sh worktree-remove) — not crash-safe" >&2
   exit 1
 fi
 
-# --- (e) the old shared-checkout `git switch -c "archive/` is gone (asymmetric oracle) -
 if grep -Fq 'git switch -c "archive/' "$CRON"; then
   echo "REGRESSION: old shared-checkout 'git switch -c \"archive/' pattern still present" >&2
   exit 1

--- a/.oh/evals/probes/cleanup-tasks-worktree-grooming.sh
+++ b/.oh/evals/probes/cleanup-tasks-worktree-grooming.sh
@@ -9,9 +9,6 @@
 #       staged / untracked / missing-upstream / unpushed preservation gates before
 #       `git worktree remove --force`, avoid recursive orphan deletion, and report
 #       the groomed count in cron liveness.
-# NOTE: this is a STATIC grep oracle over markdown (.oh/crons/cleanup-tasks.md), NOT a
-#       runtime execution test of the cron. It guards the documented procedure
-#       against silent revert, not shell behavior.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
@@ -22,8 +19,6 @@ if [[ ! -f "$CRON" ]]; then
   exit 2
 fi
 
-# The grooming pass must be explicit and must not be mistaken for the temporary
-# archive worktree used to commit task moves.
 if ! grep -Fq 'Groom stale `.oh/worktrees/` branch checkouts' "$CRON"; then
   echo "REGRESSION: cleanup-tasks lacks the .oh/worktrees grooming pass" >&2
   exit 1
@@ -33,7 +28,6 @@ if ! grep -Fq 'git worktree list --porcelain' "$CRON"; then
   exit 1
 fi
 
-# Durable namespaces are never cleanup candidates.
 if ! grep -Fq '.oh/worktrees/agent/' "$CRON" || ! grep -Fq '.oh/worktrees/project/' "$CRON"; then
   echo "REGRESSION: grooming pass does not explicitly preserve .oh/worktrees/agent/ and .oh/worktrees/project/" >&2
   exit 1
@@ -47,8 +41,6 @@ if ! grep -Fq 'excluding `.oh/worktrees/agent/`' "$CRON"; then
   exit 1
 fi
 
-# Safety gates before removal: live pane, open PR, 30-day age, and local-work
-# preservation. The latter prevents stale age from becoming proof of disposability.
 if ! grep -Fq "tmux list-panes -a -F '#{pane_current_path}'" "$CRON"; then
   echo "REGRESSION: grooming pass lacks live tmux-pane protection" >&2
   exit 1
@@ -80,16 +72,11 @@ for reason in dirty staged untracked missing-upstream unpushed; do
   fi
 done
 
-# Registered worktrees use forced worktree removal only after the preservation
-# gate — inline `git worktree remove --force` or (post cc-safety-net) the
-# guard-compatible shim `git-maintenance.sh worktree-remove`.
 if ! grep -Eq 'git worktree remove --force "\$path"|git-maintenance\.sh worktree-remove "\$path"' "$CRON"; then
   echo "REGRESSION: stale registered worktrees are not removed via forced worktree removal" >&2
   exit 1
 fi
 
-# Corrupt/orphan folders are not registered worktrees; they must not be recursively
-# deleted when non-empty/suspicious because that can destroy the only copy of work.
 if grep -Fq 'rm -rf "$path"' "$CRON"; then
   echo "REGRESSION: orphan-folder pruning still authorizes recursive rm -rf" >&2
   exit 1
@@ -103,15 +90,11 @@ if ! grep -Fq 'orphan-nonempty' "$CRON"; then
   exit 1
 fi
 
-# Reporting/liveness includes the groomed count, so the weekly archive's output
-# reflects this second cleanup surface.
 if ! grep -Fq 'groomed W worktrees' "$CRON"; then
   echo "REGRESSION: cleanup-tasks liveness/reporting omits groomed worktree count" >&2
   exit 1
 fi
 
-# The reserved namespace cleanup must not delete agent/project even when removing
-# empty top-level directories.
 if ! grep -Fq '! -name agent ! -name project -empty -delete' "$CRON"; then
   echo "REGRESSION: empty namespace pruning does not preserve agent/project" >&2
   exit 1

--- a/.oh/evals/probes/close-issues-on-development.sh
+++ b/.oh/evals/probes/close-issues-on-development.sh
@@ -38,23 +38,16 @@ has 'state_reason: "completed"' "completed state reason"
 has 'PR_TITLE: ${{ github.event.pull_request.title }}' "title passed through env"
 has 'PR_BODY: ${{ github.event.pull_request.body }}' "body passed through env"
 
-# pull_request_target resolves the workflow from the DEFAULT branch (main), where
-# this file does not exist — it would never fire. This is the bug the trigger swap
-# fixed; the probe keeps it from coming back.
 if grep -Eq '^[[:space:]]*pull_request_target:' <<<"$text"; then
   echo "REGRESSION close-issues-on-development must not use pull_request_target: it resolves from the default branch, where this workflow does not exist" >&2
   exit 1
 fi
 
-# The workflow must never run head-branch code: it checks out the base ref and
-# only imports the parser. An explicit head ref would make this an ACE surface.
 if grep -Eq 'ref:[[:space:]]*\$\{\{[[:space:]]*github\.event\.pull_request\.head' <<<"$text"; then
   echo "REGRESSION close-issues-on-development must not check out the pull request head ref" >&2
   exit 1
 fi
 
-# Author-controlled strings must reach the script through env, never through
-# template interpolation inside the script body.
 if grep -Eq '^[[:space:]]+.*\$\{\{[[:space:]]*github\.event\.pull_request\.(title|body)' <<<"$(sed -n '/script: |/,$p' <<<"$text")"; then
   echo "REGRESSION close-issues-on-development interpolates PR title/body into the script body" >&2
   exit 1

--- a/.oh/evals/probes/compose-config-path-parity.sh
+++ b/.oh/evals/probes/compose-config-path-parity.sh
@@ -3,24 +3,6 @@
 # desc: the wrapper path and the VS Code "Reopen in Container" path resolve the same service — the parity harness.yaml made impossible
 set -euo pipefail
 
-# WHY THIS PROBE EXISTS, AND WHY IT COULD NOT PASS BEFORE 0.3.0.
-#
-# There are two ways a sandbox comes up:
-#   A. `make ...` / `oh ...`  -> .oh/scripts/docker-compose.sh -> docker compose
-#   B. VS Code "Reopen in Container" -> .devcontainer/devcontainer.json names
-#      .devcontainer/docker-compose.yml DIRECTLY, so compose auto-loads
-#      .devcontainer/.env from that directory and the wrapper never runs.
-#
-# harness.yaml was readable only on path A. Any key set there produced a
-# different resolved service on the two paths, silently. That was the reason to
-# remove it, and this probe is the assertion that the reason is now discharged:
-# with .devcontainer/.env as the only surface, both paths must resolve the same
-# service, because both read the same file.
-#
-# Note the ASYMMETRY that is legitimate: path A also applies the opt-in overlays
-# (ssh, docker-sock, hermes-dashboard). Those are the wrapper's job and are
-# tested elsewhere. This probe pins the BASE service, with every toggle off, so
-# a difference can only come from a configuration surface one path cannot read.
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 WRAPPER="$ROOT/.oh/scripts/docker-compose.sh"
@@ -33,9 +15,6 @@ fi
 
 fails=()
 
-# --- 1. Structural: ONE env-file, and it is the one compose auto-loads --------
-# This half needs no docker. A second --env-file would be a surface path B
-# cannot see — exactly the harness.yaml shape, rebuilt.
 argv="$(bash "$WRAPPER" --repo-dir "$ROOT" --print-argv config 2>/dev/null || true)"
 env_file_count="$(grep -cx -- '--env-file' <<<"$argv" || true)"
 
@@ -50,7 +29,6 @@ fi
 grep -q 'harness-config.sh' <<<"$argv" \
   && fails+=("the wrapper still shells out to harness-config.sh")
 
-# --- 2. Behavioural: both paths resolve the same service ----------------------
 if ! command -v docker >/dev/null 2>&1 || ! docker compose version >/dev/null 2>&1; then
   if (( ${#fails[@]} > 0 )); then
     echo "REGRESSION: compose config path parity broken:" >&2
@@ -64,9 +42,6 @@ fi
 work="$(mktemp -d)"
 trap 'rm -rf "$work"' EXIT
 
-# A fixture repo with a .env that sets keys on BOTH paths. Every overlay toggle
-# is left off so the two argv lists differ in nothing but the wrapper's own
-# --env-file, which is the point being tested.
 mkdir -p "$work/.devcontainer"
 cp -R "$ROOT/.devcontainer/." "$work/.devcontainer/"
 mkdir -p "$work/.oh/scripts"
@@ -81,14 +56,6 @@ rm -f "$work/.oh/config.json"
   printf 'CRON_AGENT_BIN=codex\n'
 } > "$work/.devcontainer/.env"
 
-# `docker compose config` needs the build context to exist; both invocations get
-# the same tree, so any difference is configuration, not layout.
-#
-# THE `env -u` MATTERS. Compose resolves a shell-exported variable AHEAD of any
-# env-file, and this probe usually runs INSIDE the sandbox, whose own compose
-# run exported SANDBOX_NAME, TZ and friends into every process. Without clearing
-# them the fixture's .env would be shadowed by the ambient values and the probe
-# would measure the container it is running in, not the file under test.
 clear_ambient=(env -u SANDBOX_NAME -u TZ -u INSTALL_HERMES -u CRON_AGENT_BIN)
 
 via_wrapper="$(cd "$work" && "${clear_ambient[@]}" bash "$work/.oh/scripts/docker-compose.sh" --repo-dir "$work" config 2>/dev/null || true)"
@@ -104,8 +71,6 @@ if [[ -z "$via_wrapper" || -z "$via_vscode" ]]; then
   exit 2
 fi
 
-# Compare the values that came from .env, not the whole document: the two
-# invocations legitimately differ in the working directory they record.
 for pair in "container_name: parityprobe" "TZ: America/Denver" "INSTALL_HERMES" "CRON_AGENT_BIN: codex"; do
   grep -qF "$pair" <<<"$via_wrapper" || fails+=("wrapper path did not resolve '$pair' from .devcontainer/.env")
   grep -qF "$pair" <<<"$via_vscode"  || fails+=("VS Code path did not resolve '$pair' from .devcontainer/.env")

--- a/.oh/evals/probes/context-tier-size-budget.sh
+++ b/.oh/evals/probes/context-tier-size-budget.sh
@@ -13,15 +13,9 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 
-# --- the budget ------------------------------------------------------------
-# Raising these is allowed; doing it silently is not. Whoever raises one owns the answer to
-# "what does every future session now read that it did not read before, and why is that
-# worth it?" — and should say so in the CHANGELOG entry that raises it.
-TIER_BUDGET_BYTES=96000     # ~24,000 tokens. Today: 85,256 B (~21,300).
-SINGLE_FILE_SHARE_MAX=60    # percent. Historical worst case: one file at 56%.
+TIER_BUDGET_BYTES=96000
+SINGLE_FILE_SHARE_MAX=60
 
-# `memory` is shared across worktrees and gitignored — resolve it through oh-path (which
-# would point at a per-worktree empty ledger and understate the tier.
 
 FILES=(
   "$ROOT/AGENTS.md"
@@ -37,8 +31,6 @@ largest=0
 largest_name=""
 report=()
 for f in "${FILES[@]}"; do
-  # A missing file is not a failure: a fresh clone may not carry every context file.
-  # It just does not contribute to the tier that clone actually loads.
   [[ -f "$f" ]] || continue
   b=$(wc -c < "$f" | tr -d ' ')
   total=$((total + b))

--- a/.oh/evals/probes/datasets-schema.sh
+++ b/.oh/evals/probes/datasets-schema.sh
@@ -12,7 +12,6 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 DS="$ROOT/.oh/evals/datasets"
 README="$DS/README.md"
 
-# Assertion 1 — corpus not present on this branch => SKIPPED (not a regression).
 if [[ ! -f "$README" ]]; then
   echo "SKIPPED: datasets corpus absent: $README" >&2
   exit 2
@@ -21,7 +20,6 @@ command -v jq >/dev/null 2>&1 || { echo "SKIPPED: jq not on PATH" >&2; exit 2; }
 
 fails=()
 
-# Assertion 2 — >=3 example folders matching <dataset>/DS-*/.
 shopt -s nullglob
 example_dirs=("$DS"/*/DS-*/)
 shopt -u nullglob
@@ -33,13 +31,11 @@ ids=()
 for d in "${example_dirs[@]}"; do
   d="${d%/}"
   rel="${d#"$ROOT"/}"
-  # Assertion 3 — required files per example folder.
   [[ -f "$d/manifest.json" ]] || fails+=("$rel: missing manifest.json")
   [[ -f "$d/prompt.md" ]]     || fails+=("$rel: missing prompt.md")
   [[ -d "$d/oracle" ]]        || fails+=("$rel: missing oracle/ directory")
   [[ -x "$d/verify.sh" ]]     || fails+=("$rel: missing executable verify.sh")
 
-  # Assertion 4 — manifest parses + required fields + DS-<n> id.
   if [[ -f "$d/manifest.json" ]]; then
     jq -e '.id and .slug and .dataset and .title and (.source|type=="object") and (.reward_kind|type=="array") and (.oracle|type=="object")' \
       "$d/manifest.json" >/dev/null 2>&1 || fails+=("$rel/manifest.json: missing required fields or invalid JSON")
@@ -51,13 +47,11 @@ for d in "${example_dirs[@]}"; do
     fi
   fi
 
-  # Assertion 5 — hermetic verify.sh self-check exits 0.
   if [[ -x "$d/verify.sh" ]]; then
     bash "$d/verify.sh" >/dev/null 2>&1 || fails+=("$rel/verify.sh: self-check did not exit 0")
   fi
 done
 
-# Assertion 6 — bidirectional drift: every example id has a `| DS-NNN |` catalogue row, and vice-versa.
 cat_ids=()
 while read -r cid; do
   [[ -n "$cid" ]] && cat_ids+=("$cid")
@@ -74,7 +68,6 @@ else
   fails+=("could not extract example ids (${#ids[@]}) or catalogue ids (${#cat_ids[@]})")
 fi
 
-# Assertion 7 — every capability `datasets:` frontmatter ref resolves to a real example id.
 CAP_TASKS="$ROOT/.oh/evals/capability/tasks"
 if [[ -d "$CAP_TASKS" && ${#ids[@]} -gt 0 ]]; then
   while read -r ref; do

--- a/.oh/evals/probes/debugmcp-availability.sh
+++ b/.oh/evals/probes/debugmcp-availability.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 # desc: Detect DebugMCP MCP server on :3001/mcp via an MCP initialize handshake — SKIPPED if unbound, PASS on a valid JSON-RPC initialize result, REGRESSION if bound-but-bad.
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
-: "$ROOT"  # repo root resolved per probe contract; runtime-only probe needs nothing under it
+: "$ROOT"
 
 URL="http://127.0.0.1:3001/mcp"
 HEADERS_FILE=""
@@ -18,14 +18,6 @@ cleanup() {
 }
 trap cleanup EXIT
 
-# 1) Reachability + handshake in ONE request.
-#    DebugMCP speaks MCP Streamable HTTP: a bare GET /mcp returns 404, so the
-#    probe MUST POST a JSON-RPC `initialize` (with the SSE-capable Accept header)
-#    to elicit a real response. `curl -s` returns 0 for ANY HTTP response (incl.
-#    4xx/5xx) and a non-zero exit ONLY on a connect-level failure (7 = couldn't
-#    connect, 28 = timeout). A connect failure is the clean-sandbox default →
-#    SKIPPED, never REGRESSION. The `|| connect_rc=$?` guard keeps `set -e` from
-#    aborting before exit 2.
 HEADERS_FILE="$(mktemp)"
 BODY_FILE="$(mktemp)"
 INIT_BODY='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"openharness-probe","version":"0.0.1"}}}'
@@ -41,15 +33,10 @@ if [ "$connect_rc" -ne 0 ]; then
   exit 2
 fi
 
-# The server answered at the HTTP level; the port is bound. Parse the last HTTP
-# status line (handles 1xx/redirect preludes), defaulting to 000 if none seen.
 status="$(grep -iE '^HTTP/[0-9.]+ [0-9]{3}' "$HEADERS_FILE" 2>/dev/null | tr -d '\r' | tail -1 | awk '{print $2}' || true)"
 [ -n "$status" ] || status="000"
 content_type="$(grep -i '^content-type:' "$HEADERS_FILE" 2>/dev/null | tr -d '\r' | head -1 | cut -d: -f2- | tr '[:upper:]' '[:lower:]' | tr -d ' ' || true)"
 
-# 2) PASS only on HTTP 2xx AND an MCP content-type AND a JSON-RPC initialize
-#    result. The body is SSE (`data: {...}`) or plain JSON; both carry the
-#    result fields, so a substring check for the MCP handshake markers suffices.
 if [ "$status" -ge 200 ] && [ "$status" -lt 300 ]; then
   case "$content_type" in
     text/event-stream*|application/json*)
@@ -67,6 +54,5 @@ if [ "$status" -ge 200 ] && [ "$status" -lt 300 ]; then
   esac
 fi
 
-# 3) Bound and responded, but not 2xx — a definite detected-bad-state.
 echo "REGRESSION :3001/mcp bound but returned HTTP $status (expected 2xx from MCP initialize)" >&2
 exit 1

--- a/.oh/evals/probes/delegate-model-effort-policy.sh
+++ b/.oh/evals/probes/delegate-model-effort-policy.sh
@@ -14,12 +14,10 @@ fi
 
 problems=()
 
-# Default worker routing inherits the active session model by leaving model unset.
 if ! grep -Eiq 'omit(ted)? (the )?(Agent )?`?model`? (argument|parameter).*(inherit|parent|session)|inherit.*(parent|session).*(omit|omitted|unset).*(model|`model`)' "$SKILL"; then
   problems+=("default policy does not inherit the parent/session model through an omitted Agent model argument")
 fi
 
-# The real Agent argument is `thinking`, not an invented `effort` argument.
 if ! grep -Eiq 'Agent( tool)?[^.]*`thinking` parameter|pass Agent `thinking`|call Agent with `thinking:' "$SKILL"; then
   problems+=("policy does not explicitly use the Agent thinking parameter")
 fi
@@ -27,7 +25,6 @@ if grep -Eiq '`effort` (argument|parameter)|`effort:|with `effort:|\*\*Effort\*\
   problems+=("policy still presents effort as an Agent parameter or task-schema field")
 fi
 
-# Keep every complexity mapping independently recognizable.
 if ! grep -Eiq 'simple.*mechanical.*`?low`?' "$SKILL"; then
   problems+=("thinking matrix is missing simple/mechanical -> low")
 fi
@@ -54,15 +51,12 @@ if ! { grep -Eiq 'override.*model|model.*override' "$SKILL" && grep -Eiq 'record
   problems+=("model overrides do not require a recorded explicit reason")
 fi
 
-# Routine named-tier routing is incompatible with inherited-model routing.
 for tier in luna terra sol haiku sonnet opus; do
   if grep -Eiq "(^|[^[:alnum:]_-])${tier}([^[:alnum:]_-]|$)" "$SKILL"; then
     problems+=("legacy routine model-routing tier remains: $tier")
   fi
 done
 
-# DeepSWE is external evidence about coding performance, not proof of harness
-# inheritance or simple-task routing; keep that volatile claim out of this policy.
 if grep -Eiq 'DeepSWE|leaderboard' "$SKILL"; then
   problems+=("volatile external benchmark language appears in durable delegate policy")
 fi

--- a/.oh/evals/probes/devtcp-hook.sh
+++ b/.oh/evals/probes/devtcp-hook.sh
@@ -12,24 +12,18 @@ if [[ ! -x "$HOOK" ]]; then
   exit 2
 fi
 
-# --- file-fixture driver ---
-# Hold the sensitive token in a variable; write fixtures to /tmp so the
-# hook never scans the probe's own command text.
 
 DEVTCP_TOKEN="/dev/tcp/"
 TMPDIR_PROBE=$(mktemp -d /tmp/devtcp-probe-XXXXXX)
 trap 'rm -rf "$TMPDIR_PROBE"' EXIT
 
-# Fixture A: command that references /dev/tcp/
 FIXTURE_A="$TMPDIR_PROBE/fixture-a.json"
 printf '{"tool_input":{"command":"bash -c '\''exec 3<>%s10.0.0.1/80'\''"}}\n' \
   "$DEVTCP_TOKEN" > "$FIXTURE_A"
 
-# Fixture B: benign command that references .devcontainer (must NOT trigger)
 FIXTURE_B="$TMPDIR_PROBE/fixture-b.json"
 printf '{"tool_input":{"command":"ls .devcontainer/"}}\n' > "$FIXTURE_B"
 
-# --- assertion A: /dev/tcp → warning on stderr, exit 0 ---
 stderr_a=$(bash "$HOOK" < "$FIXTURE_A" 2>&1 >/dev/null) || {
   echo "REGRESSION: hook exited non-zero for /dev/tcp command (must be non-blocking)" >&2
   exit 1
@@ -40,7 +34,6 @@ if [[ "$stderr_a" != *"warn-devtcp"* ]]; then
   exit 1
 fi
 
-# --- assertion B: .devcontainer → no warning, exit 0 ---
 stderr_b=$(bash "$HOOK" < "$FIXTURE_B" 2>&1 >/dev/null) || {
   echo "REGRESSION: hook exited non-zero for benign .devcontainer command" >&2
   exit 1

--- a/.oh/evals/probes/docker-inspect-env-guard.sh
+++ b/.oh/evals/probes/docker-inspect-env-guard.sh
@@ -36,7 +36,6 @@ decision_for() {
 }
 
 assert() {
-  # assert <want> <command> <label>
   local want="$1" got
   got=$(decision_for "$2")
   if [[ "$got" != "$want" ]]; then
@@ -45,8 +44,7 @@ assert() {
   fi
 }
 
-# --- group A: env-exposing inspect shapes are denied ---
-ENV_FIELD='.Config.'"En"'v'   # split so a plain grep of this probe is not itself a leak vector
+ENV_FIELD='.Config.'"En"'v'
 assert deny "docker inspect openharness" \
   "bare inspect dumps full JSON including the env block"
 assert deny "docker container inspect openharness" \
@@ -66,7 +64,6 @@ assert deny "docker inspect web | jq '.[0].State'" \
 assert deny "podman inspect mycontainer" \
   "the podman equivalent bypassed the guard"
 
-# --- group B: narrow field reads stay allowed (inspect is NOT blanket-blocked) ---
 assert allow "docker inspect --format '{{.State.Health.Status}}' openharness" \
   "guard over-blocked a narrow health-status read"
 assert allow "docker container inspect -f '{{.State.Status}}' openharness" \
@@ -80,16 +77,13 @@ assert allow "docker inspect oh-sbx-local --format '{{range \$name, \$_ := .Netw
 assert allow "docker image inspect --format '{{.Id}}' node:20" \
   "guard over-blocked an image-id read"
 
-# --- group C: neighbouring docker commands are untouched ---
 assert allow "docker ps -a" "guard leaked onto docker ps"
 assert allow "docker compose up -d --build" "guard leaked onto docker compose"
 assert allow "docker exec -it openharness tmux ls" "guard leaked onto docker exec"
 
-# --- group D: secret/config objects stay hard-denied (no template makes them safe) ---
 assert deny "docker sec""ret inspect foo" "docker secret inspect stopped being denied"
 assert deny "docker con""fig inspect foo" "docker config inspect stopped being denied"
 
-# --- group E: wiring — deny-list mirrors the env-shaped patterns ---
 for rule in "Bash(command=*inspect*Config.Env*)" "Bash(command=*inspect*{{json .}}*)" "Bash(command=*inspect*{{.}}*)"; do
   if ! jq -e --arg r "$rule" '.permissions.deny | index($r)' "$SETTINGS" >/dev/null; then
     echo "REGRESSION: permissions.deny is missing '$rule'" >&2
@@ -97,13 +91,11 @@ for rule in "Bash(command=*inspect*Config.Env*)" "Bash(command=*inspect*{{json .
   fi
 done
 
-# --- group F: wiring — the blanket block stays OFF (deliberate: inspect is usable) ---
 if jq -e '.permissions.deny | index("Bash(command=*docker inspect*)")' "$SETTINGS" >/dev/null; then
   echo "REGRESSION: permissions.deny blanket-blocks docker inspect again — the policy is field-level denial, not a full block" >&2
   exit 1
 fi
 
-# --- group G: wiring — the Bash guard is still attached to the Bash matcher ---
 matcher=$(jq -r '.hooks.PreToolUse[]? | select(.hooks[]?.command // "" | contains("deny-env-dump")) | .matcher' "$SETTINGS")
 if [[ "$matcher" != *"Bash"* ]]; then
   echo "REGRESSION: deny-env-dump.sh is no longer wired to the Bash matcher in $SETTINGS" >&2

--- a/.oh/evals/probes/docs-build-fast-path.sh
+++ b/.oh/evals/probes/docs-build-fast-path.sh
@@ -26,8 +26,6 @@ script_value() {
 
 failures=()
 
-# .oh/docs now holds the GitHub-readable markdown docs; only Docusaurus BUILD
-# machinery (a package.json / docusaurus.config.* / sidebars.*) is forbidden there.
 [[ ! -e "$ROOT/.oh/docs/package.json" ]] || failures+=(".oh/docs must not regain a Docusaurus package.json (the rendered site stays in openharness-web)")
 for __cfg in "$ROOT/.oh/docs"/docusaurus.config.* "$ROOT/.oh/docs"/sidebars.*; do
   [[ -e "$__cfg" ]] && failures+=(".oh/docs must not contain Docusaurus build config: $(basename "$__cfg")")
@@ -78,8 +76,6 @@ done
 grep -Fiq 'deepwiki' "$README" || failures+=("README.md must point readers to DeepWiki for generated navigation")
 grep -Fq '.oh/docs/README.md' "$README" || failures+=("README.md must point readers to .oh/docs/README.md")
 
-# Keep eval/probe code from reintroducing docs-build commands. Historical task
-# artifacts are excluded because they describe old completed work.
 if git -C "$ROOT" grep -nE 'docusaurus build|pnpm (run )?docs:build|pnpm --dir \.oh/docs build|@openharness/docs' -- \
   ':!.oh/evals/probes/docs-build-fast-path.sh' \
   ':!.oh/tasks/**' \

--- a/.oh/evals/probes/drift-check-cron-staleness-glob.sh
+++ b/.oh/evals/probes/drift-check-cron-staleness-glob.sh
@@ -15,7 +15,6 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 SKILL="${DRIFT_CHECK_SKILL:-$ROOT/.oh/skills/audit/references/drift.md}"
 
-# --- SKIPPED: hard prerequisites genuinely absent --------------------------
 if [[ ! -f "$SKILL" ]]; then
   echo "SKIPPED: audit drift reference absent: $SKILL" >&2
   exit 2
@@ -25,10 +24,6 @@ if ! command -v stat >/dev/null 2>&1; then
   exit 2
 fi
 
-# --- Extract the live Step C-2 bash block ----------------------------------
-# Anchor on the heading line `**Step C-2 — compare cron file mtimes:**` (matched
-# without relying on the em-dash byte sequence), then capture the lines of the
-# first following ```bash fence up to its closing ```.
 BLOCK="$(awk '
   /^\*\*Step C-2 /   { hit=1; next }
   hit && /^```bash$/ { cap=1; next }
@@ -42,7 +37,6 @@ BLOCK="$(awk '
   echo "---- end extracted block ----"
 } >&2
 
-# --- REGRESSION: mis-extraction can never yield a false PASS ----------------
 if [[ -z "${BLOCK//[[:space:]]/}" ]]; then
   echo "REGRESSION: Step C-2 bash block extraction was empty — heading/fence anchor broken in $SKILL" >&2
   exit 1
@@ -58,15 +52,6 @@ for required in schedule enabled agent tmux worktree preflight RESTART_REQUIRED_
   fi
 done
 
-# --- SKIPPED: the behavioral predicate needs node + croner -------------------
-# The extracted Step C-2 block's is_valid_cron_schedule() shells out to `node`
-# and resolves the `croner` package from DRIFT_CHECK_ROOT/package.json (here
-# $ROOT). A cold CI runner (the eval-probes job: checkout + bash, no
-# `pnpm install`) has no node_modules/croner, so the predicate cannot run and the
-# valid-cron fixture would be mis-excluded — a false REGRESSION. SKIP when node or
-# croner is unavailable (the extraction-integrity checks above still gate in CI;
-# the full behavioral predicate is exercised by manual /eval and the weekly cron
-# where deps are installed). Mirrors the block's own croner resolution exactly.
 if ! command -v node >/dev/null 2>&1; then
   echo "SKIPPED: node unavailable — Step C-2 schedule validation needs node + croner" >&2
   exit 2
@@ -80,13 +65,10 @@ if ! DRIFT_CHECK_ROOT="$ROOT" node --input-type=module -e '
   exit 2
 fi
 
-# --- Fixtures: trap-based cleanup registered BEFORE any fixture exists ------
 WORK="$(mktemp -d)"
 trap 'rm -rf "$WORK"' EXIT
 mkdir -p "$WORK/.oh/crons"
 
-# (a) README-style: first line is an H1, NO line-1 '---'. The '---' lines live
-#     inside a fenced code block — the .oh/crons/README.md trap. Must be EXCLUDED.
 cat > "$WORK/.oh/crons/aaa-readme.md" <<'EOF_A'
 # Crons Directory
 
@@ -101,8 +83,6 @@ enabled: true
 ```
 EOF_A
 
-# (b) Valid scheduled cron: line-1 '---', anchored schedule:, enabled: true,
-#     closing '---'. Must be INCLUDED (flagged inert).
 cat > "$WORK/.oh/crons/bbb-valid.md" <<'EOF_B'
 ---
 id: bbb-valid
@@ -120,8 +100,6 @@ preflight: scripts/example-caps.sh
 Body.
 EOF_B
 
-# (c) Disabled cron: schedule: present but enabled: false → loadCrons drops it.
-#     Must be EXCLUDED.
 cat > "$WORK/.oh/crons/ccc-disabled.md" <<'EOF_C'
 ---
 id: ccc-disabled
@@ -134,8 +112,6 @@ enabled: false
 Body.
 EOF_C
 
-# (d) Missing schedule: parseCronFile returns null because fm.schedule is absent.
-#     Must be EXCLUDED.
 cat > "$WORK/.oh/crons/ddd-missing-schedule.md" <<'EOF_D'
 ---
 id: ddd-missing-schedule
@@ -147,8 +123,6 @@ enabled: true
 Body.
 EOF_D
 
-# (e) Empty bare schedule: parseCronFile returns null because fm.schedule is empty.
-#     Must be EXCLUDED.
 cat > "$WORK/.oh/crons/eee-empty-schedule-bare.md" <<'EOF_E'
 ---
 id: eee-empty-schedule-bare
@@ -161,8 +135,6 @@ enabled: true
 Body.
 EOF_E
 
-# (f) Empty double-quoted schedule: parseCronFile strips quotes to empty.
-#     Must be EXCLUDED.
 cat > "$WORK/.oh/crons/fff-empty-schedule-double-quoted.md" <<'EOF_F'
 ---
 id: fff-empty-schedule-double-quoted
@@ -175,8 +147,6 @@ enabled: true
 Body.
 EOF_F
 
-# (g) Empty single-quoted schedule: parseCronFile strips quotes to empty.
-#     Must be EXCLUDED.
 cat > "$WORK/.oh/crons/ggg-empty-schedule-single-quoted.md" <<'EOF_G'
 ---
 id: ggg-empty-schedule-single-quoted
@@ -189,8 +159,6 @@ enabled: true
 Body.
 EOF_G
 
-# (h) Invalid cron: frontmatter and schedule key exist, but Croner rejects it.
-#     loadCrons logs SCHED_INVALID and drops it, so it must be EXCLUDED.
 cat > "$WORK/.oh/crons/hhh-invalid-schedule-not-a-cron.md" <<'EOF_H'
 ---
 id: hhh-invalid-schedule-not-a-cron
@@ -205,12 +173,6 @@ EOF_H
 
 printf '%s' "$BLOCK" > "$WORK/block.sh"
 
-# --- Run the extracted predicate against the fixtures ----------------------
-# RUNTIME_START=1 (epoch 1s) sits before every freshly-written fixture mtime, so
-# under the OLD raw-glob logic ALL fixtures would be flagged inert; only the
-# corrected predicate excludes the non-cron (a), disabled cron (c), missing
-# schedule (d), empty schedules (e-g), and invalid schedule (h).
-# (i) Invalid id: loadCrons logs ID_INVALID and drops it. Must be EXCLUDED.
 cat > "$WORK/.oh/crons/iii-invalid-id.md" <<'EOF_I'
 ---
 id: bad_id
@@ -223,7 +185,6 @@ enabled: true
 Body.
 EOF_I
 
-# (j) ID mismatch: loadCrons logs ID_MISMATCH and drops it. Must be EXCLUDED.
 cat > "$WORK/.oh/crons/jjj-id-mismatch.md" <<'EOF_J'
 ---
 id: not-jjj-id-mismatch
@@ -236,7 +197,6 @@ enabled: true
 Body.
 EOF_J
 
-# (k) Unsafe agent override: loadCrons logs AGENT_INVALID and drops it. Must be EXCLUDED.
 cat > "$WORK/.oh/crons/kkk-unsafe-agent.md" <<'EOF_K'
 ---
 id: kkk-unsafe-agent
@@ -250,8 +210,6 @@ enabled: true
 Body.
 EOF_K
 
-# The block prints one `DRIFT-CHECK (C): .oh/crons/<file> ...` line per inert file —
-# we read that observable contract rather than the internal INERT array name.
 output="$(cd "$WORK" && DRIFT_CHECK_ROOT="$ROOT" RUNTIME_START=1 bash block.sh 2>/dev/null)" || true
 
 inert_contains() { printf '%s\n' "$output" | grep -q "$1"; }

--- a/.oh/evals/probes/env-schema-parity.sh
+++ b/.oh/evals/probes/env-schema-parity.sh
@@ -3,17 +3,6 @@
 # desc: .devcontainer/.example.env is the schema — the oh-init template carries the same keys, and every var docker-compose interpolates is documented there
 set -euo pipefail
 
-# WHY THIS PROBE EXISTS. Removing harness.yaml made .devcontainer/.example.env
-# the one schema document, so two silent failure modes became possible:
-#
-#   1. a key added to the core template but not the `oh init` one, which ships a
-#      scaffold documenting less than the harness it scaffolds;
-#   2. a var interpolated by a compose file but documented nowhere, which is how
-#      DOCKER_SOCKET, SANDBOX_SSH, OH_SANDBOX_IMAGE, OH_PULL_POLICY and
-#      SKIP_PNPM_INSTALL were all consumed-but-undocumented before 0.4.0.
-#
-# It compares KEY NAMES only. Values and prose deliberately differ (the template
-# tells an `oh init` repo to run `oh`, not `make`).
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 
@@ -25,8 +14,6 @@ if [[ ! -f "$CORE" || ! -f "$TEMPLATE" ]]; then
   exit 2
 fi
 
-# Every `KEY=` at column 0, live or commented. A trailing `# note` after the
-# value is prose, not a second key, so only the leading token is taken.
 keys_in() {
   grep -oE '^[[:space:]]*#?[[:space:]]*[A-Z_][A-Z0-9_]*=' "$1" \
     | tr -d '# \t' | tr -d '=' | sort -u
@@ -34,15 +21,11 @@ keys_in() {
 
 fails=()
 
-# --- 1. The two templates carry the same keys ---------------------------------
 only_core="$(comm -23 <(keys_in "$CORE") <(keys_in "$TEMPLATE") | paste -sd, -)"
 only_tmpl="$(comm -13 <(keys_in "$CORE") <(keys_in "$TEMPLATE") | paste -sd, -)"
 [[ -z "$only_core" ]] || fails+=("documented in .devcontainer/.example.env but not in .oh/templates/.devcontainer/.example.env: $only_core")
 [[ -z "$only_tmpl" ]] || fails+=("documented in the oh-init template but not in .devcontainer/.example.env: $only_tmpl")
 
-# --- 2. Every compose-interpolated var is documented --------------------------
-# GH_TOKEN and friends are secrets, but they are still interpolated and still
-# have to be named, so no key is exempt.
 mapfile -t interpolated < <(
   grep -ohE '\$\{[A-Z_][A-Z0-9_]*' "$ROOT"/.devcontainer/docker-compose*.yml 2>/dev/null \
     | sed 's/${//' | sort -u
@@ -55,11 +38,6 @@ done
 (( ${#undocumented[@]} == 0 )) \
   || fails+=("interpolated by a docker-compose file but undocumented in .devcontainer/.example.env: ${undocumented[*]}")
 
-# --- 3. The wrapper-only toggles are documented too ---------------------------
-# DOCKER_SOCKET and SANDBOX_SSH select overlays inside
-# .oh/scripts/docker-compose.sh and are interpolated by no compose file, so
-# check 2 cannot see them. They are the two most security-relevant keys in the
-# file; name them explicitly rather than trusting the general rule.
 for var in DOCKER_SOCKET SANDBOX_SSH; do
   grep -qxF "$var" <<<"$documented" \
     || fails+=("$var selects a compose overlay but is undocumented in .devcontainer/.example.env")

--- a/.oh/evals/probes/eval-ci-gate.sh
+++ b/.oh/evals/probes/eval-ci-gate.sh
@@ -12,8 +12,6 @@ if [[ ! -f "$WORKFLOW" ]]; then
   exit 2
 fi
 
-# Unanchored match: the invocation is indented under the eval-probes job's
-# `run:` step, so a `^bash` anchor would match nothing. Mirror boot-lint-glob.sh.
 if grep -q 'bash .oh/skills/eval/run.sh' "$WORKFLOW"; then
   echo "PASS: eval-probes CI gate invokes 'bash .oh/skills/eval/run.sh' in $WORKFLOW" >&2
   exit 0

--- a/.oh/evals/probes/eval-gate.sh
+++ b/.oh/evals/probes/eval-gate.sh
@@ -19,8 +19,6 @@ for f in "$SPEC"; do
   fi
 done
 
-# --- the rule, on the surface that runs the gate ---------------------------
-# The gate now lives inside execute.md's build ⇄ audit loop rather than a numbered stage.
 spec_section=$(awk '
   /^### 5\. `build ⇄ audit`/ {f=1; print; next}
   f && /^### / {f=0}
@@ -32,13 +30,11 @@ if [[ -z "$spec_section" ]]; then
   exit 1
 fi
 
-# Negative assertion: the old bare-presence gate rule must be gone.
 if grep -qE 'Any[[:space:]]+.?REGRESSION' <<<"$spec_section"; then
   echo "REGRESSION: /spec execute's eval gate still uses the bare \"Any \`REGRESSION\`\" rule (must key on delta + exit code)" >&2
   exit 1
 fi
 
-# Positive assertions (AND-logic): the corrected vocabulary must be present.
 missing=()
 grep -qiE 'green.*red'         <<<"$spec_section" || missing+=("green->red language")
 grep -qi 'exit'                <<<"$spec_section" || missing+=("runner exit-code language")

--- a/.oh/evals/probes/eval-results-atomic.sh
+++ b/.oh/evals/probes/eval-results-atomic.sh
@@ -16,24 +16,18 @@ fail() { echo "REGRESSION: $1" >&2; exit 1; }
 
 content="$(cat "$RUN_SH")"
 
-# (a) No bare `cat > "$RESULTS"` truncation — the header/rows must be built into the
-#     temp sibling, never streamed straight onto the live scoreboard.
 if grep -qE 'cat[[:space:]]+>[[:space:]]*"\$RESULTS"' <<<"$content"; then
   fail "non-atomic write reintroduced: bare \`cat > \"\$RESULTS\"\` truncation present (build into \$tmp, then mv -f)"
 fi
 
-# (b) Final replacement via `mv -f ... "$RESULTS"`.
 if ! grep -qE 'mv[[:space:]]+-f[[:space:]]+.*"\$RESULTS"' <<<"$content"; then
   fail "atomic replacement missing: no \`mv -f ... \"\$RESULTS\"\` found for the final scoreboard swap"
 fi
 
-# (c) EXIT trap referencing the temp-file handle, so a crash mid-write removes the sibling temp.
 if ! grep -qE 'trap[[:space:]].*\$tmp.*EXIT' <<<"$content"; then
   fail "temp-file cleanup trap missing: no \`trap ... \$tmp ... EXIT\` found"
 fi
 
-# (d) prior_row() body must resolve carry-forward from the \$RESULTS_ORIG snapshot,
-#     never via a live \`grep ... "\$RESULTS"\` read of the file being rewritten.
 prior_row_body="$(awk '/^prior_row\(\)/{f=1} f{print} f&&/^}/{exit}' <<<"$content")"
 if [[ -z "$prior_row_body" ]]; then
   fail "prior_row() function not found in run.sh"

--- a/.oh/evals/probes/eval-runner-exit.sh
+++ b/.oh/evals/probes/eval-runner-exit.sh
@@ -12,10 +12,8 @@ if [[ ! -f "$RUN_SH" ]]; then
   exit 2
 fi
 
-# Read only the file tail to assert the gate is CO-LOCATED at the exit point.
 tail_content="$(tail -n 12 "$RUN_SH")"
 
-# Require that the regressions-count check AND the exit 1 appear together in the tail.
 if ! grep -qE 'regressions\[@\].*-gt 0.*exit 1' <<<"$tail_content"; then
   echo "REGRESSION: run.sh tail does not contain the co-located regressions-gated exit-1 guard (if [ \"\${#regressions[@]}\" -gt 0 ]; then exit 1; fi)" >&2
   exit 1

--- a/.oh/evals/probes/eval-runs-once-per-cycle.sh
+++ b/.oh/evals/probes/eval-runs-once-per-cycle.sh
@@ -24,10 +24,6 @@ done
 
 missing=()
 
-# Section-scoped reads. A whole-file grep is satisfied by ANY line in the file --
-# including a historical note saying the gate was REMOVED -- so each assertion below
-# reads only the section that must carry it. Verified by rejection: gutting a gate
-# and appending one prose line carrying its literals keeps a whole-file grep green.
 EXEC_GATE="$(awk '/^\*\*The `\/eval` gate/{f=1} f && /^### [0-9]+\./{if (seen++) exit} f' "$EXEC")"
 IMPL_GATE="$(awk '/^### Gate 2 /{f=1} f{print} f && /^### Gate 3 /{exit}' "$IMPL")"
 BENCH_GATE="$(awk '/^### Signal 1 /{f=1} f{print} f && /^### Signal 2 /{exit}' "$BENCH")"
@@ -39,17 +35,12 @@ for pair in "spec-execute:$EXEC_GATE" "audit-implementation:$IMPL_GATE" "benchma
   fi
 done
 
-# --- the producer ----------------------------------------------------------
 grep -Fq 'eval-result.json' <<<"$EXEC_GATE" || missing+=("/spec execute does not publish eval-result.json in its /eval gate section")
 grep -Fq 'run ONCE per cycle' <<<"$EXEC_GATE" || missing+=("/spec execute no longer states that the suite runs once per cycle")
 grep -Fq 'git rev-parse HEAD' <<<"$EXEC_GATE" || missing+=("/spec execute's eval-result.json records no commit key (downstream reuse could not be validated)")
-# The record must be committed, or a downstream reader in a fresh worktree cannot see it.
 grep -Fq "git add -f \".oh/tasks/<slug>/eval-result.json\"" <<<"$EXEC_GATE" \
   || missing+=("/spec execute does not 'git add -f' eval-result.json (.oh/tasks/ is gitignored, so it would not travel)")
 
-# --- the two readers ------------------------------------------------------
-# Each must (a) read the record, and (b) compare its commit to HEAD before trusting it.
-# (b) is the whole guarantee: without it, "reuse" silently becomes "assume".
 for pair in "audit-implementation:$IMPL_GATE" "benchmark:$BENCH_GATE"; do
   name="${pair%%:*}"
   file="${pair#*:}"
@@ -63,7 +54,6 @@ for pair in "audit-implementation:$IMPL_GATE" "benchmark:$BENCH_GATE"; do
     || missing+=("$name does not resolve HEAD to validate the record's freshness")
   grep -Fq 'jq -r .runnerExit' <<<"$file" \
     || missing+=("$name does not read the recorded runner exit code")
-  # The fallback must still exist: a stale or missing record means RUN, never PASS.
   grep -Fq 'run.sh' <<<"$file" \
     || missing+=("$name has no fallback that actually runs the suite when the record is stale or absent")
 done

--- a/.oh/evals/probes/execution-target-contract.sh
+++ b/.oh/evals/probes/execution-target-contract.sh
@@ -6,19 +6,15 @@
 #       operator-facing Makefile shell line is byte-for-byte unchanged.
 set -euo pipefail
 
-ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)" # .oh/evals/probes/<id>.sh -> root
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 TARGET="$ROOT/.oh/cli/src/lib/execution/target.ts"
 LIFECYCLE="$ROOT/.oh/cli/src/commands/lifecycle.ts"
 MAKEFILE="$ROOT/Makefile"
 
-# Not a source checkout of the harness itself (an `oh update`-vendored .oh/ payload has no
-# CLI sources and no Makefile). Nothing to verify — never a silent green.
 [[ -d "$ROOT/.oh/cli/src" ]] || { echo "SKIPPED: missing $ROOT/.oh/cli/src — not a harness source checkout" >&2; exit 2; }
 [[ -f "$MAKEFILE" ]] || { echo "SKIPPED: missing $MAKEFILE — not a harness source checkout" >&2; exit 2; }
 [[ -f "$LIFECYCLE" ]] || { echo "SKIPPED: missing $LIFECYCLE" >&2; exit 2; }
 
-# Strip TypeScript comments (block + line) with a character scanner, so doc prose can neither
-# trip a code-level check nor falsely satisfy one. Emits code text only.
 strip_comments() {
   awk '
     BEGIN { inblock = 0 }
@@ -43,17 +39,12 @@ strip_comments() {
 
 missing=()
 
-# --- C1: the provider-neutral contract file exists ---------------------------
 if [[ ! -f "$TARGET" ]]; then
   missing+=("C1: $TARGET is absent — the execution contract has no home")
-  # C2/C3 read that file; without it they cannot be evaluated.
   printf 'REGRESSION: execution-target contract broken: %s\n' "${missing[*]}" >&2
   exit 1
 fi
 
-# --- C2: no Docker nouns in the contract -------------------------------------
-# Exception (and only this): the "docker" capability string literal and the doc comment
-# immediately above it. Everything else in the file must name no substrate.
 cap_line="$(grep -n '^[[:space:]]*|[[:space:]]*"docker"[[:space:]]*$' "$TARGET" | head -1 | cut -d: -f1 || true)"
 if [[ -n "$cap_line" ]]; then
   nouns="$(awk -v a="$cap_line" -v b="$((cap_line - 1))" 'NR != a && NR != b' "$TARGET" |
@@ -65,17 +56,11 @@ if [[ -n "$nouns" ]]; then
   missing+=("C2: target.ts names a substrate outside the \"docker\" capability literal ($(echo "$nouns" | head -3 | tr '\n' ';'))")
 fi
 
-# --- C3: no snapshot method on the interface ---------------------------------
-# "snapshot" is a capability literal in this slice, deliberately with no method behind it.
 snapshot_method="$(strip_comments "$TARGET" | grep -nE 'snapshot[[:space:]]*\(' || true)"
 if [[ -n "$snapshot_method" ]]; then
   missing+=("C3: target.ts declares a snapshot method ($(echo "$snapshot_method" | head -1))")
 fi
 
-# --- C4: runShell builds no engine argv of its own ---------------------------
-# Argv-LITERAL inspection, not a text grep: comments are stripped first and whitespace is
-# collapsed, so a multi-line array literal cannot hide and surviving doc prose about the old
-# `docker exec` invocation cannot trip this.
 code="$(strip_comments "$LIFECYCLE")"
 if ! grep -q 'export function runShell' <<<"$code"; then
   echo "SKIPPED: comment stripping did not yield recognizable code from $LIFECYCLE" >&2
@@ -86,9 +71,6 @@ if grep -qF '["exec"' <<<"$flat" || grep -qF '"exec","-it"' <<<"$flat"; then
   missing+=("C4: lifecycle.ts constructs an engine argv literal beginning with \"exec\" — that belongs behind the contract")
 fi
 
-# --- C5: the operator-facing Makefile shell line is unchanged ----------------
-# Whole-line exact match (modulo the recipe tab), NOT a loose "docker exec" substring test,
-# which would stay green through an argument-level regression.
 if ! sed 's/^[[:space:]]*//' "$MAKEFILE" |
   grep -Fxq 'docker exec -it -u $(SHELL_USER) $(SHELL_CONTAINER) zsh'; then
   missing+=("C5: Makefile no longer contains the verbatim line \`docker exec -it -u \$(SHELL_USER) \$(SHELL_CONTAINER) zsh\`")

--- a/.oh/evals/probes/executor-kill-clears-session.sh
+++ b/.oh/evals/probes/executor-kill-clears-session.sh
@@ -27,8 +27,6 @@ if ! command -v git >/dev/null 2>&1; then
   exit 2
 fi
 
-# NEVER a real slug. A destructive verification needs a target it can afford to
-# destroy, and it must live outside the real repo and the real /tmp namespace.
 DECOY="firstmate-kill-probe"
 WORK="$(mktemp -d)"
 TMPD="$WORK/tmp"
@@ -42,11 +40,6 @@ printf '# progress\n' >"$WORK/repo/.oh/tasks/$DECOY/progress.txt"
 
 missing=()
 
-# --- (1) the exact abort: a non-zero best-effort lookup must not kill its caller ---
-# `herdr agent get` exits 1 for a nonexistent agent. Under `set -euo pipefail` that
-# return propagated out of the command substitution in runner_teardown and killed the
-# whole --kill run before its first teardown branch. A stub herdr reproduces that
-# without needing a real herdr server.
 printf '#!/bin/sh\nexit 1\n' >"$WORK/bin/herdr"
 printf '#!/bin/sh\nexit 1\n' >"$WORK/bin/jq"
 chmod +x "$WORK/bin/herdr" "$WORK/bin/jq"
@@ -61,14 +54,12 @@ if ! PATH="$WORK/bin:$PATH" bash -c '
   missing+=("runner_resolve_pane_id kills its caller when 'herdr agent get' exits non-zero — this is the exact defect that made --kill exit 1 silently")
 fi
 
-# --- (2) end to end: --kill on a live decoy session ------------------------
 tmux_used=0
 if command -v tmux >/dev/null 2>&1 && tmux -V >/dev/null 2>&1; then
   if tmux new-session -d -s "agent-firstmate-$DECOY" 'sleep 600' 2>/dev/null; then
     tmux_used=1
   fi
 fi
-# Claim the launch lock the way a real run does, so --kill has something to clear.
 mkdir -p "$TMPD/firstmate-$DECOY.lock"
 
 kill_out="$(cd "$WORK/repo" && RUNNER_TMPDIR="$TMPD" bash .oh/scripts/firstmate.sh --kill "$DECOY" 2>&1)"

--- a/.oh/evals/probes/executor-launch-interactive.sh
+++ b/.oh/evals/probes/executor-launch-interactive.sh
@@ -6,8 +6,6 @@
 #       `--print` (which makes the harness answer once and exit), and no arm pipes or
 #       redirects the launched command (which replaces the child's TTY with a pipe, and an
 #       interactive agent session cannot run without a terminal). Both defects were live.
-#
-# The single-quoted grep patterns below are pinned LITERALS.
 # shellcheck disable=SC2016
 set -u
 
@@ -24,37 +22,23 @@ done
 
 missing=()
 
-# Both files DOCUMENT these rules in their header comments at length, so a whole-file grep
-# would stay green after the actual defect was reintroduced. Strip full-line comments first;
-# every assertion below reads CODE only.
 fm_code="$(grep -v '^[[:space:]]*#' "$FIRSTMATE")"
 rn_code="$(grep -v '^[[:space:]]*#' "$RUNNER")"
 
-# --- (1) no `--print` on any launch path ------------------------------------
-# `--print` makes the harness answer once and exit; a session that walks a whole task
-# graph over many turns cannot be one-shot.
 printf '%s\n' "$fm_code" | grep -Fq -- '--print' \
   && missing+=("firstmate.sh: a launch path still carries --print (the child would answer once and exit)")
 printf '%s\n' "$rn_code" | grep -Fq -- '--print' \
   && missing+=("session-runner.sh: a launch path still carries --print")
 
-# --- (2) the prompt travels as ARGV, never on stdin -------------------------
-# `cat <prompt> | claude` makes stdin a PIPE rather than a TTY.
 printf '%s\n' "$fm_code" | grep -Eq 'cat [^|]*\| *(claude|pi|codex)' \
   && missing+=("firstmate.sh: a launch arm still pipes the prompt into the harness on stdin (stdin would not be a TTY)")
 
-# Each of the three harness arms must build the prompt as an argv read back inside the
-# LAUNCHED shell. Without this the assertion above is satisfied vacuously by an arm that
-# passes no prompt at all.
 for arm in claude pi codex; do
   printf '%s\n' "$fm_code" | grep -Fq "printf '$arm" \
     || printf '%s\n' "$fm_code" | grep -Fq "$arm %s \"\$(cat" \
     || missing+=("firstmate.sh: the $arm arm does not deliver the prompt as \"\$(cat <file>)\" initial argv")
 done
 
-# --- (3) the launched command is never piped or redirected ------------------
-# `tmux pipe-pane` is the sanctioned logging path: it attaches to the pane AFTER it
-# exists, so the child keeps its terminal. A pipe or redirect ON the command does not.
 printf '%s\n' "$rn_code" | grep -Fq '| tee' \
   && missing+=("session-runner.sh: the launched command is piped into tee again (this takes the child's TTY away — the exact defect observed 2026-08-23)")
 printf '%s\n' "$rn_code" | grep -Eq '\$cmd[^\n]*(\||>)' \

--- a/.oh/evals/probes/firstmate-executor-contract.sh
+++ b/.oh/evals/probes/firstmate-executor-contract.sh
@@ -8,14 +8,6 @@
 #       its body in the order its own contract header records — the template OWNS that order
 #       now, since the advisor prompt pack it was derived from was deleted in US-004; and
 #       CLAUDE.md is still a symlink to AGENTS.md.
-#
-# The `| tee` launch pipe is deliberately NOT asserted here — it was REMOVED in US-002
-# because it takes the child's TTY away and an interactive agent session cannot run
-# without a terminal. Asserting its survival would pin that defect in place. Its absence
-# is asserted by `executor-launch-interactive.sh` instead.
-#
-# The single-quoted grep patterns below are pinned LITERALS — the dollar signs are part of
-# the text being searched for, not expansions this file wants performed.
 # shellcheck disable=SC2016
 set -u
 
@@ -25,19 +17,14 @@ RUNNER="$ROOT/.oh/scripts/lib/session-runner.sh"
 TEMPLATE="$ROOT/.oh/skills/firstmate/templates/session-prompt.md"
 SPEC="$ROOT/.claude/skills/spec/references/execute.md"
 
-# No SKIPPED path: this probe ships in the same commit as the executor it pins, so a missing
-# artifact is a REGRESSION rather than a not-applicable run.
 missing=()
 
-# --- (1) the executor entrypoint exists and is executable -------------------
 if [ ! -f "$FIRSTMATE" ]; then
   missing+=(".oh/scripts/firstmate.sh absent (the build-executor entrypoint is gone)")
 elif [ ! -x "$FIRSTMATE" ]; then
   missing+=(".oh/scripts/firstmate.sh is not executable")
 fi
 
-# --- (2) the invariant terminal interface -----------------------------------
-# The build terminates on the WHOLE LINE `STATUS: COMPLETE` in progress.txt.
 if [ -f "$FIRSTMATE" ]; then
   grep -Fq 'STATUS: COMPLETE' "$FIRSTMATE" \
     || missing+=("firstmate.sh does not name the STATUS: COMPLETE sentinel")
@@ -47,19 +34,11 @@ if [ -f "$RUNNER" ]; then
     || missing+=("session-runner.sh: the whole-line sentinel match ^STATUS: COMPLETE\$ is gone (a substring match would fire on prose)")
 fi
 
-# The entrypoint must actually reach the shared ladder, or the assertions above pin
-# files that no longer form one surface.
 if [ -f "$FIRSTMATE" ]; then
   grep -Fq 'lib/session-runner.sh' "$FIRSTMATE" \
     || missing+=("firstmate.sh no longer sources .oh/scripts/lib/session-runner.sh (the executor and the ladder have diverged)")
 fi
 
-# --- (3) NO executor toggle survives, anywhere ------------------------------
-# US-002 removed the toggles rather than reducing them to one accepted value: a
-# single-value toggle is still a selection surface a reader must resolve. Full-line
-# comments are excluded so a file may DOCUMENT the removal without failing this check.
-# `--executor` is matched with a leading `--` guard so words like "executor" in prose
-# stay legal; the point is that no *flag* or env var selects a build arm.
 for pair in "spec-execute:$SPEC"; do
   name="${pair%%:*}"
   file="${pair#*:}"
@@ -76,22 +55,9 @@ for pair in "spec-execute:$SPEC"; do
     && missing+=("$name still references AUTOPILOT_EXECUTOR")
 done
 
-# The build arms the toggle used to select must be gone from the repo, not merely
-# unreferenced by the two skills above.
 [ -e "$ROOT/.oh/scripts/ralph.sh" ] \
   && missing+=(".oh/scripts/ralph.sh still exists — the second executor arm must be deleted, not left dormant")
 
-# --- (4) step-order equivalence, asserted MECHANICALLY ----------------------
-# The ordered anchor-keyword list below is recorded verbatim in the session-prompt template's
-# own contract header (.oh/skills/firstmate/templates/session-prompt.md), which is the OWNER
-# of the build's step order. It was originally derived from the advisor prompt pack; that pack
-# was deleted in US-004, so the derivative became the source and there is no second file to
-# stay in sync with. "Equivalence" means exactly this: these anchors appear in the template
-# BODY in the same relative order, compared by first occurrence. Nothing fuzzy.
-#
-# ORDERING SCOPE IS BODY-ONLY. The header records the list in the asserted order, so
-# including it would make this check vacuous; the template ends its header with the literal
-# `END CONTRACT HEADER -->` marker for exactly this reason.
 ANCHORS=(
   'dependency graph'
   '/compact'
@@ -126,12 +92,6 @@ else
   fi
 fi
 
-# --- (5) the deleted prompt pack must not come back -------------------------
-# The old assertion here was `git diff --quiet -- .oh/prompts/`, guarding that the template
-# stayed a derivative of a pack it must never edit. US-004 deleted the pack instead: a second
-# discoverable implementation path is a route an agent can be pulled onto mid-task. The guard
-# is REMOVED rather than stubbed to true, and replaced by its successor claim — the path must
-# stay gone, and the template must carry the step order itself.
 [ -e "$ROOT/.oh/prompts/advisor" ] \
   && missing+=(".oh/prompts/advisor/ is back — the second implementation path was deleted in US-004 and must stay deleted")
 [ -e "$ROOT/.pi/prompts/advisor" ] \
@@ -143,9 +103,6 @@ if [ -f "$TEMPLATE" ]; then
     || missing+=("session-prompt.md no longer claims ownership of the step order (it is the source now, not a mirror)")
 fi
 
-# --- (6) CLAUDE.md is still a symlink to AGENTS.md -------------------------
-# A severed alias (an independently written CLAUDE.md) must surface as a REGRESSION rather
-# than silently passing a diff that happens to be empty at write time.
 link="$(readlink "$ROOT/CLAUDE.md" 2>/dev/null)" || link=""
 [ "$link" = "AGENTS.md" ] \
   || missing+=("CLAUDE.md is not a symlink to AGENTS.md (readlink printed '${link:-<not a symlink>}')")

--- a/.oh/evals/probes/get-oh-bootstrap.sh
+++ b/.oh/evals/probes/get-oh-bootstrap.sh
@@ -9,7 +9,6 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 SCRIPT="$ROOT/.oh/scripts/get-oh.sh"
 
-# SKIPPED: bootstrap not present on this base (lets the probe land green pre-slice).
 if [ ! -f "$SCRIPT" ]; then
   echo 'SKIPPED .oh/scripts/get-oh.sh not present' >&2
   exit 2
@@ -17,30 +16,21 @@ fi
 
 [ -x "$SCRIPT" ] || { echo 'REGRESSION .oh/scripts/get-oh.sh is not executable' >&2; exit 1; }
 
-# Overridable upstream-repo form (mirrors install.sh; keeps forks working).
 # shellcheck disable=SC2016  # the ${...:-} literal is grepped, not expanded
 grep -q '${OH_GITHUB_REPO:-' "$SCRIPT" || { echo 'REGRESSION get-oh.sh lost the OH_GITHUB_REPO override' >&2; exit 1; }
 
-# Core contract v2: install a PREBUILT oh.js (default oh.mifune.dev/oh.js) to a bin dir.
 grep -q 'OH_JS_URL' "$SCRIPT" || { echo 'REGRESSION get-oh.sh no longer downloads a prebuilt oh.js (OH_JS_URL)' >&2; exit 1; }
 grep -q 'oh.mifune.dev/oh.js' "$SCRIPT" || { echo 'REGRESSION get-oh.sh lost the default prebuilt URL' >&2; exit 1; }
 grep -Eq 'install -m 0755 .*"\$OH_BIN_DIR/oh"' "$SCRIPT" || { echo 'REGRESSION get-oh.sh no longer installs oh to $OH_BIN_DIR/oh' >&2; exit 1; }
 
-# MUST NOT persist a repo clone / touch the sandbox install dir (the core user requirement).
 grep -qE '\.openharness|OH_HOME=' "$SCRIPT" && { echo 'REGRESSION get-oh.sh reintroduced a persistent ~/.openharness / OH_HOME clone' >&2; exit 1; }
 
-# Offers to install Node when missing (nvm path).
 grep -q 'nvm' "$SCRIPT" || { echo 'REGRESSION get-oh.sh no longer offers to install Node via nvm' >&2; exit 1; }
 
-# v2: supports being sourced so it can mutate the caller's live PATH in the same
-# shell (`source <(curl ...)`) — strict mode/traps scoped to the executed path.
 grep -q '_OH_SOURCED' "$SCRIPT" || { echo 'REGRESSION get-oh.sh lost sourced-vs-executed detection (same-shell PATH activation)' >&2; exit 1; }
 
-# Documented in the README.
 grep -q 'get-oh.sh' "$ROOT/README.md" || { echo 'REGRESSION README no longer documents get-oh.sh' >&2; exit 1; }
 
-# link-providers.sh must tolerate a non-git tree (falls back to OH_PROJECT_ROOT/PWD),
-# so `oh init`-equipped sandboxes boot without `git init` instead of crash-looping.
 LP="$ROOT/.oh/scripts/link-providers.sh"
 if [ -f "$LP" ]; then
   # shellcheck disable=SC2016

--- a/.oh/evals/probes/harness-yaml-migration.sh
+++ b/.oh/evals/probes/harness-yaml-migration.sh
@@ -3,18 +3,6 @@
 # desc: migrate-harness-yaml.sh carries a live harness.yaml into .devcontainer/.env, renames the file, and is a no-op on the second run
 set -euo pipefail
 
-# WHY THIS PROBE EXISTS. harness.yaml was removed in 0.4.0, and the ONE thing
-# standing between an existing install and a silently lost setting is this
-# migrator. It runs from .oh/scripts/docker-compose.sh and .oh/scripts/install.sh,
-# so it fires on every lifecycle verb — which also means a regression in it is
-# invisible until someone's sandbox comes up with the wrong name.
-#
-# The fixture exercises all four cases that differ:
-#   - a key ABSENT from .env               -> appended
-#   - a key COMMENTED in .env              -> uncommented IN PLACE
-#   - a key already holding the SAME value -> unchanged
-#   - a key holding a DIFFERENT value      -> overwritten (harness.yaml won at
-#     runtime before, so preserving the .env value would change behaviour)
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 MIGRATOR="$ROOT/.oh/scripts/migrate-harness-yaml.sh"
@@ -43,9 +31,6 @@ compose:
     - .devcontainer/docker-compose.probe.yml
 YAML
 
-# TZ commented (must uncomment in place), GIT_USER_NAME already matching,
-# SANDBOX_NAME holding a different value (must be overwritten), INSTALL_HERMES
-# absent entirely (must be appended).
 {
   printf '# TZ=America/Los_Angeles\n'
   printf 'GIT_USER_NAME=Probe User\n'
@@ -68,23 +53,18 @@ get() { grep -E "^$1=" "$work/.devcontainer/.env" | head -1 | cut -d= -f2-; }
 [[ "$(get GIT_USER_NAME)"  == "Probe User"     ]] || fails+=("GIT_USER_NAME lost its already-correct value (got '$(get GIT_USER_NAME)')")
 [[ "$(get INSTALL_HERMES)" == "true"           ]] || fails+=("INSTALL_HERMES not appended (got '$(get INSTALL_HERMES)')")
 
-# Uncomment-in-place, not append: the commented TZ line is REPLACED, so the file
-# gains one line for INSTALL_HERMES and nothing else.
 env_lines_after="$(wc -l < "$work/.devcontainer/.env")"
 (( env_lines_after == env_lines_before + 1 )) \
   || fails+=("expected exactly one new line (INSTALL_HERMES); went from $env_lines_before to $env_lines_after — a commented key was appended instead of uncommented in place")
 grep -qE '^[[:space:]]*#[[:space:]]*TZ=' "$work/.devcontainer/.env" \
   && fails+=("the commented TZ line survived — it must be replaced, not shadowed by an appended duplicate")
 
-# The summary names what changed. A silent migration is the failure mode this
-# whole design exists to avoid.
 grep -qF 'SANDBOX_NAME' <<<"$out" || fails+=("the summary does not name SANDBOX_NAME")
 grep -qF 'stalename'    <<<"$out" || fails+=("the summary does not print the replaced value, so the change is invisible")
 
 [[ -f "$work/harness.yaml.migrated" ]] || fails+=("harness.yaml was not renamed to harness.yaml.migrated")
 [[ -f "$work/harness.yaml"          ]] && fails+=("harness.yaml still exists after migration")
 
-# compose.overrides is a list .env cannot hold, so it moves to .oh/config.json.
 if command -v jq >/dev/null 2>&1; then
   [[ -f "$work/.oh/config.json" ]] || fails+=(".oh/config.json was not created for compose.overrides")
   if [[ -f "$work/.oh/config.json" ]]; then
@@ -94,7 +74,6 @@ if command -v jq >/dev/null 2>&1; then
   fi
 fi
 
-# --- Second run: a pure no-op --------------------------------------------------
 before="$(cat "$work/.devcontainer/.env")"
 set +e
 out2="$(sh "$MIGRATOR" "$work" 2>&1)"

--- a/.oh/evals/probes/health-check-docker-stats.sh
+++ b/.oh/evals/probes/health-check-docker-stats.sh
@@ -4,8 +4,6 @@
 # desc: /health-check retains the docker stats in-container-reclaim step
 set -euo pipefail
 
-# Resolve repo root from this script's location, never cwd: /eval runs probes
-# from an arbitrary working directory.
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 SKILL="$ROOT/.claude/skills/health-check/SKILL.md"
 

--- a/.oh/evals/probes/health-check-socket-degrade.sh
+++ b/.oh/evals/probes/health-check-socket-degrade.sh
@@ -2,17 +2,6 @@
 # tier: A
 # source: issue #762 (refs #756) — /health-check degrades to one statement, not nine failures
 # desc: /health-check's scope preflight resolves every endpoint to a decided state, contacts no daemon on the host-only path, and never calls a dead socket available
-#
-# This probe EXECUTES the preflight and asserts its behaviour. It deliberately does
-# not assert that a file exists: a skill file can exist and still emit the wall of
-# connection errors #762 is about.
-#
-# The `available` arm cannot be faked with a real socket — a python-bound socket does
-# not speak Docker's HTTP API, so a genuine round-trip against it can only fail. The
-# arms therefore drive a `docker` SHIM first on PATH, which both decides the
-# round-trip outcome and records every invocation. That shim is also what proves the
-# host-only branch contacts no daemon: a static grep cannot show what the runtime
-# path did not do.
 set -uo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
@@ -25,19 +14,11 @@ NOTICE='HEALTH-CHECK SCOPE-NOTICE:'
 [ -f "$SKILL" ]     || { echo "SKIPPED: skill not found at $SKILL" >&2; exit 2; }
 bash -n "$PREFLIGHT" 2>/dev/null || { echo "REGRESSION: preflight fails bash -n" >&2; exit 1; }
 
-# Fixtures live outside the repo tree so a crash cannot leak into git status, and
-# under a SHORT path: AF_UNIX sun_path is capped at 108 bytes and a deep temp path
-# fails to bind for reasons unrelated to what this probe tests.
 TMP="$(mktemp -d /tmp/hc-probe.XXXXXX)" || { echo "SKIPPED: cannot create temp dir" >&2; exit 2; }
 trap 'rm -rf "$TMP"' EXIT
 
 mkdir -p "$TMP/bin" "$TMP/nodocker"
 
-# The shim: one line per invocation carrying the resolved SUBCOMMAND, so the
-# host-only assertion is about calls made rather than about strings in the source.
-# `-H <value>` is skipped explicitly — capturing the first non-flag argument would
-# record the endpoint and silently never record `version`, which would make the
-# available arm's assertion pass for the wrong reason.
 cat > "$TMP/bin/docker" <<'SHIM'
 #!/usr/bin/env bash
 sub=""
@@ -53,9 +34,6 @@ exit "${SHIM_RC:-0}"
 SHIM
 chmod +x "$TMP/bin/docker"
 
-# A PATH with the tools the preflight needs but WITHOUT docker, for the absent-CLI
-# arm. Pointing PATH at an empty directory would break the probe's own utilities
-# instead of testing the branch.
 NODOCKER_BASH=""
 for t in bash env grep head timeout sed cut; do
   p="$(command -v "$t" 2>/dev/null)" && ln -sf "$p" "$TMP/nodocker/$t"
@@ -65,7 +43,6 @@ done
 fails=0
 note() { echo "REGRESSION: $*" >&2; fails=$((fails + 1)); }
 
-# run <shim-rc> <endpoint> [extra env assignments...] -> stdout in $OUT, rc in $RC
 run() {
   local rc="$1" ep="$2"; shift 2
   : > "$TMP/log"
@@ -78,7 +55,6 @@ field()   { printf '%s\n' "$OUT" | sed -n "s/^$1=//p" | head -1; }
 notices() { printf '%s\n' "$OUT" | grep -cF "$NOTICE"; }
 calls()   { tr '\n' ' ' < "$TMP/log"; }
 
-# --- ARM 1: absent unix endpoint -> host-only, exactly one notice, exit 0 --------
 run 0 "$TMP/absent.sock"
 [ "$(field DOCKER_TRIAGE)" = "host-only" ] \
   || note "A1 absent endpoint: DOCKER_TRIAGE='$(field DOCKER_TRIAGE)', want host-only"
@@ -87,13 +63,9 @@ run 0 "$TMP/absent.sock"
 [ "$RC" -eq 0 ] \
   || note "A1 absent endpoint: exit $RC, want 0 — a classification step must not read as a failure"
 
-# --- ARM 2: the host-only branch contacts NO daemon ------------------------------
-# Same run as ARM 1. An explicit endpoint override short-circuits resolution, so a
-# correct preflight invokes docker zero times here.
 [ -z "$(calls)" ] \
   || note "A2 host-only branch invoked docker [$(calls)] — the branch must contact no daemon"
 
-# --- ARM 3: reachable endpoint -> available, and NO notice -----------------------
 run 0 "tcp://127.0.0.1:2375"
 [ "$(field DOCKER_TRIAGE)" = "available" ] \
   || note "A3 reachable endpoint: DOCKER_TRIAGE='$(field DOCKER_TRIAGE)', want available"
@@ -104,10 +76,6 @@ case " $(calls)" in
   *) note "A3 reachable endpoint: docker calls were [$(calls)], want a 'version' round-trip" ;;
 esac
 
-# --- ARM 4: endpoint present, daemon dead -> unreachable, ONE notice, exit 0 -----
-# The central regression guard. `[ -S path ]` is true for a socket an OOM-killed
-# daemon left behind and for a chmod-000 socket; classifying either `available` is
-# how the nine-failure wall comes back wearing a passing preflight.
 run 1 "tcp://127.0.0.1:2375"
 [ "$(field DOCKER_TRIAGE)" = "unreachable" ] \
   || note "A4 dead daemon: DOCKER_TRIAGE='$(field DOCKER_TRIAGE)', want unreachable — a present-but-dead endpoint must never be called available"
@@ -116,7 +84,6 @@ run 1 "tcp://127.0.0.1:2375"
 [ "$RC" -eq 0 ] \
   || note "A4 dead daemon: exit $RC, want 0"
 
-# --- ARM 5: a real unix socket counts as an endpoint -----------------------------
 if command -v python3 >/dev/null 2>&1; then
   if python3 -c 'import socket,sys
 s = socket.socket(socket.AF_UNIX)
@@ -132,10 +99,6 @@ else
   echo "note: A5 skipped — python3 unavailable" >&2
 fi
 
-# --- ARM 6: no docker CLI at all -> host-only -----------------------------------
-# The CLI and the endpoint are separate facts. Testing for the binary is what made
-# the old behaviour wrong: /usr/bin/docker is present in this sandbox and proves
-# nothing about reachability. The inverse must also hold.
 OUT=""
 if [ -n "$NODOCKER_BASH" ]; then
   OUT="$(SHIM_LOG="$TMP/log" PATH="$TMP/nodocker" HEALTH_CHECK_DOCKER_SOCK="$TMP/live.sock" \
@@ -150,21 +113,14 @@ else
   echo "note: A6 skipped — minimal PATH could not run the preflight" >&2
 fi
 
-# --- ARM 7: no terminal `unverified` state --------------------------------------
-# An earlier design reported `unverified` for endpoints no file test could settle and
-# never required resolving it, which left a tcp:// operator exactly where the old
-# skill left them. Every path must end at a decided state.
 grep -qF 'unverified' "$PREFLIGHT" \
   && note "A7 preflight reintroduces an 'unverified' state — every endpoint must resolve to available|host-only|unreachable"
 
-# --- ARM 8: SKILL.md actually wires step 0 to the script ------------------------
-# An unwired script is a no-op no matter how correct it is.
 grep -qF 'scripts/scope-preflight.sh' "$SKILL" \
   || note "A8 SKILL.md does not invoke scripts/scope-preflight.sh — the preflight is unwired"
 grep -qF 'DOCKER_TRIAGE' "$SKILL" \
   || note "A8 SKILL.md does not branch on DOCKER_TRIAGE"
 
-# --- ARM 9: the relocated Docker steps are marked host-only, not deleted --------
 grep -qF 'docker stats' "$SKILL" \
   || note "A9 SKILL.md lost the 'docker stats' RAM-reclaim step"
 grep -qiF 'host-only' "$SKILL" \

--- a/.oh/evals/probes/heartbeat-logging-contract.sh
+++ b/.oh/evals/probes/heartbeat-logging-contract.sh
@@ -12,17 +12,12 @@ missing=()
 [[ -f "$HEARTBEAT" ]] || { echo "SKIPPED: missing $HEARTBEAT" >&2; exit 2; }
 [[ -x "$HELPER" ]] || { echo "SKIPPED: missing executable $HELPER" >&2; exit 2; }
 
-# `.oh/crons/.cron.log` is the heartbeat's ONLY per-pulse durable signal since the
-# `.oh/memory` tier was deleted. It must stay locked, and it must stay mandatory.
 grep -Fq 'scripts/locked-append.sh .oh/crons/.cron.log' "$HEARTBEAT" || missing+=("heartbeat liveness line uses scripts/locked-append.sh")
 grep -Fq 'Mandatory closing step' "$HEARTBEAT" || missing+=("heartbeat marks the liveness append mandatory")
 grep -Fq 'STATUS="<status>"' "$HEARTBEAT" || missing+=("heartbeat computes a STATUS token for the liveness line")
 
-# Regression guard for the old race-prone shared log append.
 grep -Fq '>> .oh/crons/.cron.log' "$HEARTBEAT" && missing+=("heartbeat must not append liveness with raw >>")
 
-# Regression guard: the deleted memory tier must not come back through this prompt.
-# A reintroduced `.oh/memory` write is the defect, not a stylistic drift.
 grep -Fq '.oh/memory' "$HEARTBEAT" && missing+=("heartbeat references the deleted .oh/memory tier")
 grep -Fq 'Memory log contract' "$HEARTBEAT" && missing+=("heartbeat reintroduced the memory log contract")
 

--- a/.oh/evals/probes/make-oh-lifecycle-parity.sh
+++ b/.oh/evals/probes/make-oh-lifecycle-parity.sh
@@ -13,8 +13,6 @@ CLI="$ROOT/.oh/cli/src/cli.ts"
 LIFECYCLE="$ROOT/.oh/cli/src/commands/lifecycle.ts"
 MAP="$ROOT/.oh/docs/lifecycle-commands.md"
 
-# A published `oh init` repo has no Makefile, and a non-source checkout has no
-# CLI sources. Neither is a regression.
 if [[ ! -f "$MAKEFILE" || ! -f "$CLI" ]]; then
   echo "SKIPPED: not a source checkout (Makefile or .oh/cli/src absent)" >&2
   exit 2
@@ -22,12 +20,6 @@ fi
 
 missing=()
 
-# Targets that deliberately have NO `oh` verb. Each must be justified in the
-# mapping doc (A2), so this list cannot grow silently.
-#   help/harness-config — build plumbing, not lifecycle
-#   shell               — has `oh shell`, but the recipe is pinned raw (see A3)
-#   destroy             — `down -v` wipes auth volumes; needs a confirm policy
-#   config              — `oh config` already means "configure an integration"
 EXCEPTIONS=(help harness-config shell destroy config)
 is_exception() {
   local t=$1 e
@@ -35,56 +27,37 @@ is_exception() {
   return 1
 }
 
-# --- A1: every .PHONY target has an `oh` verb, or is a listed exception -------
-#
-# Fails in BOTH directions: a new make target with no verb, and a verb whose
-# dispatch was removed while the target stayed.
 phony=$(sed -n 's/^\.PHONY:[[:space:]]*//p' "$MAKEFILE" | tr ' ' '\n' | sed '/^$/d')
 if [[ -z $phony ]]; then
   missing+=("A1: no .PHONY line found in the Makefile — cannot enumerate targets")
 fi
 for target in $phony; do
   is_exception "$target" && continue
-  # `sandbox`, `shell` and `gateway` dispatch by name; the compose verbs come
-  # from COMPOSE_VERBS. Either form counts as a verb existing.
   if grep -qF "first === \"$target\"" "$CLI"; then continue; fi
   if grep -qE "^  $target: " "$LIFECYCLE"; then continue; fi
   missing+=("A1: make target \`$target\` has no \`oh $target\` verb and is not a documented exception")
 done
 
-# --- A2: every exception is named in the mapping doc --------------------------
 if [[ ! -f "$MAP" ]]; then
   missing+=("A2: .oh/docs/lifecycle-commands.md is missing — the mapping has no home")
 else
   for target in "${EXCEPTIONS[@]}"; do
-    # help/harness-config are plumbing; the three real exceptions must be argued.
     case "$target" in help|harness-config) continue;; esac
     grep -qF "make $target" "$MAP" \
       || missing+=("A2: exception \`make $target\` is not explained in lifecycle-commands.md")
   done
 fi
 
-# --- A3: both doors go through docker-compose.sh ------------------------------
-#
-# The single implementation is the script. A recipe calling `docker compose`
-# directly would fork overlay resolution and project naming.
 while IFS= read -r line; do
-  # Recipe lines only (tab-indented), and skip the documented `docker exec`.
   [[ $line == *"docker compose"* ]] || continue
   missing+=("A3: a Makefile recipe calls \`docker compose\` directly — go through \$(COMPOSE)")
 done < <(grep -P '^\t' "$MAKEFILE" || true)
 
-# The one permitted raw invocation. Deliberately consistent with
-# execution-target-contract.sh C5, which pins this same line verbatim.
 if ! sed 's/^[[:space:]]*//' "$MAKEFILE" |
   grep -Fxq 'docker exec -it -u $(SHELL_USER) $(SHELL_CONTAINER) zsh'; then
   missing+=("A3: the pinned \`make shell\` line changed — see execution-target-contract.sh C5")
 fi
 
-# --- A4: the new verbs assemble no compose argv in TypeScript -----------------
-#
-# The failure mode: someone "improves" a verb by building the overlay list in
-# TS, and the two doors start to drift.
 if [[ -f "$LIFECYCLE" ]]; then
   code=$(perl -0pe 's{/\*.*?\*/}{}gs; s{(^|[^:])//[^\n]*}{$1}gm' "$LIFECYCLE")
   if ! grep -qF 'COMPOSE_VERBS' <<<"$code"; then
@@ -93,14 +66,12 @@ if [[ -f "$LIFECYCLE" ]]; then
   if ! grep -qF 'docker-compose.sh' <<<"$code"; then
     missing+=("A4: lifecycle.ts no longer names docker-compose.sh — a verb may bypass the script")
   fi
-  # `runComposeVerb` must not name an engine; the script owns that.
   body=$(awk '/export function runComposeVerb/,/^}/' <<<"$code")
   if grep -qE '"docker"|docker compose' <<<"$body"; then
     missing+=("A4: runComposeVerb names docker directly — the script owns the engine argv")
   fi
 fi
 
-# --- A5: exactly one mapping table, and the others link to it -----------------
 if [[ -f "$MAP" ]]; then
   for doc in AGENTS.md README.md .oh/cli/README.md; do
     [[ -f "$ROOT/$doc" ]] || continue

--- a/.oh/evals/probes/markitdown-wiki-ingest.sh
+++ b/.oh/evals/probes/markitdown-wiki-ingest.sh
@@ -30,7 +30,6 @@ need_regex() {
   grep -Eqi -- "$regex" "$INGEST" || failures+=("$label")
 }
 
-# Pilot routing and exact upstream CLI identity.
 for ext in .pdf .docx .pptx .xlsx; do
   need_literal "supported extension absent: $ext" "$ext"
 done
@@ -45,7 +44,6 @@ need_literal "existing text route is not excluded from MarkItDown" 'Do not send 
 need_literal "plugin prohibition absent" 'do not pass `-p`/`--use-plugins`'
 need_literal "cloud/LLM prohibition absent" '`--use-cu`'
 
-# Prospective conversion and archive/input ceilings.
 need_literal "conversion timeout absent" 'timeout 120s'
 need_literal "dedicated temporary directory absent" 'mktemp -d'
 need_literal "native thread-pool bounding absent" 'OMP_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1 MKL_NUM_THREADS=1'
@@ -59,7 +57,6 @@ need_literal "whitespace-only output check absent" "grep -q '[^[:space:]]'"
 need_regex "non-zero/timeout/cap failure semantics absent" 'non-zero .*including timeout or file-limit termination'
 need_literal "set-e-safe conversion status capture absent" ') || CONVERT_STATUS=$?'
 
-# Input identity/signature and archive traversal boundaries.
 need_literal "symlink rejection absent" 'symlinks are not accepted'
 need_literal "regular-file rejection absent" 'source is not a regular file'
 need_literal "option-like basename rejection absent" 'option-like basenames are not accepted'
@@ -73,7 +70,6 @@ need_literal "OOXML traversal component rejection absent" '".." in parts'
 need_literal "metadata-only no-extraction boundary absent" 'Do not extract members.'
 need_regex "malformed ZIP fail-closed semantics absent" 'malformed or uninspectable ZIP metadata fails closed'
 
-# Trust, review, provenance, atomic publication, and rollback.
 need_regex "untrusted extraction boundary absent" 'lossy, untrusted (source data|extracted content)'
 need_regex "embedded instructions are not prohibited" 'embedded instructions.*must never be executed'
 need_regex "document relationships/links are not prohibited" 'OOXML external relationship.*zero converter-originated requests'
@@ -109,10 +105,8 @@ need_regex "rollback changelog explanation absent" 'separate reviewed PR with a 
 need_regex "raw provenance rollback default absent" 'immutable raw original/Markdown provenance remains by default'
 need_regex "no-schema-dependency rollback absent" 'No schema migration.*depend on MarkItDown'
 
-# This load-bearing probe must protect itself in the same change.
 grep -Fxq "$SELF_REL" "$PROTECTED" || failures+=("$SELF_REL not registered in .claude/protected-paths.txt")
 
-# No repository-owned executable/code wrapper and no image/package installation.
 while IFS= read -r -d '' path; do
   [[ "$path" == "$SELF_REL" ]] && continue
   if grep -qi 'markitdown' "$ROOT/$path"; then

--- a/.oh/evals/probes/next-dev-prod.sh
+++ b/.oh/evals/probes/next-dev-prod.sh
@@ -4,19 +4,9 @@
 # desc: public mifune.dev is not served by next dev
 set -euo pipefail
 
-# Strategy:
-#   1. Scan for any process whose args contain "next dev" (dev mode launcher).
-#   2. Scan for any next-server process whose cwd resolves under a mifunedev/website path.
-#   3. Use `tmux ls` for the app-website session as a corroborating signal only —
-#      not sufficient alone (session may exist after a server stop).
-# If a dev-mode process is found → REGRESSION (exit 1).
-# If no website process/context found at all → SKIPPED (exit 2).
-# If website context found but no dev-mode process → PASS (exit 0).
-# Exiting 0 when nothing can be verified is FORBIDDEN.
 
 WEBSITE_PATH_PATTERN="mifunedev/website"
 
-# --- 1. Detect explicit "next dev" invocations ---
 dev_pids=()
 while IFS= read -r line; do
     dev_pids+=("$line")
@@ -27,7 +17,6 @@ if [[ ${#dev_pids[@]} -gt 0 && -n "${dev_pids[0]}" ]]; then
     exit 1
 fi
 
-# --- 2. Detect next-server processes whose cwd is under mifunedev/website ---
 found_website_context=0
 
 while IFS= read -r pid; do
@@ -36,39 +25,28 @@ while IFS= read -r pid; do
     cwd=$(readlink "/proc/${pid}/cwd" 2>/dev/null || true)
     if [[ "$cwd" == *"$WEBSITE_PATH_PATTERN"* ]]; then
         found_website_context=1
-        # next-server launched by "next dev" will NOT have "start" in its cmdline;
-        # "next start" (production) spawns a next-server too, but the parent
-        # process will be "next start", not "next dev".
-        # We already checked for "next dev" parents above.
-        # A remaining next-server under mifunedev/website with no "next start"
-        # parent indicates a dev-mode server.
         parent_pid=""
         parent_pid=$(awk '/^PPid:/{print $2}' "/proc/${pid}/status" 2>/dev/null || true)
         parent_args=""
         if [[ -n "$parent_pid" ]]; then
             parent_args=$(tr -d '\0' < "/proc/${parent_pid}/cmdline" 2>/dev/null || true)
         fi
-        # Flag as dev if parent args contain "next dev" or do NOT contain "next start"
-        # (i.e., orphaned/direct next-server without a production start parent)
         if echo "$parent_args" | grep -q "next dev"; then
             echo "REGRESSION: next-server under mifunedev/website has 'next dev' parent (pid=${pid}, parent_args=${parent_args})" >&2
             exit 1
         fi
         if ! echo "$parent_args" | grep -qE "next[[:space:]]start|next-server"; then
-            # Parent is not a known production launcher — treat as dev-mode
             echo "REGRESSION: next-server under mifunedev/website without production parent (pid=${pid}, cwd=${cwd})" >&2
             exit 1
         fi
     fi
 done < <(pgrep -f "next-server" 2>/dev/null || true)
 
-# --- 3. Corroborating: app-website tmux session ---
 website_session=0
 if tmux ls 2>/dev/null | grep -q "^app-website:"; then
     website_session=1
 fi
 
-# --- 4. Verdict ---
 if [[ $found_website_context -eq 0 && $website_session -eq 0 ]]; then
     echo "SKIPPED: no mifunedev/website process or app-website tmux session found — cannot verify" >&2
     exit 2

--- a/.oh/evals/probes/oh-devcontainer-restructure.sh
+++ b/.oh/evals/probes/oh-devcontainer-restructure.sh
@@ -12,7 +12,6 @@ COMPOSE="$DC/docker-compose.yml"
 DEVCONTAINER_JSON="$DC/devcontainer.json"
 DOCKERIGNORE="$ROOT/.dockerignore"
 
-# SKIPPED: the consolidation has not landed yet (the moved Dockerfile is the anchor).
 if [[ ! -f "$DOCKERFILE" ]]; then
   echo "SKIPPED: consolidation not present — $DOCKERFILE absent" >&2
   exit 2
@@ -23,7 +22,6 @@ regress() {
   exit 1
 }
 
-# 1. All six build assets exist under .devcontainer/.
 for asset in \
   Dockerfile \
   docker-compose.yml \
@@ -34,11 +32,9 @@ for asset in \
   [[ -f "$DC/$asset" ]] || regress "build asset missing from .devcontainer/: $asset"
 done
 
-# 2. Nothing lingers under the retired .oh/devcontainer/.
 [[ ! -d "$ROOT/.oh/devcontainer" ]] \
   || regress ".oh/devcontainer/ still present (assets should have consolidated into .devcontainer/)"
 
-# 3. The VS Code devcontainer.json points at the same-dir compose (no ../.oh shim).
 [[ -f "$DEVCONTAINER_JSON" ]] || regress "devcontainer.json missing: $DEVCONTAINER_JSON"
 grep -Fq '"docker-compose.yml"' "$DEVCONTAINER_JSON" \
   || regress "devcontainer.json does not point dockerComposeFile at the same-dir docker-compose.yml"
@@ -46,17 +42,14 @@ if grep -Fq '.oh/devcontainer' "$DEVCONTAINER_JSON"; then
   regress "devcontainer.json still references .oh/devcontainer (stale shim)"
 fi
 
-# 4. Compose references the co-located Dockerfile and a repo-root build context.
 grep -Fq 'dockerfile: .devcontainer/Dockerfile' "$COMPOSE" \
   || regress "docker-compose.yml does not set dockerfile: .devcontainer/Dockerfile"
 grep -Eq '^[[:space:]]*context: \.\.$' "$COMPOSE" \
   || regress "docker-compose.yml build context is not the repo root (context: ..)"
 
-# 5. Dockerfile copies the co-located entrypoint.
 grep -Fq 'COPY .devcontainer/entrypoint.sh' "$DOCKERFILE" \
   || regress "Dockerfile does not COPY .devcontainer/entrypoint.sh"
 
-# 6. No moved build asset still references the retired .oh/devcontainer/ path.
 for asset in Dockerfile docker-compose.yml docker-compose.hermes-dashboard.yml \
              entrypoint.sh client-slack-supervise.sh seed-msg-bridge.sh devcontainer.json; do
   if grep -Fq '.oh/devcontainer' "$DC/$asset" 2>/dev/null; then
@@ -64,8 +57,6 @@ for asset in Dockerfile docker-compose.yml docker-compose.hermes-dashboard.yml \
   fi
 done
 
-# 7. .dockerignore must NOT exclude the whole .devcontainer/ dir (else the
-#    entrypoint COPY has no source) but must still exclude env secrets.
 if [[ -f "$DOCKERIGNORE" ]]; then
   if grep -Eq '^[[:space:]]*\.devcontainer/?[[:space:]]*$' "$DOCKERIGNORE"; then
     regress ".dockerignore excludes the whole .devcontainer/ dir — the entrypoint COPY would fail"
@@ -74,7 +65,6 @@ if [[ -f "$DOCKERIGNORE" ]]; then
     || regress ".dockerignore no longer excludes env files (secret-leak risk)"
 fi
 
-# 8. The compat generator is retired (no split left to keep in sync).
 [[ ! -f "$ROOT/.oh/scripts/sync-devcontainer.sh" ]] \
   || regress ".oh/scripts/sync-devcontainer.sh still present (compat generator retired by consolidation)"
 

--- a/.oh/evals/probes/oh-image-only-deploy.sh
+++ b/.oh/evals/probes/oh-image-only-deploy.sh
@@ -21,8 +21,6 @@ COMPOSE_PRIMARY="$ROOT/.devcontainer/docker-compose.yml"
 DOCKERFILE="$ROOT/.devcontainer/Dockerfile"
 DOC="$ROOT/.oh/docs/deployment-prebuilt-image.md"
 
-# SKIPPED (exit 2): Flavor B (image-only) artifacts are not present on this
-# branch yet — do not REGRESSION on absence.
 if [[ ! -f "$COMPOSE_IO" ]] || [[ ! -f "$ENTRYPOINT" ]] || ! grep -q 'OH_IMAGE_ONLY' "$ENTRYPOINT"; then
   echo "SKIPPED: Flavor B (image-only) artifacts not present (docker-compose.image-only.yml and/or entrypoint.sh OH_IMAGE_ONLY gate absent)" >&2
   exit 2
@@ -30,13 +28,6 @@ fi
 
 fails=()
 
-# (1) entrypoint.sh: the OH_IMAGE_ONLY gate must appear strictly BEFORE the
-#     host-UID-sync `elif [ -d "$HARNESS_DIR" ]` branch, and the seed helper
-#     + its marker must be present.
-# NOTE: each pipe is `|| true`-guarded at the statement level — under
-# `pipefail`, a no-match `grep -n` (exit 1) makes the WHOLE pipeline's exit
-# status non-zero even though `head`/`cut` succeed on empty input, which
-# would otherwise abort the script under `set -e` with no named failure.
 gate_line="$(grep -n 'if \[.*OH_IMAGE_ONLY' "$ENTRYPOINT" | head -1 | cut -d: -f1)" || true
 elif_line="$(grep -n 'elif \[ -d "\$HARNESS_DIR" \]' "$ENTRYPOINT" | head -1 | cut -d: -f1)" || true
 if [[ -z "$gate_line" ]] || [[ -z "$elif_line" ]] || (( gate_line >= elif_line )); then
@@ -47,9 +38,6 @@ grep -Fq 'seed_workspace_volume' "$ENTRYPOINT" \
 grep -Fq '.image-seeded' "$ENTRYPOINT" \
   || fails+=("entrypoint.sh must reference the .image-seeded marker")
 
-# (2) BEHAVIORAL seed sim — extract ONLY the fenced seed_workspace_volume
-#     function (entrypoint.sh ends in `exec "$@"`, so we never source the
-#     whole file) and run it against real mktemp -d dirs.
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
 
@@ -73,7 +61,6 @@ else
     echo "fixture-sentinel-$$" > "$fixture/.oh/SENTINEL_FIXTURE"
     export OH_IMAGE_SEED_SRC="$fixture"
 
-    # (a) fresh empty dest: seeds .oh/, writes the marker, flags this-boot.
     dest_a="$(mktemp -d "$tmp/dest-a.XXXXXX")"
     if seed_workspace_volume "$dest_a"; then :; fi
     if [[ ! -d "$dest_a/.oh" ]] || [[ ! -f "$dest_a/.oh/.image-seeded" ]] \
@@ -81,15 +68,11 @@ else
       fails+=("seed sim (a): fresh empty dest must seed .oh/, write the .image-seeded marker, and set OH_IMAGE_SEEDED_THIS_BOOT=1")
     fi
 
-    # (b) second call on the same (now-seeded) dest: idempotent, no re-copy.
     if seed_workspace_volume "$dest_a"; then :; fi
     if [[ "${OH_IMAGE_SEEDED_THIS_BOOT:-}" != "0" ]]; then
       fails+=("seed sim (b): a second call on an already-seeded dest must be idempotent (OH_IMAGE_SEEDED_THIS_BOOT=0, no re-copy)")
     fi
 
-    # (c) fresh dest pre-populated with its OWN .oh/ (distinct sentinel, no
-    #     marker): existing content is preserved and the fixture is NOT
-    #     copied in (no clobber of a populated-but-unmarked volume).
     dest_c="$(mktemp -d "$tmp/dest-c.XXXXXX")"
     mkdir -p "$dest_c/.oh"
     echo "own-sentinel-$$" > "$dest_c/.oh/OWN_SENTINEL"
@@ -103,8 +86,6 @@ else
   fi
 fi
 
-# (3) docker-compose.image-only.yml shape: named volume mount, OH_IMAGE_ONLY=1,
-#     parameterized image:, a pull_policy:, and NO build:/`..:` bind mount.
 grep -Eq '^[[:space:]]*-[[:space:]]*oh_workspace:\$\{OH_PROJECT_ROOT' "$COMPOSE_IO" \
   || fails+=("docker-compose.image-only.yml must mount a named oh_workspace volume at \${OH_PROJECT_ROOT}")
 grep -Fq 'OH_IMAGE_ONLY=1' "$COMPOSE_IO" \
@@ -120,8 +101,6 @@ if grep -Eq '^[[:space:]]*-[[:space:]]*\.\.:' "$COMPOSE_IO"; then
   fails+=("docker-compose.image-only.yml must NOT have a '..:' bind mount (no checkout)")
 fi
 
-# (4) REGRESSION FLOOR: the primary docker-compose.yml must still keep its
-#     `..:` bind mount — Flavor B must not touch Flavor A's contract.
 if [[ ! -f "$COMPOSE_PRIMARY" ]]; then
   fails+=("primary docker-compose.yml not found at $COMPOSE_PRIMARY")
 else
@@ -129,7 +108,6 @@ else
     || fails+=("docker-compose.yml lost its '..:' bind mount — regression floor broken")
 fi
 
-# (5) Deploy doc: placeholder gone, mentions oh_workspace + OH_IMAGE_ONLY.
 if [[ ! -f "$DOC" ]]; then
   fails+=("deploy doc not found at $DOC")
 else
@@ -143,8 +121,6 @@ else
     || fails+=("deployment-prebuilt-image.md must mention OH_IMAGE_ONLY")
 fi
 
-# (6) Dockerfile: if present, it must stage /opt/oh-seed for the entrypoint
-#     to seed from. SKIP just this sub-check if the Dockerfile is absent.
 if [[ -f "$DOCKERFILE" ]]; then
   grep -Eq 'COPY.*/opt/oh-seed' "$DOCKERFILE" \
     || fails+=("Dockerfile must stage the seed source (COPY ... /opt/oh-seed/)")
@@ -152,12 +128,6 @@ else
   echo "[oh-image-only-deploy] Dockerfile not present — skipping /opt/oh-seed staging sub-check" >&2
 fi
 
-# (7) .claude control-plane seed contract. The no-bind seed must carry
-#     .claude/protected-paths.txt or link-providers.sh --init crash-loops. Guard
-#     BOTH halves: (a) .dockerignore re-includes it into the /opt/oh-seed build
-#     context (a bare `.claude/` exclusion starves the seed), and (b) the
-#     entrypoint seed fn backfills it so an already-seeded-but-incomplete volume
-#     self-heals without a wipe.
 DOCKERIGNORE="$ROOT/.dockerignore"
 if [[ -f "$DOCKERIGNORE" ]]; then
   grep -Eq '^[[:space:]]*!\.claude/protected-paths\.txt[[:space:]]*$' "$DOCKERIGNORE" \

--- a/.oh/evals/probes/oh-init-headless-config.sh
+++ b/.oh/evals/probes/oh-init-headless-config.sh
@@ -8,7 +8,6 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 CLI_DIR="$ROOT/.oh/cli"
 TEMPLATE="$ROOT/.oh/templates/.devcontainer/.example.env"
 
-# SKIPPED (exit 2): the CLI or its build output is not present on this branch.
 if [[ ! -d "$CLI_DIR" || ! -f "$TEMPLATE" ]]; then
   echo "SKIPPED: oh CLI not present (.oh/cli and/or .oh/templates/.devcontainer/.example.env absent)" >&2
   exit 2
@@ -27,13 +26,6 @@ fails=()
 work="$(mktemp -d)"
 trap 'rm -rf "$work"' EXIT
 
-# CI provisioning and cron runs have no TTY and must never block on a prompt.
-# `--yes` is the contract: the wizard is skipped entirely, so the seeded
-# .devcontainer/.example.env is the untouched template AND no .devcontainer/.env
-# is written at all — with no answers there is nothing to record, and compose
-# falls through to the defaults baked into docker-compose.yml. A future wizard
-# expansion that leaks a prompt into the --yes path, or that writes a key before
-# the user answers, is a provisioning outage — this probe is the tripwire.
 set +e
 out="$(cd "$work" && node "$CLI_DIR/dist/oh.js" init --yes </dev/null 2>&1)"
 rc=$?
@@ -42,7 +34,6 @@ set -e
 if (( rc != 0 )); then
   fails+=("oh init --yes exited $rc (headless provisioning must succeed): ${out%%$'\n'*}")
 else
-  # Any wizard prompt reaching stdout/stderr under --yes is a regression.
   if grep -qiE 'Configure your harness|\[y/N\]|\[Y/n\]|blank to skip' <<<"$out"; then
     fails+=("oh init --yes emitted a wizard prompt (must be non-interactive)")
   fi

--- a/.oh/evals/probes/oh-init-scaffold.sh
+++ b/.oh/evals/probes/oh-init-scaffold.sh
@@ -11,7 +11,6 @@ INIT_CMD="$ROOT/.oh/cli/src/commands/init.ts"
 CLI="$ROOT/.oh/cli/src/cli.ts"
 DEVCONTAINER="$TEMPLATES/.devcontainer/devcontainer.json"
 
-# SKIPPED (exit 2): the feature is not present on this branch yet.
 if [[ ! -d "$TEMPLATES" || ! -f "$INIT_CMD" ]]; then
   echo "SKIPPED: oh init scaffold not present (.oh/templates dir and/or .oh/cli/src/commands/init.ts absent)" >&2
   exit 2

--- a/.oh/evals/probes/oh-npm-package.sh
+++ b/.oh/evals/probes/oh-npm-package.sh
@@ -10,56 +10,46 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 PKG="$ROOT/.oh/cli/package.json"
 
-# SKIPPED: CLI package not present on this base (lets the probe land green pre-slice).
 if [ ! -f "$PKG" ]; then
   echo 'SKIPPED .oh/cli/package.json not present' >&2
   exit 2
 fi
 
-# Must parse as JSON.
 if ! jq -e . "$PKG" >/dev/null 2>&1; then
   echo 'REGRESSION .oh/cli/package.json is not valid JSON' >&2
   exit 1
 fi
 
-# MUST NOT be private (npm publish refuses a private package).
 if jq -e '.private == true' "$PKG" >/dev/null; then
   echo 'REGRESSION .oh/cli/package.json is marked private — npm publish would refuse it' >&2
   exit 1
 fi
 
-# Scoped package name.
 if ! jq -e '.name == "@mifune/openharness"' "$PKG" >/dev/null; then
   echo 'REGRESSION .oh/cli/package.json name is not @mifune/openharness' >&2
   exit 1
 fi
 
-# publishConfig.access must be public (mandatory for a scoped pkg's first publish).
 if ! jq -e '.publishConfig.access == "public"' "$PKG" >/dev/null; then
   echo 'REGRESSION .oh/cli/package.json lost publishConfig.access="public"' >&2
   exit 1
 fi
 
-# files allowlist must ship the built bundle dir (and thus survive dist/ being git-ignored).
 if ! jq -e '.files | index("dist")' "$PKG" >/dev/null; then
   echo 'REGRESSION .oh/cli/package.json files[] no longer ships "dist"' >&2
   exit 1
 fi
 
-# bin `oh` -> the built bundle.
 if ! jq -e '.bin.oh == "./dist/oh.js"' "$PKG" >/dev/null; then
   echo 'REGRESSION .oh/cli/package.json bin.oh is not ./dist/oh.js' >&2
   exit 1
 fi
 
-# engines.node declared (Node >= 20 to run the bundle).
 if ! jq -e 'has("engines") and (.engines.node != null)' "$PKG" >/dev/null; then
   echo 'REGRESSION .oh/cli/package.json lost engines.node' >&2
   exit 1
 fi
 
-# A README + LICENSE must sit alongside the package so npm renders a landing page
-# (npm force-includes README/LICENSE even under a files[] allowlist).
 for f in README.md LICENSE; do
   if [ ! -f "$ROOT/.oh/cli/$f" ]; then
     echo "REGRESSION .oh/cli/$f is missing — npm package would ship without it" >&2
@@ -67,10 +57,6 @@ for f in README.md LICENSE; do
   fi
 done
 
-# CI must carry the publish-npm job that pushes the package to the registry. The
-# publish lives in its own workflow (publish-cli.yml) so a CLI-only change can
-# publish via workflow_dispatch without a harness release; fall back to release.yml
-# for older layouts that still chain the job there.
 PUB="$ROOT/.github/workflows/publish-cli.yml"
 REL="$ROOT/.github/workflows/release.yml"
 WF=""

--- a/.oh/evals/probes/oh-payload-manifest.sh
+++ b/.oh/evals/probes/oh-payload-manifest.sh
@@ -10,19 +10,16 @@ MANIFEST="$ROOT/.oh/manifest.json"
 LIB_TS="$ROOT/.oh/cli/src/lib/manifest.ts"
 UPDATE_TS="$ROOT/.oh/cli/src/commands/update.ts"
 
-# SKIPPED: manifest not present on this base (lets the probe land green pre-slice).
 if [ ! -f "$MANIFEST" ]; then
   echo 'SKIPPED .oh payload manifest not present' >&2
   exit 2
 fi
 
-# manifest.json must parse as JSON with a non-empty include array.
 if ! jq -e 'has("include") and (.include|type=="array") and (.include|length>0)' "$MANIFEST" >/dev/null; then
   echo "REGRESSION .oh/manifest.json missing a non-empty include array" >&2
   exit 1
 fi
 
-# The include allowlist must ship docs/**.
 if ! jq -e '.include | index("docs/**")' "$MANIFEST" >/dev/null; then
   echo "REGRESSION .oh/manifest.json include must contain docs/**" >&2
   exit 1
@@ -32,7 +29,6 @@ if ! jq -e '.include | index("patches/**") | not' "$MANIFEST" >/dev/null; then
   exit 1
 fi
 
-# The pure matcher/loader module must exist and export shouldShip + loadManifest.
 if [ ! -f "$LIB_TS" ]; then
   echo "REGRESSION .oh/cli/src/lib/manifest.ts missing" >&2
   exit 1
@@ -46,7 +42,6 @@ if ! grep -q 'export function loadManifest' "$LIB_TS"; then
   exit 1
 fi
 
-# update.ts must import the matcher and emit the skip marker for non-payload paths.
 if ! grep -q "from '../lib/manifest.js'" "$UPDATE_TS"; then
   echo "REGRESSION update.ts does not import from '../lib/manifest.js'" >&2
   exit 1

--- a/.oh/evals/probes/oh-sandbox-image-mode.sh
+++ b/.oh/evals/probes/oh-sandbox-image-mode.sh
@@ -12,7 +12,6 @@ LIFECYCLE="$ROOT/.oh/cli/src/commands/lifecycle.ts"
 CLI="$ROOT/.oh/cli/src/cli.ts"
 GETOH="$ROOT/.oh/scripts/get-oh.sh"
 
-# SKIPPED (exit 2): prebuilt-image mode is not present on this branch yet.
 if [[ ! -f "$COMPOSE" || ! -f "$EXAMPLE_ENV" || ! -f "$LIFECYCLE" ]]; then
   echo "SKIPPED: prebuilt-image mode not present (docker-compose.yml, .devcontainer/.example.env, and/or lifecycle.ts absent)" >&2
   exit 2
@@ -20,8 +19,6 @@ fi
 
 fails=()
 
-# (a) Compose: image parameterized via OH_SANDBOX_IMAGE, a pull_policy is set, and
-#     the build: block is RETAINED (local build stays the default — backward compat).
 grep -Eq 'image:[[:space:]]*\$\{OH_SANDBOX_IMAGE:-' "$COMPOSE" \
   || fails+=("docker-compose.yml image: must interpolate \${OH_SANDBOX_IMAGE:-...}")
 grep -Eq 'pull_policy:[[:space:]]*\$\{OH_PULL_POLICY:-' "$COMPOSE" \
@@ -29,24 +26,18 @@ grep -Eq 'pull_policy:[[:space:]]*\$\{OH_PULL_POLICY:-' "$COMPOSE" \
 grep -Eq '^[[:space:]]*build:' "$COMPOSE" \
   || fails+=("docker-compose.yml must RETAIN the build: block (local build stays default)")
 
-# (b) Both image-mode keys are documented in the schema template. Since
-#     harness.yaml was removed there is no envmap to translate them — the key IS
-#     the env var, and .example.env is where an operator learns it exists.
 grep -Eq '^#[[:space:]]*OH_SANDBOX_IMAGE=' "$EXAMPLE_ENV" \
   || fails+=(".devcontainer/.example.env must document OH_SANDBOX_IMAGE")
 grep -Eq '^#[[:space:]]*OH_PULL_POLICY=' "$EXAMPLE_ENV" \
   || fails+=(".devcontainer/.example.env must document OH_PULL_POLICY")
 
-# (b2) Behavioral: the CLI pins OH_SANDBOX_IMAGE from .env when the key is set,
-#      and falls through to DEFAULT_SANDBOX_IMAGE when it is not. This is the
-#      half that used to be tested through the deleted parser.
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
 mkdir -p "$tmp/set/.devcontainer" "$tmp/unset/.devcontainer"
 printf 'OH_SANDBOX_IMAGE=ghcr.io/x/y:probe\n' > "$tmp/set/.devcontainer/.env"
 printf 'SANDBOX_NAME=demo\n'                  > "$tmp/unset/.devcontainer/.env"
 
-read_key() {   # $1 = fixture dir, $2 = key
+read_key() {
   awk -F= -v k="$2" '$0 ~ "^[[:space:]]*#" { next } $1 == k { print substr($0, index($0, "=") + 1); exit }' \
     "$1/.devcontainer/.env"
 }
@@ -57,16 +48,12 @@ read_key() {   # $1 = fixture dir, $2 = key
 grep -Fq 'readEnvValue(root, "OH_SANDBOX_IMAGE")' "$LIFECYCLE" \
   || fails+=("lifecycle.ts must resolve OH_SANDBOX_IMAGE from .devcontainer/.env via readEnvValue")
 
-# (c) The compose wrapper passes its compose args through VERBATIM, so the CLI's
-#     `up -d --no-build` (image mode) reaches docker compose unchanged.
 if [[ -f "$WRAPPER" ]]; then
   argv="$(bash "$WRAPPER" --repo-dir "$ROOT" --print-argv up -d --no-build 2>/dev/null || true)"
   printf '%s\n' "$argv" | grep -Fxq -- '--no-build' \
     || fails+=("docker-compose.sh must pass 'up -d --no-build' through verbatim (--print-argv)")
 fi
 
-# (d) oh sandbox source wiring: image-mode threads OH_SANDBOX_IMAGE, swaps to
-#     --no-build, and defaults the ref to the published GHCR image.
 grep -Fq 'OH_SANDBOX_IMAGE' "$LIFECYCLE" \
   || fails+=("lifecycle.ts must thread OH_SANDBOX_IMAGE into the child env")
 grep -Fq -- '--no-build' "$LIFECYCLE" \
@@ -80,7 +67,6 @@ if [[ -f "$CLI" ]]; then
     || fails+=("cli.ts parseSandboxArgs must handle --image=<ref>")
 fi
 
-# (e) get-oh.sh must not still claim the CLI is unpublished (it is on npm).
 if [[ -f "$GETOH" ]] && grep -Fq 'not published to npm' "$GETOH"; then
   fails+=("get-oh.sh still claims the oh CLI is 'not published to npm' — it is published as @mifune/openharness")
 fi

--- a/.oh/evals/probes/oh-shipped-repo-overridable.sh
+++ b/.oh/evals/probes/oh-shipped-repo-overridable.sh
@@ -6,21 +6,12 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 
-# SKIPPED: shipped installer not present on this base (lets the probe land green pre-slice).
 if [ ! -f "$ROOT/.oh/scripts/install.sh" ]; then
   echo 'SKIPPED .oh/scripts/install.sh not present' >&2
   exit 2
 fi
 
-# WHITELIST heuristic: collect every shipped-.sh line mentioning the upstream repo,
-# then drop the four LEGITIMATE forms and flag the rest:
-#   :-          → bash default-override (overridable)
-#   :NN: #      → a comment line
 #   !=          → a test/comparison
-#   default:    → help-text
-# Exclude .oh/evals/ — eval probes are test infrastructure (not part of the
-# shipped .oh CLI payload), so their intentional canonical-repo test literals are
-# not "shipped scripts" the override contract governs.
 hits=$(grep -rn 'mifunedev/openharness\|ryaneggz/openharness' "$ROOT/.oh" --include='*.sh' --exclude-dir=evals 2>/dev/null || true)
 bad=$(printf '%s\n' "$hits" | grep -v ':-' | grep -vE ':[0-9]+:[[:space:]]*#' | grep -v '!=' | grep -v 'default:' || true)
 if [ -n "$bad" ]; then
@@ -28,7 +19,6 @@ if [ -n "$bad" ]; then
   exit 1
 fi
 
-# Positively assert the known override is intact.
 # shellcheck disable=SC2016  # the ${...:-} literal is grepped, not expanded
 grep -q '${OH_GITHUB_REPO:-' "$ROOT/.oh/scripts/install.sh" || { echo 'REGRESSION install.sh lost the OH_GITHUB_REPO override' >&2; exit 1; }
 

--- a/.oh/evals/probes/oh-standalone-lifecycle.sh
+++ b/.oh/evals/probes/oh-standalone-lifecycle.sh
@@ -11,7 +11,6 @@ LIFECYCLE="$ROOT/.oh/cli/src/commands/lifecycle.ts"
 INIT="$ROOT/.oh/cli/src/commands/init.ts"
 SRC="$ROOT/.oh/cli/src"
 
-# SKIPPED (exit 2): the standalone lifecycle is not present on this branch yet.
 if [[ ! -f "$CLI" || ! -f "$LIFECYCLE" || ! -f "$INIT" ]]; then
   echo "SKIPPED: standalone lifecycle not present (cli.ts, commands/lifecycle.ts, and/or commands/init.ts absent)" >&2
   exit 2
@@ -19,24 +18,16 @@ fi
 
 fails=()
 
-# (a) cli.ts registers the three lifecycle verbs (actual dispatch literals) + --from-remote.
 grep -q '=== "sandbox"' "$CLI" || fails+=(".oh/cli/src/cli.ts has a sandbox dispatch branch")
 grep -q '=== "shell"' "$CLI" || fails+=(".oh/cli/src/cli.ts has a shell dispatch branch")
 grep -q '=== "gateway"' "$CLI" || fails+=(".oh/cli/src/cli.ts has a gateway dispatch branch")
 grep -Fq -- '--from-remote' "$CLI" || fails+=(".oh/cli/src/cli.ts registers --from-remote")
 
-# (b) No stale #531 deferred-work marker remains under .oh/cli/src/.
-# Broad grep; #564-retargeted bundling notes (lines that also name #564) are allowed.
-# Guarded so a no-match grep (the desired state) cannot trip pipefail/set -e.
 stale_531=$(grep -rn '#531' "$SRC" | grep -v '#564' || true)
 if [[ -n "$stale_531" ]]; then
   fails+=("no stale #531 marker under .oh/cli/src/ (found: ${stale_531})")
 fi
 
-# (c) init.ts scaffolds the consumer devcontainer workspace at /home/sandbox/harness.
-# The compose file is now copied VERBATIM (its mounts are already parameterized as
-# ${OH_PROJECT_ROOT:-/home/sandbox/harness}), so the older /home/sandbox/project
-# rewrite must NOT reappear.
 grep -Fq '/home/sandbox/harness' "$INIT" || fails+=(".oh/cli/src/commands/init.ts scaffolds the consumer workspace at /home/sandbox/harness")
 if grep -Fq '/home/sandbox/project' "$INIT"; then
   fails+=(".oh/cli/src/commands/init.ts must NOT reintroduce the /home/sandbox/project rewrite")

--- a/.oh/evals/probes/oh-update.sh
+++ b/.oh/evals/probes/oh-update.sh
@@ -11,22 +11,16 @@ VENDOR_TS="$ROOT/.oh/cli/src/lib/vendor.ts"
 CLI_TS="$ROOT/.oh/cli/src/cli.ts"
 TEST_TS="$ROOT/.oh/cli/src/__tests__/update.test.ts"
 
-# SKIPPED: command not present on this base (lets the probe land green pre-slice).
 if [ ! -f "$UPDATE_TS" ]; then
   echo "SKIPPED oh update command not present" >&2
   exit 2
 fi
 
-# update.ts must expose the runUpdate entrypoint.
 if ! grep -q 'export async function runUpdate' "$UPDATE_TS"; then
   echo "REGRESSION update.ts missing 'export async function runUpdate'" >&2
   exit 1
 fi
 
-# Path-escape guard: the guard (assertDestInTarget + its message literal) now lives
-# in the shared lib/vendor.ts, which update.ts imports and applies via copyOhPayload.
-# Verify the message at its source of truth, and that update.ts routes writes through
-# the guarded copier.
 if ! grep -q 'refusing to write outside target .oh' "$VENDOR_TS"; then
   echo "REGRESSION vendor.ts missing path-escape guard message" >&2
   exit 1
@@ -36,7 +30,6 @@ if ! grep -q 'copyOhPayload' "$UPDATE_TS"; then
   exit 1
 fi
 
-# Version gating: must read package.json and refuse downgrades.
 if ! grep -q 'package.json' "$UPDATE_TS"; then
   echo "REGRESSION update.ts missing package.json version reference" >&2
   exit 1
@@ -46,7 +39,6 @@ if ! grep -q 'downgrade' "$UPDATE_TS"; then
   exit 1
 fi
 
-# cli.ts must wire runUpdate and dispatch on the 'update' subcommand.
 if ! grep -q 'runUpdate' "$CLI_TS"; then
   echo "REGRESSION cli.ts does not reference runUpdate" >&2
   exit 1
@@ -56,20 +48,16 @@ if ! grep -Eq 'first === "update"' "$CLI_TS"; then
   exit 1
 fi
 
-# cli.ts help must advertise the update command.
 if ! grep -q 'oh update' "$CLI_TS"; then
   echo "REGRESSION cli.ts help does not advertise 'oh update'" >&2
   exit 1
 fi
 
-# Test file must exist.
 if [ ! -f "$TEST_TS" ]; then
   echo "REGRESSION update.test.ts missing" >&2
   exit 1
 fi
 
-# Negative-guard (static deletion proxy): update.ts must import + reference the
-# shared .oh-scoped path guard (defined in lib/vendor.ts, message checked above).
 for token in 'assertDestInTarget' 'targetOh'; do
   if ! grep -q "$token" "$UPDATE_TS"; then
     echo "REGRESSION update.ts missing negative-guard token: $token" >&2

--- a/.oh/evals/probes/operator-config-guard.sh
+++ b/.oh/evals/probes/operator-config-guard.sh
@@ -29,15 +29,11 @@ if ! command -v jq >/dev/null 2>&1; then
   exit 2
 fi
 
-# --- file-fixture driver ---
-# Hold the protected segment in a variable and write fixtures to /tmp so the
-# probe's own command text never carries the path the guards deny.
 SEG=".config"
 TMPDIR_PROBE=$(mktemp -d /tmp/operator-config-probe-XXXXXX)
 trap 'rm -rf "$TMPDIR_PROBE"' EXIT
 
 decision_for() {
-  # decision_for <hook> <fixture>; echoes deny | ask | allow
   local out
   out=$(bash "$1" < "$2" 2>/dev/null)
   if [[ -z "$out" ]]; then
@@ -48,14 +44,12 @@ decision_for() {
 }
 
 fixture() {
-  # fixture <name> <json>; echoes the path written
   local path="$TMPDIR_PROBE/$1.json"
   printf '%s\n' "$2" > "$path"
   echo "$path"
 }
 
 assert() {
-  # assert <want> <hook> <fixture> <label>
   local want="$1" got
   got=$(decision_for "$2" "$3")
   if [[ "$got" != "$want" ]]; then
@@ -64,7 +58,6 @@ assert() {
   fi
 }
 
-# --- assertion group A: file tools deny read AND write under the directory ---
 A_READ=$(fixture a-read "$(jq -nc --arg p "/home/sandbox/$SEG/gh/hosts.yml" '{tool_input:{file_path:$p}}')")
 A_WRITE=$(fixture a-write "$(jq -nc --arg p "/home/sandbox/harness/$SEG/main.yaml" '{tool_input:{file_path:$p}}')")
 A_DIR=$(fixture a-dir "$(jq -nc --arg p "/home/sandbox/harness/$SEG" '{tool_input:{file_path:$p}}')")
@@ -80,13 +73,11 @@ assert deny "$FILE_HOOK" "$A_LOCAL_WRITE" "shared file guard allowed a settings.
 assert deny "$CODEX_HOOK" "$A_LOCAL_READ"  "Codex file guard allowed a settings.local.json read"
 assert deny "$CODEX_HOOK" "$A_LOCAL_WRITE" "Codex file guard allowed a settings.local.json write"
 
-# --- assertion group B: file tools stay silent on ordinary tool config ---
 B_JEST=$(fixture b-jest "$(jq -nc '{tool_input:{file_path:"/home/sandbox/harness/jest.config.js"}}')")
 B_OH=$(fixture b-oh "$(jq -nc '{tool_input:{file_path:"/home/sandbox/harness/.oh/config.json"}}')")
 assert allow "$FILE_HOOK" "$B_JEST" "file guard falsely denied jest.config.js (segment anchor lost)"
 assert allow "$FILE_HOOK" "$B_OH"   "file guard falsely denied .oh/config.json (segment anchor lost)"
 
-# --- assertion group C: Bash guard closes non-shell verbs, not just readers ---
 C_CAT=$(fixture c-cat "$(jq -nc --arg c "cat ~/$SEG/gh/hosts.yml" '{tool_input:{command:$c}}')")
 C_MKDIR=$(fixture c-mkdir "$(jq -nc --arg c "mkdir -p $SEG/foo" '{tool_input:{command:$c}}')")
 C_TAR=$(fixture c-tar "$(jq -nc --arg c "tar czf out.tgz /home/sandbox/$SEG" '{tool_input:{command:$c}}')")
@@ -100,7 +91,6 @@ C_LOCAL_WRITE=$(fixture c-local-write "$(jq -nc '{tool_input:{command:"python3 -
 assert deny "$CMD_HOOK" "$C_LOCAL_READ"  "command guard allowed a settings.local.json read"
 assert deny "$CMD_HOOK" "$C_LOCAL_WRITE" "command guard allowed a settings.local.json write"
 
-# --- assertion group D: Bash guard tolerates ordinary tool config ---
 D_JEST=$(fixture d-jest "$(jq -nc '{tool_input:{command:"npx jest --config jest.config.js"}}')")
 D_GIT=$(fixture d-git "$(jq -nc '{tool_input:{command:"git config --get user.name"}}')")
 D_OH=$(fixture d-oh "$(jq -nc '{tool_input:{command:"cat .oh/config.json"}}')")
@@ -108,14 +98,12 @@ assert allow "$CMD_HOOK" "$D_JEST" "command guard falsely denied a --config flag
 assert allow "$CMD_HOOK" "$D_GIT"  "command guard falsely denied git config"
 assert allow "$CMD_HOOK" "$D_OH"   "command guard falsely denied .oh/config.json"
 
-# --- assertion group E: pre-existing secret family unchanged by the new tier ---
 E_ENV=$(fixture e-env "$(jq -nc '{tool_input:{file_path:"/home/sandbox/harness/.env"}}')")
 E_TMPL=$(fixture e-tmpl "$(jq -nc '{tool_input:{file_path:"/home/sandbox/harness/.env.example"}}')")
 assert deny  "$FILE_HOOK" "$E_ENV"  "file guard stopped denying env files"
 assert allow "$FILE_HOOK" "$E_TMPL" "file guard lost the env-template exemption"
 assert allow "$CODEX_HOOK" "$E_ENV"  "Codex local-settings hook broadened beyond settings.local.json"
 
-# --- assertion F: wiring — the file guard must actually run for Grep/Glob ---
 matcher=$(jq -r '.hooks.PreToolUse[]? | select(.hooks[]?.command // "" | contains("deny-secret-paths")) | .matcher' "$SETTINGS")
 if [[ -z "$matcher" ]]; then
   echo "REGRESSION: deny-secret-paths.sh is no longer wired in $SETTINGS" >&2
@@ -128,7 +116,6 @@ for tool in Read Write Edit Grep Glob; do
   fi
 done
 
-# --- assertion G: wiring — deny-list mirrors protected paths for read and write ---
 for rule in "Read(file_path=**/$SEG/**)" "Write(file_path=**/$SEG/**)" "Edit(file_path=**/$SEG/**)" \
   "Read(file_path=**/settings.local.json)" "Write(file_path=**/settings.local.json)" "Edit(file_path=**/settings.local.json)"; do
   if ! jq -e --arg r "$rule" '.permissions.deny | index($r)' "$SETTINGS" >/dev/null; then

--- a/.oh/evals/probes/pnpm-audit-ci-gate.sh
+++ b/.oh/evals/probes/pnpm-audit-ci-gate.sh
@@ -16,10 +16,6 @@ for file in "$PACKAGE_JSON" "$CI_WORKFLOW" "$RELEASE_WORKFLOW"; do
   fi
 done
 
-# --ignore-registry-errors: npm retired the audit endpoint pnpm calls (HTTP 410),
-# which made this exit non-zero and abort every fresh `pnpm install` (and CI/release).
-# The flag exits 0 on registry-side errors while STILL failing on real advisories, so
-# the audit keeps running (issue #171) without a retired endpoint bricking installs.
 EXPECTED_AUDIT="pnpm audit --audit-level low --ignore-registry-errors"
 script_value="$(node -e 'const p=require(process.argv[1]); process.stdout.write(p.scripts?.["security:audit"] || "")' "$PACKAGE_JSON")"
 if [[ "$script_value" != "$EXPECTED_AUDIT" ]]; then
@@ -60,9 +56,6 @@ for (const file of process.argv.slice(2)) {
 process.exit(failed ? 1 : 0);
 NODE
 
-# Match any major: the guard is that pnpm is installed via the action at all,
-# not which version it is pinned to. Pinning the major here made routine
-# runtime bumps (Node 20 -> Node 24, #670) look like a regression.
 if ! grep -qE 'pnpm/action-setup@v[0-9]+' "$CI_WORKFLOW"; then
   echo "REGRESSION: ci-harness workflow no longer installs pnpm via pnpm/action-setup" >&2
   exit 1

--- a/.oh/evals/probes/project-root-seam.sh
+++ b/.oh/evals/probes/project-root-seam.sh
@@ -5,7 +5,6 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
-# The harness's devcontainer build assets live at the conventional root .devcontainer/.
 COMPOSE="$ROOT/.devcontainer/docker-compose.yml"
 DOCKERFILE="$ROOT/.devcontainer/Dockerfile"
 ENTRYPOINT="$ROOT/.devcontainer/entrypoint.sh"
@@ -16,23 +15,19 @@ ENTRYPOINT="$ROOT/.devcontainer/entrypoint.sh"
 
 missing=()
 
-# --- docker-compose.yml: OH_PROJECT_ROOT as build arg AND as env ---
 grep -qE 'OH_PROJECT_ROOT:' "$COMPOSE" \
   || missing+=("compose: OH_PROJECT_ROOT build arg missing")
 grep -qE 'OH_PROJECT_ROOT=' "$COMPOSE" \
   || missing+=("compose: OH_PROJECT_ROOT env var missing")
 
-# --- Dockerfile: ARG + ENV so it persists to entrypoint and interactive shells ---
 grep -qF 'ARG OH_PROJECT_ROOT=' "$DOCKERFILE" \
   || missing+=("Dockerfile: ARG OH_PROJECT_ROOT= missing")
 grep -qF 'ENV OH_PROJECT_ROOT' "$DOCKERFILE" \
   || missing+=("Dockerfile: ENV OH_PROJECT_ROOT missing")
 
-# --- entrypoint.sh: seam definition ---
 grep -qF "OH_PROJECT_ROOT=\"\${OH_PROJECT_ROOT:-/home/sandbox/harness}\"" "$ENTRYPOINT" \
   || missing+=("entrypoint: OH_PROJECT_ROOT seam definition missing")
 
-# --- entrypoint.sh: HARNESS alias chains through the seam, not a bare literal ---
 grep -qF "HARNESS=\"\${HARNESS:-\$OH_PROJECT_ROOT}\"" "$ENTRYPOINT" \
   || missing+=("entrypoint: HARNESS alias must be \${HARNESS:-\$OH_PROJECT_ROOT}")
 
@@ -41,12 +36,6 @@ if (( ${#missing[@]} )); then
   exit 1
 fi
 
-# Negative guard: no unconditional bare HARNESS=/home/sandbox/harness assignment.
-# Excludes:
-#   - comment lines    (grep -vE '^[[:space:]]*#')
-#   - conditional-default forms containing :-  (grep -vE ':-')
-# The two Dockerfile single-quoted JSON exceptions do not assign HARNESS at all,
-# so they cannot trigger this guard.
 bare_harness=$(grep -vE '^[[:space:]]*#' "$ENTRYPOINT" \
   | grep -E "HARNESS=['\"]?/home/sandbox/harness" \
   | grep -vE ':-' || true)

--- a/.oh/evals/probes/prompt-miner-schema-compat.sh
+++ b/.oh/evals/probes/prompt-miner-schema-compat.sh
@@ -15,7 +15,6 @@ SKILL_DIR="$ROOT/.oh/skills/prompt-miner"
 ENGINE="$SKILL_DIR/scripts/mine-traces.mjs"
 FIXTURES="$SKILL_DIR/scripts/__tests__/fixtures"
 
-# --- SKIPPED: hard prerequisites genuinely absent --------------------------
 if [[ ! -d "$SKILL_DIR" ]]; then
   echo "SKIPPED: prompt-miner skill dir absent: $SKILL_DIR" >&2
   exit 2
@@ -33,7 +32,6 @@ if ! command -v node >/dev/null 2>&1; then
   exit 2
 fi
 
-# --- Run the engine hermetically (no git, no network, fixtures only) -------
 set +e
 out="$(node "$ENGINE" --dry-run --no-git --fixtures-dir "$FIXTURES" 2>/dev/null)"
 rc=$?
@@ -44,8 +42,6 @@ if [[ "$rc" -ne 0 || -z "$out" ]]; then
   exit 1
 fi
 
-# --- Assert: non-zero sessions AND non-zero tool-errors --------------------
-# Parse the dry-run JSON with node (the dataset is printed to stdout).
 read -r sessions tool_errors < <(
   printf '%s' "$out" | node -e '
     let d = "";

--- a/.oh/evals/probes/prompt-miner-symlink-entrypoint.sh
+++ b/.oh/evals/probes/prompt-miner-symlink-entrypoint.sh
@@ -19,7 +19,6 @@ SKILL_DIR="$ROOT/.oh/skills/prompt-miner"
 ENGINE_REL="prompt-miner/scripts/mine-traces.mjs"
 FIXTURES="$SKILL_DIR/scripts/__tests__/fixtures"
 
-# --- SKIPPED: hard prerequisites genuinely absent --------------------------
 if [[ ! -d "$ROOT/.oh/skills" ]]; then
   echo "SKIPPED: skills dir absent: $ROOT/.oh/skills" >&2
   exit 2
@@ -41,16 +40,11 @@ TMP="$(mktemp -d)"
 cleanup() { rm -rf "$TMP"; }
 trap cleanup EXIT
 
-# Reproduce the provider layout: a *directory* symlink standing in for
-# `.claude/skills -> ../.oh/skills`. Built here rather than reusing the real
-# .claude/skills so the probe still guards the behavior in a checkout where the
-# provider symlinks have not been materialized.
 if ! ln -s "$ROOT/.oh/skills" "$TMP/skills" 2>/dev/null; then
   echo "SKIPPED: filesystem does not support symlinks (cannot reproduce provider layout)" >&2
   exit 2
 fi
 
-# --- Guard 1 (behavioral): the symlinked invocation must actually run ------
 set +e
 out="$(node "$TMP/skills/$ENGINE_REL" --dry-run --no-git --fixtures-dir "$FIXTURES" 2>/dev/null)"
 rc=$?
@@ -90,15 +84,6 @@ if ! [[ "$scanned" =~ ^[0-9]+$ ]] || (( scanned == 0 )); then
   exit 1
 fi
 
-# --- Guard 2 (static): the anti-pattern must not return anywhere -----------
-# Two independent patterns, because one is evadable:
-#   (a) an `import.meta.url` identity comparison in EITHER operand order —
-#       `pathToFileURL(argv[1]).href === import.meta.url` is the same bug and a
-#       left-hand-only regex misses it entirely;
-#   (b) `pathToFileURL(` applied to `process.argv` on one line — the mechanism
-#       itself, which catches operand orders and line-splits (a) cannot see.
-# Executable lines only: all three skill engines carry the comparison inside a
-# WARNING comment naming this bug, and those must not trip the check.
 offenders="$(
   git -C "$ROOT" grep -nE \
     'import\.meta\.url[[:space:]]*===|===[[:space:]]*import\.meta\.url|pathToFileURL\([^)]*process\.argv' \

--- a/.oh/evals/probes/prompt-miner-weakness-record.sh
+++ b/.oh/evals/probes/prompt-miner-weakness-record.sh
@@ -16,7 +16,6 @@ SKILL_DIR="$ROOT/.oh/skills/prompt-miner"
 ENGINE="$SKILL_DIR/scripts/mine-traces.mjs"
 FIXTURES="$SKILL_DIR/scripts/__tests__/fixtures"
 
-# --- SKIPPED: hard prerequisites genuinely absent --------------------------
 if [[ ! -d "$SKILL_DIR" ]]; then
   echo "SKIPPED: prompt-miner skill dir absent: $SKILL_DIR" >&2
   exit 2
@@ -34,7 +33,6 @@ if ! command -v node >/dev/null 2>&1; then
   exit 2
 fi
 
-# --- Run the engine hermetically (no git, no network, fixtures only) -------
 set +e
 out="$(node "$ENGINE" --dry-run --no-git --fixtures-dir "$FIXTURES" 2>/dev/null)"
 rc=$?
@@ -45,8 +43,6 @@ if [[ "$rc" -ne 0 || -z "$out" ]]; then
   exit 1
 fi
 
-# --- Assert: >= 1 WH record with all 7 non-empty fields, no promptText ------
-# Parse the dry-run JSON with node (the dataset is printed to stdout).
 verdict="$(
   printf '%s' "$out" | node -e '
     let d = "";

--- a/.oh/evals/probes/protected-path-deletion.sh
+++ b/.oh/evals/probes/protected-path-deletion.sh
@@ -16,8 +16,6 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 cd "$ROOT" || { echo "SKIPPED: cannot enter repo root" >&2; exit 2; }
 git rev-parse --git-dir >/dev/null 2>&1 || { echo "SKIPPED: not a git repository" >&2; exit 2; }
 
-# Resolve the base branch through the first ref that exists; a checkout with none
-# (a shallow CI clone, a detached export) cannot compute a deletion set at all.
 BASE_REF=""
 for ref in development upstream/development origin/development; do
   if git rev-parse --verify --quiet "$ref" >/dev/null 2>&1; then BASE_REF="$ref"; break; fi
@@ -31,12 +29,8 @@ LIST=".claude/protected-paths.txt"
 git cat-file -e "$BASE:$LIST" 2>/dev/null \
   || { echo "SKIPPED: $LIST absent at the merge base" >&2; exit 2; }
 
-# Deletions introduced by this branch. On development itself this is empty and the
-# probe is a no-op pass rather than a skip -- an empty deletion set IS the passing state.
 mapfile -t deleted < <(git diff --diff-filter=D --name-only "$BASE"..HEAD 2>/dev/null)
 
-# The protected list as of the merge base. Strip comments (including the inline kind
-# the file's own format note forbids but one entry carries) and blanks.
 mapfile -t entries < <(
   git show "$BASE:$LIST" 2>/dev/null \
     | sed 's/[[:space:]]*#.*$//' \
@@ -45,13 +39,9 @@ mapfile -t entries < <(
 )
 ((${#entries[@]})) || { echo "SKIPPED: $LIST at the merge base has no entries" >&2; exit 2; }
 
-# Every tracked evidence.md outside the archive is a place a justification may live.
 mapfile -t evidence_files < <(git ls-files '.oh/tasks/*/evidence.md' | grep -v '^\.oh/tasks/archive/')
 
-# Read the COMMITTED content, never the working tree. An uncommitted justification is
-# present on disk and absent from the PR diff -- from the reviewer's seat, identical to
-# never having written it, which is the same trap the evidence.md gate exists for.
-justified() {  # $1 = string that must appear verbatim in some committed evidence doc
+justified() {
   local needle="$1" doc
   for doc in "${evidence_files[@]}"; do
     git show "HEAD:$doc" 2>/dev/null | grep -qF -- "$needle" && return 0
@@ -62,8 +52,8 @@ justified() {  # $1 = string that must appear verbatim in some committed evidenc
 hits=() unjustified=()
 for entry in "${entries[@]}"; do
   case "$entry" in
-    */*) target="$entry" ;;          # repo-relative path
-    *)   target=".oh/skills/$entry/" ;;  # bare skill name -> its directory
+    */*) target="$entry" ;;
+    *)   target=".oh/skills/$entry/" ;;
   esac
 
   hit=""
@@ -77,7 +67,6 @@ for entry in "${entries[@]}"; do
   [ -n "$hit" ] || continue
 
   hits+=("$entry -> $hit")
-  # The entry OR the concrete deleted path satisfies it; both name the same removal.
   if ! justified "$entry" && ! justified "$hit"; then
     unjustified+=("$entry (deleted: $hit)")
   fi

--- a/.oh/evals/probes/protected-paths-resolve.sh
+++ b/.oh/evals/probes/protected-paths-resolve.sh
@@ -21,13 +21,10 @@ LIST=".claude/protected-paths.txt"
 broken=()
 count=0
 
-# Entry format, per the file's own header: bare names are skills; everything else
-# is a repo-relative path. `Makefile` is the one slash-free non-skill entry, so a
-# slash-free entry resolves as either a skill directory or a repo-root path.
 while IFS= read -r raw || [ -n "$raw" ]; do
-  line="${raw%%#*}"                              # strip trailing comment
-  line="${line#"${line%%[![:space:]]*}"}"        # ltrim
-  line="${line%"${line##*[![:space:]]}"}"        # rtrim
+  line="${raw%%#*}"
+  line="${line#"${line%%[![:space:]]*}"}"
+  line="${line%"${line##*[![:space:]]}"}"
   [ -n "$line" ] || continue
   count=$((count + 1))
   case "$line" in

--- a/.oh/evals/probes/registry-portability-gate.sh
+++ b/.oh/evals/probes/registry-portability-gate.sh
@@ -4,12 +4,6 @@
 # desc: the registry portability gate stays armed — linter present and fail-closed, exception list parseable, invocation site still cites it
 set -euo pipefail
 
-# Companion to registry-portability.sh. That probe scans the published registry
-# and therefore SKIPS whenever no checkout is supplied, which is every run in
-# CI. This probe carries the half of the contract that lives in THIS repository,
-# so it is always armed and can never skip: it asserts the gate is still wired
-# and still fails closed. A gate nobody calls, or one that exits 0 on a scan it
-# could not perform, is disarmed without anything going red.
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 LINTER="$ROOT/.oh/scripts/registry-portability.sh"
@@ -21,21 +15,14 @@ fail() {
   exit 1
 }
 
-# 1. The linter exists and is runnable.
 [[ -f "$LINTER" ]] || fail "the portability linter is absent: .oh/scripts/registry-portability.sh"
 bash -n "$LINTER" 2>/dev/null || fail "the portability linter is not valid bash: .oh/scripts/registry-portability.sh"
 
-# 2. The exception list is present and parseable. The linter fails closed when
-#    this file is unreadable, so a malformed contract would turn every run into
-#    exit 2 — a permanent SKIPPED that reads like "nothing to report".
 [[ -f "$CONTRACT" ]] || fail "the exception list is absent: .oh/scripts/registry-portability.md"
 
 blocks=$(grep -c '^```allow$' "$CONTRACT" || true)
 (( blocks == 1 )) || fail "expected exactly one fenced block tagged allow in registry-portability.md, found $blocks"
 
-# Every entry inside the block must carry five fields, a known class, and a
-# 12-hex line hash. A malformed entry is skipped with a warning by the linter,
-# which silently drops a suppression or a triage record.
 malformed=$(
   awk '
     /^```allow$/ { inblock = 1; next }
@@ -61,15 +48,9 @@ if [[ -n "$malformed" ]]; then
   exit 1
 fi
 
-# 3. The gate still has a caller. The check was landed with no invocation site
-#    at all; the publishing step in the builder reference is the one place that
-#    tells an author to run it before opening a registry pull request.
 grep -q 'registry-portability\.sh' "$CALLER" \
   || fail "the builder publishing step no longer cites registry-portability.sh — the gate has no caller"
 
-# 4. The linter fails closed. A scan that could not run must never report a pass.
-#    Verified by rejection against a path that does not exist, not by trusting
-#    the good case.
 absent="$ROOT/.oh/scripts/.registry-portability-probe-absent-$$"
 set +e
 bash "$LINTER" --registry "$absent" >/dev/null 2>&1

--- a/.oh/evals/probes/registry-portability.sh
+++ b/.oh/evals/probes/registry-portability.sh
@@ -7,10 +7,6 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 LINTER="$ROOT/.oh/scripts/registry-portability.sh"
 
-# OPT-IN probe. The harness CI has no registry checkout, so the default run must
-# SKIP (exit 2) rather than fail. Point OH_REGISTRY_CHECKOUT at a local clone of
-# the published registry to arm it:
-#   OH_REGISTRY_CHECKOUT=/path/to/skills bash .oh/evals/probes/registry-portability.sh
 REGISTRY="${OH_REGISTRY_CHECKOUT:-}"
 
 if [[ -z "$REGISTRY" ]]; then
@@ -23,8 +19,6 @@ if [[ ! -d "$REGISTRY" ]]; then
   exit 2
 fi
 
-# A registry checkout is identified by its top-level skills/ tree. Anything else
-# is a mis-pointed variable, not a finding.
 if [[ ! -d "$REGISTRY/skills" ]]; then
   echo "SKIPPED: OH_REGISTRY_CHECKOUT is not a registry checkout (no skills/ subdirectory): $REGISTRY" >&2
   exit 2
@@ -35,8 +29,6 @@ if [[ ! -f "$LINTER" || ! -x "$LINTER" ]]; then
   exit 2
 fi
 
-# --strict-exceptions is deliberately NOT passed. A stale exception entry means
-# the registry improved; that is not a regression of this probe's contract.
 set +e
 out="$(bash "$LINTER" --registry "$REGISTRY" 2>&1)"
 rc=$?
@@ -53,8 +45,6 @@ case "$rc" in
     exit 1
     ;;
   2)
-    # Fail-closed linter error (missing registry, no skills dir, zero skill
-    # folders, zero scanned files, missing allow file). Never a pass.
     echo "SKIPPED: the portability linter could not run (exit 2) against $REGISTRY" >&2
     printf '%s\n' "$out" >&2
     exit 2

--- a/.oh/evals/probes/repo-map-contract.sh
+++ b/.oh/evals/probes/repo-map-contract.sh
@@ -61,7 +61,6 @@ if [[ -f "$REPO_MAP" ]]; then
   done
 
   if grep -Eiq '(^|[^[:alnum:]_/-])tree([[:space:]]|$)' "$REPO_MAP"; then
-    # The only allowed reference is the prose warning against raw filesystem tree.
     allowed=$(grep -Fi 'do not paste a raw filesystem tree into context' "$REPO_MAP" | wc -l | tr -d ' ')
     total=$(grep -Eio '(^|[^[:alnum:]_/-])tree([[:space:]]|$)' "$REPO_MAP" | wc -l | tr -d ' ')
     if [[ "$total" != "$allowed" ]]; then
@@ -113,7 +112,6 @@ if [[ -f "$REPO_MAP" ]]; then
     }
     root_out=$(run_helper ".") || fails+=("ancestor helper failed for repo root")
     grep -Fxq 'AGENTS.md' <<<"${root_out:-}" || fails+=("ancestor helper for . did not return AGENTS.md")
-    # Root carries AGENTS.md plus a CLAUDE.md symlink to it; only one may surface.
     if grep -Fxq 'CLAUDE.md' <<<"${root_out:-}"; then
       fails+=("ancestor helper did not de-dupe the root CLAUDE.md symlink")
     fi

--- a/.oh/evals/probes/retro-deterministic-contract.sh
+++ b/.oh/evals/probes/retro-deterministic-contract.sh
@@ -46,12 +46,6 @@ if (( ${#missing[@]} > 0 )); then
   exit 1
 fi
 
-# --- the report-only contract -------------------------------------------------
-# /retro writes NO file except an approved .oh/context/IDENTITY.md line. The
-# `.oh/memory` tier it used to write — a durable ledger plus a dated run log —
-# was deleted outright, so a reintroduced write target is the defect this guards.
-# Each assertion carries a unique `ro-<id>` tag so a failure is attributable by
-# message alone.
 if grep -nF -- '.oh/memory' "$PI_DIR/SKILL.md" >/dev/null 2>&1; then
   echo "REGRESSION: ro-a SKILL.md references the deleted .oh/memory tier:" >&2
   grep -nF -- '.oh/memory' "$PI_DIR/SKILL.md" >&2
@@ -63,11 +57,8 @@ for literal in 'MEMORY.md' 'MEMORY_DIR' 'locked-append.sh' 'render-log-entry.sh'
     exit 1
   fi
 done
-# ro-c: the anti-pattern that names the rule must survive verbatim. Without it a
-# future edit re-adds a ledger "to hold" a non-generalizing lesson.
 grep -Fq 'Inventing a file to save a lesson in.' "$PI_DIR/SKILL.md" \
   || { echo "REGRESSION: ro-c SKILL.md dropped the no-new-ledger anti-pattern" >&2; exit 1; }
-# ro-d: the duplicate helper must consult IDENTITY.md and nothing else.
 helper="$PI_DIR/scripts/check-identity-duplicates.sh"
 grep -Fq 'IDENTITY_FILE="$ROOT/.oh/context/IDENTITY.md"' "$helper" \
   || { echo "REGRESSION: ro-d duplicate helper lost its IDENTITY.md target" >&2; exit 1; }
@@ -76,7 +67,6 @@ if grep -Eq 'MEMORY_FILE|MEM_DIR|oh-path" memory' "$helper"; then
   exit 1
 fi
 
-# --- validator contract -------------------------------------------------------
 report=$(mktemp)
 cat > "$report" <<'REPORT'
 ## Session signals
@@ -103,8 +93,6 @@ REPORT
 "$PI_DIR/scripts/validate-retro-report.sh" "$report" >/dev/null
 rm -f "$report"
 
-# (ro-e) The validator must REJECT the retired `MEMORY` promotion value. Asserting
-# only that a good report passes would leave the enum widening undetected.
 bad=$(mktemp)
 sed 's/| supported | medium | IDENTITY |/| supported | medium | MEMORY |/' > "$bad" <<'REPORT'
 ## Session signals
@@ -131,7 +119,6 @@ if "$PI_DIR/scripts/validate-retro-report.sh" "$bad" >/dev/null 2>&1; then
 fi
 rm -f "$bad"
 
-# (ro-f) An IDENTITY candidate without its triage tag / probe id must be refused.
 bad=$(mktemp)
 cat > "$bad" <<'REPORT'
 ## Session signals

--- a/.oh/evals/probes/rl-delegation-write-worker.sh
+++ b/.oh/evals/probes/rl-delegation-write-worker.sh
@@ -13,33 +13,20 @@ if [[ ! -f "$SKILL" ]]; then
   exit 2
 fi
 
-# --- Scope the check to the warning region, NOT the whole file --------------
-# The read-only warning lives in two places (US-001 / US-002); the AC allows
-# either ("and/or"). Extract both candidate regions and check the union so an
-# unrelated `read-only`/`general-purpose` occurrence elsewhere in the file
-# cannot cause a false PASS.
-#
-#   Region 1 — the "Worker configuration:" bullet block under §5 Execute waves:
-#              from the 'Worker configuration:' line to the trailing blank line.
-#   Region 2 — the §Reference "Key Resources" block: from the '### Key Resources'
-#              heading to the next '### '/'## ' heading (or EOF).
 worker_block="$(awk '/^Worker configuration:/{f=1} f{print} f && /^[[:space:]]*$/{exit}' "$SKILL")"
 keyres_block="$(awk '/^### Key Resources/{f=1; next} f && /^(### |## )/{exit} f{print}' "$SKILL")"
 
 region="$(printf '%s\n%s\n' "$worker_block" "$keyres_block")"
 
-# --- Distinguish "region not found" from "phrase missing" -------------------
 if [[ -z "${region//[[:space:]]/}" ]]; then
   echo "REGRESSION: warning region not found in $SKILL (neither the 'Worker configuration:' block nor the '### Key Resources' section could be located)" >&2
   exit 1
 fi
 
 missing=()
-# (a) a read-only warning that explicitly names at least one of implementer/pm/critic
 grep -qi 'read-only' <<<"$region"                 || missing+=("'read-only' warning")
 grep -qiE 'implementer|critic|(^|[^a-z])pm([^a-z]|$)' <<<"$region" \
                                                    || missing+=("an agent name (implementer/pm/critic)")
-# (b) a general-purpose recommendation for write/edit workers
 grep -qi 'general-purpose' <<<"$region"           || missing+=("'general-purpose' recommendation")
 
 if (( ${#missing[@]} > 0 )); then

--- a/.oh/evals/probes/rlm-context-budget.sh
+++ b/.oh/evals/probes/rlm-context-budget.sh
@@ -10,7 +10,6 @@ QC="$ROOT/.oh/skills/rlm/scripts/query-context.mjs"
 BUDGET="$ROOT/.oh/skills/rlm/references/recursion-budget.md"
 FIXTURE="$ROOT/.oh/skills/rlm/scripts/__tests__/fixtures/big-sample.txt"
 
-# --- Assertion 1: prerequisites absent => SKIPPED (not a regression) ----------
 if ! command -v node >/dev/null 2>&1; then
   echo "SKIPPED: node not on PATH" >&2
   exit 2
@@ -19,14 +18,11 @@ if [[ ! -f "$QC" ]]; then
   echo "SKIPPED: query-context primitive absent: $QC" >&2
   exit 2
 fi
-# recursion-budget.md is authored by a sibling US-005 story; until it lands the
-# budget-ceiling half of this contract has nothing to assert against -> SKIP.
 if [[ ! -f "$BUDGET" ]]; then
   echo "SKIPPED: recursion-budget reference absent (sibling US-005): $BUDGET" >&2
   exit 2
 fi
 
-# --- Assertion 2: recursion-budget.md declares depth/children/step ceilings ----
 for term in depth children step; do
   if ! grep -qi "$term" "$BUDGET"; then
     echo "REGRESSION: recursion-budget.md missing '$term' ceiling declaration" >&2
@@ -34,22 +30,16 @@ for term in depth children step; do
   fi
 done
 
-# --- Assertion 3: query-context.mjs enforces a max-bytes guard -----------------
-# 3a. structural: the byte-cap constant exists in the source.
 if ! grep -q 'MAX_SLICE_BYTES' "$QC"; then
   echo "REGRESSION: byte-cap constant (MAX_SLICE_BYTES) absent from query-context.mjs" >&2
   exit 1
 fi
 
-# 3b. runtime needs the large fixture; absent => SKIP (no input to bound).
 if [[ ! -f "$FIXTURE" ]]; then
   echo "SKIPPED: max-bytes fixture absent: $FIXTURE" >&2
   exit 2
 fi
 
-# 3c. runtime: a whole-file slice of a large input is bounded by the cap and is
-#     flagged truncated when the input exceeds it. Parse the JSON via node (a
-#     declared prerequisite of this probe) rather than a fragile shell grep.
 set +e
 verdict="$(node "$QC" "$FIXTURE" 2>/dev/null | node -e '
   let raw = "";

--- a/.oh/evals/probes/runtime-preflight-gate.sh
+++ b/.oh/evals/probes/runtime-preflight-gate.sh
@@ -22,16 +22,7 @@ fi
 
 missing=()
 
-# --- 1. No runtime selector -------------------------------------------------
-#
-# #806 § B1 records this as an OPEN decision owned by #731, and states that
-# settling it elsewhere forks the ExecutionTarget seam. The command therefore
-# writes nothing. Comments explaining that are required; a KEY is not.
-#
-# Strip comments before matching, so the explanation can name the keys freely.
 strip_comments() {
-  # Block comments, then line comments whose `//` is not preceded by `:`
-  # (which would truncate a `https://` URL inside a string literal).
   perl -0pe 's{/\*.*?\*/}{}gs; s{(^|[^:])//[^\n]*}{$1}gm' "$1"
 }
 
@@ -45,55 +36,33 @@ for src in "$CATALOG" "$CMD"; do
   fi
 done
 
-# The .devcontainer/.env writers exist one directory away and are easy to reach for.
 for sym in setInstallFlag seedHarnessYaml; do
   if grep -qF "$sym" "$CMD"; then
     missing+=("commands/runtime.ts: imports $sym — this command persists no configuration")
   fi
 done
 
-# A build arg would bake a guaranteed-failing install into the image (#805).
 if grep -qE 'buildArg|harnessKey' "$CATALOG"; then
   missing+=("runtimes/catalog.ts: declares a build arg / INSTALL_* key — see the file header")
 fi
 
-# --- 2. Both measured blockers are declared -----------------------------------
-#
-# These are the numbers `install` refuses on. If the catalog drops one, the
-# command silently starts claiming a host is ready when #805 says it is not.
 grep -qF '"2.39"' "$CATALOG" \
   || missing+=("runtimes/catalog.ts: no glibc 2.39 floor — blocker 1 of #805")
 grep -qF '/dev/kvm' "$CATALOG" \
   || missing+=("runtimes/catalog.ts: no /dev/kvm requirement — blocker 2 of #805")
 
-# The installer command must stay the one the P0 spike recorded (#803), because
-# no msb binary has ever existed in this harness to derive another from.
 grep -qF 'get.microsandbox.dev' "$CATALOG" \
   || missing+=("runtimes/catalog.ts: installer is not the command recorded by the #803 spike")
 
-# --- 2b. The runtime in use is listed and checked, not assumed ----------------
-#
-# A table that showed only the runtimes you CANNOT use would answer "what could
-# I move to" while silently skipping "what am I on, and is it healthy". The
-# docker entry exists so `status` can say "your daemon is down".
 grep -qE 'id: *"docker"' "$CATALOG" \
   || missing+=("runtimes/catalog.ts: the active runtime (docker) is not listed")
 grep -qE 'state: *"active"' "$CATALOG" \
   || missing+=("runtimes/catalog.ts: no runtime is marked active — nothing reports what is in use")
 grep -qF '{{.Server.Version}}' "$CATALOG" \
   || missing+=("runtimes/catalog.ts: docker is listed but never probed — presence is assumed, not measured")
-# The daemon lives on the machine holding `oh`, not inside the sandbox. A check
-# scoped to the target would answer about the wrong kernel.
 grep -qE 'scope: *"host"' "$CATALOG" \
   || missing+=("runtimes/catalog.ts: no host-scoped check — the docker daemon cannot be probed from inside the container")
 
-# --- 3. The preflight is a gate, not a warning --------------------------------
-#
-# The failure mode this guards: someone converts the early return into a printed
-# warning, and `install` starts spending a network round trip to reproduce an
-# error #805 already documents.
-# Checks 3 and 4 read CODE only. The module header describes the very patterns
-# being banned, so matching raw text would flag the explanation of the rule.
 cmd_code=$(strip_comments "$CMD")
 
 if ! grep -qF 'if (!opts.force) return 1;' <<<"$cmd_code"; then
@@ -103,10 +72,6 @@ if ! grep -qF -e '--force' <<<"$cmd_code"; then
   missing+=("commands/runtime.ts: no --force override — the operator has no way past the gate")
 fi
 
-# --- 4. Container work stays behind the ExecutionTarget contract --------------
-#
-# rfc-brain-hands-boundary.md: callers branch on capabilities, never on `kind`,
-# and never spawn `docker exec` directly.
 if grep -qE '\("docker"|\bdocker exec\b' <<<"$cmd_code"; then
   missing+=("commands/runtime.ts: names docker directly — go through ExecutionTarget.exec")
 fi
@@ -114,7 +79,6 @@ if grep -qE '\.kind ===' <<<"$cmd_code"; then
   missing+=("commands/runtime.ts: branches on target.kind — use capability discovery")
 fi
 
-# --- 5. The command is reachable ---------------------------------------------
 CLI="$ROOT/.oh/cli/src/cli.ts"
 if [[ -f "$CLI" ]]; then
   grep -qF 'first === "runtime"' "$CLI" \

--- a/.oh/evals/probes/session-runner-ladder.sh
+++ b/.oh/evals/probes/session-runner-ladder.sh
@@ -11,17 +11,12 @@
 #       has no agent stop/kill verb); the sourceable library sets no file-scope shell options; and
 #       the herdr commands that would disturb a shared server stay absent while `herdr agent get`
 #       (the liveness oracle) stays present.
-#
-# The single-quoted grep patterns below are pinned LITERALS — the dollar signs are part of
-# the text being searched for, not expansions this file wants performed.
 # shellcheck disable=SC2016
 set -u
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 RUNNER="$ROOT/.oh/scripts/lib/session-runner.sh"
 
-# No SKIPPED path: this probe ships in the same commit as the library it pins, so an absent
-# library is a REGRESSION, not a not-applicable run.
 missing=()
 
 if [ ! -f "$RUNNER" ]; then
@@ -29,23 +24,14 @@ if [ ! -f "$RUNNER" ]; then
   exit 1
 fi
 
-# Extracts one top-level function body: from `<name>() {` at column 0 through the closing
-# brace at column 0. Every assertion that cares about WHERE a literal lives uses this rather
-# than grepping the whole file, so a matching line in the header block cannot satisfy it.
-fn_body() { # <name>
+fn_body() {
   awk -v pat="$1() {" 'index($0, pat) == 1 { f = 1 } f { print } f && $0 == "}" { exit }' "$RUNNER"
 }
 
-# Filters stdin down to lines that actually RUN something: full-line comments and
-# diagnostic-only lines (printf/echo/runner_log) are dropped. Every assertion about a guard
-# or an invocation pipes through this, because prose that merely NAMES a command must not be
-# able to satisfy a check that the command is called — the failure mode that lets a deleted
-# guard pass while its explanatory comment survives.
 code_only() {
   grep -vE '^[[:space:]]*#' | grep -vE '^[[:space:]]*(printf|echo|runner_log)[[:space:]]'
 }
 
-# --- (1) the five public entrypoints plus the budget helper exist -----------
 for fn in runner_detect runner_launch runner_verify_cwd runner_alive runner_teardown resolve_timeout_ms; do
   grep -qE "^$fn\(\) \{" "$RUNNER" || missing+=("session-runner.sh: function $fn is missing")
 done
@@ -56,13 +42,9 @@ watch="$(fn_body runner_watch)"
 teardown="$(fn_body runner_teardown)"
 abort="$(fn_body runner_abort)"
 
-# --- (2) ladder order: herdr -> tmux -> foreground -------------------------
 grep -qE 'herdr[^A-Za-z]+->[^A-Za-z]+tmux[^A-Za-z]+->[^A-Za-z]+foreground' "$RUNNER" \
   || missing+=("session-runner.sh: the ladder order herdr -> tmux -> foreground is not declared")
 
-# Mechanical, not documentary: inside runner_detect's AUTOMATIC ladder tail (comment lines
-# stripped, so the declaring comment cannot satisfy this), herdr must be reached before tmux
-# before foreground.
 ladder="$(printf '%s\n' "$detect" | awk '/Automatic ladder/{f=1; next} f' | grep -v '^[[:space:]]*#')"
 if [ -z "$ladder" ]; then
   missing+=("runner_detect: no automatic-ladder branch found (only explicit-request handling remains)")
@@ -77,25 +59,15 @@ else
   fi
 fi
 
-# --- (3) the health predicate is the two literal `herdr status` fields ------
-# There is no single "healthy" flag in herdr status output, so these two literals ARE the
-# whole predicate. A vague check would let binary-up/server-down select herdr.
 if [ -z "$eligible" ]; then
   missing+=("session-runner.sh: runner_herdr_eligible is missing — herdr eligibility has no gate")
 else
-  # Each literal must appear in an actual grep of the `herdr status` output, not merely in
-  # the ineligibility MESSAGE that names it — otherwise deleting the test while keeping its
-  # error string would pass.
   for field in 'status: running' 'compatible: yes'; do
     printf '%s\n' "$eligible" | grep -F "$field" | grep -q 'grep' \
       || missing+=("runner_herdr_eligible: the literal field '$field' is not TESTED (naming it in a message is not a health check)")
   done
 fi
 
-# --- (4) NESTING GUARD before any probe pane -------------------------------
-# HERDR_ENV / HERDR_PANE_ID are herdr 0.7.4's own in-pane markers, inherited by every child
-# of a pane. The permanent detection path must never itself nest a pane, so the guard has to
-# run BEFORE the probe-pane launch, not after it.
 if [ -n "$eligible" ]; then
   eligible_code="$(printf '%s\n' "$eligible" | code_only)"
   guard_at="$(printf '%s\n' "$eligible_code" | grep -n 'HERDR_ENV' | head -1 | cut -d: -f1)"
@@ -107,10 +79,6 @@ if [ -n "$eligible" ]; then
   fi
 fi
 
-# --- (5) EXECUTION-CONTEXT GATE: fingerprint compare, degrade, log ---------
-# herdr panes may be host processes driving a mounted socket while this caller runs inside
-# the sandbox. AGENTS.md requires building and testing to happen INSIDE the sandbox, so
-# same-environment execution is proven by a probe-pane fingerprint, never assumed.
 for fn in runner_local_fingerprint runner_probe_fingerprint; do
   grep -qE "^$fn\(\) \{" "$RUNNER" || missing+=("session-runner.sh: the execution-context gate helper $fn is gone")
 done
@@ -122,22 +90,14 @@ if [ -n "$eligible" ]; then
   printf '%s\n' "$eligible" | grep -Fq 'fingerprint mismatch' \
     || missing+=("runner_herdr_eligible: a fingerprint mismatch sets no named ineligibility reason")
 fi
-# The mismatch degrades DOWN the ladder and says why, in the firstmate log.
 printf '%s\n' "$detect" | grep -Fq 'degrading to tmux' \
   || missing+=("runner_detect: an ineligible herdr does not degrade to tmux with a logged reason")
 printf '%s\n' "$detect" | grep -Fq 'RUNNER_INELIGIBLE_REASON' \
   || missing+=("runner_detect: the degrade reason is not carried into the log (a silent degrade is unauditable)")
-# The probe pane is torn down on BOTH verdicts — no pane is left behind either way.
 probe_fn="$(fn_body runner_probe_fingerprint)"
 printf '%s\n' "$probe_fn" | code_only | grep -Fq 'herdr pane close' \
   || missing+=("runner_probe_fingerprint: the probe pane is not closed (the gate leaks a pane per detection)")
 
-# The probe pane must OUTLIVE its own read (#761). herdr destroys a pane as soon as its
-# command returns, and a read against a destroyed pane answers pane_not_found — so a probe
-# that prints one line and exits loses the race and the gate reports "no fingerprint" for an
-# environment that actually matches. That failure is invisible where the environment already
-# differs, which is why it survived the original build: it makes the herdr rung unreachable
-# EVERYWHERE rather than only where it should be.
 printf '%s\n' "$probe_fn" | code_only | grep -Fq 'runner_probe_pane_script' \
   || missing+=("runner_probe_fingerprint: the pane runs the bare fingerprint snippet — it exits before the read and the gate can never admit herdr (#761)")
 grep -Fq 'RUNNER_PROBE_KEEPALIVE_SUFFIX=' "$RUNNER" \
@@ -148,15 +108,11 @@ printf '%s\n' "$pane_script_fn" | code_only | grep -Fq 'RUNNER_PROBE_SCRIPT' \
 printf '%s\n' "$pane_script_fn" | code_only | grep -Fq 'RUNNER_PROBE_KEEPALIVE_SUFFIX' \
   || missing+=("runner_probe_pane_script: the keep-alive suffix is not applied to the pane snippet")
 
-# The keep-alive belongs to the PANE invocation only. RUNNER_PROBE_SCRIPT also runs in-process
-# via runner_local_fingerprint, so a sleep folded into it would stall every caller and would
-# break "the same snippet runs in the probe pane and locally".
 grep -E '^RUNNER_PROBE_SCRIPT=' "$RUNNER" | grep -Fq 'sleep' \
   && missing+=("session-runner.sh: the keep-alive leaked into RUNNER_PROBE_SCRIPT — runner_local_fingerprint would sleep on every call")
 printf '%s\n' "$(fn_body runner_local_fingerprint)" | code_only | grep -Fq 'runner_probe_pane_script' \
   && missing+=("runner_local_fingerprint: the caller-side fingerprint runs the keep-alive pane snippet instead of the bare one")
 
-# The keep-alive budget is DERIVED from the single timeout source, so the two cannot drift.
 keepalive_fn="$(fn_body runner_probe_keepalive_s)"
 if [ -z "$keepalive_fn" ]; then
   missing+=("session-runner.sh: runner_probe_keepalive_s is missing — the keep-alive budget has no source")
@@ -165,7 +121,6 @@ else
     || missing+=("runner_probe_keepalive_s: the keep-alive is not derived from RUNNER_PROBE_TIMEOUT_MS — the pane can die inside the read window")
 fi
 
-# --- (6) session budget: one source, the 14400000 default, bounded polling --
 grep -Fq 'RUNNER_DEFAULT_TIMEOUT_MS=14400000' "$RUNNER" \
   || missing+=("session-runner.sh: the 14400000 (4h) session-budget default literal is gone")
 if [ -z "$watch" ]; then
@@ -181,8 +136,6 @@ else
     || missing+=("runner_watch: the herdr wait output timeout is not the resolved budget")
 fi
 
-# --- (7) every exit path: teardown, lock removal, FIRSTMATE-INCOMPLETE ------
-# A stale lock permanently wedges that slug, so no ending may leave one behind.
 if [ -z "$abort" ]; then
   missing+=("session-runner.sh: runner_abort is missing — there is no single exit path")
 else
@@ -195,23 +148,17 @@ else
   printf '%s\n' "$abort" | grep -Fq 'FIRSTMATE-INCOMPLETE' \
     || missing+=("runner_abort: does not append FIRSTMATE-INCOMPLETE to progress.txt")
 fi
-# Budget expiry and death-without-sentinel both route through that one path.
 if [ -n "$watch" ]; then
   abort_calls="$(printf '%s\n' "$watch" | grep -c 'runner_abort')"
   [ "$abort_calls" -ge 2 ] \
     || missing+=("runner_watch: only $abort_calls of the two non-sentinel endings (expiry, death) route through runner_abort")
 fi
-# Operator abort (Ctrl-C / SIGTERM) uses the same path.
 trap_fn="$(fn_body runner_install_abort_trap)"
 printf '%s\n' "$trap_fn" | grep -Fq 'runner_abort' \
   || missing+=("runner_install_abort_trap: an operator abort does not route through runner_abort")
 printf '%s\n' "$trap_fn" | grep -Fq 'INT TERM' \
   || missing+=("runner_install_abort_trap: INT/TERM are not trapped")
 
-# --- (8) --no-focus on EVERY herdr launch ----------------------------------
-# Only real invocations count. Comment lines are excluded so the documenting header cannot
-# satisfy this, and printf/echo/runner_log lines are excluded because they merely NAME the
-# command in a diagnostic (e.g. "herdr agent start returned no pane id") rather than run it.
 start_lines="$(grep -n 'herdr agent start' "$RUNNER" \
   | grep -vE '^[0-9]+:[[:space:]]*#' \
   | grep -vE '^[0-9]+:[[:space:]]*(printf|echo|runner_log)[[:space:]]')" || start_lines=""
@@ -219,24 +166,16 @@ if [ -z "$start_lines" ]; then
   missing+=("session-runner.sh: no herdr agent start invocation — the herdr rung of the ladder is gone")
 else
   for ln in $(printf '%s\n' "$start_lines" | cut -d: -f1); do
-    # The invocation may wrap; look at the line plus its two continuations.
     sed -n "${ln},$((ln + 2))p" "$RUNNER" | grep -Fq -- '--no-focus' \
       || missing+=("session-runner.sh:$ln — a herdr agent start invocation is missing --no-focus (it would steal the operator's focus)")
   done
 fi
 
-# --- (9) teardown verb: pane close, and no nonexistent stop/kill verb -------
-# herdr 0.7.4 has NO agent stop / agent kill verb (agent --help lists only
-# list/get/read/send/rename/focus/wait/start/attach/explain), and a nonexistent verb inside
-# a teardown trap fails silently — the session would survive the teardown.
 printf '%s\n' "$teardown" | code_only | grep -Fq 'herdr pane close' \
   || missing+=("runner_teardown: the herdr branch does not INVOKE the live-verified 'herdr pane close' teardown verb (a log line naming it is not a teardown)")
 printf '%s\n' "$teardown" | code_only | grep -Fq 'tmux kill-session' \
   || missing+=("runner_teardown: the tmux branch does not kill the agent- session")
 
-# --- (10) commands that must not appear in the library ---------------------
-# These would disturb a SHARED herdr server or its operator config. `herdr agent get` is
-# deliberately NOT on this list — it is the liveness oracle and is required (assertion 11).
 FORBIDDEN=(
   'herdr server stop'
   'herdr update'
@@ -250,16 +189,12 @@ for cmd in "${FORBIDDEN[@]}"; do
     && missing+=("session-runner.sh contains a forbidden command or path: '$cmd'")
 done
 
-# --- (11) the liveness oracle is present -----------------------------------
 alive="$(fn_body runner_alive | code_only)"
 printf '%s\n' "$alive" | grep -Fq 'herdr agent get' \
   || missing+=("runner_alive: herdr-mode liveness no longer uses 'herdr agent get' (its exit code is the oracle)")
 printf '%s\n' "$alive" | grep -Fq 'tmux has-session' \
   || missing+=("runner_alive: tmux-mode liveness no longer uses 'tmux has-session'")
 
-# --- (12) sourceable library: the caller owns shell options ----------------
-# A file-scope `set` in a sourced file silently rewrites the caller's option state for the
-# rest of its execution, and no linter flags it. Strictness belongs inside the functions.
 if grep -nE '^set ' "$RUNNER" >/dev/null 2>&1; then
   missing+=("session-runner.sh sets shell options at file scope — a sourced library must not mutate the caller's options")
 fi

--- a/.oh/evals/probes/skill-paths.sh
+++ b/.oh/evals/probes/skill-paths.sh
@@ -12,13 +12,6 @@ if [[ ! -d "$SKILLS" ]]; then
   exit 2
 fi
 
-# Guard 1 — the two dead renamed-directory tokens from the wiki/cron restructure
-# (docs/wiki/ -> wiki/, workspace/heartbeats/ -> .oh/crons/). No legitimate use anywhere
-# under .claude/skills/.
-#
-# Exclusion: harness-context/SKILL.md contains the prose string "docs/wiki/changelog"
-# (an enumeration of surfaces, not a path). Exclude it by FULL PATH via a piped
-# `grep -v` — GNU `grep --exclude` matches basenames only and is not used here.
 hits=$(grep -rnE 'docs/wiki/|workspace/heartbeats/' "$SKILLS" \
          | grep -v 'harness-context/SKILL.md' || true)
 
@@ -28,12 +21,6 @@ if [[ -n "$hits" ]]; then
   exit 1
 fi
 
-# Guard 2 — the apps/->packages/ monorepo rename (issue #69). The `apps/` tree no
-# longer exists; the canonical paths are `packages/docs/` and `packages/README.md`.
-# (`src/data/roadmap.ts` retired to `docs/roadmap.md`, itself removed in 0.3.0.) These tokens have NO
-# legitimate use under .claude/skills/, so any reappearance is the exact drift PR #44
-# left behind — it corrected some apps/ refs but silently missed apps/docs. No
-# exclusion is needed: zero skills legitimately mention these tokens.
 rename_hits=$(grep -rnE 'apps/docs|apps/README|apps/\*|src/data/roadmap' "$SKILLS" || true)
 
 if [[ -n "$rename_hits" ]]; then

--- a/.oh/evals/probes/skills-dir-clean.sh
+++ b/.oh/evals/probes/skills-dir-clean.sh
@@ -20,13 +20,9 @@ fail() {
 
 [ -d "$SKILLS" ] || fail ".oh/skills is missing"
 
-# Inspect every TOP-LEVEL entry. Directories are skills; the only files allowed are
-# single-file skills, which Pi requires to carry a `description:` in frontmatter.
 while IFS= read -r -d '' entry; do
   base="$(basename "$entry")"
   if [[ "$base" == *.md ]]; then
-    # A top-level .md is a single-file skill — it MUST have a description.
-    # Read the leading YAML frontmatter (between the first pair of `---` fences).
     fm="$(awk 'NR==1 && $0!="---"{exit} NR==1{next} /^---[[:space:]]*$/{exit} {print}' "$entry")"
     if ! grep -qE '^description:[[:space:]]*\S' <<<"$fm"; then
       fail "top-level skills file $base has no \`description:\` frontmatter — Pi loads it as a malformed single-file skill (\"description is required\"). Move non-skill docs out of .oh/skills/."

--- a/.oh/evals/probes/skills-vendored.sh
+++ b/.oh/evals/probes/skills-vendored.sh
@@ -14,16 +14,13 @@ fail() {
   exit 1
 }
 
-# 1. The submodule must be GONE — no .gitmodules, no .mifune gitlink, no .mifune path.
 [ ! -e .gitmodules ] || fail ".gitmodules still exists — the .mifune submodule was not removed"
 [ -z "$(git ls-files .mifune)" ] || fail ".mifune is still tracked in the index"
 [ ! -e .mifune ] || fail ".mifune path still exists in the working tree"
 
-# 2. The provider-link helper exists and replaces ensure-mifune.sh.
 [ -x .oh/scripts/link-providers.sh ] || fail ".oh/scripts/link-providers.sh is missing or not executable"
 [ ! -e .oh/scripts/ensure-mifune.sh ] || fail ".oh/scripts/ensure-mifune.sh should be removed (renamed to link-providers.sh)"
 
-# 3. The skill pack is vendored + tracked directly in this repo.
 for path in \
   .oh/skills/git/SKILL.md \
   .oh/skills/t3/references/sandbox-processes.md \
@@ -32,33 +29,25 @@ for path in \
   git ls-files --error-unmatch "$path" >/dev/null 2>&1 || fail "pack file not tracked in-repo: $path"
 done
 
-# 4. Provider symlinks resolve into the vendored .oh/ pack.
 for link in .pi/skills .claude/skills .codex/skills .claude/agents .claude/hooks .codex/agents .prime/agent/skills; do
   [ -L "$link" ] || fail "$link is not a symlink"
   [ -e "$link" ] || fail "$link target does not resolve"
 done
 
-# 5. link-providers.sh --check passes against the live tree. The Hermes link is
-#    optional + runtime-created (gitignored), so check the base providers with
-#    INSTALL_HERMES=false to stay deterministic regardless of the ambient env.
 INSTALL_HERMES=false bash .oh/scripts/link-providers.sh --check >/dev/null
 
-# 6. Clean-clone proof: a fresh clone has the skills IMMEDIATELY (vendored, tracked) —
-#    no submodule fetch, no network. Skippable only for ad-hoc local debugging.
 if [ "${SKILLS_VENDORED_SKIP_CLEAN_CLONE:-0}" != "1" ]; then
   tmp="$(mktemp -d)"
   trap 'rm -rf "$tmp"' EXIT
   git clone --no-recurse-submodules "$ROOT" "$tmp/openharness" >/dev/null 2>&1
   cd "$tmp/openharness"
-  # Vendored — present with zero init, unlike the old submodule that needed materializing.
   [ -f .oh/skills/git/SKILL.md ] || fail "clean clone is missing the vendored .oh/skills pack"
   [ -f .pi/skills/git/SKILL.md ] || fail "Pi skill symlink does not resolve in a clean clone"
   [ -f .claude/skills/spec/SKILL.md ] || fail "Claude skill symlink does not resolve in a clean clone"
   [ -f .codex/skills/git/SKILL.md ] || fail "Codex skill symlink does not resolve in a clean clone"
   [ -f .prime/agent/skills/git/SKILL.md ] || fail "prime-agent skill symlink does not resolve in a clean clone"
   INSTALL_HERMES=false bash .oh/scripts/link-providers.sh --check >/dev/null
-  INSTALL_HERMES=false bash .oh/scripts/link-providers.sh --init >/dev/null   # idempotent
-  # Opt-in Hermes: --init creates the runtime link on demand.
+  INSTALL_HERMES=false bash .oh/scripts/link-providers.sh --init >/dev/null
   INSTALL_HERMES=true bash .oh/scripts/link-providers.sh --init >/dev/null
   [ -f .hermes/skills/openharness/git/SKILL.md ] || fail "Hermes skill symlink missing after INSTALL_HERMES init"
   cd "$ROOT"

--- a/.oh/evals/probes/slack-admin-command-surface.sh
+++ b/.oh/evals/probes/slack-admin-command-surface.sh
@@ -31,7 +31,6 @@ reject_regex() {
 [ -f "$DOC" ] || fail "missing Slack integration doc"
 [ -f "$MANIFEST" ] || fail "missing Slack manifest"
 
-# Positive contract: Pi command surface, Slack DM admin handlers, caveat, fallbacks.
 need_literal "$DOC" "Pi command surface" "Inside the Pi session, the bridge exposes **one** Pi slash command"
 need_literal "$DOC" "Pi /msg-bridge command" '`/msg-bridge status` — connection state plus trusted-user/channel counts.'
 need_literal "$DOC" "Slack admin command boundary" "manifest-backed Slack admin commands"
@@ -49,28 +48,24 @@ need_literal "$ROOT_PACKAGE_AUDIT" "root package audit artifact" "## Grounded RC
 need_literal "$ROOT_PACKAGE_AUDIT" "root package README evidence" "README.md:141 ### Admin commands (in DM with the bot)"
 need_literal "$ROOT_PACKAGE_AUDIT" "root package source evidence" "src/index.ts:275 pi.registerCommand(\"msg-bridge\", {"
 
-# Negative contract: old misleading in-session guidance must not return.
 reject_regex "$DOC" "old in-session /trusted guidance" 'inside the session.*(/trusted|/channels)'
 reject_regex "$DOC" "old attach guidance" 'run `/msg-bridge`, `/trusted`, or `/channels` inside the session'
 reject_regex "$T3_PROCESSES" "old t3 pane command guidance" '`/msg-bridge`, `/trusted`,[[:space:]]*$'
 reject_regex "$T3_PROCESSES" "old t3 /channels pane guidance" '`/channels` are typed \*\*into\*\* that pane'
 reject_regex "$DOC" "DM table mislabels /msg-bridge" '^\| `/msg-bridge status` \|'
 
-# The shipped app manifest must declare every package-owned admin command.
 need_literal "$MANIFEST" "DM event subscription" '"message.im"'
 for command in /help /trusted /revoke /channels /enable /disable /toggletools; do
   need_literal "$MANIFEST" "manifest admin command $command" "\"command\": \"$command\""
 done
 cmp -s "$MANIFEST" "$TEMPLATE_MANIFEST" || fail "root and full-template Slack manifests differ"
 
-# `/trusted` and `/channels` must live under the Slack admin command section.
 trusted_line=$(grep -nF '| `/trusted` |' "$DOC" | cut -d: -f1 | head -1 || true)
 heading_line=$(grep -nF '## 6. Admin Slack commands' "$DOC" | cut -d: -f1 | head -1 || true)
 if [ -z "$trusted_line" ] || [ -z "$heading_line" ] || [ "$trusted_line" -le "$heading_line" ]; then
   fail "/trusted must appear under Admin Slack commands"
 fi
 
-# Runtime pin must select the fork branch containing Slack slash handlers.
 need_literal "$ROOT/.oh/scripts/gateway.sh" "bridge slash-command handler pin" 'c8b96e9d0fb69611c4e67ae298d1d10d83792a26'
 need_literal "$ROOT/.oh/scripts/gateway.sh" "bridge pin reconciliation marker" '.openharness-pin'
 need_literal "$ROOT/.oh/scripts/gateway.sh" "bridge pin reconciliation check" 'installed_pin" != "$FORK_PIN'

--- a/.oh/evals/probes/spec-family-contract.sh
+++ b/.oh/evals/probes/spec-family-contract.sh
@@ -21,12 +21,9 @@ SKILLS="$ROOT/.claude/skills"
 SPEC="$SKILLS/spec"
 AGENTS="$ROOT/AGENTS.md"
 
-# The three surviving subcommands. `critique` was removed in spec-simplification US-001:
-# approving prd.md IS the commitment gate (AGENTS.md § The Workflow).
 subs=(plan execute retro)
 retired_subs=(critique)
 
-# Not applicable when the /spec dispatcher is absent (cold runner / pre-merge main).
 if [ ! -f "$SPEC/SKILL.md" ]; then
   echo "SKIPPED: /spec dispatcher absent (no .claude/skills/spec/SKILL.md)" >&2
   exit 2
@@ -34,19 +31,14 @@ fi
 
 missing=()
 
-# (0) the legacy split skills must be gone (consolidation invariant — one surface, not two).
 for s in spec-plan spec-critique spec-execute spec-retro; do
   [ -e "$SKILLS/$s" ] && missing+=("$s: legacy split skill still present (must be consolidated into /spec)")
 done
 
-# (1) all three subcommand procedures must exist under references/ (a partial family is a bug).
 for s in "${subs[@]}"; do
   [ -f "$SPEC/references/$s.md" ] || missing+=("references/$s.md absent (partial /spec family)")
 done
 
-# (1b) the retired gate must NOT come back — neither as a fourth reference-doc, a
-# standalone skill, nor a dispatched subcommand. This is the assertion US-001 added:
-# a fourth reference-doc is a regression, not a completion.
 for s in "${retired_subs[@]}"; do
   [ -e "$SPEC/references/$s.md" ] && missing+=("references/$s.md present (the $s node was retired — /spec dispatches exactly ${#subs[@]} subcommands)")
   [ -e "$SKILLS/$s" ] && missing+=("$s: retired skill directory still present (.claude/skills/$s)")
@@ -54,36 +46,25 @@ for s in "${retired_subs[@]}"; do
 done
 [ -e "$SKILLS/approve" ] && missing+=("approve: retired skill directory still present (.claude/skills/approve)")
 
-# (2) per-surface contract: folder interface + AGENTS authority + no loop ## Handoff.
 for f in "$SPEC/SKILL.md" "$SPEC/references"/plan.md \
          "$SPEC/references"/execute.md "$SPEC/references"/retro.md; do
   [ -f "$f" ] || continue
   rel="${f#"$ROOT"/}"
   grep -qF '.oh/tasks/<slug>/' "$f" || missing+=("$rel: does not name the .oh/tasks/<slug>/ folder interface")
   grep -qF 'AGENTS.md § The Workflow' "$f" || missing+=("$rel: does not cite AGENTS.md § The Workflow as authority")
-  # The /spec dispatcher is the canonical workflow. A loop-style '## Handoff' section is a
-  # vestige of the executable-loop framework (removed in #263); /spec declares its place with
-  # '## Pipeline position' instead.
   grep -qE '^## Handoff' "$f" && missing+=("$rel: carries a loop-style ## Handoff section (must use ## Pipeline position)")
 done
 
-# (3) there is NO all-in-one composer beside the dispatcher, and execute.md holds the build
-#     mechanics itself rather than deferring to one. Both halves are needed: deleting the
-#     composer while execute.md still says "reuses those by reference" would leave the only
-#     build path pointing at nothing.
 [ -e "$SKILLS/ship-spec" ] && missing+=("ship-spec: the all-in-one composer must be absorbed and deleted, not left beside /spec")
 EXEC="$SPEC/references/execute.md"
 if [ -f "$EXEC" ]; then
   grep -qF 'reuses those by reference' "$EXEC" && missing+=("execute.md still defers its build mechanics by reference instead of holding them")
   grep -qF 'single source of build literals' "$EXEC" && missing+=("execute.md still names another skill as the single source of build literals")
-  # The mechanics must actually be present, or "no deferral" is satisfied by an empty file.
   for literal in 'gh pr create' 'gh pr ready' 'gh issue' 'git push' 'firstmate.sh' '/audit pr' '/eval'; do
     grep -qF "$literal" "$EXEC" || missing+=("execute.md does not carry the build literal '$literal'")
   done
 fi
 
-# (4) AGENTS.md § The Workflow must name each /spec <sub> invocation so an operator can find it,
-#     and must NOT name a retired one.
 if [ -f "$AGENTS" ]; then
   section="$(awk '/^## The Workflow/{f=1; print; next} f && /^## /{f=0} f{print}' "$AGENTS")"
   for s in "${subs[@]}"; do

--- a/.oh/evals/probes/spec-ready-finalization.sh
+++ b/.oh/evals/probes/spec-ready-finalization.sh
@@ -29,14 +29,6 @@ for token in 'ready-for-review' 'gh pr ready' 'Finalization contract' '/eval' '/
   fi
 done
 
-# The undraft must be gated, not merely mentioned: an unconditional `gh pr ready` would
-# satisfy the token check above while destroying the guarantee.
-#
-# SCOPE MATTERS. `gh pr ready` and the word "only" both appear in the Advisor `/goal`
-# prompt earlier in the file, so an unscoped context grep stays green after the actual
-# step-9 gate is deleted. Assert against the FINALIZATION SECTION alone.
-# Anchor on the section's NAME, not its number: steps get inserted and renumbered, and a
-# number-anchored awk silently selects the wrong region (or the whole tail) when they do.
 final_section="$(awk '/^### [0-9]+\. Promotable gate/{f=1} f' "$EXEC")"
 if [[ -z "$final_section" ]]; then
   echo "REGRESSION: /spec execute has no 'Promotable gate → undraft' section" >&2
@@ -55,8 +47,6 @@ if ! grep -qF 'Never `gh pr merge`' <<<"$final_section"; then
   exit 1
 fi
 
-# US-005: the merge gate answers back to the approved plan. evidence.md is a GATE
-# CONDITION, not a step in a rendered prompt — the undraft path must refuse without it.
 if ! grep -qF 'evidence.md' <<<"$final_section"; then
   echo "REGRESSION: /spec execute's merge gate no longer requires .oh/tasks/<slug>/evidence.md" >&2
   exit 1
@@ -65,13 +55,10 @@ if ! grep -qE 'Refuse the undraft|left draft[^|]*evidence\.md is missing' <<<"$f
   echo "REGRESSION: /spec execute mentions evidence.md but no longer REFUSES the undraft without it" >&2
   exit 1
 fi
-# .oh/tasks/ is gitignored, so an untracked evidence.md is absent from the PR diff — which
-# is the same as not having it. The gate must check tracked-ness, not just existence.
 if ! grep -qF 'git ls-files --error-unmatch' <<<"$final_section"; then
   echo "REGRESSION: /spec execute's evidence gate no longer verifies evidence.md is TRACKED (gitignored path)" >&2
   exit 1
 fi
-# The two sections a reviewer cannot reconstruct from the diff.
 for section in 'diverged' 'unverified'; do
   if ! grep -qi "$section" <<<"$final_section"; then
     echo "REGRESSION: /spec execute's PR body no longer carries the '$section' section" >&2
@@ -95,8 +82,6 @@ if ! grep -qE 'ready PR|ready-for-review' <<<"$spec_line"; then
   exit 1
 fi
 
-# Runtime Pi skills are symlinked to .claude/skills in this repo. If that ever stops
-# being true, the Pi copy must still carry the same finalization contract.
 if [[ -e "$PI_EXEC" ]] && ! grep -qF 'Finalization contract' "$PI_EXEC"; then
   echo "REGRESSION: .pi /spec execute surface lacks the finalization contract" >&2
   exit 1

--- a/.oh/evals/probes/ste-checker-contract.sh
+++ b/.oh/evals/probes/ste-checker-contract.sh
@@ -24,38 +24,27 @@ bash -n "$CHECK" || fail "the /ste checker has a syntax error"
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 
-rc_of() { # rc_of <expected> <label> <args...>
+rc_of() {
   local want="$1" label="$2"; shift 2
   local got=0
   bash "$CHECK" "$@" >/dev/null 2>&1 || got=$?
   [ "$got" -eq "$want" ] || fail "$label: exit $got, expected $want"
 }
 
-# ---------------------------------------------------------------------------
-# 1. The corpus accepts. A checker its own standard cannot satisfy is unshippable.
-# ---------------------------------------------------------------------------
 for f in "$SKILL/SKILL.md" "$SKILL"/references/*.md; do
   rc_of 0 "clean scan of ${f#"$ROOT"/}" "$f"
 done
 
-# ---------------------------------------------------------------------------
-# 2. The committed fixture rejects. Exit 0 everywhere proves nothing.
-# ---------------------------------------------------------------------------
 EX="$SKILL/references/examples.md"
 rc_of 0 "--blocks after on the after-specimens" --blocks after "$EX"
 rc_of 1 "--blocks before on the before-fixture" --blocks before "$EX"
 
-# The checker exits 1 here by design, so shield the assignment from set -e.
 FOUND="$( { bash "$CHECK" --blocks before "$EX" 2>/dev/null || true; } | awk '{print $2}' | sort -u)"
 for cls in HEDGE VAGUE PASSIVE LONG COMPOUND WORD; do
   printf '%s\n' "$FOUND" | grep -qx "$cls" \
     || fail "detector $cls never fires on the committed before-fixture"
 done
 
-# ---------------------------------------------------------------------------
-# 3. The four fail-open shapes the PR audit found. Each one exited 0 before the
-#    fix while scanning little or nothing.
-# ---------------------------------------------------------------------------
 printf 'Intro.\n\n```bash\ncode\nThe runner basically utilizes things.\n' > "$TMP/unclosed.md"
 rc_of 1 "unclosed fence must not exempt the rest of the file" "$TMP/unclosed.md"
 { bash "$CHECK" "$TMP/unclosed.md" 2>/dev/null || true; } | grep -q ' FENCE ' \
@@ -73,45 +62,22 @@ rc_of 0 "a backtick line must not close a tilde fence" "$TMP/mixed.md"
 rc_of 2 "an unknown --blocks tag must not pass vacuously" --blocks nosuchtag "$EX"
 rc_of 2 "an empty --blocks tag is a usage error" --blocks '' "$EX"
 
-# ---------------------------------------------------------------------------
-# 4. Argument handling stays a usage error, never a silent pass.
-# ---------------------------------------------------------------------------
 rc_of 2 "no arguments"
 rc_of 2 "a missing file" "$TMP/does-not-exist.md"
 rc_of 2 "a directory argument" "$TMP"
 rc_of 2 "an unknown option" --nope "$EX"
 rc_of 2 "a non-numeric --max-words" --max-words abc "$EX"
 
-# ---------------------------------------------------------------------------
-# 5. Detectors fire standalone, and the known false positives stay silent.
-# ---------------------------------------------------------------------------
 printf 'The data is processed by the worker.\n' > "$TMP/passive.md"
 rc_of 1 "PASSIVE fires on a real passive clause" "$TMP/passive.md"
 
 printf 'The measured value is indeed correct.\nThe disk is speed limited.\n' > "$TMP/nonverb.md"
 rc_of 0 "PASSIVE stays silent on non-participles ending in ed" "$TMP/nonverb.md"
 
-# ---------------------------------------------------------------------------
-# 6. The checker reads. It never writes the file it scans.
-# ---------------------------------------------------------------------------
 BEFORE="$(md5sum "$EX" | cut -d' ' -f1)"
 bash "$CHECK" --blocks before "$EX" >/dev/null 2>&1 || true
 [ "$(md5sum "$EX" | cut -d' ' -f1)" = "$BEFORE" ] || fail "the checker modified the file it scanned"
 
-# ---------------------------------------------------------------------------
-# 7. A clean exit names the two defects it cannot see.
-#
-#    Measured 2026-08-13, first production use of the skill: ste-check.sh exited
-#    0 with zero findings on a document carrying BOTH defects, and the hand-run
-#    10-question check then caught them. Neither is worth a detector — a
-#    question-4 detector fires on approved `after` specimens and turns
-#    --blocks after red, and a question-7 detector cannot separate a bare
-#    pronoun from one whose antecedent sits in the previous sentence, because
-#    the checker reads one line at a time.
-#
-#    So the exit-0 line carries the residual instead. Without this, a green run
-#    reads as approval of prose the detectors never examined.
-# ---------------------------------------------------------------------------
 printf 'The operator runs the migration.\n' > "$TMP/clean-residual.md"
 clean_err="$(bash "$CHECK" "$TMP/clean-residual.md" 2>&1 >/dev/null || true)"
 case "$clean_err" in

--- a/.oh/evals/probes/submitted-by-trailers.sh
+++ b/.oh/evals/probes/submitted-by-trailers.sh
@@ -22,15 +22,11 @@ missing=()
 grep -q 'Submitted-by:' "$SPEC" || missing+=("/spec execute scaffold commit trailer")
 grep -q 'Submitted-by:' "$PROMPT" || missing+=("build session-prompt commit trailer")
 
-# The trailer must name whoever ACTUALLY submits, not a fixed name. Both surfaces state
-# this in their own words, so accept either phrasing on either file.
 grep -qi 'active submitter\|active harness\|model/agent that actually' "$SPEC" \
   || missing+=("/spec execute does not tie the trailer to the active submitter")
 grep -qi 'active submitter\|active harness\|model/agent that actually' "$PROMPT" \
   || missing+=("the session prompt does not tie the trailer to the active submitter")
 
-# The trailer is MANDATORY on the build path — a merely-suggested trailer is how
-# attribution silently stops happening.
 grep -qi 'mandatory' "$PROMPT" || missing+=("the session prompt does not mark the Submitted-by trailer mandatory")
 
 if grep -q 'Co-Authored-By: Claude Opus' "$SPEC"; then

--- a/.oh/evals/probes/sync-skill-contract.sh
+++ b/.oh/evals/probes/sync-skill-contract.sh
@@ -14,7 +14,6 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 SKILLS="$ROOT/.oh/skills"
 SYNC="$SKILLS/sync"
 
-# Not applicable when the /sync dispatcher is absent (cold runner / pre-merge main).
 if [ ! -f "$SYNC/SKILL.md" ]; then
   echo "SKIPPED: /sync dispatcher absent (no .oh/skills/sync/SKILL.md)" >&2
   exit 2
@@ -22,7 +21,6 @@ fi
 
 missing=()
 
-# (1) all four required files must exist.
 for f in \
   "$SYNC/SKILL.md" \
   "$SYNC/references/publish.md" \
@@ -32,13 +30,11 @@ do
   [ -f "$f" ] || missing+=("${f#"$ROOT"/}: required file absent")
 done
 
-# (2) all three subcommand routes must appear in SKILL.md.
 for sub in publish catchup status; do
   grep -qF "$sub" "$SYNC/SKILL.md" || \
     missing+=("SKILL.md: '$sub' subcommand route not present")
 done
 
-# (3) composition declarations must be present in SKILL.md.
 grep -qiF 'composes /audit drift' "$SYNC/SKILL.md" || \
   missing+=("SKILL.md: 'composes /audit drift' declaration absent (dispatcher must name the composition)")
 
@@ -53,10 +49,6 @@ if grep -qiE 'audit pr.*ready bucket|confirm it is in the ready bucket' "$SYNC/S
   missing+=("SKILL.md: top-level focused draft semantics incorrectly use the non-draft ready bucket")
 fi
 
-# (4) drift detection must NOT be reimplemented in SKILL.md or any reference doc.
-#     /audit drift uses 'git rev-list --left-right --count' as its canonical
-#     divergence command; its presence anywhere in the sync skill indicates
-#     reimplementation rather than composition.
 if grep -qF 'git rev-list --left-right --count' "$SYNC/SKILL.md"; then
   missing+=("SKILL.md: contains 'git rev-list --left-right --count' — drift detection reimplemented (must compose /audit drift instead)")
 fi
@@ -67,7 +59,6 @@ for ref_f in "$SYNC/references/"*.md; do
   fi
 done
 
-# (5) topology.md must document both remote names (origin and upstream).
 if [ -f "$SYNC/references/topology.md" ]; then
   grep -qF 'origin' "$SYNC/references/topology.md" || \
     missing+=("references/topology.md: 'origin' remote not documented")
@@ -79,22 +70,16 @@ if [ -f "$SYNC/references/topology.md" ]; then
     missing+=("references/topology.md: upstream repo (mifunedev) not named")
 fi
 
-# (6) catchup.md must UNCONDITIONALLY prohibit 'git merge upstream/development'.
-#     This is an independent assertion — it does NOT require the merge command
-#     itself to be present in the file (stripping the example must not let this pass).
 if [ -f "$SYNC/references/catchup.md" ]; then
   grep -qiE '(NEVER|never|must not|Do NOT|do not).*(git merge upstream|merge upstream/development)' \
     "$SYNC/references/catchup.md" || \
     missing+=("references/catchup.md: must explicitly prohibit 'git merge upstream/development' (catchup must use cherry-pick, not a full merge)")
 fi
 
-# Focused promotion gates must include the required PR number and repository.
 grep -qF '/audit pr <N> --repo mifunedev/openharness' "$SYNC/references/publish.md" || \
   missing+=("references/publish.md: focused /audit pr invocation lacks PR number/repo")
 grep -qF "/audit pr <N> --repo \"\$ORIGIN_REPO\"" "$SYNC/references/catchup.md" || \
   missing+=("references/catchup.md: focused /audit pr invocation lacks PR number/repo")
-# The draft classifier gate must precede the mutation and key on draftStatus,
-# not the non-draft ready bucket.
 for proc_f in "$SYNC/references/publish.md" "$SYNC/references/catchup.md"; do
   audit_line=$(grep -nF '/audit pr <N> --repo' "$proc_f" | head -1 | cut -d: -f1)
   ready_line=$(grep -nF 'gh pr ready <N>' "$proc_f" | head -1 | cut -d: -f1)
@@ -109,8 +94,6 @@ for proc_f in "$SYNC/references/publish.md" "$SYNC/references/catchup.md"; do
   fi
 done
 
-# (7) both publish.md and catchup.md must invoke the eval oracle (eval/run.sh).
-#     The eval gate is non-negotiable in both directions.
 for proc_f in "$SYNC/references/publish.md" "$SYNC/references/catchup.md"; do
   [ -f "$proc_f" ] || continue
   rel="${proc_f#"$ROOT"/}"

--- a/.oh/evals/probes/tool-catalog-boundary.sh
+++ b/.oh/evals/probes/tool-catalog-boundary.sh
@@ -25,19 +25,10 @@ fi
 
 missing=()
 
-# Comments describe the very patterns being banned, so code-level assertions
-# read stripped source. Line comments whose `//` follows `:` are left alone so a
-# `https://` inside a string literal is not truncated.
 strip_comments() {
   perl -0pe 's{/\*.*?\*/}{}gs; s{(^|[^:])//[^\n]*}{$1}gm' "$1"
 }
 
-# --- 1. agent-browser is installed by the ENTRYPOINT, not the image ----------
-#
-# This is the premise that justifies a separate `entrypointGuard` field instead
-# of reusing the harness catalog's `buildArg`. The harness drift test enforces
-# "buildArg names appear in the Dockerfile"; agent-browser has no Dockerfile
-# presence at all, so borrowing that field would quietly falsify the invariant.
 if ! grep -qF 'INSTALL_AGENT_BROWSER' "$ENTRY"; then
   missing+=("entrypoint.sh: no INSTALL_AGENT_BROWSER guard — the tool catalog's ground truth moved")
 fi
@@ -47,14 +38,10 @@ fi
 if ! grep -qF 'entrypointGuard' "$TOOLS"; then
   missing+=("tools/catalog.ts: no entrypointGuard field — the entrypoint install shape is unrecorded")
 fi
-# Stripped: the field's own doc comment explains why buildArg is NOT reused, and
-# that explanation must survive while the field itself stays absent.
 if grep -qE '\bbuildArg\b' <<<"$(strip_comments "$TOOLS")"; then
   missing+=("tools/catalog.ts: uses buildArg — that field carries a Dockerfile invariant this catalog cannot satisfy")
 fi
 
-# The version pin must match the entrypoint's, or the CLI installs a different
-# agent-browser than a container rebuild would.
 pin=$(grep -oE 'agent-browser@[0-9]+\.[0-9]+\.[0-9]+' "$ENTRY" | head -1 || true)
 if [[ -z $pin ]]; then
   missing+=("entrypoint.sh: no pinned agent-browser version found")
@@ -62,10 +49,6 @@ elif ! grep -qF "$pin" "$TOOLS"; then
   missing+=("tools/catalog.ts: version pin disagrees with entrypoint.sh ($pin)")
 fi
 
-# --- 2. The three catalogs stay disjoint -------------------------------------
-#
-# A tool in two tables means two commands claim it and two drift tests assert
-# different ground truths.
 if grep -qE 'harnessKey: *"agent_browser"' "$HARNESSES"; then
   missing+=("harnesses/catalog.ts: agent_browser moved into the harness catalog — it is a browser, not an agent CLI")
 fi
@@ -73,10 +56,6 @@ if grep -qE 'id: *"docker"' <<<"$(strip_comments "$TOOLS")"; then
   missing+=("tools/catalog.ts: declares id \"docker\" — that id belongs to the runtime catalog; the CLI binary is \"docker-cli\"")
 fi
 
-# --- 3. The large download stays gated ---------------------------------------
-#
-# The failure mode: someone removes the gate and a CI run silently pulls ~1 GB
-# of Chromium.
 cmd_code=$(strip_comments "$CMD")
 if ! grep -qF 'downloadSize' "$TOOLS"; then
   missing+=("tools/catalog.ts: no downloadSize — nothing arms the confirmation gate")
@@ -84,7 +63,6 @@ fi
 if ! grep -qF 'confirmDownload' <<<"$cmd_code"; then
   missing+=("commands/tool.ts: no confirmDownload gate — a ~1 GB pull can start unprompted")
 fi
-# Fail closed: the non-interactive path must return false, not fall through.
 if ! grep -qF 'process.stdin.isTTY' <<<"$cmd_code"; then
   missing+=("commands/tool.ts: the gate does not check for a TTY — it cannot fail closed")
 fi
@@ -92,7 +70,6 @@ if ! grep -qF -e '--yes' <<<"$cmd_code"; then
   missing+=("commands/tool.ts: no --yes escape hatch for non-interactive installs")
 fi
 
-# --- 4. Container work stays behind the ExecutionTarget contract -------------
 if grep -qE '\("docker"|\bdocker exec\b' <<<"$cmd_code"; then
   missing+=("commands/tool.ts: names docker directly — go through ExecutionTarget.exec")
 fi
@@ -100,7 +77,6 @@ if grep -qE '\.kind ===' <<<"$cmd_code"; then
   missing+=("commands/tool.ts: branches on target.kind — use capability discovery")
 fi
 
-# --- 5. The command is reachable ---------------------------------------------
 CLI="$ROOT/.oh/cli/src/cli.ts"
 if [[ -f "$CLI" ]]; then
   grep -qF 'first === "tool"' "$CLI" \

--- a/.oh/evals/probes/weigh-scorer-contract.sh
+++ b/.oh/evals/probes/weigh-scorer-contract.sh
@@ -8,7 +8,6 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 SCORER="${SCORER:-$ROOT/.oh/skills/weigh/scripts/score-trajectories.mjs}"
 FIXTURE="${FIXTURE:-$ROOT/.oh/skills/weigh/scripts/__tests__/fixtures/cohort-sample.json}"
 
-# 1) Prerequisites — SKIPPED only when node/scorer/fixture are ABSENT.
 if ! command -v node >/dev/null 2>&1; then
   echo "SKIPPED: node not on PATH" >&2
   exit 2
@@ -22,10 +21,6 @@ if [[ ! -f "$FIXTURE" ]]; then
   exit 2
 fi
 
-# 2) + 3) Frozen DEFAULT_WEIGHTS (exact keys + sum 100) AND the required exports,
-# asserted by importing the module (absolute file:// URL → works through the
-# .claude/skills → .oh/skills symlink). A node import/runtime error here is a
-# REAL regression, not a skip.
 if ! err="$(node -e '
   // argv[1] is a guard-neutral placeholder so the scorer module does NOT auto-run
   // main() on import (its CLI guard fires when process.argv[1] ends with
@@ -49,7 +44,6 @@ if ! err="$(node -e '
   exit 1
 fi
 
-# 4) The four selection method names appear in the .mjs source.
 for method in best-of-n vote softmax synthesis; do
   if ! grep -q "$method" "$SCORER"; then
     echo "REGRESSION: selection method name '$method' not found in scorer source" >&2
@@ -57,10 +51,6 @@ for method in best-of-n vote softmax synthesis; do
   fi
 done
 
-# 5) Run the scorer on the fixture (deterministic --now) and assert the evalRc:1
-# floor-breaker is NEVER selected. The scorer is executed (CLI), its JSON output is
-# parsed, and the floor-breaker id is derived from the fixture (no hard-coded id). A
-# scorer runtime/parse error is a REAL regression (exit 1), never a skip.
 if ! err="$(node -e '
   const { execFileSync } = require("node:child_process");
   const fs = require("node:fs");

--- a/.oh/evals/probes/wiki-readme-index.sh
+++ b/.oh/evals/probes/wiki-readme-index.sh
@@ -23,12 +23,6 @@ actual_tmp="$(mktemp)"
 rows_tmp="$(mktemp)"
 trap 'rm -f "$expected_tmp" "$actual_tmp" "$rows_tmp"' EXIT
 
-# Enumerate ONLY git-tracked entries (the whitelisted curated corpus), not a raw
-# filesystem glob: corpus/* is gitignored-by-default, so a fresh CI clone carries
-# only the whitelisted set the committed README is built from, and an operator's
-# local-only scratch entry can never make this probe red. raw/ snapshots are
-# excluded explicitly (they carry no slug: frontmatter anyway). The skill pack is
-# vendored under .oh/, so the corpus is tracked directly in the Open Harness repo.
 tracked_wiki_files() {
   git -C "$ROOT" ls-files -- '.oh/skills/wiki/corpus/*.md' ':!:.oh/skills/wiki/corpus/raw/*'
 }

--- a/.oh/evals/probes/workflow-boundaries.sh
+++ b/.oh/evals/probes/workflow-boundaries.sh
@@ -2,7 +2,6 @@
 # tier: A
 # source: conversation 2026-06-19 (workflow consolidation, issue #259)
 # desc: AGENTS.md § The Workflow names the canonical operative path (in order) and states that no automated selection node exists — guards the consolidated workflow from silent re-drift.
-# note: the critique/approve node was removed 2026-08-23 (spec-simplification US-001); the path literal below is the post-removal one and must not regain a critique stage.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
@@ -13,7 +12,6 @@ if [[ ! -f "$AGENTS" ]]; then
   exit 2
 fi
 
-# Extract the '## The Workflow' section: from its heading to the next '## ' heading.
 section=$(awk '
   /^## The Workflow/ {f=1; print; next}
   f && /^## / {f=0}
@@ -25,17 +23,11 @@ if [[ -z "$section" ]]; then
   exit 1
 fi
 
-# All required markers must be present in the section. The full operative-path literal
-# encodes phase ORDER, so a single fixed-string match guards both presence and ordering.
 missing=()
 grep -qF '<!-- workflow-canonical -->' <<<"$section" || missing+=("the <!-- workflow-canonical --> anchor")
 grep -qF 'spec-plan → spec-execute → merge → reset|clean' <<<"$section" || missing+=("the in-order operative-path string")
 if grep -qF 'spec-critique' <<<"$section"; then missing+=("no revived spec-critique node (the gate was removed in US-001)"); fi
 grep -qF 'no automated selection node' <<<"$section" || missing+=("the no-automated-selection statement")
-# /ship-spec was absorbed into /spec execute and deleted (spec-simplification US-003), so the
-# caveat that named it is replaced by its successor claim: this section is the sole workflow
-# and there is no all-in-one composer beside the dispatcher. Both halves are asserted, or a
-# revived monolith could sit beside /spec unnoticed.
 grep -qF 'sole canonical workflow' <<<"$section" || missing+=("the sole-canonical-workflow statement")
 grep -qF 'no all-in-one composer' <<<"$section" || missing+=("the no-all-in-one-composer statement")
 if grep -qF '/ship-spec' <<<"$section"; then missing+=("no revived /ship-spec composer (it was absorbed into /spec execute in US-003)"); fi

--- a/.oh/hooks/deny-env-dump.sh
+++ b/.oh/hooks/deny-env-dump.sh
@@ -1,98 +1,44 @@
 #!/usr/bin/env bash
-# PreToolUse Bash guard: two-tier check for secret exposure.
-#   Tier 1 (deny) — bulk env dumps, history dumps, token-printing CLI commands,
-#                   echo/printf of secret-named variables, auth headers with
-#                   variable interpolation.
-#   Tier 2 (ask)  — narrow reads where the value *might* be public.
-#   otherwise     — allow (hook exits silently).
-#
-# Scans the raw command string, so patterns inside `docker exec ... '...'`
-# or `bash -c '...'` subshells are still caught.
 set -euo pipefail
 
 input=$(cat)
 cmd=$(jq -r '.tool_input.command // ""' <<<"$input")
 
-# Strip HEREDOC bodies before any pattern matching. PR / issue / commit
-# bodies passed via `gh ... --body "$(cat <<'EOF' ... EOF)"` are prose, not
-# shell commands — words like "history" or phrases like "cat .env" inside
-# that prose otherwise match command-shape regexes below and produce false
-# denies. Handles `<<DELIM`, `<<'DELIM'`, `<<"DELIM"`, and `<<-DELIM`.
 if command -v perl >/dev/null 2>&1; then
   cmd=$(perl -0777 -pe 's{<<-?\s*(["\x27]?)(\w+)\1(.*?)\n\s*\2\b}{<<HEREDOC_STRIPPED}gs' <<<"$cmd")
 fi
 
-# Collapse newlines to spaces so character classes don't need to care about
-# them (and so grep's line-oriented regex doesn't split the pattern string
-# either). The literal \n written inside [^#\n] would mean "not \ or n",
-# which wrongly excludes the letter n from any text between cmd and target.
 cmd=${cmd//$'\n'/ }
 
-# Secret-ish variable-name fragments. Matched case-insensitively inside ${VAR}
-# or $VAR dereferences in echo / printf / curl / etc.
 SECRET_NAME='(TOKEN|SECRET|PASSWORD|PASSWD|APIKEY|API_KEY|ACCESS_KEY|PRIVATE_KEY|CREDENTIAL|AUTH|BEARER|SESSION|COOKIE|SLACK_[A-Z_]*|OPENAI_[A-Z_]*|ANTHROPIC_[A-Z_]*|GITHUB_TOKEN|GH_TOKEN|AWS_SECRET|AWS_SESSION|GCP_[A-Z_]*|DATABASE_URL|DB_PASSWORD)'
 
-# Tier 1 — hard deny.
-DENY='(^|[^A-Za-z0-9._/-])env[[:space:]]*[|>;&]'     # env | / env > / env ; / env & at command position
-DENY+='|(^|[^A-Za-z0-9._/-])env[[:space:]]*$'        # bare env at command position (not .env / path/env / example.env)
-DENY+='|\bset[[:space:]]*[|>]'                       # set | / set >
-DENY+='|\bexport[[:space:]]+-p\b'                    # export -p
-DENY+='|\bdeclare[[:space:]]+-[xp]\b'                # declare -x / -p
-DENY+='|\bcompgen[[:space:]]+-[vxAe]'                # compgen -v / -x / -A / -e
-DENY+='|/proc/[^/[:space:]]+/environ'                # /proc/<pid|self>/environ
-DENY+='|\bprintenv[[:space:]]*([|;>&]|$)'            # printenv with no args
-DENY+='|\bhistory\b'                                 # shell history dump
-DENY+='|\bfc[[:space:]]+-l'                          # fc -l (also lists history)
+DENY='(^|[^A-Za-z0-9._/-])env[[:space:]]*[|>;&]'
+DENY+='|(^|[^A-Za-z0-9._/-])env[[:space:]]*$'
+DENY+='|\bset[[:space:]]*[|>]'
+DENY+='|\bexport[[:space:]]+-p\b'
+DENY+='|\bdeclare[[:space:]]+-[xp]\b'
+DENY+='|\bcompgen[[:space:]]+-[vxAe]'
+DENY+='|/proc/[^/[:space:]]+/environ'
+DENY+='|\bprintenv[[:space:]]*([|;>&]|$)'
+DENY+='|\bhistory\b'
+DENY+='|\bfc[[:space:]]+-l'
 DENY+="|\\b(echo|printf)\\b[^#]*\\\$\\{?[A-Z0-9_]*${SECRET_NAME}[A-Z0-9_]*\\}?"
-DENY+="|Authorization:[[:space:]]*['\"]?(Bearer|Basic|Token)[[:space:]]+\\\$"  # auth header with var interpolation
+DENY+="|Authorization:[[:space:]]*['\"]?(Bearer|Basic|Token)[[:space:]]+\\\$"
 DENY+='|\baws[[:space:]]+configure[[:space:]]+get\b'
 DENY+='|\bgh[[:space:]]+auth[[:space:]]+token\b'
 DENY+='|\bgcloud[[:space:]]+auth[[:space:]]+print-(access|identity)-token\b'
 DENY+='|\bkubectl[[:space:]]+get[[:space:]]+secret[^|]*-o[[:space:]]*(yaml|json)'
 DENY+='|\bdocker[[:space:]]+(secret|config)[[:space:]]+inspect\b'
 
-# Tier 1c — `docker inspect` (and podman/nerdctl equivalents). A bare inspect
-# dumps the full container JSON, which carries `Config.Env` — every secret the
-# container was started with. Rather than blocking inspect outright (it is the
-# only way to read health, mounts, networks, labels, restart state), this tier
-# allows exactly the shape that cannot leak env: an explicit narrow Go template.
-#
-#   allowed   docker inspect --format '{{.State.Health.Status}}' web
-#   denied    docker inspect web                    (full JSON → Config.Env)
-#   denied    docker inspect --format '{{json .}}'  (full JSON by template)
-#   denied    docker inspect --format '{{.Config.Env}}'  (the env itself)
-#
-# `docker secret inspect` / `docker config inspect` stay in the hard-deny tier
-# above — those objects are secrets whole, so no template makes them safe.
-# The CLI name must be followed by whitespace and `inspect` must start its own
-# word, so hyphenated filenames (`docker-inspect-env-guard.sh`) and paths do not
-# match — only a real invocation with `inspect` in argument position does.
 DOCKER_INSPECT='\b(docker|podman|nerdctl)[[:space:]]+([^|;&]{0,160}[[:space:]])?inspect\b'
-# A format flag must be present…
 DOCKER_FMT='(--format[=[:space:]]|(^|[[:space:]])-f[=[:space:]])'
-# …and must not name env, nor dump the whole object (or the whole Config
-# subtree, which contains Env) via `{{.}}` / `{{json .}}` / `--format json`.
 DOCKER_FMT_UNSAFE='env'
 DOCKER_FMT_UNSAFE+='|\{\{[[:space:]]*(json[[:space:]]*)?\.(Config)?[[:space:]]*\}\}'
 DOCKER_FMT_UNSAFE+='|(--format|(^|[[:space:]])-f)[=[:space:]]+["\x27]?json["\x27]?([[:space:]]|$)'
 
-# Tier 1a — operator-only `.config/` directory (repo root and $HOME). Unlike the
-# path family below, this is denied for ANY command that names it, not just the
-# READ_CMD verbs: the operator owns the directory outright, so read, write,
-# traversal, and archive routes are all closed rather than enumerated (a verb
-# allowlist leaks through python/node/perl/tar and every tool added later).
-# Anchored to a whole path SEGMENT, so ordinary tool config is untouched —
-# `jest.config.js`, `--config foo`, `git config`, and `.oh/config.json` all have
-# no `.config` path segment and do not match. HEREDOC bodies are stripped above,
-# so prose that merely mentions the path in a commit/PR body still passes; the
-# `-F file` / `--body-file` pattern covers the inline-message case.
 OPERATOR_PATH='(^|[^A-Za-z0-9._-])\.config([^A-Za-z0-9_-]|$)'
 OPERATOR_PATH+='|(^|[^A-Za-z0-9._-])settings\.local\.json([^A-Za-z0-9._-]|$)'
 
-# Tier 1b — reading secret-laden files via shell tools. Checked separately from
-# the main DENY (below) so a basename-allowlist can exempt tracked template env
-# files (.example.env, .env.example, .env.sample, .env.template, …). Mirrors
-# the Read(**/.env*) family of deny rules so bypassPermissions can't slip past.
 SECRET_PATH="(\\.env[^[:space:]/\"']*"
 SECRET_PATH+='|[^[:space:]]*\.pem\b'
 SECRET_PATH+='|[^[:space:]]*\.p12\b'
@@ -126,14 +72,7 @@ SECRET_PATH+='|\.wget-hsts\b)'
 READ_CMD='(cat|tac|less|more|bat|head|tail|xxd|od|strings|hexdump|base64|nano|vim|vi|emacs|view|sed|awk|grep|rg|ripgrep|jq|yq|tee|cp|mv|scp|rsync|install|source|\.)'
 SECRET_PATH_DENY="\\b${READ_CMD}\\b[^#|]*${SECRET_PATH}"
 
-# Tier 2 — ask (narrow / possibly legitimate).
-ASK='\bprintenv[[:space:]]+[A-Za-z_]'                # printenv VAR [VAR ...]
-# Note: the previous catch-all `echo|printf` of any $UPPERCASE_VAR was too
-# broad — it asked on benign `echo "Branch: $BRANCH"` / `echo $SHA` /
-# `echo $VERSION` patterns used throughout skills. The deny tier above
-# already catches `echo`/`printf` of secret-named variables (TOKEN, SECRET,
-# AUTH, KEY, GH_TOKEN, AWS_*, …) with prefix/suffix tolerance, which covers
-# the actual leak surface. Trust other uppercase vars.
+ASK='\bprintenv[[:space:]]+[A-Za-z_]'
 
 emit() {
   jq -n --arg d "$1" --arg r "$2" '{
@@ -148,8 +87,6 @@ emit() {
 if grep -qEi -- "$DENY" <<<"$cmd"; then
   emit deny 'Secret-exposure guard (deny): command matches a high-risk pattern — bulk env dump (env/set/export -p/declare -x/-p/compgen/printenv/proc environ), shell history, echo/printf of a secret-named variable (TOKEN/SECRET/KEY/PASSWORD/AUTH/CREDENTIAL/BEARER/SLACK_*/OPENAI_*/ANTHROPIC_*/GH_TOKEN/AWS_SECRET), Authorization header with variable interpolation, or a token-printing CLI (gh auth token, gcloud auth print-*-token, aws configure get, kubectl get secret -o yaml/json, docker secret/config inspect). These almost always leak credentials into the transcript and prompt cache. Do NOT retry a variant that bypasses this check. Ask the user to run the command themselves and paste only the specific non-secret output you need.'
 elif grep -qEi -- "$DOCKER_INSPECT" <<<"$cmd"; then
-  # Evaluate only the text from `inspect` onward — a format flag belonging to
-  # some earlier command in the same line must not vouch for this one.
   seg=$(grep -oEi -- "${DOCKER_INSPECT}.*" <<<"$cmd" | head -1)
   if ! grep -qEi -- "$DOCKER_FMT" <<<"$seg"; then
     emit deny 'Container-inspect guard (deny): a bare `docker inspect` prints the full container JSON, including `Config.Env` — every environment variable the container was started with, secrets included. Inspect is NOT blocked outright: re-run it with an explicit narrow Go template naming only the field you need, e.g. `docker inspect --format "{{.State.Health.Status}}" <container>`, `--format "{{.NetworkSettings.IPAddress}}"`, or `--format "{{range .Mounts}}{{.Source}} {{end}}"`. Piping the full JSON through jq/grep does not qualify — the guard cannot verify the filter, so use --format. If you genuinely need an env value, ask the operator to paste that one value.'
@@ -159,9 +96,6 @@ elif grep -qEi -- "$DOCKER_INSPECT" <<<"$cmd"; then
 elif grep -qEi -- "$OPERATOR_PATH" <<<"$cmd"; then
   emit deny 'Operator-only path guard (deny): command references .config/ or settings.local.json, which hold operator-managed configuration and are off-limits to agents for both read and write. This is a deliberate policy, not a misconfiguration — do not retry a variant that spells the path differently, resolves it through a variable or symlink, or reaches it from a subshell. If you need a value from it, ask the operator to paste only that value into the chat. If you only need to mention the path in prose (commit message, PR body), pass it via a file (`git commit -F msg.txt`, `gh pr create --body-file body.md`) or a HEREDOC, which this guard strips.'
 elif grep -qEi -- "$SECRET_PATH_DENY" <<<"$cmd"; then
-  # Allowlist: template env files (.example.env, .env.example, .env.sample, .env.template, …)
-  # are tracked and hold no real secrets — allow reads against them. Deny all other env
-  # paths and all non-env secret paths (pem, id_rsa, .aws/credentials, …).
   ALLOWED=0
   mapfile -t env_tokens < <(grep -oEi "[^[:space:]\"']*\\.env[^[:space:]\"']*" <<<"$cmd" || true)
   if [ "${#env_tokens[@]}" -gt 0 ]; then

--- a/.oh/hooks/deny-secret-paths.sh
+++ b/.oh/hooks/deny-secret-paths.sh
@@ -1,20 +1,8 @@
 #!/usr/bin/env bash
-# PreToolUse file-path guard: blocks Read/Write/Edit/NotebookEdit/Grep/Glob
-# against operator-only paths and known secret/credential paths. Mirrors the
-# Read(...) deny list in .claude/settings.json — present as a hook because
-# `bypassPermissions` defaultMode skips the permission engine entirely, so deny
-# rules alone don't fire.
-#
-# Works by inspecting every path-shaped field of tool_input and matching each
-# case-insensitively against a combined regex of the deny-listed globs.
 set -euo pipefail
 
 input=$(cat)
 
-# Path-shaped inputs across the matched tools: Read/Write/Edit use file_path,
-# NotebookEdit uses notebook_path, Grep/Glob use path (and Grep also takes a
-# glob filter). Grep's `pattern` is a regex over file *contents*, not a path,
-# so it is deliberately not scanned.
 mapfile -t paths < <(jq -r '
   [.tool_input.file_path, .tool_input.notebook_path, .tool_input.path, .tool_input.glob]
   | map(select(type == "string" and . != ""))
@@ -22,44 +10,39 @@ mapfile -t paths < <(jq -r '
 
 [ "${#paths[@]}" -eq 0 ] && exit 0
 
-# Operator-only configuration. `.config/` — at the repo root and in $HOME — and
-# provider-local settings are owned by the operator; agents get neither read nor
-# write. Anchors prevent ordinary tool config (jest.config.js, app.config,
-# .configrc) from matching.
 OPERATOR_PATH='(^|/)\.config(/|$)|(^|/)settings\.local\.json$'
 
-# Mirrors .claude/settings.json permissions.deny Read(...) globs.
-DENY_PATH='(^|/)\.env([^/]*)?$'                 # **/.env*
-DENY_PATH+='|\.pem$'                            # **/*.pem
-DENY_PATH+='|\.key$'                            # **/*.key
-DENY_PATH+='|\.cert$'                           # **/*.cert
-DENY_PATH+='|\.p12$'                            # **/*.p12
-DENY_PATH+='|[^/]*id_rsa[^/]*$'                 # **/*id_rsa*
-DENY_PATH+='|[^/]*id_ed25519[^/]*$'             # **/*id_ed25519*
-DENY_PATH+='|/\.aws/credentials$'               # **/.aws/credentials
-DENY_PATH+='|/\.aws/config$'                    # **/.aws/config
-DENY_PATH+='|/\.gcp/'                           # **/.gcp/**
-DENY_PATH+='|/\.config/gcloud/'                 # **/.config/gcloud/**
-DENY_PATH+='|/\.azure/'                         # **/.azure/**
-DENY_PATH+='|/\.kube/config$'                   # **/.kube/config
-DENY_PATH+='|/\.docker/config\.json$'           # **/.docker/config.json
-DENY_PATH+='|/\.npmrc$'                         # **/.npmrc
-DENY_PATH+='|/\.pypirc$'                        # **/.pypirc
-DENY_PATH+='|/\.cargo/credentials[^/]*$'        # **/.cargo/credentials*
-DENY_PATH+='|/\.git-credentials$'               # **/.git-credentials
-DENY_PATH+='|/\.netrc$'                         # **/.netrc
-DENY_PATH+='|/\.config/gh/hosts\.yml$'          # **/.config/gh/hosts.yml
-DENY_PATH+='|/\.config/gh/config\.yml$'         # **/.config/gh/config.yml
-DENY_PATH+='|/\.claude/\.credentials\.json$'    # **/.claude/.credentials.json
-DENY_PATH+='|/\.anthropic/'                     # **/.anthropic/**
-DENY_PATH+='|/\.pi/.*auth\.json$'               # **/.pi/**/auth.json
-DENY_PATH+='|/\.gnupg/'                         # **/.gnupg/**
-DENY_PATH+='|/\.bash_history$'                  # **/.bash_history
-DENY_PATH+='|/\.zsh_history$'                   # **/.zsh_history
-DENY_PATH+='|/\.psql_history$'                  # **/.psql_history
-DENY_PATH+='|/\.python_history$'                # **/.python_history
-DENY_PATH+='|/\.node_repl_history$'             # **/.node_repl_history
-DENY_PATH+='|/\.wget-hsts$'                     # **/.wget-hsts
+DENY_PATH='(^|/)\.env([^/]*)?$'
+DENY_PATH+='|\.pem$'
+DENY_PATH+='|\.key$'
+DENY_PATH+='|\.cert$'
+DENY_PATH+='|\.p12$'
+DENY_PATH+='|[^/]*id_rsa[^/]*$'
+DENY_PATH+='|[^/]*id_ed25519[^/]*$'
+DENY_PATH+='|/\.aws/credentials$'
+DENY_PATH+='|/\.aws/config$'
+DENY_PATH+='|/\.gcp/'
+DENY_PATH+='|/\.config/gcloud/'
+DENY_PATH+='|/\.azure/'
+DENY_PATH+='|/\.kube/config$'
+DENY_PATH+='|/\.docker/config\.json$'
+DENY_PATH+='|/\.npmrc$'
+DENY_PATH+='|/\.pypirc$'
+DENY_PATH+='|/\.cargo/credentials[^/]*$'
+DENY_PATH+='|/\.git-credentials$'
+DENY_PATH+='|/\.netrc$'
+DENY_PATH+='|/\.config/gh/hosts\.yml$'
+DENY_PATH+='|/\.config/gh/config\.yml$'
+DENY_PATH+='|/\.claude/\.credentials\.json$'
+DENY_PATH+='|/\.anthropic/'
+DENY_PATH+='|/\.pi/.*auth\.json$'
+DENY_PATH+='|/\.gnupg/'
+DENY_PATH+='|/\.bash_history$'
+DENY_PATH+='|/\.zsh_history$'
+DENY_PATH+='|/\.psql_history$'
+DENY_PATH+='|/\.python_history$'
+DENY_PATH+='|/\.node_repl_history$'
+DENY_PATH+='|/\.wget-hsts$'
 
 emit() {
   jq -n --arg d "$1" --arg r "$2" '{
@@ -80,7 +63,6 @@ done
 
 for path in "${paths[@]}"; do
   if grep -qEi -- "$DENY_PATH" <<<"$path"; then
-    # Template env files (.example.env, .env.example, etc.) are tracked and hold no real secrets — allow.
     base=$(basename "$path")
     if grep -qiE '\.env' <<<"$base" && grep -qiE '(example|sample|template)' <<<"$base"; then
       continue

--- a/.oh/hooks/notify_slack.sh
+++ b/.oh/hooks/notify_slack.sh
@@ -2,10 +2,8 @@
 
 set -euo pipefail
 
-# Get script directory for fallback env path
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-# Prefer global env file, fall back to repo-local .claude/.env.claude
 PREFERRED_ENV_PATH="$HOME/.env/.claude/.env.claude"
 FALLBACK_ENV_PATH="$(dirname "$SCRIPT_DIR")/.env.claude"
 
@@ -15,10 +13,7 @@ else
     DOTENV_PATH="$FALLBACK_ENV_PATH"
 fi
 
-# Load env file if it exists. Slack notifications are optional, so missing
-# env files are a no-op instead of a hook failure.
 if [[ -f "$DOTENV_PATH" ]]; then
-    # Export variables from env file (handles quoted values and comments)
     set -a
     # shellcheck disable=SC1090
     source "$DOTENV_PATH"
@@ -26,14 +21,11 @@ if [[ -f "$DOTENV_PATH" ]]; then
     echo "Loaded env from: $DOTENV_PATH" >&2
 fi
 
-# Skip Slack notifications when no webhook is configured. This hook should
-# never fail a Claude stop/notification event just because Slack is disabled.
 if [[ -z "${SLACK_WEBHOOK_URL:-}" ]]; then
     echo "Slack notification skipped: SLACK_WEBHOOK_URL is not set" >&2
     exit 0
 fi
 
-# Read input JSON from stdin
 INPUT_JSON=$(cat)
 
 if [[ -z "$INPUT_JSON" ]]; then
@@ -41,20 +33,16 @@ if [[ -z "$INPUT_JSON" ]]; then
     exit 1
 fi
 
-# Parse JSON fields using jq
 EVENT=$(echo "$INPUT_JSON" | jq -r '.hook_event_name // ""')
 CWD=$(echo "$INPUT_JSON" | jq -r '.cwd // ""')
 SESSION_ID=$(echo "$INPUT_JSON" | jq -r '.session_id // ""')
 
-# Get current timestamp
 TIMESTAMP=$(date '+%Y-%m-%d %H:%M:%S')
 
-# Function to extract final response from transcript JSONL file
 get_final_response() {
     local transcript_path="$1"
     local max_length="${2:-1500}"
 
-    # Expand ~ in path
     transcript_path="${transcript_path/#\~/$HOME}"
 
     if [[ -z "$transcript_path" || ! -f "$transcript_path" ]]; then
@@ -62,8 +50,6 @@ get_final_response() {
         return
     fi
 
-    # Extract final assistant response from JSONL
-    # Look for entries with type=assistant and extract text content
     local final_response=""
     final_response=$(jq -rs '
         [.[] | select(.type == "assistant" and .message.role == "assistant" and .message.content)]
@@ -85,7 +71,6 @@ get_final_response() {
         return
     fi
 
-    # Truncate if too long
     if [[ ${#final_response} -gt $max_length ]]; then
         echo "${final_response:0:$max_length}...
 _(truncated)_"
@@ -94,7 +79,6 @@ _(truncated)_"
     fi
 }
 
-# Build Slack message based on event type
 TEXT=""
 case "$EVENT" in
     "Notification")
@@ -129,10 +113,8 @@ ${FINAL_RESPONSE}
         ;;
 esac
 
-# Build Slack payload
 SLACK_PAYLOAD=$(jq -n --arg text "$TEXT" '{"text": $text}')
 
-# Send to Slack
 HTTP_RESPONSE=$(curl -s -w "\n%{http_code}" \
     -X POST "$SLACK_WEBHOOK_URL" \
     -H "Content-Type: application/json" \
@@ -143,10 +125,8 @@ HTTP_RESPONSE=$(curl -s -w "\n%{http_code}" \
     exit 1
 }
 
-# Extract HTTP status code (last line)
 HTTP_CODE=$(echo "$HTTP_RESPONSE" | tail -n1)
 
-# Check for success (2xx status codes)
 if [[ ! "$HTTP_CODE" =~ ^2[0-9][0-9]$ ]]; then
     RESPONSE_BODY=$(echo "$HTTP_RESPONSE" | sed '$d')
     echo "Failed to send Slack notification: HTTP $HTTP_CODE - $RESPONSE_BODY" >&2

--- a/.oh/hooks/warn-devtcp.sh
+++ b/.oh/hooks/warn-devtcp.sh
@@ -1,17 +1,11 @@
 #!/usr/bin/env bash
-# PreToolUse Bash hook: warn when a command uses /dev/tcp or /dev/udp.
-# Non-blocking — always exits 0. Prints one warning to stderr on match.
 set -euo pipefail
 
 input=$(cat)
 cmd=$(jq -r '.tool_input.command // ""' <<<"$input")
 
-# Collapse newlines to spaces so the pattern search works line-independently.
 cmd=${cmd//$'\n'/ }
 
-# Match the literal path /dev/tcp/ or /dev/udp/ only.
-# Word-boundary anchors prevent false matches on paths like
-# .devcontainer, path/dev/x, or the word "develop".
 if printf '%s' "$cmd" | grep -qE '(^|[^A-Za-z0-9._])/dev/(tcp|udp)/'; then
   echo "warn-devtcp: /dev/tcp or /dev/udp detected in command. Prefer 'ss', 'curl', or 'nc' for network connectivity checks instead." >&2
 fi

--- a/.oh/install/.zshrc
+++ b/.oh/install/.zshrc
@@ -1,28 +1,18 @@
-# Completion (zsh native)
 autoload -Uz compinit && compinit
 
-# Git info in RPROMPT: [sandbox] (branch @short-hash) — empty outside a repo.
-#   sandbox — cyan, only shown when $SANDBOX_NAME is set (inside a sandbox)
-#   branch  — yellow
-#   @hash   — dim (first 7 chars of HEAD)
-#   action  — red during rebase/merge/cherry-pick
 autoload -Uz vcs_info
 zstyle ':vcs_info:*' enable git
 zstyle ':vcs_info:git:*' get-revision true
 zstyle ':vcs_info:git:*' formats       '(%F{yellow}%b%f %F{244}@%i%f)'
 zstyle ':vcs_info:git:*' actionformats '(%F{yellow}%b%f|%F{red}%a%f %F{244}@%i%f)'
 
-# Abbreviate SHA to 7 chars
 +vi-shorten-rev() { hook_com[revision]=${hook_com[revision][1,7]} }
 zstyle ':vcs_info:git+set-message:*' hooks shorten-rev
 
 precmd() { vcs_info }
 
-# Bash-like left prompt (Ubuntu default: green user@host, blue path).
-# Sandbox + branch live in RPROMPT.
 setopt PROMPT_SUBST
 PROMPT='%B%F{green}%n@%m%f%b:%B%F{blue}%~%f%b$ '
-# $SANDBOX_NAME is exported by docker-compose inside the sandbox; empty on the host.
 if [[ -n "$SANDBOX_NAME" ]]; then
   _sandbox_prompt="%F{cyan}[$SANDBOX_NAME]%f "
 else
@@ -30,20 +20,16 @@ else
 fi
 RPROMPT='${_sandbox_prompt}${vcs_info_msg_0_}'
 
-# History — dedup + share across sessions
 HISTFILE=~/.zsh_history
 HISTSIZE=10000
 SAVEHIST=10000
 setopt HIST_IGNORE_DUPS SHARE_HISTORY
 
-# Keybindings — emacs mode (matches bash default)
 bindkey -e
 
-# Aliases (mirror .bashrc)
 alias claude='claude --dangerously-skip-permissions'
 alias codex='codex --dangerously-bypass-approvals-and-sandbox'
 
 cd ~/harness 2>/dev/null
 
-# One-shot onboarding status and canonical next action (shared with bash).
 source "${OH_PROJECT_ROOT:-$HOME/harness}/.oh/install/banner.sh" 2>/dev/null

--- a/.oh/install/banner.sh
+++ b/.oh/install/banner.sh
@@ -1,25 +1,15 @@
 #!/usr/bin/env bash
-# banner.sh — sourced from bash and zsh to print a one-shot onboarding banner
-# on interactive shell start. Never use `exit` here; always use `return`.
 
-# Only print in interactive shells
 case $- in *i*) ;; *) return 0 ;; esac
 
-# Guard against nested shells
 [ -n "$OH_BANNER_SHOWN" ] && return 0
 export OH_BANNER_SHOWN=1
 
-# ---------------------------------------------------------------------------
-# Collect environment info
-# ---------------------------------------------------------------------------
 
 sandbox_name="${SANDBOX_NAME:-$(hostname)}"
 timezone="${TZ:-$(date +%Z 2>/dev/null)}"
 project_dir="${HOME}/harness"
 
-# Parse compose overlays from the harness config.json. Canonical location is
-# .oh/config.json (the OpenHarness machinery namespace; see .oh/README.md); the
-# legacy repo-root config.json is still read as a fallback for older installs.
 overlays=""
 config_json="${HOME}/harness/.oh/config.json"
 [ -f "$config_json" ] || config_json="${HOME}/harness/config.json"
@@ -31,9 +21,6 @@ if command -v jq >/dev/null 2>&1; then
 fi
 [ -z "$overlays" ] && overlays="(none)"
 
-# ---------------------------------------------------------------------------
-# Onboarding status checks
-# ---------------------------------------------------------------------------
 
 case "${OH_BANNER_STATUS_STYLE:-auto}" in
   emoji)
@@ -59,7 +46,6 @@ case "${OH_BANNER_STATUS_STYLE:-auto}" in
     ;;
 esac
 
-# gh — check auth status and extract username
 gh_status="$status_x"
 gh_detail="not authenticated — run: gh auth login"
 if command -v gh >/dev/null 2>&1 && gh auth status -h github.com >/dev/null 2>&1; then
@@ -73,7 +59,6 @@ if command -v gh >/dev/null 2>&1 && gh auth status -h github.com >/dev/null 2>&1
   fi
 fi
 
-# claude — check for populated .credentials.json
 claude_status="$status_x"
 claude_detail="not authenticated — run: claude"
 if [ -s "${HOME}/.claude/.credentials.json" ]; then
@@ -81,7 +66,6 @@ if [ -s "${HOME}/.claude/.credentials.json" ]; then
   claude_detail="authenticated"
 fi
 
-# codex — check for populated auth.json
 codex_status="$status_x"
 codex_detail="not authenticated — run: codex"
 if [ -s "${HOME}/.codex/auth.json" ]; then
@@ -89,7 +73,6 @@ if [ -s "${HOME}/.codex/auth.json" ]; then
   codex_detail="authenticated"
 fi
 
-# pi — check for populated .pi directory
 pi_status="$status_x"
 pi_detail="not authenticated — run: pi"
 if [ -s "${HOME}/.pi/agent/auth.json" ]; then
@@ -97,7 +80,6 @@ if [ -s "${HOME}/.pi/agent/auth.json" ]; then
   pi_detail="authenticated"
 fi
 
-# opencode — check for populated provider auth file
 opencode_status="$status_x"
 opencode_detail="not installed — set INSTALL_OPENCODE=true and rebuild"
 if command -v opencode >/dev/null 2>&1; then
@@ -110,8 +92,6 @@ if command -v opencode >/dev/null 2>&1; then
   fi
 fi
 
-# grok — optional image-level CLI; auth state lives under ~/.grok, with
-# XAI_API_KEY as a secret-only non-interactive fallback.
 grok_status="$status_x"
 grok_detail="not installed — enable via install.grok_build / INSTALL_GROK_BUILD"
 if command -v grok >/dev/null 2>&1; then
@@ -127,9 +107,6 @@ if command -v grok >/dev/null 2>&1; then
   fi
 fi
 
-# deepagents — installed status from PATH; configured status from
-# ~/.deepagents/.env or ~/.deepagents/config.toml so that an empty mounted
-# directory (named volume on first boot) is not treated as authenticated.
 deepagents_status="$status_x"
 deepagents_detail="not installed — set INSTALL_DEEPAGENTS=true and rebuild"
 if command -v deepagents >/dev/null 2>&1; then
@@ -142,9 +119,6 @@ if command -v deepagents >/dev/null 2>&1; then
   fi
 fi
 
-# hermes — optional image-level CLI; auth status checks HERMES_HOME's
-# auth.json (project-local, gitignored) rather than config.yaml/.env,
-# because setup can seed config files before the user authenticates.
 hermes_status="$status_x"
 hermes_detail="not installed — set INSTALL_HERMES=true and rebuild"
 if command -v hermes >/dev/null 2>&1; then
@@ -157,7 +131,6 @@ if command -v hermes >/dev/null 2>&1; then
   fi
 fi
 
-# dashboard — hermes-related dashboard service; leave empty if hermes not installed
 dashboard_status=""
 dashboard_detail=""
 if command -v hermes >/dev/null 2>&1; then
@@ -184,9 +157,6 @@ if command -v oh >/dev/null 2>&1; then
   oh_detail="${oh_version:-installed}"
 fi
 
-# ---------------------------------------------------------------------------
-# Print banner
-# ---------------------------------------------------------------------------
 
 printf '\n'
 printf '━━━ openharness: %s ━━━\n' "$sandbox_name"
@@ -218,9 +188,6 @@ printf '  Complete setup, authentication, agents, tests, and servers inside Herd
 printf '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n'
 printf '\n'
 
-# Migration guard — orchestrator → sandbox user revert
-# Fires only when the old /home/orchestrator directory still exists and the
-# current user is sandbox (upgraded container post-revert, no volume reset).
 if [ -d "/home/orchestrator" ] && [ "$(whoami)" = "sandbox" ]; then
   printf '\n'
   printf '  [!] Container reverted orchestrator → sandbox. /home/orchestrator still present.\n'

--- a/.oh/scripts/__tests__/boot-banner.test.ts
+++ b/.oh/scripts/__tests__/boot-banner.test.ts
@@ -36,8 +36,6 @@ describe("boot banners", () => {
     expect(block).not.toContain("Start an agent from this shell");
     expect(block).not.toContain("openharness onboard");
     expect(block).not.toContain("Complete setup");
-    // The `oh config slack` wizard was removed with the pi-messenger-bridge
-    // swap (#481/#287); the banner must not advertise a command that errors.
     expect(block).not.toContain("oh config slack");
   });
 

--- a/.oh/scripts/__tests__/check-pnpm-pin.test.ts
+++ b/.oh/scripts/__tests__/check-pnpm-pin.test.ts
@@ -15,7 +15,7 @@ interface RunResult {
   stdout: string;
   stderr: string;
   status: number;
-  output: string; // stdout + stderr combined for convenience
+  output: string;
 }
 
 function run(dockerfile: string, packageJson: string, opts?: { cwd?: string }): RunResult {
@@ -52,9 +52,6 @@ afterEach(() => {
   rmSync(tmp, { recursive: true, force: true });
 });
 
-// ---------------------------------------------------------------------------
-// Case A — matching versions → exit 0
-// ---------------------------------------------------------------------------
 
 describe("check-pnpm-pin.sh — Case A: matching versions", () => {
   it("exits 0 when Dockerfile and package.json pin the same pnpm version", () => {
@@ -67,9 +64,6 @@ describe("check-pnpm-pin.sh — Case A: matching versions", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// Case B — differing versions → exit non-zero, output contains both versions
-// ---------------------------------------------------------------------------
 
 describe("check-pnpm-pin.sh — Case B: version mismatch", () => {
   it("exits non-zero and mentions both versions when they differ", () => {
@@ -84,9 +78,6 @@ describe("check-pnpm-pin.sh — Case B: version mismatch", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// Case C — Dockerfile has NO corepack prepare pnpm@ line → exit non-zero
-// ---------------------------------------------------------------------------
 
 describe("check-pnpm-pin.sh — Case C: missing corepack line in Dockerfile", () => {
   it("exits non-zero when there is no corepack prepare pnpm@ line", () => {
@@ -99,9 +90,6 @@ describe("check-pnpm-pin.sh — Case C: missing corepack line in Dockerfile", ()
   });
 });
 
-// ---------------------------------------------------------------------------
-// Case D — package.json has +sha suffix; Dockerfile pin is bare semver → exit 0
-// ---------------------------------------------------------------------------
 
 describe("check-pnpm-pin.sh — Case D: package.json has +sha suffix", () => {
   it("exits 0 when the sha suffix is stripped and versions match", () => {
@@ -114,9 +102,6 @@ describe("check-pnpm-pin.sh — Case D: package.json has +sha suffix", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// Case E — Dockerfile pins pnpm@latest → exit non-zero (non-semver)
-// ---------------------------------------------------------------------------
 
 describe("check-pnpm-pin.sh — Case E: Dockerfile pins 'latest' (non-semver)", () => {
   it("exits non-zero when Dockerfile uses pnpm@latest instead of a semver", () => {
@@ -126,15 +111,11 @@ describe("check-pnpm-pin.sh — Case E: Dockerfile pins 'latest' (non-semver)", 
     );
     const { status, output } = run(df, pj);
     expect(status).not.toBe(0);
-    // The script emits a distinct error about non-semver, not the missing-line error
     expect(output).toContain("latest");
     expect(output).not.toContain("no 'corepack prepare pnpm@");
   });
 });
 
-// ---------------------------------------------------------------------------
-// CWD-independence — run from a non-repo-root cwd, still passes flags correctly
-// ---------------------------------------------------------------------------
 
 describe("check-pnpm-pin.sh — CWD independence", () => {
   it("exits 0 for matching versions even when cwd is os.tmpdir()", () => {

--- a/.oh/scripts/__tests__/compose-args.test.ts
+++ b/.oh/scripts/__tests__/compose-args.test.ts
@@ -65,11 +65,6 @@ function runWithFakeDocker(args: string[]): string[] {
 
 describe("scripts/docker-compose.sh", () => {
   it("passes .devcontainer/.env as the ONE --env-file, and derives nothing", () => {
-    // Before 0.4.0 this script generated a SECOND env-file from harness.yaml —
-    // a temporary one for read-like invocations, a persistent
-    // .devcontainer/.harness.yaml.env otherwise. That derived file was
-    // invisible to the VS Code path, which reads .devcontainer/.env only. It is
-    // gone: one surface, one --env-file, and no artifact left behind.
     const derived = path.join(tmp, ".devcontainer", ".harness.yaml.env");
     writeFileSync(path.join(tmp, ".devcontainer", ".env"), "SANDBOX_NAME=example\n");
 
@@ -99,10 +94,6 @@ describe("scripts/docker-compose.sh", () => {
   });
 
   it("keeps config.json override paths as literal argv entries", () => {
-    // Shell-metacharacter-bearing paths must survive as ONE argv entry each.
-    // harness.yaml's compose.overrides list is gone; .oh/config.json's
-    // composeOverrides[] is the only list surface, and the migrator moves any
-    // existing entries into it.
     const sentinel = path.join(tmp, "SHOULD_NOT_EXIST");
     const hostile = `over rides/config ; touch ${sentinel}.yml`;
     const substitution = "local config/override $(printf hacked).yml";
@@ -145,7 +136,6 @@ describe("scripts/docker-compose.sh", () => {
       path.join(tmp, ".oh", "config.json"),
       JSON.stringify({ composeOverrides: [canonicalOverride] }),
     );
-    // Legacy root config.json present too — the canonical .oh/ copy must win.
     writeFileSync(
       path.join(tmp, "config.json"),
       JSON.stringify({ composeOverrides: [legacyOverride] }),
@@ -170,7 +160,6 @@ describe("scripts/docker-compose.sh", () => {
       "up",
       "-d",
     ]);
-    // No derived artifact is created on the executing path either.
     expect(existsSync(path.join(tmp, ".devcontainer", ".harness.yaml.env"))).toBe(false);
   });
 
@@ -187,10 +176,6 @@ describe("scripts/docker-compose.sh", () => {
   });
 
   it("migrates a leftover harness.yaml on first run, then never again", () => {
-    // The wrapper is the path every `make` and `oh` lifecycle verb goes
-    // through, so it is where an existing install gets carried over. Migration
-    // output goes to STDERR so --print-argv stays parseable — which is exactly
-    // why printArgv() asserts an empty stderr and cannot be used here.
     writeFileSync(path.join(tmp, "harness.yaml"), "sandbox:\n  name: from-yaml\n");
 
     const first = spawnSync("bash", [SCRIPT, "--repo-dir", tmp, "--print-argv", "config"], {
@@ -203,7 +188,6 @@ describe("scripts/docker-compose.sh", () => {
     expect(readFileSync(path.join(tmp, ".devcontainer", ".env"), "utf8")).toContain(
       "SANDBOX_NAME=from-yaml",
     );
-    // stdout is still nothing but argv.
     expect(first.stdout.trimEnd().split("\n")).toEqual([
       "docker",
       "compose",
@@ -223,26 +207,15 @@ describe("scripts/docker-compose.sh", () => {
   });
 });
 
-/**
- * The compose argv `oh sandbox` produced BEFORE it routed through the execution
- * contract (issue #733) — the same verb the Makefile pins at
- * `$(COMPOSE) up -d --build`. Frozen here as the oracle's expected side, so the
- * comparison below is against recorded history, not against itself.
- */
 const TODAYS_SANDBOX_COMPOSE_ARGS = ["up", "-d", "--build"];
 
 describe("execution target argv equivalence (issue #733)", () => {
   it("provision() expands to argv identical to today's, via --print-argv as the non-executing oracle", async () => {
-    // Make the fixture an equipped repo: the adapter delegates to the VENDORED
-    // script, so copy the real one rather than stubbing it — the oracle must be
-    // the genuine script. No config reader is copied alongside it any more;
-    // the script parses no YAML and shells out to nothing.
     mkdirSync(path.join(tmp, ".oh", "scripts"), { recursive: true });
     const vendored = path.join(tmp, ".oh", "scripts", "docker-compose.sh");
     copyFileSync(SCRIPT, vendored);
     writeFileSync(path.join(tmp, ".devcontainer", ".env"), "SANDBOX_NAME=from-env\n");
 
-    // Fake runner: capture what the adapter WOULD spawn; never spawn it.
     const calls: { cmd: string; args: string[] }[] = [];
     const run: LifecycleRunner = (cmd, args) => {
       calls.push({ cmd, args: [...args] });
@@ -257,12 +230,9 @@ describe("execution target argv equivalence (issue #733)", () => {
     expect(script).toBe(vendored);
     expect(rest.slice(0, 2)).toEqual(["--repo-dir", tmp]);
 
-    // (1) The adapter neither invents, drops, nor reorders a compose verb.
     const adapterComposeArgs = rest.slice(2);
     expect(adapterComposeArgs).toEqual(TODAYS_SANDBOX_COMPOSE_ARGS);
 
-    // (2) The real script expands the adapter's tail and today's tail to the
-    //     same compose argv — the equivalence the seam is required to preserve.
     const expand = (args: string[]): string[] => {
       const result = spawnSync("bash", [script, "--repo-dir", tmp, "--print-argv", ...args], {
         encoding: "utf8",
@@ -275,7 +245,6 @@ describe("execution target argv equivalence (issue #733)", () => {
     const viaToday = expand(TODAYS_SANDBOX_COMPOSE_ARGS);
     expect(viaAdapter).toEqual(viaToday);
 
-    // (3) And that argv is still the real thing, not two identical empties.
     expect(viaAdapter).toEqual([
       "docker",
       "compose",
@@ -307,42 +276,25 @@ describe("compose helper wiring", () => {
     expect(text).not.toContain("COMPOSE_FILES=\"-f .devcontainer/docker-compose.yml\"");
   });
 
-  // REVERSED TWICE. The installer first wrote every non-secret answer to
-  // .devcontainer/.env while naming harness.yaml as the file that wins, so the
-  // answers landed in the LOSING file; that was fixed by routing them to
-  // harness.yaml. harness.yaml is now gone, and .env is the file BOTH doors
-  // read — so the answers come back here, and this time the two agree.
   it("installer writes every answer to .devcontainer/.env, and the config writes ALWAYS run", () => {
     const text = readFileSync(INSTALL, "utf8");
-    // The single line editor, uncommenting the template line in place.
     expect(text).toContain("_env_set() {");
     expect(text).toContain("_env_set SANDBOX_NAME");
     expect(text).toContain("_env_set GIT_USER_NAME");
     expect(text).not.toContain("_yaml_set");
     expect(text).not.toContain("_cfg_set");
 
-    // .env must be materialized BEFORE the prompts, or the answers have
-    // nowhere to land.
     expect(text.indexOf("Created .devcontainer/.env from")).toBeLessThan(
       text.indexOf("_env_set SANDBOX_NAME"),
     );
 
-    // THE REGRESSION THIS PINS: the config block used to sit inside
-    // `if [ ! -f .devcontainer/.env ]`, so re-running the installer over an
-    // existing install wrote nothing. With .env as the only surface that would
-    // be a total no-op. The existing-file branch must now only REPORT, never
-    // gate the writes that follow.
     expect(text).toContain("Existing .devcontainer/.env preserved — updating keys in place");
     expect(text).toContain("THE CONFIG WRITES ALWAYS RUN");
 
-    // Optional installs land as INSTALL_* keys, matching what
-    // `oh harness install <name>` writes.
     expect(text).toContain('_env_set "INSTALL_$1" true');
 
-    // A pre-0.4.0 harness.yaml is carried over exactly once.
     expect(text).toContain("migrate-harness-yaml.sh");
 
-    // Secrets live in the same file, and no key writes one by another name.
     expect(text).toContain("GH_TOKEN=");
   });
 });

--- a/.oh/scripts/__tests__/cron-runtime.property.test.ts
+++ b/.oh/scripts/__tests__/cron-runtime.property.test.ts
@@ -50,7 +50,6 @@ describe("loadCrons — property: ordering-stability (alphabetical regardless of
         (filenames) => {
           const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "cron-prop-"));
           try {
-            // Write files in REVERSE-alphabetical order to exercise the sort invariant
             const reversed = [...filenames].sort().reverse();
             for (const filename of reversed) {
               fs.writeFileSync(
@@ -62,8 +61,6 @@ describe("loadCrons — property: ordering-stability (alphabetical regardless of
             const entries = loadCrons(tmpDir);
             const returnedFilePaths = entries.map((e) => e.filePath);
 
-            // Assert returned order is ascending alphabetical sort of input filenames
-            // filePath is now dir-qualified (path.join(dir, f)) so compare against full paths
             const expectedOrder = [...filenames].sort().map((f) => path.join(tmpDir, f));
             expect(returnedFilePaths).toEqual(expectedOrder);
           } finally {

--- a/.oh/scripts/__tests__/cron-runtime.test.ts
+++ b/.oh/scripts/__tests__/cron-runtime.test.ts
@@ -14,12 +14,6 @@ import {
 import { tmpdir } from "node:os";
 import path from "node:path";
 
-// Repoint the runtime's CRONS_DIR — a const captured at module-load time from
-// process.env.CRONS_DIR — at an isolated tmp path BEFORE ../cron-runtime is
-// imported. vi.hoisted runs ahead of all imports, so the exported
-// sighupHandler()'s internal scheduleAll() (called with no dir arg) re-reads
-// THIS dir and never the repo's real .oh/crons/ directory (US-004 AC). Per-pid keeps
-// parallel vitest workers from colliding on the path.
 const SIGHUP_CRONS_DIR = vi.hoisted(() => {
   const dir = `/tmp/cron-sighup-test-crons-${process.pid}`;
   process.env.CRONS_DIR = dir;
@@ -54,9 +48,6 @@ import {
   worktreeInUse,
 } from "../cron-runtime";
 
-// Mock only appendFileSync (the log() writer) as a no-op spy so reloadBody's
-// BODY_RELOADED / BODY_RELOAD_ERR signals are observable without polluting the
-// real .oh/crons/.cron.log during test runs. All other node:fs exports pass through.
 vi.mock("node:fs", async (importOriginal) => {
   const real = await importOriginal<typeof import("node:fs")>();
   return { ...real, appendFileSync: vi.fn() };
@@ -160,7 +151,6 @@ Heartbeat body.
         "autopilot.md",
       )?.preflight,
     ).toBe("scripts/autopilot-caps.sh");
-    // Absent frontmatter key → undefined (forward-compat additive parse).
     expect(
       parseCronFile(`---\nschedule: "* * * * *"\n---\nbody\n`, "c.md")?.preflight,
     ).toBeUndefined();
@@ -192,8 +182,6 @@ Heartbeat body.
 });
 
 describe("decideOverlap", () => {
-  // worktree:true ALWAYS isolates (the issue #142 default) — independent of the
-  // overlap flag, whether a pidfile exists, or whether its holder is alive.
   it("returns 'worktree' for a worktree cron regardless of lock state", () => {
     for (const pidfileExists of [false, true]) {
       for (const holderAlive of [false, true]) {
@@ -216,7 +204,6 @@ describe("decideOverlap", () => {
     expect(
       decideOverlap({ overlap: false, worktree: false, pidfileExists: false, holderAlive: false }),
     ).toBe("run");
-    // stale pidfile (exists but its pid is dead) → reclaim, do not skip
     expect(
       decideOverlap({ overlap: false, worktree: false, pidfileExists: true, holderAlive: false }),
     ).toBe("run");
@@ -299,9 +286,6 @@ describe("isValidSchedule", () => {
   });
 
   it("never throws and leaves no live timer behind for any input", () => {
-    // appendFileSync is mocked, so a probe that wrongly armed a timer and fired
-    // would not surface here — instead assert the contract directly: no input
-    // (valid or garbage) throws, and the call is fully synchronous.
     for (const s of ["0 * * * *", "not-a-cron", "", "* * * *", "@@@"]) {
       expect(() => isValidSchedule(s)).not.toThrow();
     }
@@ -310,11 +294,9 @@ describe("isValidSchedule", () => {
 
 describe("tmuxSessionName", () => {
   it("formats cron-<id>-<MMDD>-<HHMM> from local time, zero-padded", () => {
-    // 2026-06-10 18:05 local (month is 0-indexed → 5 = June).
     expect(tmuxSessionName("autopilot", new Date(2026, 5, 10, 18, 5))).toBe(
       "cron-autopilot-0610-1805",
     );
-    // Single-digit month/day/hour/minute all pad to two digits.
     expect(tmuxSessionName("x", new Date(2026, 0, 2, 3, 4))).toBe("cron-x-0102-0304");
   });
 });
@@ -453,19 +435,15 @@ describe("buildTmuxWrapper", () => {
       pidFile: "/tmp/cron-autopilot-0610-1805.pid",
       worktree: "/home/sandbox/harness/.oh/worktrees/cron/cron-autopilot-0610-1805",
     });
-    // session-scoped lock (NOT the id-scoped /tmp/cron-autopilot.pid) so a worktree
-    // fire never clobbers the primary run's overlap lock.
     expect(wt).toContain("echo $$ > '/tmp/cron-autopilot-0610-1805.pid';");
     expect(wt).toContain("rm -f '/tmp/cron-autopilot-0610-1805.pid';");
     expect(wt).not.toContain("/tmp/cron-autopilot.pid");
-    // CRON_WORKTREE is exported so the agent (autopilot §1/§7) knows it is isolated.
     expect(wt).toContain(
       "CRON_OVERLAP_PIDFILE='/tmp/cron-autopilot-0610-1805.pid' CRON_WORKTREE='/home/sandbox/harness/.oh/worktrees/cron/cron-autopilot-0610-1805';",
     );
   });
 
   it("omits CRON_WORKTREE and defaults to the id-scoped pidfile for a primary fire", () => {
-    // No pidFile/worktree opts → byte-identical to the historical primary path.
     expect(wrapper).toContain("echo $$ > '/tmp/cron-autopilot.pid';");
     expect(wrapper).not.toContain("CRON_WORKTREE=");
   });
@@ -729,24 +707,18 @@ describe("scheduleAll", () => {
     `---\nid: ${id}\nschedule: "${schedule}"\nenabled: true\n---\nbody\n`;
 
   it("schedules valid crons, skips an invalid sibling, and logs an accurate BOOT summary", () => {
-    // Files load in alphabetical order: agood (valid), bbad (invalid → dropped
-    // at load time by US-002's filter), cgood (valid).
     writeFileSync(path.join(tmp, "agood.md"), cron("agood", "0 * * * *"));
     writeFileSync(path.join(tmp, "bbad.md"), cron("bbad", "not-a-cron"));
     writeFileSync(path.join(tmp, "cgood.md"), cron("cgood", "*/5 * * * *"));
 
     const spy = vi.fn();
     const constructed: string[] = [];
-    // Inject a no-op mkCron so no real croner timer is armed in the test.
     const result = scheduleAll(tmp, spy, (e) => {
       constructed.push(e.id);
     });
 
-    // The two valid crons are constructed; the invalid one never reaches mkCron.
     expect(constructed).toEqual(["agood", "cgood"]);
     expect(result).toEqual({ scheduled: 2, skipped: 1 });
-    // The BOOT summary preserves the token and reads "2 scheduled, 1 skipped";
-    // logging it at all proves the loop completed without exiting early.
     expect(spy).toHaveBeenCalledWith("system", "BOOT", "2 scheduled, 1 skipped");
   });
 
@@ -766,9 +738,6 @@ describe("scheduleAll", () => {
   });
 
   it("fault-isolates a construction throw (defense-in-depth): skips only the throwing cron", () => {
-    // All three schedules are VALID, so they pass the load-time filter — this
-    // bypasses US-002 and exercises the construction try/catch directly via an
-    // injected mkCron that simulates a residual croner construction throw.
     writeFileSync(path.join(tmp, "aok.md"), cron("aok", "0 * * * *"));
     writeFileSync(path.join(tmp, "bboom.md"), cron("bboom", "0 * * * *"));
     writeFileSync(path.join(tmp, "cok.md"), cron("cok", "0 * * * *"));
@@ -780,10 +749,8 @@ describe("scheduleAll", () => {
       constructed.push(e.id);
     });
 
-    // The throwing cron is skipped; construction continues for the rest.
     expect(constructed).toEqual(["aok", "cok"]);
     expect(result).toEqual({ scheduled: 2, skipped: 1 });
-    // The construction throw is logged SCHED_INVALID for that id, with the error.
     const invalid = spy.mock.calls.find(
       (c) => c[0] === "bboom" && c[1] === "SCHED_INVALID",
     );
@@ -862,7 +829,6 @@ describe("scheduleAll", () => {
       if (e.id === "cboom") throw new Error("construct fail");
     });
 
-    // bload dropped at load time, cboom dropped at construction, aok scheduled.
     expect(result).toEqual({ scheduled: 1, skipped: 2 });
     expect(spy).toHaveBeenCalledWith("system", "BOOT", "1 scheduled, 2 skipped");
   });
@@ -896,7 +862,6 @@ describe("acquireLock", () => {
 
   it("steals stale lock when previous PID is dead", () => {
     const pidFile = path.join(tmp, ".pid");
-    // Pick a high PID unlikely to be running.
     writeFileSync(pidFile, "999999");
     expect(acquireLock(pidFile)).toBe(true);
     expect(readFileSync(pidFile, "utf-8")).toBe(String(process.pid));
@@ -987,7 +952,6 @@ describe("reloadEntryForFire", () => {
     expect(liveEntry?.agentBin).toBe("pi");
     expect(liveEntry?.preflight).toBe("scripts/autopilot-caps.sh");
     expect(liveEntry?.repo).toBe("mifunedev/openharness");
-    // Body stays cached here so reloadBody remains the single BODY_RELOADED logger.
     expect(liveEntry?.body).toBe("original body\n");
     const lines = appendSpy.mock.calls.map((c) => String(c[1]));
     expect(lines.some((line) => line.includes("ENTRY_RELOADED") && line.includes("agentBin,preflight,repo"))).toBe(true);
@@ -1000,13 +964,9 @@ describe("reloadEntryForFire", () => {
       `---\nid: hot\nschedule: "* * * * *"\nenabled: true\n---\nbody\n`,
     );
     const [entry] = loadCrons(tmp);
-    // loadCrons yields a dir-qualified (absolute) filePath.
     expect(path.isAbsolute(entry.filePath)).toBe(true);
 
     const liveEntry = reloadEntryForFire(entry);
-    // The reloaded entry MUST retain the original absolute path, not a bare
-    // basename — otherwise a later reloadBody() reads a CWD-relative path and
-    // silently falls back to the stale cached body.
     expect(liveEntry).not.toBeNull();
     expect(path.isAbsolute(liveEntry!.filePath)).toBe(true);
     expect(liveEntry!.filePath).toBe(entry.filePath);
@@ -1038,7 +998,6 @@ describe("reloadBody", () => {
   });
 
   it("returns the on-disk body when it has been mutated after CronEntry was built", () => {
-    // Write the initial cron file and load it via loadCrons to get a dir-qualified CronEntry.
     const cronFile = path.join(tmp, "hot.md");
     writeFileSync(
       cronFile,
@@ -1047,7 +1006,6 @@ describe("reloadBody", () => {
     const [entry] = loadCrons(tmp);
     expect(entry.body).toBe("original body\n");
 
-    // Mutate only the body on disk — keep frontmatter intact so parseCronFile succeeds.
     writeFileSync(
       cronFile,
       `---\nid: hot\nschedule: "* * * * *"\nenabled: true\n---\nupdated body\n`,
@@ -1057,20 +1015,13 @@ describe("reloadBody", () => {
     appendSpy.mockClear();
     const result = reloadBody(entry);
 
-    // Should return the fresh on-disk body, not the cached entry.body.
     expect(result).toBe("updated body\n");
 
-    // BODY_RELOADED must be logged because the on-disk body differed from entry.body.
     const loggedArgs = appendSpy.mock.calls.map((c) => String(c[1]));
     expect(loggedArgs.some((line) => line.includes("BODY_RELOADED"))).toBe(true);
   });
 
   it("reads the fresh body regardless of cwd after a metadata reload (regression: #275 CWD-relative read)", () => {
-    // Reproduce the LIVE failure chain: reloadEntryForFire() returns the live
-    // entry the runtime reuses for subsequent fires; that entry's filePath must
-    // stay absolute. With the basename bug it became "hot.md", so a later
-    // reloadBody() — running from a cwd that is NOT the crons dir — resolves the
-    // read CWD-relative, hits ENOENT, and silently returns the stale body.
     const cronFile = path.join(tmp, "hot.md");
     writeFileSync(
       cronFile,
@@ -1079,11 +1030,9 @@ describe("reloadBody", () => {
     const [entry] = loadCrons(tmp);
     expect(path.isAbsolute(entry.filePath)).toBe(true);
 
-    // The runtime reloads metadata before a fire; reuse that returned entry.
     const liveEntry = reloadEntryForFire(entry);
     expect(liveEntry).not.toBeNull();
 
-    // A frontmatter-preserving body edit lands on disk before the next fire.
     writeFileSync(
       cronFile,
       `---\nid: hot\nschedule: "* * * * *"\nenabled: true\n---\nupdated body\n`,
@@ -1093,7 +1042,6 @@ describe("reloadBody", () => {
     appendSpy.mockClear();
 
     const prevCwd = process.cwd();
-    // chdir to a directory that is NOT the crons dir (the OS temp root).
     process.chdir(tmpdir());
     let result: string;
     try {
@@ -1102,7 +1050,6 @@ describe("reloadBody", () => {
       process.chdir(prevCwd);
     }
 
-    // Must read the on-disk body, not silently fall back to the cached one.
     expect(result).toBe("updated body\n");
     const loggedArgs = appendSpy.mock.calls.map((c) => String(c[1]));
     expect(loggedArgs.some((line) => line.includes("BODY_RELOADED"))).toBe(true);
@@ -1110,9 +1057,6 @@ describe("reloadBody", () => {
   });
 
   it("hot-reloads via an absolute filePath after the process cwd changes", () => {
-    // loadCrons() invoked with a RELATIVE dir must still resolve filePath to an
-    // absolute path (#517 path.resolve), so a later reloadBody() from a changed
-    // cwd reads the on-disk body instead of falling back to the cached one.
     const prevCwd = process.cwd();
     const root = path.join(tmp, "cron-root");
     const cronsDir = path.join(root, "crons");
@@ -1147,7 +1091,6 @@ describe("reloadBody", () => {
   });
 
   it("returns cached entry.body and logs BODY_RELOAD_ERR when filePath is unreadable", () => {
-    // Build a hand-crafted entry pointing at a nonexistent path.
     const missingPath = path.join(tmp, "ghost.md");
     const entry = {
       id: "ghost",
@@ -1165,10 +1108,8 @@ describe("reloadBody", () => {
     appendSpy.mockClear();
     const result = reloadBody(entry);
 
-    // Should fall back to the cached body.
     expect(result).toBe("cached body\n");
 
-    // BODY_RELOAD_ERR must appear in at least one appendFileSync call.
     const loggedArgs = appendSpy.mock.calls.map((c) => String(c[1]));
     expect(loggedArgs.some((line) => line.includes("BODY_RELOAD_ERR"))).toBe(true);
   });
@@ -1278,18 +1219,12 @@ esac
 
     const state = inspectFallbackWorktree(orphanWt);
 
-    // The regression this pins: a `git status` FAILURE was being reported as
-    // dirty=true, which made the reaper preserve the directory forever and log
-    // WORKTREE_DIRTY on every fire (15 consecutive days in production).
     expect(state.orphaned).toBe(true);
     expect(state.dirty).toBe(false);
     expect(state.changes).toEqual([]);
     expect(state.reason ?? "").not.toBe("");
   });
 
-  // Orphan a linked worktree the way it happens in production: the directory
-  // survives while its .git/worktrees/<name> admin entry is gone, so `git
-  // status` fails outright instead of reporting changes (#694).
   const orphanWorktree = (repo: string, name: string): string => {
     const wt = path.join(repo, ".oh/worktrees", "cron", name);
     git(repo, ["worktree", "add", "--detach", wt, "HEAD"]);
@@ -1298,9 +1233,6 @@ esac
   };
 
   it("does NOT classify a worktree as orphaned when its .git file is unreadable", () => {
-    // Fail-closed guard. An I/O failure reading the .git pointer is not evidence
-    // that the worktree is disposable — and the caller DELETES what is reported
-    // orphaned. A permissions error must preserve, not remove.
     const { repo } = initRepoWithFallbackWorktrees();
     const wt = path.join(repo, ".oh/worktrees", "cron", "cron-autopilot-unreadable");
     git(repo, ["worktree", "add", "--detach", wt, "HEAD"]);
@@ -1315,8 +1247,6 @@ esac
   });
 
   it("does NOT classify a worktree as orphaned when its .git file is corrupt", () => {
-    // A present-but-unparseable .git file (e.g. an interrupted write) is a
-    // corruption signal, not an orphan signal.
     const { repo } = initRepoWithFallbackWorktrees();
     const wt = path.join(repo, ".oh/worktrees", "cron", "cron-autopilot-corrupt");
     git(repo, ["worktree", "add", "--detach", wt, "HEAD"]);
@@ -1338,7 +1268,6 @@ esac
     } finally {
       process.chdir(priorCwd);
     }
-    // Only in-use worktrees count; an orphan is reaped, never counted.
     expect(live).toBe(0);
   });
 
@@ -1356,7 +1285,6 @@ esac
       process.chdir(priorCwd);
     }
 
-    // The orphan is reaped under its own outcome...
     expect(existsSync(orphanWt)).toBe(false);
     expect(
       appendSpy.mock.calls.some((c) =>
@@ -1364,7 +1292,6 @@ esac
       ),
     ).toBe(true);
 
-    // ...and it must NOT be reported as dirty, or the distinction is pointless.
     expect(
       appendSpy.mock.calls.some((c) =>
         String(c[1]).includes("\tautopilot\tWORKTREE_DIRTY\t") &&
@@ -1372,7 +1299,6 @@ esac
       ),
     ).toBe(false);
 
-    // Genuinely dirty worktrees keep the old behavior exactly.
     expect(existsSync(dirtyWt)).toBe(true);
     expect(readFileSync(path.join(dirtyWt, "uncommitted.txt"), "utf-8")).toBe("salvage me\n");
     expect(
@@ -1386,8 +1312,6 @@ esac
 
 describe("onJobError", () => {
   it("logs an ERR_JOB line through the injected logger", () => {
-    // Inject a spy logger so the test is fully deterministic and never touches
-    // the filesystem or the real .oh/crons/.cron.log (the default logger is log()).
     const spy = vi.fn();
     onJobError("testjob", new Error("disk full"), spy);
     expect(spy).toHaveBeenCalledTimes(1);
@@ -1426,11 +1350,6 @@ describe("readFailureTail", () => {
 });
 
 describe("SIGHUP reload", () => {
-  // These tests drive the exported sighupHandler() directly (not scheduleAll) per
-  // US-004. The handler calls scheduleAll() with no dir arg, so it re-reads
-  // SIGHUP_CRONS_DIR — repointed via the vi.hoisted block at the top of this file
-  // — instead of the repo's real .oh/crons/. resetActiveJobs() clears the
-  // module-private registry between cases.
   const appendSpy = () => vi.mocked(fsModule.appendFileSync);
   const loggedLines = (): string[] =>
     appendSpy().mock.calls.map((c) => String(c[1]));
@@ -1438,9 +1357,6 @@ describe("SIGHUP reload", () => {
     loggedLines().filter((l) => l.includes("\tRELOAD\t"));
   const validCron = (id: string, schedule = "0 * * * *"): string =>
     `---\nid: ${id}\nschedule: "${schedule}"\nenabled: true\n---\nbody\n`;
-  // A valid 5-field pattern whose next run (next Jan 1) is far enough out that a
-  // real croner timer armed by the handler's private constructCron never fires
-  // during the test; the afterEach safety-reschedule stops it afterward.
   const FAR_FUTURE = "0 0 1 1 *";
 
   const emptyCronsDir = (): void => {
@@ -1455,11 +1371,6 @@ describe("SIGHUP reload", () => {
   });
 
   afterEach(() => {
-    // The handler arms REAL croner timers (via the private constructCron, which
-    // croner does not unref) for any file left in SIGHUP_CRONS_DIR; those handles
-    // live in the module-private activeJobs registry and aren't otherwise
-    // reachable to .stop(). Empty the dir and run one more reschedule so the
-    // handler stops the last generation (and arms nothing), leaving no live timer.
     emptyCronsDir();
     sighupHandler();
     resetActiveJobs();
@@ -1471,8 +1382,6 @@ describe("SIGHUP reload", () => {
   });
 
   it("stops every prior job handle before re-arming (.stop on each)", () => {
-    // Seed activeJobs with two fake handles via an injected mkCron so no real
-    // timer is armed and each handle carries an observable .stop spy.
     writeFileSync(path.join(tmp, "a.md"), validCron("a"));
     writeFileSync(path.join(tmp, "b.md"), validCron("b"));
     const stops = [vi.fn(), vi.fn()];
@@ -1490,13 +1399,11 @@ describe("SIGHUP reload", () => {
     sighupHandler();
     expect(reloadLines().at(-1)).toContain("1 scheduled, 0 skipped");
 
-    // Add a second file: the next reload re-reads the dir and counts both.
     appendSpy().mockClear();
     writeFileSync(path.join(SIGHUP_CRONS_DIR, "two.md"), validCron("two", FAR_FUTURE));
     sighupHandler();
     expect(reloadLines().at(-1)).toContain("2 scheduled, 0 skipped");
 
-    // Remove the first file: the next reload drops it.
     appendSpy().mockClear();
     rmSync(path.join(SIGHUP_CRONS_DIR, "one.md"));
     sighupHandler();
@@ -1504,9 +1411,6 @@ describe("SIGHUP reload", () => {
   });
 
   it("isolates a malformed cron file during reload without crashing", () => {
-    // A valid sibling plus a file with an invalid schedule: loadCrons drops the
-    // bad one (SCHED_INVALID) at reload time exactly as at boot, the good one
-    // stays scheduled, and the handler neither throws nor exits.
     writeFileSync(path.join(SIGHUP_CRONS_DIR, "good.md"), validCron("good", FAR_FUTURE));
     writeFileSync(path.join(SIGHUP_CRONS_DIR, "bad.md"), validCron("bad", "not-a-cron"));
 
@@ -1517,7 +1421,6 @@ describe("SIGHUP reload", () => {
   it("writes a RELOAD liveness line via the appendFileSync spy", () => {
     sighupHandler();
     expect(loggedLines().some((l) => l.includes("\tRELOAD\t"))).toBe(true);
-    // RELOAD reuses the private log() format with id "system" (BOOT precedent).
     expect(reloadLines().at(-1)).toContain("\tsystem\tRELOAD\t");
   });
 
@@ -1528,35 +1431,23 @@ describe("SIGHUP reload", () => {
   });
 
   it("is re-entrancy-safe: a SIGHUP arriving mid-reload is a no-op", () => {
-    // Seed one fake handle whose .stop re-enters sighupHandler() while the first
-    // reload is still in progress; the reload-lock must make that second call a
-    // no-op so the reschedule runs exactly once.
     writeFileSync(path.join(tmp, "a.md"), validCron("a"));
     const stop = vi.fn(() => {
-      sighupHandler(); // mid-reload: must return immediately (reloading === true)
+      sighupHandler();
     });
     scheduleAll(tmp, vi.fn(), () => ({ stop }) as unknown as Cron);
 
     sighupHandler();
 
-    // The handle is stopped exactly once: the re-entrant call returned before the
-    // stop loop, so it neither re-stopped the handle nor re-ran scheduleAll.
     expect(stop).toHaveBeenCalledTimes(1);
-    // Exactly one reschedule completed → exactly one BOOT and one RELOAD line.
     expect(reloadLines()).toHaveLength(1);
     expect(loggedLines().filter((l) => l.includes("\tBOOT\t"))).toHaveLength(1);
   });
 });
 
 describe("runPreflight + the fire() preflight gate", () => {
-  // Build a real executable preflight script with a chosen exit code and stdout,
-  // then point a CronEntry at it. This mirrors buildTmuxWrapper's runWrapper
-  // helper (real spawn against a throwaway script) — there is no child_process
-  // mock in this suite, and runPreflight calls spawnSync for real.
   const preflightScript = (opts: { exit: number; stdout?: string; sleep?: number }): string => {
     const p = path.join(tmp, `preflight-${process.pid}-${Math.random().toString(16).slice(2)}.sh`);
-    // Emit one `echo` per line so a multi-line `stdout` becomes real newlines in
-    // the child's output (a single `echo "a\nb"` would print a literal backslash-n).
     const echoes =
       opts.stdout != null
         ? opts.stdout.split("\n").map((l) => `echo ${JSON.stringify(l)}`).join("\n") + "\n"
@@ -1626,7 +1517,6 @@ describe("runPreflight + the fire() preflight gate", () => {
   });
 
   it("fails CLOSED (non-zero status) and logs PREFLIGHT_ERROR when the gate times out", () => {
-    // 50ms budget against a 2s sleep → spawnSync kills it (error/null status).
     const r = runPreflight(entry(preflightScript({ exit: 10, sleep: 2 })), 50);
     expect(r.status).not.toBe(0);
     expect(r.reason).toBe("preflight-error: exec-error");
@@ -1634,8 +1524,6 @@ describe("runPreflight + the fire() preflight gate", () => {
   });
 
   it("fire() short-circuits on a non-zero gate: logs SKIPPED_PREFLIGHT and never spawns", () => {
-    // tmux:true would normally reach fireTmux's real `spawn("tmux", …)`, but the
-    // gate returns first, so no SPAWNED/SPAWNED_WORKTREE line is ever logged.
     const cronFile = path.join(tmp, "autopilot.md");
     const script = preflightScript({ exit: 10, stdout: "SKIPPED-CAP-DAILY" });
     writeFileSync(

--- a/.oh/scripts/__tests__/entrypoint.test.ts
+++ b/.oh/scripts/__tests__/entrypoint.test.ts
@@ -52,10 +52,6 @@ describe("devcontainer entrypoint auth volume ownership", () => {
 
     expect(block).toContain("uid_reconcile_step()");
     expect(block).toContain("WARNING: failed to");
-    // Scope the "no swallowed failures" guard to the host-reconciliation
-    // branch itself. The sibling `OH_IMAGE_ONLY` (no-bind) branch legitimately
-    // best-efforts a volume chown with `2>/dev/null || true`; it is not host
-    // UID reconciliation (it deliberately skips it), so it is excluded here.
     const reconBranch = block.slice(block.indexOf('elif [ -d "$HARNESS_DIR" ]'));
     expect(reconBranch).not.toContain("2>/dev/null || true");
     expect(reconBranch).not.toContain("groupmod -g \"$HOST_GID\" sandbox 2>/dev/null");
@@ -118,14 +114,8 @@ describe("client-slack bridge supervisor", () => {
 
   it("restarts pi on stale-ctx and crash, clears the lock, stops on a clean exit", () => {
     const text = readFileSync(SUPERVISOR, "utf8");
-    // Detects the pi "extension ctx is stale" failure and kills the bridge pi
-    // (matched by its unique --extension path) so the loop relaunches it fresh.
     expect(text).toContain("ctx is stale");
     expect(text).toContain("pkill -f 'pi-messenger-bridge/dist/index.js'");
-    // pi runs interactive on the pane TTY: no `| tee` pipe and no --mode rpc, so
-    // the loaded UI extensions render instead of flooding stdout with JSON. A 2nd
-    // --extension co-loads the Codex retry-recovery extension. Assert on the pi
-    // command line itself so comment wording can't satisfy the negatives.
     const piLine = text.split("\n").find((l) => /^\s*pi --extension/.test(l)) ?? "";
     expect(piLine).toContain("--approve");
     expect(piLine).toContain('--extension "$RECOVERY_ENTRY"');
@@ -134,9 +124,7 @@ describe("client-slack bridge supervisor", () => {
     expect(piLine).toContain('2>>"$LOG"');
     expect(text).toContain("bridge-recovery");
     expect(text).toContain("rc=$?");
-    // Clears the single-instance lock before each (re)launch.
     expect(text).toContain('rm -f "$LOCK"');
-    // A clean pi exit (rc=0) breaks the loop; anything else restarts.
     expect(text).toMatch(/\$rc"?\s+-eq\s+0/);
     expect(text).toContain("break");
     expect(text).toContain("restarting in 3s");
@@ -145,7 +133,6 @@ describe("client-slack bridge supervisor", () => {
   it("is referenced by gateway.sh, which the entrypoint delegates to", () => {
     const gateway = readFileSync(join(ROOT, ".oh/scripts/gateway.sh"), "utf8");
     expect(gateway).toContain(".devcontainer/client-slack-supervise.sh");
-    // The entrypoint no longer launches the supervisor directly — it hands off.
     expect(entrypoint()).toContain(".oh/scripts/gateway.sh pi");
   });
 });
@@ -203,8 +190,6 @@ describe("msg-bridge seed/merge (seed-msg-bridge.sh)", () => {
   });
 
   it("preserves operator grants on reboot while adopting non-grant seed structure", () => {
-    // Tracked seed ships EMPTY grants but a NEW non-grant field (showWidget).
-    // The package-written runtime file holds the operator's real grants.
     const { raw } = runSeed(
       { autoConnect: true, showWidget: true, auth: { trustedUsers: [] } },
       JSON.stringify({
@@ -216,10 +201,8 @@ describe("msg-bridge seed/merge (seed-msg-bridge.sh)", () => {
       }),
     ) as { raw: string };
     const merged = JSON.parse(raw);
-    // A restart must NOT wipe the operator's trust (bug #289).
     expect(merged.auth.trustedUsers).toEqual(["slack:UOPERATOR"]);
     expect(merged.auth.channels).toHaveProperty("CCHANNEL");
-    // Non-grant structure is adopted from the tracked seed.
     expect(merged.showWidget).toBe(true);
   });
 
@@ -228,7 +211,6 @@ describe("msg-bridge seed/merge (seed-msg-bridge.sh)", () => {
     const { raw } = runSeed({ autoConnect: true, auth: { trustedUsers: [] } }, malformed) as {
       raw: string;
     };
-    // jq fails → the existing runtime file is preserved, never overwritten by the seed.
     expect(raw).toBe(malformed);
   });
 });

--- a/.oh/scripts/__tests__/firstmate.test.ts
+++ b/.oh/scripts/__tests__/firstmate.test.ts
@@ -31,8 +31,6 @@ const TEMPLATE_REL = path.join(
 const TEMPLATE = path.join(REPO_ROOT, TEMPLATE_REL);
 const SCRIPT_SOURCE = readFileSync(SCRIPT, "utf-8");
 
-// Absolute bash, resolved once via the parent's PATH — the child env is fully
-// controlled below, so a bare "bash" would resolve against the child's PATH.
 const BASH = (() => {
   const r = spawnSync("bash", ["-c", "command -v bash"], { encoding: "utf-8" });
   return (r.stdout ?? "").trim() || "/usr/bin/bash";
@@ -52,14 +50,6 @@ afterEach(() => {
   }
 });
 
-// ---------------------------------------------------------------------------
-// Fixture binaries
-//
-// Same shape as session-runner.test.ts: one stub per tool, driven entirely by
-// STUB_* env vars, appending every invocation to $STUB_CALLS. The calls file is
-// also how a NEGATIVE is proven — "the short-circuit launched nothing" is
-// asserted as "the calls file does not exist".
-// ---------------------------------------------------------------------------
 
 const HERDR_STUB = `#!/usr/bin/env bash
 printf '%s\\n' "herdr $*" >> "\${STUB_CALLS:-/dev/null}"
@@ -102,9 +92,6 @@ case "$sub" in
 esac
 `;
 
-// has-session is target-aware: firstmate asks about TWO different names — the
-// bare slug (the ralph cross-executor guard) and agent-firstmate-<slug> (its own
-// liveness oracle) — and the tests must be able to answer them differently.
 const TMUX_STUB = `#!/usr/bin/env bash
 printf '%s\\n' "tmux $*" >> "\${STUB_CALLS:-/dev/null}"
 verb="\${1:-}"
@@ -141,11 +128,6 @@ function makeBin(opts: { herdr?: boolean; tmux?: boolean }): string {
   return dir;
 }
 
-// ---------------------------------------------------------------------------
-// Fixture repo: a task folder honouring the four-file contract, plus the real
-// session-prompt template copied in so the renderer runs against the shipped
-// artifact rather than a stand-in.
-// ---------------------------------------------------------------------------
 
 interface Repo {
   root: string;
@@ -221,8 +203,6 @@ function run(
 ): RunResult {
   const repo = opts.repo;
   const env: NodeJS.ProcessEnv = {
-    // The stub bin is PREPENDED to the real PATH: the tests here need git, jq,
-    // sed and tee to be real, and only want herdr/tmux shadowed.
     PATH: opts.bin ? `${opts.bin}:${process.env.PATH ?? ""}` : process.env.PATH,
     ...(repo
       ? {
@@ -245,7 +225,6 @@ function run(
   };
 }
 
-/** Source firstmate.sh (the source guard stops before the main body) and run a snippet. */
 function sourceCall(
   snippet: string,
   opts: { env?: NodeJS.ProcessEnv; cwd?: string } = {},
@@ -270,11 +249,6 @@ function readCalls(repo: Repo): string {
   }
 }
 
-/**
- * The probe-pane output that MATCHES the caller's own fingerprint, so the
- * execution-context gate lets herdr through. The library strips the marker when
- * it reads a fingerprint back, so the stub has to re-emit the marked line.
- */
 function matchingProbeOutput(worktree: string): string {
   const r = spawnSync(
     BASH,
@@ -284,9 +258,6 @@ function matchingProbeOutput(worktree: string): string {
   return `FIRSTMATE-FINGERPRINT ${(r.stdout ?? "").trim()}`;
 }
 
-// ---------------------------------------------------------------------------
-// Slug + four-file contract (the shared sourced helper)
-// ---------------------------------------------------------------------------
 
 describe("task-folder validation", () => {
   it("rejects a slug that is not kebab-case, with the canonical message", () => {
@@ -304,8 +275,6 @@ describe("task-folder validation", () => {
     expect(r.stderr).toContain("scaffold a task with /prd then /ralph first");
   });
 
-  // The four-file contract is the interface both executors share; a partial
-  // folder is a scaffolding bug, never something to launch a session against.
   for (const missing of ["prd.md", "prd.json", "prompt.md", "progress.txt"]) {
     it(`rejects a task folder missing ${missing}`, () => {
       const files = ["prd.md", "prd.json", "prompt.md", "progress.txt"].filter(
@@ -344,9 +313,6 @@ describe("task-folder validation", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// Sentinel short-circuit
-// ---------------------------------------------------------------------------
 
 describe("sentinel short-circuit", () => {
   it("exits 0 without launching anything when STATUS: COMPLETE is already present", () => {
@@ -358,7 +324,6 @@ describe("sentinel short-circuit", () => {
 
     expect(r.status).toBe(0);
     expect(r.stdout).toContain("already present");
-    // Proof of the negative: no runner was ever consulted, and no lock claimed.
     expect(readCalls(repo)).toBe("");
     expect(existsSync(repo.lock)).toBe(false);
   });
@@ -379,16 +344,8 @@ describe("sentinel short-circuit", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// No cross-executor guard: there is only one executor
-// ---------------------------------------------------------------------------
 
 describe("single-executor surface", () => {
-  // The guard that refused to launch beside a bare-slug tmux session existed only
-  // because a SECOND executor named its sessions that way. With one executor, an
-  // unrelated tmux session that happens to share the slug's name is not a conflict
-  // and must not block a build. Concurrency on the same slug is stopped by the
-  // atomic launch-claim lock instead.
   it("launches even when an unrelated tmux session shares the bare slug name", () => {
     const repo = makeRepo("busy-slug");
     const bin = makeBin({ tmux: true });
@@ -409,9 +366,6 @@ describe("single-executor surface", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// Idempotency: the atomic mkdir launch-claim + the stale-lock reclaim
-// ---------------------------------------------------------------------------
 
 describe("launch-claim lock", () => {
   it("claims /tmp/firstmate-<slug>.lock with an atomic mkdir on a clean launch", () => {
@@ -445,8 +399,6 @@ describe("launch-claim lock", () => {
     expect(readCalls(repo)).not.toContain("new-session");
   });
 
-  // The herdr-mode oracle is `herdr agent get <name>`'s EXIT CODE: 0 =
-  // agent_info (live), 1 = agent_not_found (gone).
   it("cross-checks liveness with `herdr agent get` in herdr mode", () => {
     const repo = makeRepo("held-slug");
     const bin = makeBin({ herdr: true });
@@ -466,7 +418,6 @@ describe("launch-claim lock", () => {
     expect(live.stderr).toContain("already running");
     expect(readCalls(repo)).toContain("herdr agent get firstmate-held-slug");
 
-    // Same lock, but the agent is gone (agent_not_found, exit 1) — reclaimable.
     const gone = run(["--runner", "herdr", "--no-watch", "held-slug"], {
       repo,
       bin,
@@ -480,13 +431,10 @@ describe("launch-claim lock", () => {
     expect(gone.stderr).toContain("stale lock");
   });
 
-  // The kill -9 shape: the lock survived, the session did not. A stale lock must
-  // never wedge a slug permanently.
   it("treats a lock with no live session as stale and reclaimable", () => {
     const repo = makeRepo("stale-slug");
     const bin = makeBin({ tmux: true });
     mkdirSync(repo.lock);
-    // Debris inside the lock proves the reclaim really recreated the directory.
     writeFileSync(path.join(repo.lock, "debris"), "from the crashed run\n");
 
     const r = run(["--runner", "tmux", "--no-watch", "stale-slug"], {
@@ -503,9 +451,6 @@ describe("launch-claim lock", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// Exit paths — no path may leave the lock behind
-// ---------------------------------------------------------------------------
 
 describe("exit paths", () => {
   it("removes the lock and appends FIRSTMATE-INCOMPLETE after a launch failure", () => {
@@ -533,8 +478,6 @@ describe("exit paths", () => {
       bin,
       env: {
         STUB_HERDR_PROBE_OUT: fp,
-        // The pane reports a DIFFERENT cwd than the one we launched into: the
-        // cwd flag lied, which in herdr mode means a different environment.
         STUB_HERDR_FG_CWD: "/somewhere/else",
       },
     });
@@ -548,9 +491,6 @@ describe("exit paths", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// render_session_prompt — the renderer lives here (US-003), the contract in US-002
-// ---------------------------------------------------------------------------
 
 describe("render_session_prompt", () => {
   const DECLARED = ["<slug>", "<branch>", "<issue>"];
@@ -561,24 +501,18 @@ describe("render_session_prompt", () => {
     );
     expect(r.status).toBe(0);
 
-    // Every declared token is gone …
     for (const token of DECLARED) {
       expect(r.stdout).not.toContain(token);
     }
-    // … and no OTHER angle-bracket token was introduced either, which is the
-    // second half of the contract: the renderer adds no token of its own.
     const survivors = [...r.stdout.matchAll(/<[^ <>]+>/g)].map((m) => m[0]);
     expect(survivors).toEqual([]);
 
-    // … replaced by the real values, in every position they occurred.
     expect(r.stdout).toContain("# First Mate session — demo-slug");
     expect(r.stdout).toContain(".oh/tasks/demo-slug/prd.json");
     expect(r.stdout).toContain("feat/9-demo");
     expect(r.stdout).toContain("Issue: #9");
   });
 
-  // `{curly}` is US-002's second notation: runtime-fill text the SESSION writes.
-  // Substituting it would destroy the progress-entry and commit templates.
   it("leaves {curly-brace} runtime-fill text untouched", () => {
     const r = sourceCall(
       `render_session_prompt '${TEMPLATE}' demo-slug feat/9-demo 9`,
@@ -594,7 +528,6 @@ describe("render_session_prompt", () => {
     );
     expect(r.stdout).not.toContain("END CONTRACT HEADER");
     expect(r.stdout).not.toContain("ANCHOR 1:");
-    // The body's first and last sections both survive the header strip.
     expect(r.stdout).toContain("## 1. Load the task graph");
     expect(r.stdout).toContain("## 9. Reference");
   });
@@ -622,10 +555,6 @@ describe("render_session_prompt", () => {
     expect(r.stdout).toContain("body for s and <undeclared>");
   });
 
-  // A surviving <slug> in a live session prompt is silent and expensive. The
-  // substitutions run in declaration order, so a later value carrying an earlier
-  // token is the one shape that can reintroduce one — and the self-check refuses
-  // to emit the prompt rather than shipping it half-rendered.
   it("refuses to emit a prompt in which a declared placeholder survived", () => {
     const dir = tmpDir("fm-tpl-");
     const tpl = path.join(dir, "session-prompt.md");
@@ -655,9 +584,6 @@ describe("render_session_prompt", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// Launch reporting + the naming contract
-// ---------------------------------------------------------------------------
 
 describe("launch", () => {
   it("prints the resolved runner mode, the session handle, the log path and the watch command", () => {
@@ -691,9 +617,6 @@ describe("launch", () => {
     expect(r.status).toBe(0);
     expect(r.stdout).toContain("runner:   herdr");
     expect(r.stdout).toContain("handle:   firstmate-herdr-slug (pane w7:p3)");
-    // herdr owns its own pane capture and writes no file at the session-log path, so the
-    // banner must NOT advertise one — an operator sent to `tail` an unwritten file reads
-    // an empty session as a dead one. The watch command is the real handle.
     expect(r.stdout).not.toContain(
       path.join(repo.runnerTmp, "firstmate-herdr-slug.log"),
     );
@@ -721,9 +644,6 @@ describe("launch", () => {
     expect(rendered).toContain("feat/4242-prompt-slug");
     expect(rendered).not.toContain("<slug>");
 
-    // The launch string reads that file back as INITIAL ARGV inside the launched
-    // shell, and is never piped or redirected: a pipe on either end leaves the
-    // child without a TTY, and an interactive agent session cannot start there.
     const calls = readCalls(repo);
     expect(calls).toContain(repo.promptFile);
     expect(calls).toContain('"$(cat ');
@@ -744,7 +664,6 @@ describe("launch", () => {
     });
 
     expect(r.status).toBe(0);
-    // The foreground child is detached from this process's wait, so poll briefly.
     const deadline = Date.now() + 10_000;
     while (!existsSync(marker) && Date.now() < deadline) {
       spawnSync(BASH, ["-c", "sleep 0.2"]);
@@ -756,9 +675,6 @@ describe("launch", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// End-to-end: a session that reaches the sentinel
-// ---------------------------------------------------------------------------
 
 describe("watch to completion", () => {
   it("exits 0, tears down and releases the lock once STATUS: COMPLETE lands", () => {
@@ -782,9 +698,6 @@ describe("watch to completion", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// --kill: the manual escape hatch
-// ---------------------------------------------------------------------------
 
 describe("--kill", () => {
   it("clears the lock, tears the session down and records the outcome", () => {
@@ -805,12 +718,10 @@ describe("--kill", () => {
     );
 
     const calls = readCalls(repo);
-    // herdr 0.7.4 has NO agent stop/kill verb — `pane close` is the primitive.
     expect(calls).toContain("herdr pane close w7:p3");
     expect(calls).toContain("tmux kill-session -t agent-firstmate-kill-slug");
     expect(calls).not.toContain("agent stop");
     expect(calls).not.toContain("agent kill");
-    // The server is never stopped or restarted.
     expect(calls).not.toContain("server stop");
     expect(r.stdout).toContain("the herdr server was not stopped or restarted");
   });
@@ -823,9 +734,6 @@ describe("--kill", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// Static contract — the things a probe will also pin
-// ---------------------------------------------------------------------------
 
 describe("static contract", () => {
   it("is executable and launches via the US-001 session-runner library", () => {

--- a/.oh/scripts/__tests__/gateway.test.ts
+++ b/.oh/scripts/__tests__/gateway.test.ts
@@ -37,10 +37,7 @@ describe("gateway client-session launcher", () => {
   });
 
   it("matches session names EXACTLY (no client-slack-hermes prefix collision)", () => {
-    // grep -Fxq guards against `has-session -t client-slack` prefix-matching the
-    // sibling client-slack-hermes session.
     expect(gateway()).toContain("grep -Fxq");
-    // No actual `tmux has-session` CALL (a comment may explain why we avoid it).
     expect(gateway()).not.toMatch(/^\s*tmux has-session/m);
   });
 
@@ -71,23 +68,18 @@ describe("gateway pi: launches client-slack-pi handling tokens as data", () => {
     mkdirSync(home, { recursive: true });
     mkdirSync(bin);
 
-    // Malicious tokens: a command-injection attempt + an embedded single quote.
     writeFileSync(
       join(harness, ".devcontainer", ".env"),
       ["PI_SLACK_APP_TOKEN=xapp token; touch $PWNED", "PI_SLACK_BOT_TOKEN=xoxb'quoted"].join("\n"),
     );
-    // Versioned, non-secret bridge config gateway.sh seeds into ~/.pi.
     writeFileSync(
       join(harness, ".pi", "msg-bridge.json"),
       JSON.stringify({ autoConnect: true, auth: { trustedUsers: [] } }),
     );
-    // gateway.sh invokes the real seed-msg-bridge.sh; copy it in.
     cpSync(
       join(ROOT, ".devcontainer/seed-msg-bridge.sh"),
       join(harness, ".devcontainer/seed-msg-bridge.sh"),
     );
-    // Stub tmux: ls reports no sessions (so start proceeds); new-session captures
-    // the launch command; pipe-pane/kill-session/has-session are no-ops.
     writeFileSync(
       join(bin, "tmux"),
       [
@@ -103,16 +95,12 @@ describe("gateway pi: launches client-slack-pi handling tokens as data", () => {
       ].join("\n"),
       { mode: 0o755 },
     );
-    // pi stub: records the PI_SLACK_* values it actually received in its env.
     writeFileSync(
       join(bin, "pi"),
       `#!/usr/bin/env bash\nprintf 'PI_SLACK_APP_TOKEN=%s\nPI_SLACK_BOT_TOKEN=%s\n' "$PI_SLACK_APP_TOKEN" "$PI_SLACK_BOT_TOKEN" > "$PI_ENV_FILE"\n`,
       { mode: 0o755 },
     );
-    // npm stub: gateway.sh npm-installs the bridge when missing; no-op here.
     writeFileSync(join(bin, "npm"), "#!/usr/bin/env bash\nexit 0\n", { mode: 0o755 });
-    // Stub supervisor: the real one runs a restart loop (covered separately);
-    // here it just exec's the pi stub once so we can inspect the env it got.
     writeFileSync(
       join(harness, ".devcontainer", "client-slack-supervise.sh"),
       '#!/usr/bin/env bash\nexec pi --extension "${BRIDGE_ENTRY:-x}" --extension "${RECOVERY_ENTRY:-y}" --approve\n',
@@ -135,7 +123,6 @@ describe("gateway pi: launches client-slack-pi handling tokens as data", () => {
       },
     });
 
-    // The captured tmux launch command must not carry raw token text in argv.
     const tmuxLines = readFileSync(tmuxArgs, "utf8").trim().split("\n");
     const tmuxCommand = tmuxLines[tmuxLines.length - 1] ?? "";
     expect(tmuxCommand).toContain("bash -c");
@@ -143,8 +130,6 @@ describe("gateway pi: launches client-slack-pi handling tokens as data", () => {
     expect(tmuxCommand).not.toContain("xapp token; touch $PWNED");
     expect(tmuxCommand).not.toContain("xoxb'quoted");
 
-    // Run that launch command: it sources the mode-600 env file, deletes it,
-    // and exec's the supervisor → pi stub, which records the env it received.
     execFileSync("bash", ["-c", tmuxCommand], {
       env: {
         ...env,
@@ -155,13 +140,11 @@ describe("gateway pi: launches client-slack-pi handling tokens as data", () => {
       },
     });
 
-    // Tokens round-trip to pi verbatim as data, and the injection never fired.
     expect(readFileSync(piEnv, "utf8")).toBe(
       ["PI_SLACK_APP_TOKEN=xapp token; touch $PWNED", "PI_SLACK_BOT_TOKEN=xoxb'quoted", ""].join("\n"),
     );
     expect(existsSync(pwned)).toBe(false);
 
-    // The non-secret config was seeded into ~/.pi (tokens stay out of it).
     const seeded = join(home, ".pi/msg-bridge.json");
     expect(existsSync(seeded)).toBe(true);
     expect(readFileSync(seeded, "utf8")).toContain("autoConnect");

--- a/.oh/scripts/__tests__/install-prereqs.test.ts
+++ b/.oh/scripts/__tests__/install-prereqs.test.ts
@@ -37,23 +37,17 @@ describe("installer host prerequisite docs", () => {
   it("installer surfaces make as a soft (non-fatal) lifecycle prerequisite", () => {
     const install = readRepoFile(".oh", "scripts", "install.sh");
 
-    // Help text lists make for the post-install lifecycle (make shell / destroy).
     expect(install).toContain("make (build-essential)");
-    // Preflight checks for make...
     expect(install).toMatch(/command -v make/);
-    // ...and warns rather than dies when it's absent.
     expect(install).toContain("make not found");
   });
 
   it("refuses to overwrite a sandbox that already exists under the same name", () => {
     const install = readRepoFile(".oh", "scripts", "install.sh");
 
-    // Checks existing containers (running OR stopped) by name before up...
     expect(install).toContain("docker ps -a --format");
-    // ...and hard-errors (die) rather than silently recreating it,
     expect(install).toContain('die "A sandbox named');
     expect(install).toContain("already exists");
-    // with an explicit opt-in to replace in place.
     expect(install).toContain("OH_REPLACE");
   });
 
@@ -62,7 +56,6 @@ describe("installer host prerequisite docs", () => {
 
     expect(install).toContain("_opt_install HERMES");
     expect(install).toContain("_opt_install AGENT_BROWSER");
-    // interactive prompt that writes the toggle the compose build args read
     expect(install).toContain('prompt_yn "Install ');
     expect(install).toContain("INSTALL_");
   });

--- a/.oh/scripts/__tests__/provision-python.test.ts
+++ b/.oh/scripts/__tests__/provision-python.test.ts
@@ -25,8 +25,6 @@ describe("provision-python.sh", () => {
   });
 
   it("creates every level of the uv tree explicitly, parents first", () => {
-    // `install -d -o U -g G a/b/c` chowns only the final component; naming the
-    // parents is what keeps `.../share/uv` from being left root-owned.
     const text = script();
     const dirs = text.slice(text.indexOf('install -d -o "$SANDBOX_USER"'));
     const uvIdx = dirs.indexOf('"$USER_HOME/.local/share/uv" \\');
@@ -42,7 +40,6 @@ describe("provision-python.sh", () => {
     const text = script();
     expect(text).toContain('export UV_PYTHON_INSTALL_DIR="${UV_PYTHON_INSTALL_DIR:-$HOME/.local/share/uv/python}"');
     expect(text).toContain('export UV_CACHE_DIR="${UV_CACHE_DIR:-$HOME/.cache/uv}"');
-    // A managed interpreter that resolved under /root is a hard failure, not a warning.
     expect(text).toContain("/root/*) die");
     expect(text).not.toMatch(/^\s*sudo uv/m);
   });
@@ -51,8 +48,6 @@ describe("provision-python.sh", () => {
     const text = script();
     const install = text.indexOf('uv python install "$PY_VERSION"');
     expect(install).toBeGreaterThan(-1);
-    // Guarding the install behind `uv python find` would let a system
-    // interpreter mask an unwritable managed tree.
     expect(text).toContain('uv python find --managed-python "$PY_VERSION"');
   });
 

--- a/.oh/scripts/__tests__/release-latest.test.ts
+++ b/.oh/scripts/__tests__/release-latest.test.ts
@@ -140,8 +140,6 @@ describe("promote-release-latest.sh", () => {
     expect(existsSync(dockerLog)).toBe(false);
   });
 
-  // Exit 0 on a valid version proves nothing about the validator. Feed it the
-  // CalVer forms that are not valid SemVer and require the rejection.
   it.each(["2026.8.3-1", "2026.08.03", "1.2", "1.2.3.4", "v0.1.0", "0.1.0-rc.1"])(
     "rejects the non-SemVer version %j before invoking docker",
     (version) => {
@@ -153,7 +151,6 @@ describe("promote-release-latest.sh", () => {
     },
   );
 
-  // An unset version is caught earlier, by the required-variable guard.
   it("requires RELEASE_VERSION in promote mode", () => {
     const result = run("promote", { RELEASE_VERSION: "" });
 

--- a/.oh/scripts/__tests__/release-notes.test.ts
+++ b/.oh/scripts/__tests__/release-notes.test.ts
@@ -7,9 +7,6 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 const ROOT = join(import.meta.dirname, "../../..");
 const WORKFLOW = join(ROOT, ".github", "workflows", "release.yml");
 
-// The exact CHANGELOG shape that broke the v0.1.0 release: a populated
-// versioned section sitting under an EMPTY [Unreleased]. Both fallbacks are
-// therefore unavailable, so only a correct versioned match yields notes.
 const CHANGELOG = `# Changelog
 
 Format follows Keep a Changelog.
@@ -30,15 +27,6 @@ Format follows Keep a Changelog.
 
 let fixture = "";
 
-/**
- * Run an extraction expression the way the workflow does. `gawkSemantics`
- * selects which resolution of the pre-fix escape to feed awk: gawk drops an
- * invalid `\[` inside a string literal, mawk keeps it. Both variants are
- * spelled so the regex they build is identical under any awk, so this test
- * asserts the same thing on a mawk sandbox and a gawk runner. Passing the raw
- * `\[` through instead would make the test depend on the local awk — which is
- * exactly the trap that let the bug ship.
- */
 function extract(source: "workflow" | "legacy-dynamic-regex", version: string, gawkSemantics = true) {
   const changelog = join(fixture, "CHANGELOG.md");
   writeFileSync(changelog, CHANGELOG, "utf8");
@@ -50,13 +38,6 @@ function extract(source: "workflow" | "legacy-dynamic-regex", version: string, g
     });
   }
 
-  // The pre-fix expression, with the escape ALREADY RESOLVED the way the named
-  // awk resolves it. Both forms are written so the regex they build is the same
-  // under any awk — otherwise this test would itself depend on which awk runs,
-  // which is the very bug it exists to pin.
-  //   gawk: `\[` in a string is an invalid escape -> backslash dropped -> `[`
-  //         builds `^## [0.1.0] - `, a CHARACTER CLASS, matching nothing.
-  //   mawk: the backslash survives -> `\[` builds `^## \[0.1.0\] - `, a literal.
   const bracket = gawkSemantics ? ["[", "]"] : ["\\\\[", "\\\\]"];
   const legacy = `
     $0 ~ ("^## ${bracket[0]}" ver "${bracket[1]} - ") { in_block=1; next }
@@ -67,13 +48,11 @@ function extract(source: "workflow" | "legacy-dynamic-regex", version: string, g
   return execFileSync("awk", ["-v", `ver=${version}`, legacy, changelog], { encoding: "utf8" });
 }
 
-/** Lift the awk program out of the workflow so the test cannot drift from it. */
 function workflowProgram() {
   const source = readFileSync(WORKFLOW, "utf8");
   const match = /awk -v hdr="## \$\{?RELEASE_VERSION\}?\] - "?[^\n]*\n([\s\S]*?)\n\s*' CHANGELOG\.md/.exec(
     source,
   );
-  // Fall back to a direct slice between the awk invocation and its closing quote.
   const begin = source.indexOf(`awk -v hdr=`);
   const end = source.indexOf("' CHANGELOG.md", begin);
   expect(begin, "workflow no longer invokes awk with an hdr variable").toBeGreaterThan(0);
@@ -96,7 +75,6 @@ describe("release notes extraction", () => {
 
     expect(notes).toContain("The versioned section body.");
     expect(notes).toContain("A second line.");
-    // It must stop at the next heading, never bleed into an older release.
     expect(notes).not.toContain("An older release nobody should extract.");
   });
 
@@ -105,14 +83,10 @@ describe("release notes extraction", () => {
   });
 
   it("matches the heading literally, so regex metacharacters cannot widen it", () => {
-    // Under the broken character-class pattern `0.1.0` also matched `0`, `.`
-    // and `1`; a literal prefix must reject a near-miss version outright.
     expect(extract("workflow", "0").trim()).toBe("");
     expect(extract("workflow", "1").trim()).toBe("");
   });
 
-  // Verification by rejection: the expression this replaced must FAIL the
-  // first assertion under the runner's awk. Without this, the fix is unproven.
   it("the pre-fix dynamic regex extracts nothing under gawk semantics", () => {
     expect(extract("legacy-dynamic-regex", "0.1.0", true).trim()).toBe("");
   });
@@ -123,8 +97,6 @@ describe("release notes extraction", () => {
 
   it("the workflow builds no dynamic regex for the versioned heading", () => {
     const source = readFileSync(WORKFLOW, "utf8");
-    // Strip comments: the block deliberately quotes the broken pattern to
-    // explain why it was replaced, and that prose is not executable code.
     const code = source
       .split("\n")
       .filter((line) => !line.trim().startsWith("#"))
@@ -134,7 +106,6 @@ describe("release notes extraction", () => {
     expect(source).toContain("index($0, hdr) == 1");
     expect(code).not.toContain('("^## \\[" ver');
     expect(code).not.toMatch(/\$0 ~ \(/);
-    // The [Unreleased] fallback is a regex LITERAL and stays as it is.
     expect(source).toContain("/^## \\[Unreleased\\]$/");
     expect(source).toContain("see CHANGELOG.md and commit history.");
   });

--- a/.oh/scripts/__tests__/release-reservation.test.ts
+++ b/.oh/scripts/__tests__/release-reservation.test.ts
@@ -114,10 +114,6 @@ describe("SemVer reservation", () => {
     }
   });
 
-  // A bare CalVer date is well-formed SemVer, so the validator cannot reject it.
-  // The guard against a CalVer release is that the version now comes from
-  // package.json rather than the clock; what fails here are the CalVer forms
-  // that are not valid SemVer — the -N same-day suffix and zero-padded dates.
   it("accepts a bare date-shaped version because it is well-formed SemVer", () => {
     expect(parseSemVer("2026.8.7").version).toBe("2026.8.7");
   });
@@ -214,8 +210,6 @@ describe("GitHub reservation bridge", () => {
       releaseVersion: VERSION,
       reservationKind: "created",
     });
-    // The step output stays bare so GHCR tags and the concurrency group are
-    // unchanged; only the git ref and the Release name carry the v.
     expect(githubOutputLines(result)).toContain("releaseVersion=0.1.0\n");
     expect(githubOutputLines(result)).not.toContain("releaseVersion=v");
     assertFetchDone(fetchImpl);
@@ -240,7 +234,6 @@ describe("GitHub reservation bridge", () => {
       releaseVersion: VERSION,
       reservationKind: "already-released",
     });
-    // No second /git/refs POST: the version is an input, not a search space.
     assertFetchDone(fetchImpl);
   });
 
@@ -320,7 +313,6 @@ describe("release workflow contract", () => {
   it("triggers for main and master without dropping intermediate pushes", () => {
     expect(source).toMatch(/push:\n\s+branches:\n\s+- main\n\s+- master/);
     expect(source).not.toMatch(/^concurrency:/m);
-    // The branch push stays the only trigger; a tag push must not release.
     expect(source).not.toMatch(/push:\n(\s+branches:[\s\S]*?)?\s+tags:/);
   });
 
@@ -331,7 +323,6 @@ describe("release workflow contract", () => {
     expect(source).not.toContain("RELEASE_TIMESTAMP");
     expect(source).not.toContain("github.event.repository.pushed_at");
     expect(source).not.toContain("github.event.head_commit.timestamp");
-    // The version must be read before it is reserved.
     expect(source.indexOf("Read the release version from package.json")).toBeLessThan(
       source.indexOf("Atomically reserve the SemVer tag"),
     );
@@ -358,7 +349,6 @@ describe("release workflow contract", () => {
     expect(source).toContain("docker buildx build --load");
     expect(source).toContain('docker push "ghcr.io/mifunedev/openharness:${RELEASE_VERSION}"');
     expect(source).toContain('docker push "ghcr.io/mifunedev/openharness:sha-${RELEASE_SHA}"');
-    // GHCR tags stay bare — no v prefix reaches the registry.
     expect(source).not.toContain("openharness:v$");
     expect(source).not.toContain('openharness:${RELEASE_SHA}"');
     expect(source).toContain(".oh/scripts/promote-release-latest.sh promote");
@@ -383,7 +373,6 @@ describe("release workflow contract", () => {
     expect(source).toContain("needs.publish-cli.result == 'success'");
     expect(source).toContain("make_latest: process.env.MAKE_LATEST");
     expect(source).toContain("draft: false");
-    // The GitHub Release name carries the v prefix; the version stays bare.
     expect(source).toContain("name: `v${releaseVersion}`");
   });
 });

--- a/.oh/scripts/__tests__/session-runner.test.ts
+++ b/.oh/scripts/__tests__/session-runner.test.ts
@@ -21,18 +21,11 @@ const REPO_ROOT = path.resolve(__dirname, "../../..");
 const LIB = path.join(REPO_ROOT, ".oh", "scripts", "lib", "session-runner.sh");
 const LIB_SOURCE = readFileSync(LIB, "utf-8");
 
-// Absolute bash, resolved once via the parent's PATH. The ladder tests hand the
-// child a PATH containing ONLY a fixture bin dir (that is how "herdr absent" /
-// "tmux absent" are staged), and spawnSync resolves a bare command name against
-// that stripped child PATH — which would ENOENT.
 const BASH = (() => {
   const r = spawnSync("bash", ["-c", "command -v bash"], { encoding: "utf-8" });
   return (r.stdout ?? "").trim() || "/usr/bin/bash";
 })();
 
-// Real paths of the tools the library itself shells out to. Symlinked into an
-// isolated fixture bin so a test can withhold `herdr`/`tmux` specifically
-// without also withholding coreutils.
 const PASSTHROUGH_TOOLS = [
   "bash",
   "sh",
@@ -73,14 +66,6 @@ afterEach(() => {
   }
 });
 
-// ---------------------------------------------------------------------------
-// Fixture binaries
-//
-// The stubs are driven entirely by STUB_* env vars, so one stub covers every
-// herdr/tmux shape the ladder has to cope with. Every invocation is appended to
-// $STUB_CALLS, which is how the tests assert that (for example) the nesting
-// guard never reached `herdr agent start`.
-// ---------------------------------------------------------------------------
 
 const HERDR_STUB = `#!/usr/bin/env bash
 printf '%s\\n' "herdr $*" >> "\${STUB_CALLS:-/dev/null}"
@@ -158,16 +143,8 @@ esac
 `;
 
 interface BinOpts {
-  /** Write the herdr stub into the fixture bin. */
   herdr?: boolean;
-  /** Write the tmux stub into the fixture bin. */
   tmux?: boolean;
-  /**
-   * Isolated: the child PATH is ONLY the fixture bin (plus symlinked
-   * coreutils), so a tool with no stub is genuinely absent. Non-isolated: the
-   * fixture bin is prepended to the real PATH, so stubs shadow the real
-   * binaries and everything else stays reachable.
-   */
   isolated?: boolean;
 }
 
@@ -193,7 +170,6 @@ function makeBin(opts: BinOpts): { dir: string; pathEnv: string } {
       try {
         symlinkSync(real, path.join(dir, tool));
       } catch {
-        /* already present (e.g. a stub of the same name) */
       }
     }
     return { dir, pathEnv: dir };
@@ -209,11 +185,6 @@ interface RunResult {
   ms: number;
 }
 
-/**
- * Source the library in a fresh bash and run `snippet`. Sourcing only defines
- * functions and assigns constants — the library sets no shell options, so the
- * caller's option state (and this test runner's) is never touched.
- */
 function sh(
   snippet: string,
   opts: { env?: NodeJS.ProcessEnv; timeoutMs?: number } = {},
@@ -233,7 +204,6 @@ function sh(
   };
 }
 
-/** A task folder with a progress.txt, plus an isolated RUNNER_TMPDIR. */
 function makeTask(slug: string, progress = "# progress\n") {
   const root = tmpDir("sr-task-");
   const taskDir = path.join(root, "tasks", slug);
@@ -254,10 +224,6 @@ function makeTask(slug: string, progress = "# progress\n") {
   };
 }
 
-/**
- * Everything the stubs were asked to do. Absent file = the stub was never
- * invoked at all, which is exactly what the nesting guard has to achieve.
- */
 function readCalls(t: ReturnType<typeof makeTask>): string {
   try {
     return readFileSync(t.callsFile, "utf-8");
@@ -266,7 +232,6 @@ function readCalls(t: ReturnType<typeof makeTask>): string {
   }
 }
 
-/** The fingerprint the CALLER will compute, so a stub can match or diverge. */
 function callerFingerprint(worktree: string): string {
   const r = spawnSync(
     BASH,
@@ -276,9 +241,6 @@ function callerFingerprint(worktree: string): string {
   return (r.stdout ?? "").trim();
 }
 
-// ---------------------------------------------------------------------------
-// resolve_timeout_ms — the ONLY source of the session budget
-// ---------------------------------------------------------------------------
 
 describe("resolve_timeout_ms", () => {
   const DEFAULT = "14400000";
@@ -305,9 +267,6 @@ describe("resolve_timeout_ms", () => {
     expect(r.stderr).not.toContain("rejected");
   });
 
-  // 0 is the dangerous one: herdr's `wait output --timeout 0` semantics are
-  // unknown, and an unvalidated 0 would make the poll ceilings expire instantly
-  // (or never). Routing every consumer through this helper makes it unreachable.
   for (const [label, value] of [
     ["zero", "0"],
     ["negative", "-1"],
@@ -334,9 +293,6 @@ describe("resolve_timeout_ms", () => {
   }
 });
 
-// ---------------------------------------------------------------------------
-// runner_detect — the ladder and its degrade cases
-// ---------------------------------------------------------------------------
 
 describe("runner_detect ladder", () => {
   function detectEnv(
@@ -353,7 +309,6 @@ describe("runner_detect ladder", () => {
     };
   }
 
-  // Degrade case 1 — herdr absent.
   it("degrades to tmux when herdr is not installed", () => {
     const t = makeTask("ladder");
     const bin = makeBin({ tmux: true, isolated: true });
@@ -364,7 +319,6 @@ describe("runner_detect ladder", () => {
     expect(r.stderr).toContain("herdr is not installed");
   });
 
-  // Degrade case 2 — binary up, server down.
   it("degrades to tmux when the herdr binary is up but the server is down", () => {
     const t = makeTask("ladder");
     const bin = makeBin({ herdr: true, tmux: true, isolated: true });
@@ -374,11 +328,9 @@ describe("runner_detect ladder", () => {
     expect(r.stdout.trim()).toBe("tmux");
     expect(r.stderr).toContain("status: running");
     expect(r.stderr).toContain("compatible: yes");
-    // Never probed: the health predicate failed first.
     expect(readFileSync(t.callsFile, "utf-8")).not.toContain("agent start");
   });
 
-  // Degrade case 3 — no herdr, no tmux.
   it("degrades to foreground when neither herdr nor tmux is installed", () => {
     const t = makeTask("ladder");
     const bin = makeBin({ isolated: true });
@@ -389,10 +341,6 @@ describe("runner_detect ladder", () => {
     expect(r.stderr).toContain("tmux is not installed");
   });
 
-  // Degrade case 4 — the execution-context gate, mismatch path. The stubbed
-  // probe pane answers with a fingerprint from a DIFFERENT machine, which is
-  // exactly the live topology this sandbox has (herdr panes are host
-  // processes). No real herdr is involved.
   it("degrades to tmux when the probe pane's fingerprint does not match the caller's", () => {
     const t = makeTask("ladder");
     const bin = makeBin({ herdr: true, tmux: true, isolated: true });
@@ -404,10 +352,8 @@ describe("runner_detect ladder", () => {
     });
     expect(r.stdout.trim()).toBe("tmux");
     expect(r.stderr).toContain("fingerprint mismatch");
-    // The reason names WHICH fields differed, and carries both fingerprints.
     expect(r.stderr).toMatch(/fingerprint mismatch on [a-z,]*host/);
     expect(r.stderr).toContain("host=some-other-host");
-    // And it was written to the firstmate log, not only to stderr.
     const log = readFileSync(
       path.join(t.runnerTmp, "firstmate-ladder.log"),
       "utf-8",
@@ -441,7 +387,6 @@ describe("runner_detect ladder", () => {
     expect(readFileSync(t.callsFile, "utf-8")).toMatch(/herdr pane close w7:p3/);
   });
 
-  // --- #761: the probe pane must outlive its own read ----------------------
 
   it("keeps the probe pane alive across the read, and derives the budget from the one timeout source", () => {
     const t = makeTask("ladder");
@@ -455,19 +400,13 @@ describe("runner_detect ladder", () => {
     const start = readFileSync(t.callsFile, "utf-8")
       .split("\n")
       .find((l) => l.includes("agent start"));
-    // The keep-alive rides the pane invocation ...
     expect(start).toContain('sleep "${2:-30}"');
-    // ... and its budget is the read window plus a margin, not a literal.
     expect(start).toMatch(/\s25$/);
   });
 
   it("reproduces #761: a probe pane that exits before the read is unreadable", () => {
     const t = makeTask("ladder");
     const bin = makeBin({ herdr: true, tmux: true, isolated: true });
-    // STUB_HERDR_PANE_MODEL=none restores the old, too-forgiving stub: it
-    // replays pane output regardless of whether the pane could still exist.
-    // Under the faithful default the same run must still succeed, which is
-    // what proves the keep-alive is load-bearing rather than decorative.
     const forgiving = sh(`runner_detect ladder '${t.worktree}'`, {
       env: detectEnv(t, bin, {
         STUB_HERDR_PROBE_OUT: `FIRSTMATE-FINGERPRINT ${callerFingerprint(t.worktree)}`,
@@ -488,9 +427,6 @@ describe("runner_detect ladder", () => {
   it("never puts the keep-alive on the LOCAL fingerprint path", () => {
     const t = makeTask("ladder");
     const bin = makeBin({ herdr: true, tmux: true, isolated: true });
-    // The shared snippet stays sleep-free: runner_local_fingerprint runs it
-    // in-process, so a keep-alive there would stall every caller and would
-    // also break "the same snippet runs in both places".
     const r = sh(`printf '%s' "$RUNNER_PROBE_SCRIPT"`, {
       env: detectEnv(t, bin),
     });
@@ -515,8 +451,6 @@ describe("runner_detect ladder", () => {
     expect(r.stderr).toContain("no probe fingerprint obtained");
   });
 
-  // The nesting guard is the ZEROTH check: a detection path that itself nests a
-  // pane would be self-defeating, so no probe may be launched at all.
   it("nesting guard: HERDR_ENV=1 rules herdr out without launching a probe pane", () => {
     const t = makeTask("ladder");
     const bin = makeBin({ herdr: true, tmux: true, isolated: true });
@@ -528,7 +462,6 @@ describe("runner_detect ladder", () => {
     expect(r.stderr).toContain("allow_nested=false");
     const calls = readCalls(t);
     expect(calls).not.toContain("agent start");
-    // Not even `herdr status` — the guard short-circuits before any herdr call.
     expect(calls.trim()).toBe("");
   });
 
@@ -543,9 +476,6 @@ describe("runner_detect ladder", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// Explicit overrides are hard errors, never silent degrades
-// ---------------------------------------------------------------------------
 
 describe("runner_detect overrides", () => {
   it("rejects an unknown runner name", () => {
@@ -569,8 +499,6 @@ describe("runner_detect overrides", () => {
     expect(r.stderr).toContain("herdr is not installed");
   });
 
-  // The override may never force a silent host-side run: an installed, healthy
-  // but OUT-OF-ENVIRONMENT herdr is a hard error naming the mismatch.
   it("hard-errors — naming the fingerprint mismatch — when herdr is requested but out-of-environment", () => {
     const t = makeTask("ov");
     const bin = makeBin({ herdr: true, tmux: true, isolated: true });
@@ -624,9 +552,6 @@ describe("runner_detect overrides", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// runner_launch — pane id provenance, --no-focus, and the tee in every branch
-// ---------------------------------------------------------------------------
 
 describe("runner_launch", () => {
   it("parses the pane id out of the agent_started payload and exposes it via runner_pane_id", () => {
@@ -662,12 +587,8 @@ describe("runner_launch", () => {
     expect(start).toBeDefined();
     expect(start).toContain("--no-focus");
     expect(start).toContain("firstmate-launch");
-    // No pipe, no redirect: herdr owns its own pane capture, and a pipe here
-    // would replace the child's TTY (the defect observed 2026-08-23).
     expect(start).not.toContain("| tee");
     expect(start).not.toContain("2>&1");
-    // The cd is inside the launched command, not only in the --cwd flag:
-    // runner flags that claim to set a cwd frequently set only metadata.
     expect(start).toContain(`cd ${t.worktree} &&`);
   });
 
@@ -687,9 +608,7 @@ describe("runner_launch", () => {
     expect(call).toBeDefined();
     expect(call).toContain("-s agent-firstmate-launch");
     expect(call).toContain(`-c ${t.worktree}`);
-    // The launched command itself is never piped — the pane must stay a terminal.
     expect(call).not.toContain("| tee");
-    // Logging attaches AFTER the pane exists, which preserves that terminal.
     const pipePane = readFileSync(t.callsFile, "utf-8")
       .split("\n")
       .find((l) => l.includes("pipe-pane"));
@@ -700,17 +619,11 @@ describe("runner_launch", () => {
 
   it("lets the foreground child inherit stdio and writes no session log", () => {
     const t = makeTask("launch");
-    // The child must keep the caller's terminal, so its output arrives on the
-    // caller's own stdout rather than in a log file. runner_launch's own banner
-    // goes to stderr, so stdout carries the child's output alone.
     const r = sh(
       `runner_launch foreground launch '${t.worktree}' 'echo hello-foreground' 2>/dev/null\nwait "$RUNNER_FG_PID"`,
       { env: { PATH: process.env.PATH, RUNNER_TMPDIR: t.runnerTmp } },
     );
     expect(r.stdout).toContain("hello-foreground");
-    // No session log is written in foreground mode. The runner's own narrative
-    // log shares that path, so assert on its CONTENT: the child's output must
-    // not be captured into it, which is what a pipe or redirect would do.
     const narrative = existsSync(`${t.runnerTmp}/firstmate-launch.log`)
       ? readFileSync(`${t.runnerTmp}/firstmate-launch.log`, "utf-8")
       : "";
@@ -734,9 +647,6 @@ describe("runner_launch", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// One pane id, three consumers
-// ---------------------------------------------------------------------------
 
 describe("pane id provenance", () => {
   it("feeds the SAME captured pane id to runner_verify_cwd, the watch, and teardown", () => {
@@ -763,9 +673,7 @@ describe("pane id provenance", () => {
     expect(r.stdout).toContain("WATCH_OK");
 
     const calls = readFileSync(t.callsFile, "utf-8");
-    // The watch waits on the captured id...
     expect(calls).toMatch(/herdr wait output w9:p42 --match \^STATUS: COMPLETE\$/);
-    // ...and teardown closes that same id.
     expect(calls).toContain("herdr pane close w9:p42");
   });
 
@@ -788,9 +696,6 @@ describe("pane id provenance", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// runner_alive — read-only oracles
-// ---------------------------------------------------------------------------
 
 describe("runner_alive", () => {
   it("uses `herdr agent get`'s exit code as the herdr-mode oracle", () => {
@@ -838,15 +743,11 @@ describe("runner_alive", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// runner_teardown — `pane close`, never a nonexistent stop/kill verb
-// ---------------------------------------------------------------------------
 
 describe("runner_teardown", () => {
   it("closes the pane in herdr mode, recovering the id from the server when it has none", () => {
     const t = makeTask("down");
     const bin = makeBin({ herdr: true, isolated: true });
-    // No prior launch in this shell: the id has to come back out of `agent get`.
     sh(`runner_teardown herdr down >/dev/null 2>&1`, {
       env: {
         PATH: bin.pathEnv,
@@ -878,9 +779,6 @@ describe("runner_teardown", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// runner_watch — bounded by resolve_timeout_ms, and the single exit path
-// ---------------------------------------------------------------------------
 
 describe("runner_watch", () => {
   it("returns success as soon as the whole-line sentinel is in progress.txt", () => {
@@ -897,8 +795,6 @@ describe("runner_watch", () => {
     expect(r.stdout).toContain("DONE");
   });
 
-  // The exit-path contract: teardown ran, the lock is gone, and the run is
-  // recorded as FIRSTMATE-INCOMPLETE. A retained lock would wedge the slug.
   it("on budget expiry: tears down, removes the lock, and appends FIRSTMATE-INCOMPLETE", () => {
     const t = makeTask("watch");
     const bin = makeBin({ tmux: true, isolated: true });
@@ -910,7 +806,7 @@ describe("runner_watch", () => {
           PATH: bin.pathEnv,
           RUNNER_TMPDIR: t.runnerTmp,
           STUB_CALLS: t.callsFile,
-          STUB_TMUX_HAS_SESSION: "0", // session stays "alive" until the budget runs out
+          STUB_TMUX_HAS_SESSION: "0",
           FIRSTMATE_TIMEOUT_MS: "1000",
           RUNNER_POLL_INTERVAL_S: "0.2",
         },
@@ -939,7 +835,7 @@ describe("runner_watch", () => {
         PATH: bin.pathEnv,
         RUNNER_TMPDIR: t.runnerTmp,
         STUB_CALLS: t.callsFile,
-        STUB_TMUX_HAS_SESSION: "1", // gone
+        STUB_TMUX_HAS_SESSION: "1",
         RUNNER_POLL_INTERVAL_S: "0.2",
       },
       timeoutMs: 30_000,
@@ -950,8 +846,6 @@ describe("runner_watch", () => {
     );
   });
 
-  // The poll ceiling comes from resolve_timeout_ms and nowhere else. Both
-  // halves matter: a valid budget must actually stop the loop...
   it("bounds the tmux/foreground poll loop by the resolved budget", () => {
     const t = makeTask("watch");
     const bin = makeBin({ tmux: true, isolated: true });
@@ -970,9 +864,6 @@ describe("runner_watch", () => {
     expect(r.ms).toBeLessThan(30_000);
   });
 
-  // ...and a rejected one must NOT become the ceiling. With FIRSTMATE_TIMEOUT_MS=0
-  // an unvalidated budget would expire instantly; the validated default (4h)
-  // means this watch is still polling when the test kills it.
   it("does not expire instantly when FIRSTMATE_TIMEOUT_MS=0 is rejected", () => {
     const t = makeTask("watch");
     const bin = makeBin({ tmux: true, isolated: true });
@@ -987,7 +878,6 @@ describe("runner_watch", () => {
       },
       timeoutMs: 4_000,
     });
-    // Killed by the test harness rather than having returned on its own.
     expect(r.signal).not.toBeNull();
     expect(r.stdout).not.toContain("RC=");
     expect(readFileSync(t.progressFile, "utf-8")).not.toContain(
@@ -996,10 +886,6 @@ describe("runner_watch", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// runner_abort — the single exit path, callable directly (launch failure,
-// operator abort)
-// ---------------------------------------------------------------------------
 
 describe("runner_abort", () => {
   it("removes the lock even when the task folder is missing", () => {
@@ -1020,14 +906,8 @@ describe("runner_abort", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// The caller owns shell options
-// ---------------------------------------------------------------------------
 
 describe("sourcing is option-neutral", () => {
-  // A file-scope `set` in a sourced library silently rewrites the caller's
-  // option state for the rest of its execution — and shellcheck does not flag
-  // it. Both callers below must come out exactly as they went in.
   for (const [label, prelude] of [
     ["a strict caller", "set -euo pipefail"],
     ["a non-strict caller", "set +e +u +o pipefail"],
@@ -1053,9 +933,6 @@ describe("sourcing is option-neutral", () => {
   }
 });
 
-// ---------------------------------------------------------------------------
-// Static contract — the things a future edit must not quietly drop
-// ---------------------------------------------------------------------------
 
 describe("session-runner.sh static contract", () => {
   it("defines the five public ladder functions", () => {
@@ -1095,7 +972,6 @@ describe("session-runner.sh static contract", () => {
   it("uses `herdr agent get` (the liveness oracle) and `pane close` (the only teardown verb)", () => {
     expect(LIB_SOURCE).toContain("herdr agent get");
     expect(LIB_SOURCE).toContain("herdr pane close");
-    // 0.7.4 has no stop/kill verb; either would fail silently inside a trap.
     expect(LIB_SOURCE).not.toMatch(/herdr agent (stop|kill)/);
   });
 

--- a/.oh/scripts/ablate.sh
+++ b/.oh/scripts/ablate.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-# Sole locked/versioned ablation swap, restore, and crash-recovery state machine.
 set -euo pipefail
 
 _ablate_root() { printf '%s\n' "${AUDIT_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)}"; }
@@ -53,8 +52,6 @@ _ablate_lock() {
   _ablate_reject_state_symlinks || return 1
   mkdir -p "$ABLATE_STATE_ROOT"
   _ablate_reject_state_symlinks || return 1
-  # The state directory itself is the serialization guard; no persistent guard
-  # file is left behind after a successful run.
   exec {ABLATE_GUARD_FD}<"$ABLATE_STATE_ROOT"
   flock "$ABLATE_GUARD_FD"
   exec {ABLATE_LOCK_FD}>"$ABLATE_LOCK"
@@ -67,8 +64,6 @@ _ablate_lock() {
 }
 _ablate_unlock() {
   [[ -n ${ABLATE_LOCK_FD:-} ]] || return 0
-  # Serialize unlink with lock opening. This prevents a waiter holding an old inode
-  # while a newcomer locks a newly-created inode at the same pathname.
   flock "$ABLATE_GUARD_FD"
   rm -f "$ABLATE_LOCK"
   flock -u "$ABLATE_LOCK_FD" || true
@@ -94,7 +89,6 @@ _ablate_recover_locked() {
         [[ -f $ABLATE_TARGET && ! -L $ABLATE_TARGET ]] || { echo "ablate: contradictory PREPARED state" >&2; return 1; }
         _ablate_same_bytes "$ABLATE_TARGET" "$ABLATE_BACKUP" || { echo "ablate: PREPARED copies differ; refusing overwrite" >&2; return 1; }
       else
-        # Crash window: target was removed after PREPARED, before SWAPPED landed.
         _ablate_restore_copy || return 1
       fi
       _ablate_clear_state
@@ -174,8 +168,6 @@ _ablate_on_trap() {
   case $sig in EXIT) prior=${ABLATE_PRIOR_EXIT:-};; INT) prior=${ABLATE_PRIOR_INT:-};; TERM) prior=${ABLATE_PRIOR_TERM:-};; HUP) prior=${ABLATE_PRIOR_HUP:-};; esac
   trap - EXIT INT TERM HUP
   ablate_restore "$ABLATE_TARGET" || rc=$?
-  # ablate_restore reinstates the exact prior trap definitions. Invoke the
-  # displaced handler once for the signal already being handled.
   [[ -z $prior ]] || eval "$prior"
   [[ $sig == EXIT ]] || exit $((128 + $(kill -l "$sig")))
   return "$rc"

--- a/.oh/scripts/check-host-port.sh
+++ b/.oh/scripts/check-host-port.sh
@@ -1,21 +1,4 @@
 #!/usr/bin/env bash
-# check-host-port.sh — is a host TCP port free to publish?
-#
-# Usage:
-#   check-host-port.sh <port>
-#
-# Exit 0 and print "free" when nothing owns the port on the host.
-# Exit 1 and print "<port> in use by <owner>; next free: <m>" when it is taken.
-# "Owner" is a Docker container name when the port is a published container
-# port, otherwise "a host process". The suggested next-free port is the first
-# free port at or above <port>+1 that this same check considers free.
-#
-# Detection is host-side and needs no root:
-#   - Docker published ports  (docker ps --format ... — catches other
-#     containers / sibling tenants, whether the bind is 127.0.0.1 or 0.0.0.0)
-#   - listening sockets       (ss -ltn, falling back to /proc/net/tcp{,6})
-# A loopback-only and an all-interfaces bind on the same port both count as
-# taken, since Docker cannot publish a port another binding already holds.
 
 set -eu
 
@@ -32,13 +15,9 @@ esac
   printf '%s: port out of range (1-65535)\n' "$0" >&2; exit 2
 }
 
-# Published container ports for a given host port. Prints the owning container
-# name(s) if any published host port matches. Empty output = no docker match
-# (also the case when docker is unavailable).
 _docker_owner() {
   local p="$1"
   command -v docker >/dev/null 2>&1 || return 0
-  # Format: "<names>\t<ports>" e.g. "openharness\t127.0.0.1:2222->22/tcp, ..."
   docker ps --format '{{.Names}}\t{{.Ports}}' 2>/dev/null | awk -v port="$p" '
     {
       names = $1
@@ -55,19 +34,15 @@ _docker_owner() {
   '
 }
 
-# Is the host port in a LISTEN state per the kernel? 0 = listening (taken).
 _socket_listening() {
   local p="$1"
   if command -v ss >/dev/null 2>&1; then
-    # -H omits header; match ":<port>" at end of the local-address field.
     ss -ltnH 2>/dev/null | awk -v port="$p" '
       { laddr = $4; sub(/.*:/, "", laddr); if (laddr == port) { found = 1 } }
       END { exit(found ? 0 : 1) }
     '
     return $?
   fi
-  # Fallback: parse /proc/net/tcp{,6}. Local address is field 2 "HEX:PORT",
-  # state 0A = LISTEN. Port is hex.
   local hexport
   hexport=$(printf '%04X' "$p")
   awk -v hp="$hexport" '
@@ -79,7 +54,6 @@ _socket_listening() {
   ' /proc/net/tcp /proc/net/tcp6 2>/dev/null
 }
 
-# True (0) when a port is taken by either detector.
 _port_taken() {
   local p="$1"
   [ -n "$(_docker_owner "$p")" ] && return 0
@@ -90,7 +64,6 @@ _port_taken() {
 OWNER="$(_docker_owner "$PORT")"
 if [ -n "$OWNER" ] || _socket_listening "$PORT"; then
   [ -n "$OWNER" ] || OWNER="a host process"
-  # Find next free port above PORT (bounded scan).
   next=$((PORT + 1))
   while [ "$next" -le 65535 ]; do
     if ! _port_taken "$next"; then break; fi

--- a/.oh/scripts/check-pnpm-pin.sh
+++ b/.oh/scripts/check-pnpm-pin.sh
@@ -1,25 +1,11 @@
 #!/usr/bin/env bash
-# check-pnpm-pin.sh — detect pnpm-version drift between .devcontainer/Dockerfile
-# and package.json.
-#
-# Usage:
-#   scripts/check-pnpm-pin.sh [--dockerfile <path>] [--package-json <path>]
-#
-# Exits 0 when both files pin the same pnpm version; exits 1 otherwise.
 
 set -euo pipefail
 
-# ---------------------------------------------------------------------------
-# Defaults — resolved relative to this script's own location so the script
-# is CWD-independent.
-# ---------------------------------------------------------------------------
 REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 DOCKERFILE="${REPO_ROOT}/.devcontainer/Dockerfile"
 PKG_JSON="${REPO_ROOT}/package.json"
 
-# ---------------------------------------------------------------------------
-# Argument parsing
-# ---------------------------------------------------------------------------
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --dockerfile)
@@ -37,9 +23,6 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-# ---------------------------------------------------------------------------
-# Guard: files must be readable
-# ---------------------------------------------------------------------------
 if [[ ! -r "$DOCKERFILE" ]]; then
   echo "error: cannot read Dockerfile: $DOCKERFILE" >&2
   exit 1
@@ -49,17 +32,10 @@ if [[ ! -r "$PKG_JSON" ]]; then
   exit 1
 fi
 
-# ---------------------------------------------------------------------------
-# Extract version from package.json
-# "packageManager": "pnpm@10.33.0"
-# OR with Corepack integrity suffix: "pnpm@10.33.0+sha512.abc..."
-# Strip the "+..." suffix so we always get bare semver.
-# ---------------------------------------------------------------------------
 pkg_raw=$(grep '"packageManager"' "$PKG_JSON" \
   | sed 's/.*"packageManager"[[:space:]]*:[[:space:]]*"pnpm@//' \
   | sed 's/".*//')
 
-# Strip optional +<hash> integrity suffix
 pkg_ver=$(echo "$pkg_raw" | sed 's/+.*//')
 
 if [[ -z "$pkg_ver" ]]; then
@@ -67,12 +43,7 @@ if [[ -z "$pkg_ver" ]]; then
   exit 1
 fi
 
-# ---------------------------------------------------------------------------
-# Extract version from Dockerfile
-# Expected line form: corepack enable && corepack prepare pnpm@<ver> --activate
-# ---------------------------------------------------------------------------
 
-# Check whether a corepack prepare pnpm@ line exists at all
 corepack_line=$(grep 'corepack prepare pnpm@' "$DOCKERFILE" || true)
 
 if [[ -z "$corepack_line" ]]; then
@@ -80,12 +51,10 @@ if [[ -z "$corepack_line" ]]; then
   exit 1
 fi
 
-# Extract the token after "pnpm@", stopping at the first whitespace
 df_raw=$(echo "$corepack_line" \
   | sed 's/.*corepack prepare pnpm@//' \
   | awk '{print $1}')
 
-# Validate: must be digits.digits.digits (semver), NOT e.g. "latest"
 if ! echo "$df_raw" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
   echo "error: Dockerfile pins 'pnpm@${df_raw}' which is not a valid semver (expected N.N.N) in $DOCKERFILE" >&2
   exit 1
@@ -93,9 +62,6 @@ fi
 
 df_ver="$df_raw"
 
-# ---------------------------------------------------------------------------
-# Compare
-# ---------------------------------------------------------------------------
 if [[ "$df_ver" == "$pkg_ver" ]]; then
   echo "OK: Dockerfile and package.json both pin pnpm@${df_ver}"
   exit 0

--- a/.oh/scripts/closing-keywords.mjs
+++ b/.oh/scripts/closing-keywords.mjs
@@ -1,27 +1,7 @@
-// Parse GitHub closing keywords out of a pull request title and body.
-//
-// GitHub applies `Closes #N` automatically only when a pull request merges into the
-// repository default branch. This repository's default branch is `main` while every
-// pull request targets `development`, so the trailer never fires on its own. The
-// workflow `.github/workflows/close-issues-on-development.yml` closes the issues
-// instead, and it uses this module to decide which issues those are.
-//
-// This file holds no GitHub API calls so the parsing rules stay unit-testable.
 
-// The nine keywords GitHub honours, an optional colon, then a same-repository
-// issue reference. The lookbehind rejects `owner/repo#5` and `word-closes #5`, so
-// only issues in this repository match. A bare `#5` never matches: a keyword is
-// required.
 const CLOSING_REFERENCE =
   /(?<![\w/-])(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s*:?\s+#(\d+)\b/gi;
 
-/**
- * Extract the issue numbers a pull request asks to close.
- *
- * @param {string | null | undefined} title Pull request title.
- * @param {string | null | undefined} body Pull request body.
- * @returns {number[]} Unique issue numbers, ascending.
- */
 export function parseClosingRefs(title, body) {
   const text = [title, body].filter((part) => typeof part === "string").join("\n");
   const found = new Set();

--- a/.oh/scripts/cron-runtime.ts
+++ b/.oh/scripts/cron-runtime.ts
@@ -1,5 +1,3 @@
-// scripts/cron-runtime.ts — minimal cron runtime per SPEC v0.7 §"Croner runtime".
-// Reads .oh/crons/*.md frontmatter, schedules with croner, runs body as agent prompt.
 import { Cron } from "croner";
 import { spawn, spawnSync } from "node:child_process";
 import * as fs from "node:fs";
@@ -13,29 +11,15 @@ export interface CronEntry {
   overlap: boolean;
   catchup: boolean;
   tmux: boolean;
-  // When true, a tmux fire that would otherwise log SKIPPED_OVERLAP (overlap:false
-  // + a genuinely-live previous run) instead runs in an isolated git worktree under
-  // .oh/worktrees/cron/<session>. A fire is then never silently skipped — it either
-  // runs (root or worktree) or surfaces a failure (ERR_WORKTREE/ERR_WORKTREE_CAP).
   worktree: boolean;
   agentBin?: string;
-  // Optional repo-relative path to a deterministic pre-fire gate script. When
-  // set, fire() runs it BEFORE any worktree/tmux/agent is created; a non-zero
-  // exit skips the fire (SKIPPED_PREFLIGHT) with no session, no model query, no
-  // worktree. A fail-open optimization — a gate error proceeds (PREFLIGHT_ERROR).
   preflight?: string;
-  // Optional canonical GitHub repository (`owner/name`) for this cron. The
-  // runtime exports it as CRON_REPO and resolves the matching local git
-  // remote as CRON_REMOTE so gh and git operations target the same repo.
   repo?: string;
   body: string;
   filePath: string;
 }
 
 const CRONS_DIR = path.resolve(process.env.CRONS_DIR || ".oh/crons");
-// Keep relative WORKTREES_DIR values relative until use so tests and callers that
-// chdir into a fixture repo get repo-local fallback worktrees, matching the
-// relative fallback-root behavior.
 const WORKTREES_DIR = process.env.WORKTREES_DIR || ".oh/worktrees";
 const PID_FILE = path.join(CRONS_DIR, ".pid");
 const LOG_FILE = path.join(CRONS_DIR, ".cron.log");
@@ -104,14 +88,6 @@ export function parseCronFile(content: string, file: string): CronEntry | null {
   };
 }
 
-// Side-effect-free probe: does `schedule` parse as a valid cron expression?
-// croner v9.1.0 exposes no static Cron.validate, so we construct a Cron with
-// NO callback function and NO `name` option. croner only arms the internal
-// setTimeout when a function is passed, and only pushes to its module-level
-// named-jobs array when `name` is set — so this probe schedules nothing and
-// registers nothing. The constructor parses the pattern and throws
-// synchronously on an invalid one; we catch that and return false. `.stop()`
-// in the finally is defensive cleanup. Never throws for any string input.
 export function isValidSchedule(schedule: string): boolean {
   let probe: Cron | undefined;
   try {
@@ -124,9 +100,6 @@ export function isValidSchedule(schedule: string): boolean {
   }
 }
 
-// `logFn` defaults to the module-private `log` and exists ONLY for test
-// injection (mirrors onJobError(id, err, logFn = log)); it carries no
-// external-stability guarantee. Existing loadCrons(dir) call sites stay valid.
 export function loadCrons(dir: string = CRONS_DIR, logFn = log): CronEntry[] {
   if (!fs.existsSync(dir)) return [];
   const out: CronEntry[] = [];
@@ -135,7 +108,6 @@ export function loadCrons(dir: string = CRONS_DIR, logFn = log): CronEntry[] {
     try {
       entry = parseCronFile(fs.readFileSync(path.join(dir, f), "utf-8"), path.join(dir, f));
     } catch {
-      /* skip unreadable — silent, distinct from the invalid-schedule path below */
       continue;
     }
     if (!entry || !entry.enabled) continue;
@@ -164,10 +136,6 @@ export function loadCrons(dir: string = CRONS_DIR, logFn = log): CronEntry[] {
       logFn(entry.id, "REPO_INVALID", `invalid repo: ${entry.repo}`);
       continue;
     }
-    // Invalid-schedule skip is a DISTINCT path from the silent unreadable-file
-    // catch above: it runs after a non-null entry and OUTSIDE that try/catch, and
-    // it logs SCHED_INVALID so the misconfiguration surfaces in .oh/crons/.cron.log
-    // instead of poisoning the entries list and crashing main()'s new Cron() loop.
     if (!isValidSchedule(entry.schedule)) {
       logFn(entry.id, "SCHED_INVALID", `invalid schedule: ${entry.schedule}`);
       continue;
@@ -205,7 +173,6 @@ export function acquireLock(pidFile: string = PID_FILE): boolean {
         process.kill(existing, 0);
         return false;
       } catch {
-        /* stale — unlink then retry exclusive create */
       }
     }
 
@@ -231,10 +198,6 @@ const FIRE_RELOAD_FIELDS: (keyof CronEntry)[] = [
   "repo",
 ];
 
-// Re-read execution metadata immediately before each fire. Croner still owns the
-// already-armed schedule cadence until SIGHUP reschedules the process, but safety
-// fields like `preflight:` and `repo:` must not stay stale after frontmatter
-// edits. Keep the cached body so reloadBody() remains the single body logger.
 export function reloadEntryForFire(entry: CronEntry, logFn = log): CronEntry | null {
   let fresh: CronEntry | null;
   try {
@@ -301,7 +264,6 @@ function log(id: string, status: string, msg = ""): void {
     fs.mkdirSync(path.dirname(LOG_FILE), { recursive: true });
     fs.appendFileSync(LOG_FILE, line);
   } catch {
-    /* best-effort */
   }
 }
 
@@ -339,13 +301,6 @@ export function remoteForRepo(repo: string): string | undefined {
   return undefined;
 }
 
-// Best-effort tail of a job's tee'd log, used by fire()'s exit handler to
-// enrich an EXIT_<code> liveness line with the failing job's trailing output.
-// Returns the last `maxChars` characters of the file, or "" when the file is
-// missing, empty, or unreadable — it never throws, so log()'s msg.replace()
-// can never throw on its result. The 200 default matches log()'s own slice
-// cap; the parameter exists for direct test injection (cf. onJobError's logFn)
-// and carries no external-stability guarantee.
 export function readFailureTail(logFile: string, maxChars = 200): string {
   try {
     return fs.readFileSync(logFile, "utf-8").slice(-maxChars);
@@ -354,10 +309,6 @@ export function readFailureTail(logFile: string, maxChars = 200): string {
   }
 }
 
-// Croner's `catch` handler for a scheduled job: records a synchronous
-// job-callback throw as an ERR_JOB line instead of swallowing it silently.
-// `logFn` defaults to the module-private `log` and exists ONLY for test
-// injection — onJobError carries no external-stability guarantee.
 export function onJobError(id: string, err: unknown, logFn = log): void {
   logFn(id, "ERR_JOB", String(err));
 }
@@ -376,12 +327,7 @@ export function buildTmuxWrapper(opts: {
   id: string;
   agentBin: string;
   promptFile: string;
-  // Overlap pidfile written/removed by the wrapper. Defaults to the id-scoped
-  // /tmp/cron-<id>.pid (the primary fire). A worktree-fallback fire passes a
-  // session-scoped path so it does not clobber the primary run's lock.
   pidFile?: string;
-  // Absolute path of the isolated worktree this fire runs in (worktree-fallback
-  // only). Exported as CRON_WORKTREE so the agent knows it is isolated.
   worktree?: string;
   repo?: string;
   remote?: string;
@@ -412,8 +358,6 @@ export function buildTmuxWrapper(opts: {
     }) +
     `; ` +
     `rm -f ${quotedPidFile}; ` +
-    // Kept session: resume the run's own conversation as a live, attachable
-    // agent (idle until driven); fall back to a shell if that exits.
     `[ -f ${shellQuote(`/tmp/${session}.keep`)} ] && { ` +
     `if [ "$(cat ${shellQuote(`/tmp/${session}.agent`)} 2>/dev/null || echo ${quotedAgent})" = codex ]; then codex; else ${quotedAgent} --continue; fi; ` +
     `exec bash; }; ` +
@@ -468,9 +412,6 @@ export function buildCronAgentCommand(opts: {
       `active_agent=pi; ` +
       logAgentStart +
       `set +e; ` +
-      // Pi's attachable TUI must own the tmux pane's tty directly. The
-      // headless `-p ... | tee ...` shape is useful for non-tmux jobs, but it
-      // renders as an effectively blank pane when a human attaches mid-run.
       `${quotedAgent} "$(cat ${quotedPromptFile})"; ` +
       `status=$?; ` +
       logAgentDone +
@@ -518,17 +459,8 @@ export function buildCronAgentCommand(opts: {
   );
 }
 
-// Max concurrent isolated worktree runs per cron id. worktree:true crons spawn a
-// fresh worktree EVERY fire (keeping the root checkout clean), so a genuinely-stuck
-// run (e.g. an idle Pi TUI that never exits) would otherwise accumulate a worktree
-// every hour. The cap turns runaway growth into a surfaced ERR_WORKTREE_CAP failure
-// rather than silent disk/session bloat. Dead-session worktrees are pruned before
-// the count, and the heartbeat reaps stuck sessions + their worktrees hourly, so in
-// steady state the live count tracks in-flight/kept-for-review runs and stays well
-// under this ceiling.
 const WORKTREE_MAX_CONCURRENT = 6;
 
-// Liveness probe: signal 0 throws iff the pid is gone (or unsignalable).
 function isProcessAlive(pid: number): boolean {
   try {
     process.kill(pid, 0);
@@ -540,18 +472,6 @@ function isProcessAlive(pid: number): boolean {
 
 export type OverlapDecision = "run" | "skip" | "worktree";
 
-// Pure fire policy shared by fireTmux and its tests. Decides how a tmux fire
-// proceeds given the cron's flags and whether a *live* holder owns the id-scoped
-// overlap pidfile:
-//   "worktree" — worktree:true → ALWAYS isolate in a fresh .oh/worktrees/cron/<session>
-//                worktree, every fire, so the shared root checkout never goes dirty
-//                and a fire is never skipped (it runs isolated or fails loudly).
-//   "run"      — no live holder of the id lock (no pidfile, or a stale/dead pid) →
-//                run in root, reclaiming the id-scoped lock.
-//   "skip"     — a live holder and the cron is NOT a worktree cron → SKIPPED_OVERLAP
-//                (legacy serialize-on-root behaviour, e.g. heartbeat/cleanup/eval).
-// worktree:true takes precedence over overlap/pidfile state: an isolated run shares
-// no state with the root or with sibling worktree runs, so the overlap lock is moot.
 export function decideOverlap(opts: {
   overlap: boolean;
   worktree: boolean;
@@ -566,9 +486,6 @@ export function decideOverlap(opts: {
 
 const FALLBACK_WORKTREE_DIR = path.join(WORKTREES_DIR, "cron");
 
-// First existing remote (preferred) or local base branch, mirroring the
-// development→main→master precedence in .oh/skills/git/SKILL.md. Returns a
-// commit-ish suitable for `git worktree add --detach`, or null if none exist.
 function detectBaseRef(remote = "origin"): string | null {
   if (!isValidRemote(remote)) return null;
   for (const ref of ["development", "main", "master"]) {
@@ -587,9 +504,6 @@ function detectBaseRef(remote = "origin"): string | null {
   return null;
 }
 
-// Absolute working directory of every live tmux pane. This remains the primary
-// liveness signal because a cron may rename its session and /spec execute may run work inside a
-// separate Advisor session (agent-ship-<slug>).
 function livePaneCwds(): string[] {
   const r = spawnSync("tmux", ["list-panes", "-a", "-F", "#{pane_current_path}"], {
     encoding: "utf-8",
@@ -604,12 +518,6 @@ function liveTmuxSessionNames(): string[] {
   return r.stdout.split("\n").map((s) => s.trim()).filter(Boolean);
 }
 
-// A worktree is "in use" iff some live tmux pane is working inside it (its own
-// dir or a descendant), OR the cron-created session still has the same name as
-// the worktree basename. The basename fallback protects early-run Pi sessions
-// before a cron renames its session; it is only
-// a fallback, so renamed Advisor sessions still rely on pane-cwd
-// liveness and cannot keep arbitrary stale worktrees alive by name accident.
 export function worktreeInUse(
   wtPath: string,
   cwds: string[],
@@ -627,54 +535,22 @@ export interface FallbackWorktreeState {
   ref: string;
   changes: string[];
   reason?: string;
-  /**
-   * The directory is not a usable linked worktree at all — its git admin entry
-   * under .git/worktrees/<name> is gone, so `git status` cannot report on it.
-   * Distinct from `dirty`: dirty means "there is work to salvage", orphaned
-   * means "there is nothing here to inspect". See #694.
-   */
   orphaned?: boolean;
 }
 
-/**
- * Positively identify an orphaned linked worktree.
- *
- * A linked worktree is a directory containing a `.git` FILE of the form
- * `gitdir: <abs-path-to-.git/worktrees/<name>>`. It is orphaned when that admin
- * directory no longer exists — the state that made a stale cron worktree log
- * WORKTREE_DIRTY on every fire for 15 straight days (#694).
- *
- * This is a structural test on purpose. Matching `git status` stderr for
- * "fatal: not a git repository" would be locale-dependent, and — more
- * importantly — a `git status` failure has other causes (permissions, a missing
- * git binary, a genuinely corrupt repo). Those must NOT be read as "safe to
- * delete", so anything this function cannot prove is an orphan keeps the old
- * preserve-and-log-dirty behavior.
- */
 function isOrphanedWorktree(wtPath: string): boolean {
   const dotGit = path.join(wtPath, ".git");
   let raw: string;
   try {
     const st = fs.statSync(dotGit);
-    // A real (non-linked) repository has .git as a DIRECTORY. Never treat that
-    // as an orphan — it is not a linked worktree and is not ours to remove.
     if (!st.isFile()) return false;
     raw = fs.readFileSync(dotGit, "utf-8");
   } catch {
-    // FAIL CLOSED. Reaching here means .git is absent, unreadable, or errored —
-    // and an I/O failure reading the pointer is not evidence that the pointer
-    // says what we hope. A `.git` file we cannot read (permissions, an
-    // interrupted write) belongs to a worktree that may hold real uncommitted
-    // work, and this function's caller DELETES what it returns true for. So
-    // only a pointer we successfully read and resolve can authorize removal.
     return false;
   }
-  // Likewise: a present-but-unparseable .git file is a corruption signal, not
-  // an orphan signal. Preserve it and let it surface as WORKTREE_DIRTY.
   const match = /^gitdir:\s*(.+?)\s*$/m.exec(raw);
   if (!match) return false;
   const admin = path.resolve(path.dirname(dotGit), match[1]);
-  // The one provable case: we read the pointer, and its target is gone.
   return !fs.existsSync(admin);
 }
 
@@ -698,9 +574,6 @@ export function inspectFallbackWorktree(wtPath: string): FallbackWorktreeState {
   const ref = worktreeRef(wtPath);
   if (status.status !== 0) {
     const reason = (status.stderr || status.error?.message || "git status failed").trim();
-    // A status FAILURE is not evidence of uncommitted work. Only report the
-    // orphan outcome when the directory is provably not a linked worktree;
-    // every other failure keeps preserving the directory for manual salvage.
     if (isOrphanedWorktree(wtPath)) {
       return { dirty: false, orphaned: true, ref, changes: [], reason };
     }
@@ -718,11 +591,6 @@ function formatWorktreeChanges(state: FallbackWorktreeState): string {
   return shown + suffix;
 }
 
-// Remove fallback worktrees that no live tmux pane is working inside (self-healing),
-// then return the count still in use. Pane-cwd liveness (above) is robust to the
-// cron session rename and to the Advisor session sharing the worktree. A
-// dead-pane worktree is still preserved when it has modified/untracked files —
-// cleanup may reclaim only disposable state, and dirty worktrees require manual salvage.
 export function pruneAndCountFallbackWorktrees(id: string): number {
   const dir = path.resolve(FALLBACK_WORKTREE_DIR);
   let names: string[];
@@ -744,9 +612,6 @@ export function pruneAndCountFallbackWorktrees(id: string): number {
 
     const state = inspectFallbackWorktree(wt);
     if (state.orphaned) {
-      // No git admin entry, so `git worktree remove` would itself fail and
-      // `git worktree prune` cannot reach it (prune clears entries whose
-      // DIRECTORY is missing — this is the inverse). Remove the directory.
       log(id, "WORKTREE_ORPHANED", `${wt} ref=${state.ref} reason=${(state.reason ?? "").slice(0, 160)}`);
       try {
         fs.rmSync(wt, { recursive: true, force: true });
@@ -766,10 +631,6 @@ export function pruneAndCountFallbackWorktrees(id: string): number {
   return live;
 }
 
-// Create an isolated detached worktree at .oh/worktrees/cron/<session> off the base
-// branch for a worktree cron's fire. Returns the absolute path, or null after
-// logging a FAILURE (ERR_WORKTREE_CAP at/over the cap, ERR_WORKTREE otherwise) —
-// the caller must NOT fall back to a skip on null.
 function createFallbackWorktree(entry: CronEntry, session: string): string | null {
   const live = pruneAndCountFallbackWorktrees(entry.id);
   if (live >= WORKTREE_MAX_CONCURRENT) {
@@ -794,7 +655,6 @@ function createFallbackWorktree(entry: CronEntry, session: string): string | nul
   try {
     fs.mkdirSync(dir, { recursive: true });
   } catch {
-    /* git worktree add will surface a hard failure below */
   }
   const wtPath = path.join(dir, session);
   const add = spawnSync("git", ["worktree", "add", "--detach", wtPath, base], {
@@ -842,13 +702,11 @@ function fireTmux(entry: CronEntry): void {
   }
   if (decision === "worktree") {
     const wt = createFallbackWorktree(entry, session);
-    if (wt === null) return; // createFallbackWorktree logged the FAILURE; never a skip
+    if (wt === null) return;
     cwd = wt;
     worktree = wt;
-    pidFile = `/tmp/${session}.pid`; // session-scoped: do not clobber the live primary lock
+    pidFile = `/tmp/${session}.pid`;
   }
-  // decision === "run" reclaims the id-scoped lock by simply overwriting the
-  // stale/absent pidfile below (the wrapper does `echo $$ > pidFile`).
 
   const promptFile = `/tmp/${session}.prompt`;
   const body = reloadBody(entry);
@@ -876,8 +734,6 @@ function fireTmux(entry: CronEntry): void {
     { stdio: "ignore" },
   );
   child.on("error", (e: Error) => log(entry.id, "ERR", String(e)));
-  // Detached tmux path: we observe only the spawn, not the agent's eventual
-  // exit, so no EXIT_<code> reason tail can be captured here (cf. fire()).
   if (worktree) {
     log(entry.id, "SPAWNED_WORKTREE", `${session} ${worktree}`);
   } else {
@@ -885,21 +741,8 @@ function fireTmux(entry: CronEntry): void {
   }
 }
 
-// Wall-clock bound for a preflight gate. The normal path is two ~1s `gh` calls;
-// the timeout caps worst-case scheduler-loop latency for co-firing crons since
-// spawnSync blocks the single-threaded event loop. The `timeoutMs` parameter
-// exists ONLY for test injection (mirrors loadCrons/onJobError's logFn seam) and
-// carries no external-stability guarantee.
 const PREFLIGHT_TIMEOUT_MS = 60_000;
 
-// Run a cron's `preflight:` gate synchronously and decide whether to skip the
-// fire. The gate's exit code is authoritative: a non-zero status means "skip"
-// and the final stdout line is the human-readable reason (e.g. SKIPPED-CAP-DAILY).
-// FAIL-CLOSED: an invalid path, an exec error, or a timeout returns a non-zero
-// status and logs a distinct PREFLIGHT_ERROR liveness line. A configured preflight
-// is a safety gate, not an optimization — if the gate cannot be evaluated, the
-// cron must not spawn a worktree/tmux/agent. Validation reuses isValidAgentBin
-// (relative/charset-safe path, no `..`, no flag-shaped value).
 export function runPreflight(
   entry: CronEntry,
   timeoutMs: number = PREFLIGHT_TIMEOUT_MS,
@@ -907,7 +750,7 @@ export function runPreflight(
   const scriptPath = entry.preflight;
   if (!scriptPath || !isValidAgentBin(scriptPath)) {
     log(entry.id, "PREFLIGHT_ERROR", `invalid preflight: ${scriptPath}`);
-    return { status: 12, reason: "preflight-error: invalid-path" }; // fail-closed
+    return { status: 12, reason: "preflight-error: invalid-path" };
   }
   const abs = path.resolve(process.cwd(), scriptPath);
   const repoRemote = entry.repo ? remoteForRepo(entry.repo) : undefined;
@@ -930,7 +773,7 @@ export function runPreflight(
       "PREFLIGHT_ERROR",
       `${scriptPath}: ${r.error ? String(r.error) : "no exit status"}`,
     );
-    return { status: 12, reason: "preflight-error: exec-error" }; // fail-closed
+    return { status: 12, reason: "preflight-error: exec-error" };
   }
   const out = (r.stdout || "").trim();
   const reason = out ? out.split("\n").pop()!.trim() : `exit ${r.status}`;
@@ -940,10 +783,6 @@ export function runPreflight(
 export function fire(entry: CronEntry): void {
   const liveEntry = reloadEntryForFire(entry);
   if (!liveEntry) return;
-  // Pre-fire gate: a deterministic preflight check that runs BEFORE any
-  // worktree/tmux/agent is created. A non-zero exit skips the fire entirely
-  // (SKIPPED_PREFLIGHT), mirroring the SKIPPED_OVERLAP short-circuit in
-  // fireTmux — no session, no model query, no worktree.
   if (liveEntry.preflight) {
     const { status, reason } = runPreflight(liveEntry);
     if (status !== 0) {
@@ -998,13 +837,6 @@ export interface BootResult {
   skipped: number;
 }
 
-// Construct a single live Cron for `entry`. Extracted from main()'s loop so the
-// construction is both individually fault-isolatable (scheduleAll wraps each
-// call in try/catch) and injectable in tests (scheduleAll takes `mkCron`), so a
-// test can drive the loop without arming a real timer or simulate a
-// construction throw. Returns the live Cron handle so scheduleAll can register
-// it in `activeJobs`, letting a SIGHUP reschedule (US-002) stop the prior
-// generation before re-arming.
 function constructCron(entry: CronEntry): Cron {
   return new Cron(
     entry.schedule,
@@ -1017,44 +849,19 @@ function constructCron(entry: CronEntry): Cron {
   );
 }
 
-// Module-level registry of the live Cron handles armed by scheduleAll's most
-// recent call. A SIGHUP reschedule (US-002) stops every handle here before
-// re-arming, so a reload never leaves duplicate overlapping timers. It is
-// cleared at the START of each scheduleAll() call; only truthy handles are
-// registered, so a test injecting a `() => void` mkCron registers nothing.
 let activeJobs: Cron[] = [];
 
-// Re-entrancy guard for sighupHandler: true while a reload is in progress so a
-// second SIGHUP arriving mid-reload is a safe no-op rather than re-stopping and
-// re-arming a half-built generation. Cleared in sighupHandler's finally block.
 let reloading = false;
 
-// Test-only seam: clear the module-level activeJobs registry between cases so
-// state from one test cannot leak into the next. Carries no external-stability
-// guarantee (mirrors loadCrons/onJobError's injection-only seams).
 export function resetActiveJobs(): void {
   activeJobs = [];
 }
 
-// Load every cron under `dir` and schedule each one, fault-isolating each
-// `new Cron()` construction so a residual constructor throw skips only that one
-// cron and the loop continues. This construction catch is DEFENSE-IN-DEPTH:
-// loadCrons already drops invalid schedules at load time (US-002), so it never
-// fires in normal operation — it guards a future load-path bypass or a croner
-// edge case. Logs a `BOOT` summary `"<N> scheduled, <M> skipped"` and returns
-// the counts. `M` is not double-counted: a cron dropped at load time is counted
-// once (loadSkips) and never reaches the construction loop, while a cron that
-// survives load but throws at construction is counted once (constructSkips) —
-// the two sets are disjoint. `logFn`/`mkCron` exist only for test injection and
-// default to the real `log` / `constructCron`.
 export function scheduleAll(
   dir: string = CRONS_DIR,
   logFn = log,
   mkCron: (entry: CronEntry) => Cron | void = constructCron,
 ): BootResult {
-  // Clear the prior generation's handles at the START of each call so a reload
-  // (US-002) registers only this call's jobs; the prior handles are stopped by
-  // the SIGHUP handler before it re-invokes scheduleAll.
   activeJobs = [];
   let loadSkips = 0;
   const entries = loadCrons(dir, (id, status, msg) => {
@@ -1066,9 +873,6 @@ export function scheduleAll(
   for (const entry of entries) {
     try {
       const handle = mkCron(entry);
-      // Register only truthy handles: a test's `() => void` mkCron returns
-      // undefined and is intentionally not tracked, while the real
-      // constructCron returns a live Cron that a reload must later stop.
       if (handle) activeJobs.push(handle);
       scheduled++;
     } catch (err) {
@@ -1081,29 +885,6 @@ export function scheduleAll(
   return { scheduled, skipped };
 }
 
-// SIGHUP reschedule entry point. Stops the prior generation of armed Cron
-// handles, then re-reads .oh/crons/ and re-arms via scheduleAll() — so schedule
-// edits and added/removed .oh/crons/*.md files take effect without restarting the
-// cron-system session. Exported (not buried in main()) so tests can invoke it
-// directly without going through process signals or acquireLock side effects.
-//
-// .stop() halts a handle's FUTURE fires but cannot kill a callback already in
-// flight; a non-tmux fire mid-reload may briefly overlap the new generation.
-// That window is best-effort only — croner's overlap guard (protect:!overlap)
-// remains the sole protection against concurrent fires. See Non-Goals in the PRD.
-//
-// Does NOT call process.exit() and does NOT remove the PID file: a reload keeps
-// the same process alive (unlike SIGTERM/SIGINT cleanup). The reentrancy lock
-// makes a rapid double-SIGHUP safe — the second call is a no-op while the first
-// reload is still in progress.
-//
-// A malformed cron file present during the reload is dropped by scheduleAll's
-// loadCrons() path (logged SCHED_INVALID) exactly as at boot, so one bad file
-// never crashes the reload — surviving crons stay scheduled. On a successful
-// reschedule the handler emits one `RELOAD` liveness line via the private log()
-// helper (id "system", matching the BOOT precedent) reusing scheduleAll's
-// disjoint scheduled/skipped counts — no inline appendFileSync, no duplicated
-// format.
 export function sighupHandler(): void {
   if (reloading) return;
   reloading = true;
@@ -1112,7 +893,6 @@ export function sighupHandler(): void {
       try {
         job.stop();
       } catch {
-        /* best-effort: a handle that fails to stop must not abort the reload */
       }
     }
     const { scheduled, skipped } = scheduleAll();
@@ -1131,31 +911,19 @@ function main(): void {
     try {
       fs.unlinkSync(PID_FILE);
     } catch {
-      /* already gone */
     }
     process.exit(0);
   };
   process.on("SIGTERM", cleanup);
   process.on("SIGINT", cleanup);
-  // Defer the reschedule out of the signal-callback context via setImmediate so
-  // its synchronous file I/O (loadCrons readdir/readFile) runs on the next tick
-  // rather than inside the OS signal handler. SIGHUP reloads; it never exits.
   process.on("SIGHUP", () => setImmediate(sighupHandler));
   scheduleAll();
 }
 
-// `scripts/` is a symlink to `.oh/scripts/` (the .oh machinery grouping), so
-// Node resolves THIS module's own path (import.meta.filename) to the realpath
-// under `.oh/scripts/`, while process.argv[1] keeps the path as invoked — the
-// cron watchdog launches us as `scripts/cron-runtime.ts`. A raw string compare
-// therefore never matches, main() never runs, and cron-system exits ~1s after
-// every (re)start, flapping the boot healthcheck. Compare resolved realpaths so
-// main() runs no matter which path (symlink or real) launched the process.
 let invokedRealPath = "";
 try {
   if (process.argv[1]) invokedRealPath = fs.realpathSync(process.argv[1]);
 } catch {
-  /* argv[1] is not a real file (e.g. REPL/eval) — leave empty, do not run */
 }
 if (invokedRealPath && invokedRealPath === import.meta.filename) {
   main();

--- a/.oh/scripts/docker-compose.sh
+++ b/.oh/scripts/docker-compose.sh
@@ -1,13 +1,4 @@
 #!/usr/bin/env bash
-# Build and execute the Open Harness docker compose command with argv-safe
-# handling for .oh/config.json compose override paths.
-#
-# Configuration reaches compose through exactly TWO surfaces: the shell
-# environment and .devcontainer/.env. harness.yaml was removed in 0.4.0 -- it
-# only ever translated section.key into an env var compose already interpolated,
-# and it was invisible on the VS Code "Reopen in Container" path, which names
-# .devcontainer/docker-compose.yml directly. .oh/scripts/migrate-harness-yaml.sh
-# runs first here so a checkout that still has one is carried over exactly once.
 
 set -euo pipefail
 
@@ -55,10 +46,6 @@ done
 
 ENV_FILE="$REPO_DIR/.devcontainer/.env"
 
-# One-shot harness.yaml -> .devcontainer/.env migration. Exits 0 immediately
-# when there is no harness.yaml, which is the steady state; the script is
-# self-contained so deleting it in a later release removes the whole
-# compatibility story. Output goes to stderr so `--print-argv` stays parseable.
 MIGRATOR="$SCRIPT_DIR/migrate-harness-yaml.sh"
 if [ -f "$REPO_DIR/harness.yaml" ] && [ -f "$MIGRATOR" ]; then
   sh "$MIGRATOR" "$REPO_DIR" >&2 || true
@@ -103,17 +90,11 @@ fi
 
 args+=(-f "$(compose_path ".devcontainer/docker-compose.yml")")
 
-# Each toggle below reads the shell environment first, then .devcontainer/.env.
-# That is the same precedence docker compose itself applies to interpolation, so
-# the overlays this wrapper selects and the values compose resolves cannot
-# disagree.
 hermes_value=${HERMES_DASHBOARD:-$(read_env_value HERMES_DASHBOARD)}
 if truthy "$hermes_value"; then
   args+=(-f "$(compose_path ".devcontainer/docker-compose.hermes-dashboard.yml")")
 fi
 
-# Host Docker socket is opt-in (effectively host root). Apply the overlay only
-# when the DOCKER_SOCKET key is truthy. Mirrors the hermes-dashboard toggle above.
 docker_socket_value=${DOCKER_SOCKET:-$(read_env_value DOCKER_SOCKET)}
 if truthy "$docker_socket_value"; then
   args+=(-f "$(compose_path ".devcontainer/docker-compose.docker-sock.yml")")
@@ -123,25 +104,14 @@ ssh_value=${SANDBOX_SSH:-$(read_env_value SANDBOX_SSH)}
 if truthy "$ssh_value"; then
   args+=(-f "$(compose_path ".devcontainer/docker-compose.ssh.yml")")
 
-  # Port-collision preflight — only for a real `up` (skip config/ps/down and
-  # --print-argv diagnostics). Turn Docker's opaque late "bind: address already
-  # in use" into a fail-fast at creation time so enabling SSH (or spinning up
-  # another tenant) can't silently collide with a port already in use. Opt out
-  # with SANDBOX_SSH_PORT_CHECK=off.
   if [ "$PRINT_ARGV" -eq 0 ] && [ "${1:-}" = "up" ] \
      && [ "$(printf '%s' "${SANDBOX_SSH_PORT_CHECK:-on}" | tr '[:upper:]' '[:lower:]')" != "off" ]; then
     ssh_port=${SANDBOX_SSH_PORT:-$(read_env_value SANDBOX_SSH_PORT)}
     [ -n "$ssh_port" ] || ssh_port=2222
     port_check="$SCRIPT_DIR/check-host-port.sh"
     if [ -x "$port_check" ] || [ -f "$port_check" ]; then
-      # Resolve our own container name the same way the compose file does
-      # (container_name: ${SANDBOX_NAME}): shell env, then .env, then the
-      # compose default. Needed so the own-port skip below matches a
-      # custom-named sandbox, not just "openharness".
       sandbox_name=${SANDBOX_NAME:-$(read_env_value SANDBOX_NAME)}
       [ -n "$sandbox_name" ] || sandbox_name=openharness
-      # Skip the check when the port is already OUR sandbox's published port
-      # (an idempotent re-`up` of a running sandbox is fine, not a collision).
       own_port=0
       if command -v docker >/dev/null 2>&1; then
         docker ps --format '{{.Names}}\t{{.Ports}}' 2>/dev/null \
@@ -161,9 +131,6 @@ if truthy "$ssh_value"; then
   fi
 fi
 
-# User-local compose overrides. Canonical location is .oh/config.json (the
-# OpenHarness machinery namespace); the legacy repo-root config.json is still
-# honored as a fallback for installs that predate the .oh/ relocation.
 CONFIG_JSON="$REPO_DIR/.oh/config.json"
 [ -f "$CONFIG_JSON" ] || CONFIG_JSON="$REPO_DIR/config.json"
 if command -v jq >/dev/null 2>&1 && [ -f "$CONFIG_JSON" ]; then

--- a/.oh/scripts/firstmate.sh
+++ b/.oh/scripts/firstmate.sh
@@ -1,81 +1,4 @@
 #!/usr/bin/env bash
-# .oh/scripts/firstmate.sh — the build-executor entrypoint. There is exactly one.
-#
-# Usage:
-#   .oh/scripts/firstmate.sh [--runner herdr|tmux|foreground] [--harness claude|pi|codex]
-#                            [--no-watch] <slug>
-#   .oh/scripts/firstmate.sh --kill <slug>
-#
-# Launches ONE long-lived First-Mate session over the whole `.oh/tasks/<slug>/`
-# task graph. The session manager is resolved by the shared ladder in
-# `.oh/scripts/lib/session-runner.sh` (herdr -> tmux -> foreground); the slug and
-# four-file validation come from `.oh/scripts/lib/task-contract.sh`; the session
-# prompt is rendered from `.oh/skills/firstmate/templates/session-prompt.md`.
-#
-# This is the ONLY build executor. There is no toggle and no alternative arm, so
-# there is also no fallback: recovery from a misbehaving ladder or child session
-# is fix-forward only.
-#
-# ---------------------------------------------------------------------------
-# Naming contract (PRD section 5)
-# ---------------------------------------------------------------------------
-#   herdr agent    firstmate-<slug>
-#   tmux session   agent-firstmate-<slug>
-#   herdr log      /tmp/firstmate-<slug>.log
-#   tmux log       /tmp/agent-firstmate-<slug>.log
-#   lock           /tmp/firstmate-<slug>.lock   (atomic mkdir launch-claim)
-#   rendered prompt /tmp/firstmate-<slug>.prompt.md
-#   terminal       the whole line `STATUS: COMPLETE` in progress.txt
-#
-# ---------------------------------------------------------------------------
-# Configuration (env vars)
-# ---------------------------------------------------------------------------
-#   FIRSTMATE_TIMEOUT_MS    session budget in ms (default 14400000 = 4h).
-#                           Validated ONLY by resolve_timeout_ms in
-#                           session-runner.sh — 0, negative, non-numeric and
-#                           empty are rejected there and the default applies.
-#   FIRSTMATE_HARNESS       claude | pi | codex (default: claude)
-#   FIRSTMATE_CLAUDE_FLAGS  default: --dangerously-skip-permissions
-#                           (NO --print: the child must stay an INTERACTIVE
-#                            session, see the launch note below)
-#   FIRSTMATE_PI_FLAGS      default: (empty, for the same reason)
-#   FIRSTMATE_HARNESS_CMD   full override of the launched command; the rendered
-#                           prompt path is exported as $FIRSTMATE_PROMPT_FILE
-#   FIRSTMATE_BRANCH        override the <branch> placeholder
-#   FIRSTMATE_ISSUE         override the <issue> placeholder
-#   OH_RUNNER               runner override; same values as --runner
-#   RUNNER_TMPDIR           root for logs/lock/prompt (default /tmp; tests only)
-#
-# ---------------------------------------------------------------------------
-# Deliberate deviation from the PRD section 5 launch sketch
-# ---------------------------------------------------------------------------
-# The sketch shows `<harness> "/goal <rendered-prompt>"`. There is no `/goal`
-# skill in this repo (`.oh/skills/` has no `goal` entry). The rendered prompt is
-# written to $FIRSTMATE_PROMPT_FILE and read back inside the LAUNCHED shell as
-# `"$(cat <file>)"`, so it reaches the harness as a single initial argv. The
-# rendered prompt IS the goal brief, so no wrapper verb is lost.
-#
-# ---------------------------------------------------------------------------
-# THE CHILD SESSION IS INTERACTIVE. DO NOT PIPE THE PROMPT IN, AND NO --print
-# ---------------------------------------------------------------------------
-# This was the shape until 2026-08-23 (spec-simplification US-002):
-#
-#     cat <prompt> | claude --dangerously-skip-permissions --print
-#
-# Two things it got wrong, and both are load-bearing:
-#
-#   * `--print` makes the harness answer once and exit. A First Mate session has
-#     to walk a whole task graph over many turns, so a one-shot child cannot do
-#     the job it was launched for.
-#   * Feeding the prompt on stdin makes stdin a PIPE, not a TTY. An interactive
-#     agent session refuses to run without a terminal.
-#
-# OBSERVED 2026-08-23: the child started, printed only startup warnings, and
-# never advanced. The prompt therefore travels as initial argv, and the session
-# stays live and attachable in its herdr pane or tmux session.
-#
-# The same rule binds `.oh/scripts/lib/session-runner.sh`: it must not wrap the
-# launched command in a `tee` log pipe either — see the note above runner_launch.
 
 set -euo pipefail
 
@@ -86,12 +9,8 @@ FIRSTMATE_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=/dev/null
 . "$FIRSTMATE_SCRIPT_DIR/lib/task-contract.sh"
 
-# The skill-owned session-prompt template (US-002), repo-root-relative.
 FIRSTMATE_TEMPLATE_REL=".oh/skills/firstmate/templates/session-prompt.md"
 
-# The CLOSED placeholder set US-002's contract header declares. `{curly}` text
-# is NOT a placeholder — it is runtime-fill the session writes — so the renderer
-# leaves it alone.
 FIRSTMATE_PLACEHOLDERS="slug branch issue"
 
 usage() {
@@ -102,7 +21,6 @@ Usage: firstmate.sh [--runner herdr|tmux|foreground] [--harness claude|pi|codex]
 EOF
 }
 
-# ─── argument parsing ────────────────────────────────────────────────
 
 parse_args() {
   KILL_MODE=0
@@ -177,7 +95,7 @@ parse_args() {
   SLUG="${positional[0]}"
 }
 
-normalize_harness() { # <harness>
+normalize_harness() {
   case "${1:-}" in
     claude | pi | codex)
       printf '%s\n' "$1"
@@ -189,28 +107,24 @@ normalize_harness() { # <harness>
   esac
 }
 
-# ─── paths ───────────────────────────────────────────────────────────
 
 firstmate_repo_root() {
   git rev-parse --show-toplevel 2>/dev/null || pwd
 }
 
-# Where the rendered prompt lands. Honours RUNNER_TMPDIR for the same reason the
-# log and lock paths do — so a test never writes into the real /tmp namespace.
-firstmate_prompt_path() { # <slug>
+firstmate_prompt_path() {
   printf '%s\n' "${RUNNER_TMPDIR:-/tmp}/firstmate-${1:-}.prompt.md"
 }
 
-# ─── placeholder resolution ──────────────────────────────────────────
 
-firstmate_json_field() { # <prd_json> <jq_filter>
+firstmate_json_field() {
   local prd="${1:-}" filter="${2:-}"
   [ -f "$prd" ] || return 0
   command -v jq >/dev/null 2>&1 || return 0
   jq -r "$filter" "$prd" 2>/dev/null || true
 }
 
-firstmate_branch_name() { # <prd_json>
+firstmate_branch_name() {
   local prd="${1:-}" branch=""
   if [ -n "${FIRSTMATE_BRANCH:-}" ]; then
     printf '%s\n' "$FIRSTMATE_BRANCH"
@@ -218,9 +132,6 @@ firstmate_branch_name() { # <prd_json>
   fi
   branch="$(firstmate_json_field "$prd" '.branchName // empty')"
   if [ -z "$branch" ] && [ -f "$prd" ]; then
-    # jq-free fallback: branchName is a flat top-level string. The producer is
-    # wrapped so that `head` closing the pipe early (SIGPIPE, status 141) cannot
-    # fail the whole pipeline under `set -o pipefail` and discard a real match.
     branch="$( { sed -n 's/.*"branchName"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$prd" || true; } | head -n 1)"
   fi
   [ -n "$branch" ] || branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
@@ -228,9 +139,7 @@ firstmate_branch_name() { # <prd_json>
   printf '%s\n' "$branch"
 }
 
-# BARE DIGITS, per US-002's contract: the template writes `#<issue>` wherever a
-# `#`-prefixed reference is wanted, so the renderer must never prepend one.
-firstmate_issue_number() { # <prd_json>
+firstmate_issue_number() {
   local prd="${1:-}" issue=""
   if [ -n "${FIRSTMATE_ISSUE:-}" ]; then
     printf '%s\n' "${FIRSTMATE_ISSUE#\#}"
@@ -238,24 +147,14 @@ firstmate_issue_number() { # <prd_json>
   fi
   issue="$(firstmate_json_field "$prd" '(.issue // .issueNumber // empty) | tostring')"
   if [ -z "$issue" ] && [ -f "$prd" ]; then
-    # A task folder records its issue in prose ("… (issue #746)"), not as a field.
-    # `|| true` absorbs both no-match (status 1) and SIGPIPE from `head`; under
-    # `set -o pipefail` either would otherwise sink the whole substitution.
     issue="$( { grep -oE '#[0-9]+' "$prd" || true; } | head -n 1 | tr -d '#')"
   fi
   [ -n "$issue" ] || issue="unknown"
   printf '%s\n' "$issue"
 }
 
-# ─── the renderer (US-003 owns the renderer; US-002 owns the contract) ──
 
-# Substitutes the closed placeholder set declared in the template's own contract
-# header into the template BODY, and writes the result to stdout.
-#
-# It introduces no token the template does not declare, and self-checks that no
-# declared token survived — a surviving `<slug>` in a live session prompt is a
-# silent, expensive failure.
-render_session_prompt() { # <template> <slug> <branch> <issue>
+render_session_prompt() {
   local template="${1:-}" slug="${2:-}" branch="${3:-}" issue="${4:-}"
   local body token
 
@@ -268,10 +167,6 @@ render_session_prompt() { # <template> <slug> <branch> <issue>
     return 1
   fi
 
-  # Drop the authoring contract header. It documents the placeholder set and the
-  # anchor list for maintainers and for the US-009 probe; it is not instruction
-  # for the session, and feeding it to the session would invite the session to
-  # treat the anchor bookkeeping as work.
   if grep -q 'END CONTRACT HEADER -->' "$template"; then
     body="$(sed -e '1,/END CONTRACT HEADER -->/d' "$template")"
   else
@@ -294,18 +189,11 @@ render_session_prompt() { # <template> <slug> <branch> <issue>
   printf '%s\n' "$body"
 }
 
-# ─── the launched command ────────────────────────────────────────────
 
-# Every arm delivers the rendered prompt as a single INITIAL ARGV read back from
-# $FIRSTMATE_PROMPT_FILE inside the launched shell, and no arm carries `--print`.
-# Both rules exist so the child stays an interactive, attachable, multi-turn
-# session — see the interactive-session note in this file's header.
-firstmate_harness_command() { # <harness> <prompt_file>
+firstmate_harness_command() {
   local harness="${1:-}" prompt_file="${2:-}"
 
   if [ -n "${FIRSTMATE_HARNESS_CMD:-}" ]; then
-    # Full override. The prompt path reaches it as $FIRSTMATE_PROMPT_FILE,
-    # exported below — no substitution magic, so the value stays inspectable.
     printf '%s\n' "$FIRSTMATE_HARNESS_CMD"
     return 0
   fi
@@ -313,8 +201,6 @@ firstmate_harness_command() { # <harness> <prompt_file>
   case "$harness" in
     claude)
       # shellcheck disable=SC2016  # deliberately unexpanded: the $(cat …) must
-      # be evaluated inside the LAUNCHED shell, not here. The prompt is initial
-      # ARGV, never stdin — see the interactive-session note in the header.
       printf 'claude %s "$(cat %q)"\n' \
         "${FIRSTMATE_CLAUDE_FLAGS:---dangerously-skip-permissions}" "$prompt_file"
       ;;
@@ -333,17 +219,8 @@ firstmate_harness_command() { # <harness> <prompt_file>
   esac
 }
 
-# ─── guards ──────────────────────────────────────────────────────────
 
-# THE LAUNCH-CLAIM GUARD. `mkdir` is atomic: exactly one process can create the
-# directory, which closes the check-then-start TOCTOU window that ANY read-only
-# liveness oracle (`herdr agent get`, `tmux has-session`) leaves open between
-# "no live session" and "session started". The oracle answers *is it alive*; the
-# lock answers *who may start it*.
-#
-# A lock whose slug has NO live session is the debris of a hard crash (kill -9)
-# and is STALE AND RECLAIMABLE — it must never wedge a slug permanently.
-firstmate_claim_lock() { # <mode> <slug>
+firstmate_claim_lock() {
   local mode="${1:-}" slug="${2:-}" lock
   lock="$(runner_lock_path "$slug")"
 
@@ -366,9 +243,8 @@ firstmate_claim_lock() { # <mode> <slug>
   return 1
 }
 
-# ─── launch reporting ────────────────────────────────────────────────
 
-firstmate_session_handle() { # <mode> <slug>
+firstmate_session_handle() {
   local mode="${1:-}" slug="${2:-}"
   case "$mode" in
     herdr) printf '%s (pane %s)\n' "$(runner_agent_name "$slug")" "$(runner_pane_id)" ;;
@@ -377,24 +253,17 @@ firstmate_session_handle() { # <mode> <slug>
   esac
 }
 
-firstmate_watch_command() { # <mode> <slug>
+firstmate_watch_command() {
   local mode="${1:-}" slug="${2:-}"
   case "$mode" in
     herdr) printf 'herdr agent read %s --lines 80\n' "$(runner_agent_name "$slug")" ;;
     tmux) printf 'tmux attach -t %s\n' "$(runner_tmux_session "$slug")" ;;
-    # foreground writes NO session log — the child inherits this shell's stdio so it
-    # keeps a TTY (see the interactive-session note in this file's header). Printing a
-    # `tail -f <log>` here would send the operator to a file the child never writes.
     *) printf 'this terminal (the child inherits its stdio)\n' ;;
   esac
 }
 
-# ─── --kill: the manual escape hatch ─────────────────────────────────
 
-# Clears the lock, tears the session down through runner_teardown, and records
-# the outcome in that task's progress.txt. It NEVER stops or restarts the herdr
-# server — only the one pane this slug owns.
-firstmate_kill() { # <slug>
+firstmate_kill() {
   local slug="${1:-}" root task_dir lock
   task_contract_validate_slug "$slug" || exit 2
 
@@ -402,13 +271,8 @@ firstmate_kill() { # <slug>
   task_dir="$root/.oh/tasks/$slug"
   lock="$(runner_lock_path "$slug")"
 
-  # The operator generally does not know which runner won the ladder, so tear
-  # down every mode. Each branch is a no-op when that runner never launched.
-  # herdr's branch is `pane close <pane_id>` — 0.7.4 has no agent stop/kill verb.
   runner_teardown herdr "$slug"
   runner_teardown foreground "$slug"
-  # runner_abort covers the tmux branch AND the shared tail — lock removal plus
-  # the FIRSTMATE-INCOMPLETE line — exactly once.
   runner_abort tmux "$slug" "$task_dir" "operator kill via firstmate.sh --kill"
 
   printf '✓ firstmate session for %s killed.\n' "$slug"
@@ -419,9 +283,8 @@ firstmate_kill() { # <slug>
   printf '  note:     the herdr server was not stopped or restarted.\n'
 }
 
-# ─── launch ──────────────────────────────────────────────────────────
 
-firstmate_launch() { # <slug>
+firstmate_launch() {
   local slug="${1:-}"
   local root task_dir progress template prompt_file branch issue
   local mode harness cmd lock rc=0
@@ -436,7 +299,6 @@ firstmate_launch() { # <slug>
   progress="$task_dir/progress.txt"
   lock="$(runner_lock_path "$slug")"
 
-  # SENTINEL SHORT-CIRCUIT — the task is already done; launch nothing.
   if runner_sentinel_present "$progress"; then
     printf '✓ STATUS: COMPLETE is already present in %s — nothing to launch.\n' "$progress"
     exit 0
@@ -449,8 +311,6 @@ firstmate_launch() { # <slug>
   fi
 
   firstmate_claim_lock "$mode" "$slug" || exit 1
-  # From here on EVERY non-success exit must run the exit path, so the trap goes
-  # in before anything that can fail.
   runner_install_abort_trap "$mode" "$slug" "$task_dir"
 
   template="$root/$FIRSTMATE_TEMPLATE_REL"
@@ -469,8 +329,6 @@ firstmate_launch() { # <slug>
     exit 2
   }
 
-  # The session's own signals. FIRSTMATE_SESSION=1 is the flag the rendered
-  # prompt tells inner /delegate calls to key off when choosing a runner.
   export FIRSTMATE_SESSION=1
   export FIRSTMATE_SLUG="$slug"
   export FIRSTMATE_TASK_DIR="$task_dir"
@@ -481,8 +339,6 @@ firstmate_launch() { # <slug>
     exit 1
   fi
 
-  # cwd flags silently lie, and in herdr mode a wrong cwd means the session is
-  # executing in a different environment entirely.
   if ! runner_verify_cwd "$mode" "$root"; then
     runner_abort "$mode" "$slug" "$task_dir" "launch failure: session cwd could not be verified as $root"
     exit 1
@@ -492,8 +348,6 @@ firstmate_launch() { # <slug>
   printf '│  runner:   %s\n' "$mode"
   printf '│  handle:   %s\n' "$(firstmate_session_handle "$mode" "$slug")"
   printf '│  harness:  %s\n' "$harness"
-  # Only tmux mode captures the session to a file (via pipe-pane); herdr owns its own
-  # pane capture and foreground keeps none, so advertising a path there is a lie.
   case "$mode" in
     tmux) printf '│  log:      %s\n' "$(runner_session_log_path "$mode" "$slug")" ;;
     herdr) printf '│  log:      (herdr pane capture — read it with the watch command)\n' ;;
@@ -519,17 +373,10 @@ firstmate_launch() { # <slug>
     exit 0
   fi
 
-  # runner_watch already ran the exit path via runner_abort: teardown ->
-  # lock removal -> FIRSTMATE-INCOMPLETE.
   printf '\n✗ firstmate session for %s ended without STATUS: COMPLETE — see %s\n' "$slug" "$progress" >&2
   exit 1
 }
 
-# ─── Source guard ────────────────────────────────────────────────────
-# When this file is SOURCED (the vitest suite exercises render_session_prompt
-# and the guards in isolation) rather than executed, return here so only the
-# function definitions land. The real invocation path executes the file
-# directly, keeping BASH_SOURCE[0] == "$0", so this is a strict no-op for it.
 if [ "${BASH_SOURCE[0]}" != "$0" ]; then
   return 0
 fi

--- a/.oh/scripts/gateway.sh
+++ b/.oh/scripts/gateway.sh
@@ -1,39 +1,9 @@
 #!/usr/bin/env bash
-# gateway — start / attach / stop an external-surface client session that bridges
-# the in-sandbox agent into a messaging platform (Slack today).
-#
-# Two backends bridge Slack, each in its OWN tmux session (naming per
-# .oh/docs/connecting.md: client-<platform>-<backend>) and holding its OWN Slack
-# app, so the two coexist without competing for one socket:
-#
-#   pi      client-slack-pi      pi-messenger-bridge, loaded via `pi --extension`
-#                                under the self-healing supervisor
-#                                (.devcontainer/client-slack-supervise.sh).
 #   hermes  client-slack-hermes  `hermes gateway run` — Hermes' native messaging
-#                                gateway.
-#
-# This script manages the session LIFECYCLE plus one convenience entrypoint for
-# Pi bridge configuration: `gateway msg-bridge` starts the Pi client session,
-# sends the bridge's in-session /msg-bridge command, then attaches when run from
-# an interactive terminal. Hermes platform setup remains `hermes gateway setup`,
-# but the launcher pins Hermes runtime/cwd to this harness checkout so gateway
-# chats route tools into ~/harness instead of the shell's home directory.
-#
-# Usage:
-#   gateway <pi|hermes> [--attach]      start the session (idempotent); --attach after
-#   gateway <pi|hermes> --restart       kill + start the session
-#   gateway <pi|hermes> --stop          stop the session
-#   gateway msg-bridge [--no-attach]    open the Pi /msg-bridge config UI
-#   gateway status                      show both sessions
-#
-# NOTE: intentionally no `set -e` — tmux/pkill/grep return non-zero as normal
-# control flow here (mirrors client-slack-supervise.sh).
 set -u
 
 HARNESS="${HARNESS:-${OH_PROJECT_ROOT:-/home/sandbox/harness}}"
 SLACK_ENV="$HARNESS/.devcontainer/.env"
-# TEMPORARY fork pin — carries thread replies + Slack admin slash handlers;
-# revert once upstream merges and publishes them (see .pi/UPSTREAM.md).
 FORK_PIN="github:ryaneggz/pi-messenger-bridge#c8b96e9d0fb69611c4e67ae298d1d10d83792a26"
 
 usage() {
@@ -53,19 +23,13 @@ msg_bridge_usage() {
   echo "then attaches automatically when stdin/stdout are interactive."
 }
 
-# Exact session-name match — `tmux has-session -t client-slack` would prefix-match
-# the sibling client-slack-hermes session, so always match the full name.
 session_live() { tmux ls -F '#{session_name}' 2>/dev/null | grep -Fxq "$1"; }
 
 ANSI_STRIP="sed -u 's/\\x1b\\[[0-9;?]*[A-Za-z]//g; s/\\r//g'"
 
-# Non-secret runtime state the supervisor writes (see client-slack-supervise.sh):
-# $STATE_DIR/<backend>.{state,heartbeat,stale}. Used to report health, not just
-# session existence, in `gateway status`.
 STATE_DIR="${GATEWAY_STATE_DIR:-$HOME/.pi/gateway}"
-STALE_AFTER="${GATEWAY_STALE_AFTER:-60}"   # seconds without a heartbeat => not healthy
+STALE_AFTER="${GATEWAY_STALE_AFTER:-60}"
 
-# Parse a key from a state file as DATA (grep/cut, never source/eval).
 _state_kv() {
   [ -f "$1" ] || return 1
   local line; line=$(grep -E "^$2=" "$1" 2>/dev/null | tail -1) || return 1
@@ -73,7 +37,6 @@ _state_kv() {
   printf '%s' "${line#*=}"
 }
 
-# Seconds since the epoch timestamp in $1, or non-zero if unreadable/non-numeric.
 _state_age() {
   [ -f "$1" ] || return 1
   local t; t=$(cat "$1" 2>/dev/null) || return 1
@@ -81,7 +44,6 @@ _state_age() {
   printf '%s' "$(( $(date -u +%s) - t ))"
 }
 
-# Human health phrase for a LIVE backend session, from its state files.
 backend_health() {
   local b="$1"
   local state="$STATE_DIR/$b.state" hb="$STATE_DIR/$b.heartbeat" stale="$STATE_DIR/$b.stale"
@@ -166,9 +128,6 @@ start_pi() {
   command -v pi >/dev/null 2>&1 \
     || { echo "[gateway] 'pi' not found on PATH — run inside the sandbox" >&2; return 1; }
 
-  # Tokens (optional): source from the Compose env file if not already exported.
-  # Extract only the two keys as DATA (never eval the file), never echo values.
-  # Without them /msg-bridge still loads; the bridge just stays disconnected.
   if [ -z "${PI_SLACK_BOT_TOKEN:-}" ] && [ -f "$SLACK_ENV" ]; then
     local a b
     a=$(grep -E '^PI_SLACK_APP_TOKEN=' "$SLACK_ENV" | tail -1 | cut -d= -f2-)
@@ -179,9 +138,6 @@ start_pi() {
   [ -n "${PI_SLACK_BOT_TOKEN:-}" ] \
     || echo "[gateway] no PI_SLACK_* tokens — bridge loads but stays disconnected"
 
-  # Install or reconcile the bridge when the reviewed pin changes. Existing
-  # sandboxes predate the marker, so the first restart after an upgrade refreshes
-  # the package instead of silently retaining an older branch.
   local installed_pin=""
   mkdir -p "$bridge_dir"
   [ -f "$bridge_pin_file" ] && installed_pin="$(cat "$bridge_pin_file" 2>/dev/null || true)"
@@ -192,12 +148,9 @@ start_pi() {
     printf '%s\n' "$FORK_PIN" >"$bridge_pin_file"
   fi
 
-  # Seed the non-secret bridge config (preserves runtime trust grants), clear lock.
   bash "$HARNESS/.devcontainer/seed-msg-bridge.sh" "$HARNESS/.pi/msg-bridge.json" || true
   rm -f "$HOME/.pi/msg-bridge.lock" 2>/dev/null || true
 
-  # Pass config + tokens to the session via a mode-600 runtime env file the pane
-  # sources and deletes before exec — keeps secrets out of argv / ps / tmux env.
   local envf; envf=$(mktemp /tmp/client-slack-pi-env.XXXXXX) || return 1
   chmod 600 "$envf"
   {
@@ -211,8 +164,6 @@ start_pi() {
 
   if tmux new-session -d -s "$session" \
        "bash -c '. \"$envf\"; rm -f \"$envf\"; exec bash \"$HARNESS/.devcontainer/client-slack-supervise.sh\"'"; then
-    # pi runs interactive (no `| tee`), so mirror the pane into the log,
-    # ANSI-stripped, for the stale-ctx watchdog and humans.
     tmux pipe-pane -o -t "$session" "$ANSI_STRIP >> $log" 2>/dev/null || true
   else
     rm -f "$envf"
@@ -303,10 +254,6 @@ ensure_hermes_gateway_cwd() {
   local hermes_home="$1" gateway_cwd="$2"
   local config_file="$hermes_home/config.yaml"
   mkdir -p "$hermes_home"
-  # Hermes gateway defaults terminal.cwd to $HOME when config.yaml omits it.
-  # Persist the harness cwd so relative tool/file operations route into the
-  # checkout no matter where `gateway hermes` was invoked from. Patch the YAML
-  # directly instead of `hermes config set` so user comments survive.
   command -v python3 >/dev/null 2>&1 || { echo "[gateway] warning: python3 unavailable; cannot persist terminal.cwd" >&2; return 0; }
   python3 - "$config_file" "$gateway_cwd" <<'PY'
 from pathlib import Path
@@ -363,16 +310,10 @@ start_hermes() {
   ensure_hermes_teams_deps "$hermes_home" || return 1
   ensure_hermes_gateway_cwd "$hermes_home" "$gateway_cwd"
 
-  # Hermes' gateway reads its own config (hermes gateway setup / hermes secrets),
-  # so no PI_SLACK_* plumbing here. Run under the shared supervisor's GENERIC
-  # crash-restart mode (no pi-specific stale-ctx/lock/recovery) so a hermes crash
-  # self-heals with backoff, matching the pi backend's resilience floor.
   local run_cmd
   printf -v run_cmd 'cd %q && export HERMES_HOME=%q HERMES_GATEWAY_CWD=%q && exec %q gateway run' \
     "$gateway_cwd" "$hermes_home" "$gateway_cwd" "$hermes_bin"
 
-  # No secrets in the hermes launch command, but use the same mode-600
-  # source-then-delete env-file pattern as pi for uniformity.
   local envf; envf=$(mktemp /tmp/client-slack-hermes-env.XXXXXX) || return 1
   chmod 600 "$envf"
   {
@@ -392,7 +333,6 @@ start_hermes() {
   fi
 }
 
-# ─── Arg parsing ──────────────────────────────────────────────────────────────
 cmd="${1:-}"
 case "$cmd" in
   status|--status) show_status; exit 0 ;;

--- a/.oh/scripts/get-oh.sh
+++ b/.oh/scripts/get-oh.sh
@@ -1,52 +1,19 @@
 #!/usr/bin/env bash
 
-# ─── Sourced-vs-executed detection ───────────────────────────────────
-# When this script is `source`d (e.g. `source <(curl -fsSL .../get-oh.sh)`)
-# so it can mutate the CALLER's live PATH, it must NOT enable strict mode,
-# must NOT install traps on the caller's interactive shell, and must NOT
-# `exit` — any of those would corrupt or kill the interactive session.
 if [ "${BASH_SOURCE[0]}" != "$0" ]; then _OH_SOURCED=1; else _OH_SOURCED=0; fi
 
-# Strict mode only when executed as its own process — never when sourced.
 [ "$_OH_SOURCED" = 0 ] && set -euo pipefail
 
-# get-oh.sh — install the standalone `oh` CLI onto a host.
-#
-# This script is the npm-free bootstrap: it places the single, self-contained
-# `oh` binary at its destination (default ~/.local/bin/oh) and nothing else — it
-# does NOT clone the harness repo and does NOT touch the sandbox install dir or
-# any existing config. It prefers a prebuilt bundle (https://oh.mifune.dev/oh.js)
-# and falls back to building from source in a temp dir if that download fails.
-# (The CLI is also published to npm as `@mifune/openharness` — `npm i -g
-# @mifune/openharness` — for hosts that already have Node >= 20.)
-#
-# `oh init` fetches its scaffold payload on demand (a shallow clone into a temp
-# dir that it deletes), so no local repo is needed after install.
-#
-# Requires Node.js >= 20 to RUN `oh`; if it's missing this script offers to
-# install nvm + Node 22 and sources it so `oh` works in the same shell.
-# git is only needed for the build fallback and for `oh init`'s payload fetch.
 
-# Surface silent set -e exits — without this, any non-zero return mid-script
-# kills bash with no `ERROR:` line and the user is left staring at a prompt.
-# Executed path only: never install traps on a sourcing caller's shell.
 [ "$_OH_SOURCED" = 0 ] && trap 'printf "\n\033[0;31mERROR:\033[0m get-oh.sh aborted (exit %s) at line %s: %s\n" "$?" "$LINENO" "$BASH_COMMAND" >&2' ERR
 
-# ─── Colours / helpers ───────────────────────────────────────────────
 RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; CYAN='\033[0;36m'; NC='\033[0m'
 banner() { printf "\n${CYAN}==> %s${NC}\n" "$*"; }
 ok()     { printf "${GREEN} ✓  %s${NC}\n" "$*"; }
 warn()   { printf "${YELLOW}WARN: %s${NC}\n" "$*" >&2; }
 die()    { printf "${RED}ERROR: %s${NC}\n" "$*" >&2; if [ "${_OH_SOURCED:-0}" = 1 ]; then _oh_cleanup; return 1; else exit 1; fi; }
-# Remove the temp dir. On the executed path an EXIT trap calls this; on the
-# sourced path there is no EXIT trap (we must not install one on the caller),
-# so we invoke it explicitly at the end and from die().
 _oh_cleanup() { [ -n "${TMP:-}" ] && rm -rf "$TMP" 2>/dev/null || true; }
 
-# ─── prompt_yn: yes/no prompt with /dev/tty discipline ──────────────
-# Reads keystrokes from /dev/tty so it works when the script is piped from
-# curl (stdin is the script source in pipe mode, not the keyboard).
-# Respects ASSUME_YES / ASSUME_NO. Returns 0 for yes, 1 for no.
 prompt_yn() {
   local __msg="$1"; local __default="${2:-y}"
   if [ "${ASSUME_YES:-false}" = true ]; then return 0; fi
@@ -65,7 +32,6 @@ prompt_yn() {
   fi
 }
 
-# ─── Help ────────────────────────────────────────────────────────────
 print_help() {
   cat <<HELPEOF
 Open Harness — install the standalone 'oh' CLI
@@ -102,7 +68,6 @@ Examples:
 HELPEOF
 }
 
-# ─── Arg parsing ─────────────────────────────────────────────────────
 ASSUME_YES="${OH_ASSUME_YES:+true}"; ASSUME_YES="${ASSUME_YES:-false}"
 ASSUME_NO=false
 while [ $# -gt 0 ]; do
@@ -117,7 +82,6 @@ while [ $# -gt 0 ]; do
 done
 [ "$ASSUME_YES" = true ] && [ "$ASSUME_NO" = true ] && die "--yes and --no are mutually exclusive."
 
-# ─── Config (env-overridable) ────────────────────────────────────────
 OH_BIN_DIR="${OH_BIN_DIR:-$HOME/.local/bin}"
 OH_JS_URL="${OH_JS_URL:-https://oh.mifune.dev/oh.js}"
 OH_GITHUB_REPO="${OH_GITHUB_REPO:-mifunedev/openharness}"
@@ -127,7 +91,6 @@ fi
 OH_GITHUB_REF="${OH_GITHUB_REF:-${OH_INSTALL_REF:-}}"
 OH_NVM_VERSION="${OH_NVM_VERSION:-v0.40.3}"
 
-# Detect a local OpenHarness checkout (used only as a build-fallback source).
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" 2>/dev/null && pwd)"
 LOCAL_CLI_DIR=""
 if [ -n "$SCRIPT_DIR" ]; then
@@ -135,7 +98,6 @@ if [ -n "$SCRIPT_DIR" ]; then
   if [ -n "$__cand" ] && [ -f "$__cand/.oh/cli/package.json" ]; then LOCAL_CLI_DIR="$__cand/.oh/cli"; fi
 fi
 
-# ─── Node install (offer nvm + Node 22 when missing/too old) ─────────
 node_major() { node -p 'process.versions.node.split(".")[0]' 2>/dev/null || echo 0; }
 
 install_node_via_nvm() {
@@ -144,14 +106,11 @@ install_node_via_nvm() {
   if [ ! -s "$NVM_DIR/nvm.sh" ]; then
     curl -fsSL "https://raw.githubusercontent.com/nvm-sh/nvm/${OH_NVM_VERSION}/install.sh" | bash
   fi
-  # nvm.sh is not `set -eu` clean; relax strict mode while sourcing + installing,
-  # then source it into THIS shell so `node` works right away.
   set +eu
   # shellcheck source=/dev/null
   . "$NVM_DIR/nvm.sh"
   nvm install 22
   nvm use 22
-  # Restore strict mode only when executed; never enable set -e in a sourcing caller.
   [ "$_OH_SOURCED" = 0 ] && set -eu
 }
 
@@ -175,7 +134,6 @@ ensure_node() {
   ok "Node.js $(node --version) — OK"
 }
 
-# ─── Obtain oh.js ────────────────────────────────────────────────────
 build_from_source() {
   local workdir="$1" clidir
   command -v git >/dev/null 2>&1 || die "git is required to build 'oh' from source (prebuilt download failed). Install git from https://git-scm.com"
@@ -197,17 +155,13 @@ build_from_source() {
   [ -f "$OH_JS" ] || die "build did not produce $OH_JS"
 }
 
-# ─── Main ────────────────────────────────────────────────────────────
 printf "\n${CYAN}╔══════════════════════════════════════╗${NC}\n"
 printf "${CYAN}║   Open Harness — install 'oh' CLI    ║${NC}\n"
 printf "${CYAN}╚══════════════════════════════════════╝${NC}\n\n"
 
-# `|| return 1` is dead code when executed (die exits under strict mode); it only
-# fires on the sourced path, where die returns instead of killing the caller's shell.
 ensure_node || return 1
 
 TMP="$(mktemp -d)"
-# EXIT trap only on the executed path; the sourced path cleans up explicitly.
 [ "$_OH_SOURCED" = 0 ] && trap '_oh_cleanup' EXIT
 OH_JS=""
 
@@ -220,9 +174,6 @@ else
   build_from_source "$TMP"
 fi
 
-# ─── Install to destination (single self-contained file) ─────────────
-# Guard against a sourced run continuing past a failed fetch/build (die returns
-# rather than exits when sourced), which would otherwise try to install nothing.
 if [ -z "${OH_JS:-}" ] || [ ! -f "$OH_JS" ]; then
   warn "Could not obtain the 'oh' bundle (download and source build both failed)."
   _oh_cleanup
@@ -234,8 +185,6 @@ mkdir -p "$OH_BIN_DIR"
 install -m 0755 "$OH_JS" "$OH_BIN_DIR/oh"
 ok "Installed $OH_BIN_DIR/oh"
 
-# ─── Ensure it's on PATH ─────────────────────────────────────────────
-# EXPORT_LINE is the resolved activation line ($OH_BIN_DIR expanded, $PATH literal).
 EXPORT_LINE="export PATH=\"$OH_BIN_DIR:\$PATH\""
 case ":$PATH:" in
   *":$OH_BIN_DIR:"*) PATH_OK=1 ;;
@@ -244,7 +193,6 @@ esac
 NEED_PATH=0
 if [ "$PATH_OK" = "0" ]; then
   NEED_PATH=1
-  # Idempotent profile append so FUTURE shells pick it up (append only, never dup).
   for prof in "$HOME/.zprofile" "$HOME/.profile" "$HOME/.bashrc"; do
     if [ -f "$prof" ] && ! grep -qsF "$OH_BIN_DIR" "$prof"; then
       printf '\n# Added by Open Harness get-oh.sh\n%s\n' "$EXPORT_LINE" >> "$prof"
@@ -252,8 +200,6 @@ if [ "$PATH_OK" = "0" ]; then
       break
     fi
   done
-  # Sourced path: mutate the CALLER's live PATH so `oh` is usable immediately in
-  # the current shell — prepend only when not already present.
   if [ "$_OH_SOURCED" = 1 ]; then
     export PATH="$OH_BIN_DIR:$PATH"
     PATH_OK=1
@@ -262,7 +208,6 @@ if [ "$PATH_OK" = "0" ]; then
   fi
 fi
 
-# ─── Done ────────────────────────────────────────────────────────────
 banner "Done"
 if [ "$PATH_OK" = "1" ]; then
   ok "oh $("$OH_BIN_DIR/oh" --version 2>/dev/null || echo '(run: oh --version)')"
@@ -278,11 +223,6 @@ Next steps:
 Upgrade later by re-running get-oh.sh.
 DONEEOF
 
-# ─── PATH activation (executed path) ─────────────────────────────────
-# A child `bash` cannot mutate its parent's PATH, so when run as its own
-# process we can only PRINT how to activate `oh` in the CURRENT shell. Make
-# this the last, unmissable thing the user sees — with the resolved line and
-# the same-shell sourcing alternative.
 if [ "$_OH_SOURCED" = 0 ] && [ "$NEED_PATH" = "1" ]; then
   printf "\n${YELLOW}╔══════════════════════════════════════════════════════════════╗${NC}\n"
   printf "${YELLOW}║  ACTION REQUIRED — activate 'oh' in your CURRENT shell        ║${NC}\n"
@@ -293,5 +233,4 @@ if [ "$_OH_SOURCED" = 0 ] && [ "$NEED_PATH" = "1" ]; then
   printf "  …or just open a new terminal.\n"
 fi
 
-# Sourced path has no EXIT trap — clean the temp dir up explicitly.
 [ "$_OH_SOURCED" = 1 ] && _oh_cleanup

--- a/.oh/scripts/git-maintenance.sh
+++ b/.oh/scripts/git-maintenance.sh
@@ -1,25 +1,4 @@
 #!/usr/bin/env bash
-# git-maintenance.sh — file-invoked destructive-git operations for harness automation.
-#
-# cc-safety-net's PreToolUse hook denies inline destructive git (`git reset --hard <ref>`,
-# `git clean -f`, `git branch -D`, `git worktree remove --force`, `git push --force`) in
-# every mode, and its built-in git rules are NOT allowlistable. Script-file invocation
-# (`bash .oh/scripts/git-maintenance.sh ...`) is not analyzed by the guard, so the harness's
-# own legitimate destructive git — the reset|clean runner, worktree/branch
-# grooming — routes through this script instead of inline agent Bash.
-#
-# Usage:
-#   git-maintenance.sh reset-hard <ref>            # git reset --hard <ref>
-#   git-maintenance.sh clean                       # git clean -fd
-#   git-maintenance.sh branch-delete <branch>      # git branch -D <branch>
-#   git-maintenance.sh worktree-remove <path>      # git worktree remove --force <path>
-#   git-maintenance.sh push-force <remote> <branch> # git push --force-with-lease <remote> <branch>
-#
-# Every subcommand refuses to run outside a git repository and echoes a one-line log of
-# exactly what it ran. Unknown or missing subcommands print usage and exit 2.
-#
-# This is a compatibility shim, NOT a security control: the same script-file gap is the
-# model's evasion route. Docker is the security boundary; cc-safety-net is a footgun net.
 set -euo pipefail
 
 usage() {
@@ -35,7 +14,6 @@ Subcommands:
 EOF
 }
 
-# Refuse to run outside a git repository.
 require_repo() {
   if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
     echo "git-maintenance.sh: not inside a git repository; refusing to run" >&2
@@ -43,7 +21,6 @@ require_repo() {
   fi
 }
 
-# Echo the one-line log of what we ran.
 log_run() {
   echo "git-maintenance.sh: ran: $*"
 }

--- a/.oh/scripts/install.sh
+++ b/.oh/scripts/install.sh
@@ -1,42 +1,23 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Surface silent set -e exits — without this, any non-zero return mid-script
-# kills bash with no `ERROR:` line and the user is left staring at a prompt
-# wondering why install bailed.
 trap 'printf "\n\033[0;31mERROR:\033[0m install.sh aborted (exit %s) at line %s: %s\n" "$?" "$LINENO" "$BASH_COMMAND" >&2' ERR
 
-# ─── Colours / helpers ───────────────────────────────────────────────
 RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; CYAN='\033[0;36m'; NC='\033[0m'
 banner() { printf "\n${CYAN}==> %s${NC}\n" "$*"; }
 ok()     { printf "${GREEN} ✓  %s${NC}\n" "$*"; }
 warn()   { printf "${YELLOW}WARN: %s${NC}\n" "$*" >&2; }
 die()    { printf "${RED}ERROR: %s${NC}\n" "$*" >&2; exit 1; }
 
-# ─── normalize_gh_slug: strip GitHub URL decoration → owner/repo ─────
-# Handles four forms:
-#   https://github.com/owner/repo.git  →  owner/repo
-#   https://github.com/owner/repo      →  owner/repo
-#   git@github.com:owner/repo.git      →  owner/repo
-#   git@github.com:owner/repo          →  owner/repo
 normalize_gh_slug() {
   local _url="$1"
-  # Strip https://github.com/ prefix (case-insensitive via tr would add
-  # complexity; GitHub slugs are case-insensitive but we preserve original case
-  # for comparison — OH_GITHUB_REPO is user-supplied already normalized).
   _url="${_url#https://github.com/}"
-  # Strip git@github.com: prefix
   _url="${_url#git@github.com:}"
-  # Strip trailing .git suffix
   _url="${_url%.git}"
   printf '%s' "$_url"
 }
 
 
-# ─── prompt_input: env-var > /dev/tty > default fallback > die ──────
-# Args: $1=varname, $2=prompt msg, $3=default (optional), $4=-s for secret
-# Reads from /dev/tty so curl-piped installs still get keystrokes (stdin
-# is the script source in pipe mode, not the user's keyboard).
 prompt_input() {
   local __var="$1"; local __msg="$2"; local __default="${3:-}"; local __secret="${4:-}"
   if [ -n "${!__var:-}" ]; then
@@ -67,10 +48,6 @@ prompt_input() {
   fi
 }
 
-# ─── prompt_yn: yes/no prompt with /dev/tty discipline ──────────────
-# Args: $1=prompt msg, $2=default ("y" or "n")
-# Returns 0 for yes, 1 for no.
-# Respects ASSUME_YES=true and ASSUME_NO=true.
 prompt_yn() {
   local __msg="$1"; local __default="${2:-y}"
   if [ "${ASSUME_YES:-false}" = true ]; then
@@ -103,7 +80,6 @@ prompt_yn() {
   fi
 }
 
-# ─── Help ────────────────────────────────────────────────────────────
 print_help() {
   cat <<HELPEOF
 Open Harness — Installer
@@ -164,7 +140,6 @@ Examples:
 HELPEOF
 }
 
-# ─── Arg parsing ─────────────────────────────────────────────────────
 ASSUME_YES="${OH_ASSUME_YES:+true}"; ASSUME_YES="${ASSUME_YES:-false}"
 ASSUME_NO=false
 
@@ -191,12 +166,10 @@ done
 
 [ "$ASSUME_YES" = true ] && [ "$ASSUME_NO" = true ] && die "--yes and --no are mutually exclusive."
 
-# ─── Banner ──────────────────────────────────────────────────────────
 printf "\n${CYAN}╔══════════════════════════════════════╗${NC}\n"
 printf "${CYAN}║   Open Harness — Installer           ║${NC}\n"
 printf "${CYAN}╚══════════════════════════════════════╝${NC}\n\n"
 
-# ─── 1. Check Docker ────────────────────────────────────────────────
 banner "Checking Docker"
 if ! command -v docker >/dev/null 2>&1; then
   die "Docker is not installed. Install Docker from: https://docs.docker.com/get-docker/"
@@ -207,38 +180,28 @@ fi
 ok "Docker $(docker --version | awk '{print $3}') — OK"
 ok "Docker Compose $(docker compose version --short) — OK"
 
-# ─── 2. Check git ────────────────────────────────────────────────────
 banner "Checking git"
 if ! command -v git >/dev/null 2>&1; then
   die "git is required to clone or update Open Harness. Install git from: https://git-scm.com"
 fi
 ok "git $(git --version | awk '{print $3}') — OK"
 
-# ─── 2b. Check make (soft — lifecycle convenience, not required to install) ─
-# install.sh drives docker compose directly, so make is not needed to install.
-# The documented lifecycle (make shell / make destroy / make help) is, though —
-# warn rather than die so a make-less host still gets a running sandbox.
 if ! command -v make >/dev/null 2>&1; then
   warn "make not found — the sandbox still comes up, but the documented lifecycle (make shell / make destroy / make help) needs it. Install build-essential (Debian/Ubuntu) or Xcode Command Line Tools (macOS)."
 fi
 
-# ─── 3. Resolve repo directory ────────────────────────────────────────
 banner "Resolving repository"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" 2>/dev/null && pwd)"
-# install.sh lives at .oh/scripts/install.sh; the repo root is two levels up.
 REPO_CANDIDATE="$(cd "$SCRIPT_DIR/../.." 2>/dev/null && pwd)"
 
 if [ -n "$REPO_CANDIDATE" ] && [ -f "$REPO_CANDIDATE/.devcontainer/docker-compose.yml" ] && [ -f "$REPO_CANDIDATE/.oh/scripts/install.sh" ]; then
   REPO_DIR="$REPO_CANDIDATE"
   ok "Using local repo: $REPO_DIR"
 else
-  # Install target is ~/.openharness (hidden dir, no collision with repo subdirs).
-  # OLD_REPO is the post-#200 path that was briefly the install target.
   OLD_REPO="$HOME/openharness"
   REPO_DIR="$HOME/.openharness"
 
-  # ── OH_GITHUB_REPO: fork-parameterized clone source ───────────────────
   OH_GITHUB_REPO="${OH_GITHUB_REPO:-mifunedev/openharness}"
   if [[ ! "$OH_GITHUB_REPO" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
     die "OH_GITHUB_REPO must be <owner>/<repo>: got '$OH_GITHUB_REPO'"
@@ -247,13 +210,11 @@ else
     warn "Cloning from fork: $OH_GITHUB_REPO"
   fi
 
-  # ── OH_GITHUB_REF: alias for OH_INSTALL_REF (OH_GITHUB_REF wins if set) ─
   if [ -n "${OH_GITHUB_REF:-}" ] && [ -n "${OH_INSTALL_REF:-}" ] && [ "$OH_GITHUB_REF" != "$OH_INSTALL_REF" ]; then
     warn "OH_GITHUB_REF and OH_INSTALL_REF both set with different values; OH_GITHUB_REF wins."
   fi
   OH_GITHUB_REF="${OH_GITHUB_REF:-${OH_INSTALL_REF:-}}"
 
-  # ── Population classification + migration ─────────────────────────────
   __HAS_OLD=0; __HAS_NEW=0
   [ -d "$OLD_REPO/.git" ] && __HAS_OLD=1
   if [ -d "$REPO_DIR" ] && [ ! -d "$REPO_DIR/.git" ]; then
@@ -263,12 +224,10 @@ else
   [ -d "$REPO_DIR/.git" ] && __HAS_NEW=1
 
   if [ "$__HAS_OLD" = "1" ] && [ "$__HAS_NEW" = "1" ]; then
-    # ── B+C collision: both paths exist ───────────────────────────────────
     __OLD_DIRTY=0; __NEW_DIRTY=0
     git -C "$OLD_REPO" diff --quiet 2>/dev/null && git -C "$OLD_REPO" diff --cached --quiet 2>/dev/null || __OLD_DIRTY=1
     git -C "$REPO_DIR" diff --quiet 2>/dev/null && git -C "$REPO_DIR" diff --cached --quiet 2>/dev/null || __NEW_DIRTY=1
     if [ "$__OLD_DIRTY" = "1" ] && [ "$__NEW_DIRTY" = "0" ]; then
-      # OLD has changes; keep OLD as active (rename to new), archive NEW
       __ARCHIVE="${REPO_DIR}.legacy.$(date +%Y%m%d%H%M%S)"
       mv "$REPO_DIR" "$__ARCHIVE"
       warn "Archived $REPO_DIR → $__ARCHIVE"
@@ -276,13 +235,11 @@ else
       mv "$OLD_REPO" "$REPO_DIR"
       ok "Migrated $OLD_REPO → $REPO_DIR (had local changes — autostashed)"
     elif [ "$__NEW_DIRTY" = "1" ] && [ "$__OLD_DIRTY" = "0" ]; then
-      # NEW has changes; keep NEW, archive OLD
       __ARCHIVE="${OLD_REPO}.legacy.$(date +%Y%m%d%H%M%S)"
       mv "$OLD_REPO" "$__ARCHIVE"
       warn "Archived $OLD_REPO → $__ARCHIVE"
       ok "Keeping $REPO_DIR (had local changes)"
     else
-      # Neither (or both) dirty: prefer OLD_REPO (post-#200, more recent install)
       __ARCHIVE="${REPO_DIR}.legacy.$(date +%Y%m%d%H%M%S)"
       mv "$REPO_DIR" "$__ARCHIVE"
       warn "Archived $REPO_DIR → $__ARCHIVE"
@@ -292,17 +249,13 @@ else
     fi
     unset __OLD_DIRTY __NEW_DIRTY __ARCHIVE
   elif [ "$__HAS_OLD" = "1" ] && [ "$__HAS_NEW" = "0" ]; then
-    # ── Population B: ~/openharness only — rename to ~/.openharness ────────
     git -C "$OLD_REPO" stash push -u -m "install.sh: pre-rename autostash" 2>/dev/null || true
     mv "$OLD_REPO" "$REPO_DIR"
     ok "Migrated $OLD_REPO → $REPO_DIR"
   fi
-  # Population C (~/.openharness only) and A (neither) fall through to the
-  # pull / clone logic below.
   unset __HAS_OLD __HAS_NEW OLD_REPO
 
   if [ -d "$REPO_DIR/.git" ]; then
-    # ── US-003: Validate remote origin matches OH_GITHUB_REPO ─────────────
     __ORIGIN_RAW="$(git -C "$REPO_DIR" remote get-url origin 2>/dev/null || true)"
     __ORIGIN_SLUG="$(normalize_gh_slug "${__ORIGIN_RAW:-}")"
     __EXPECTED_SLUG="$(normalize_gh_slug "$OH_GITHUB_REPO")"
@@ -314,7 +267,6 @@ else
       warn "  3. Re-run with the desired OH_GITHUB_REPO and (if needed) OH_GITHUB_REF."
       warn "  Note: rm -rf also discards any local changes and pinned OH_INSTALL_REF state."
     else
-      # ── Pull (clean tree only) ─────────────────────────────────────────────
       if git -C "$REPO_DIR" diff --quiet 2>/dev/null && git -C "$REPO_DIR" diff --cached --quiet 2>/dev/null; then
         printf "  Repository exists — pulling latest changes...\n"
         git -C "$REPO_DIR" pull --ff-only
@@ -325,7 +277,6 @@ else
     fi
     unset __ORIGIN_RAW __ORIGIN_SLUG __EXPECTED_SLUG
   else
-    # ── Population A: fresh clone ──────────────────────────────────────────
     if [ -n "$OH_GITHUB_REF" ]; then
       git clone --branch "$OH_GITHUB_REF" "https://github.com/${OH_GITHUB_REPO}.git" "$REPO_DIR"
       ok "Repository cloned at ref '$OH_GITHUB_REF': $REPO_DIR"
@@ -335,8 +286,6 @@ else
     fi
   fi
 
-  # ── Shell CWD notice (for B migration) ────────────────────────────────
-  # If the user's shell was open in ~/openharness, that path no longer exists.
   printf "\n"
   warn "If your current shell is still in ~/openharness, run: cd ~/.openharness"
   printf "\n"
@@ -344,45 +293,23 @@ fi
 
 cd "$REPO_DIR"
 
-# The skills/agents/hooks pack is vendored under .oh/. Wire (or repair) the
-# provider symlinks into it before the sandbox build/provider startup reads them.
 if [ -x .oh/scripts/link-providers.sh ]; then
   bash .oh/scripts/link-providers.sh --init
 fi
 
-# ─── 4. Configure sandbox ────────────────────────────────────────────
 banner "Configuring sandbox"
 
-# Default the sandbox/compose project name to the repo dir's basename, but strip
-# a leading dot: the install target is ~/.openharness, and ".openharness" both
-# reads like a folder path and is an invalid docker-compose project name (must
-# start with an alphanumeric). Fall back to "openharness" if stripping empties it.
 DEFAULT_NAME=$(basename "$REPO_DIR"); DEFAULT_NAME="${DEFAULT_NAME#.}"
 [ -n "$DEFAULT_NAME" ] || DEFAULT_NAME="openharness"
 prompt_input SANDBOX_NAME "Container name" "$DEFAULT_NAME"
 ok "Name: $SANDBOX_NAME"
 
-# ─── Guard: don't clobber a sandbox that already exists under this name ──
-# The compose service uses container_name=$SANDBOX_NAME and image
-# sandbox-$SANDBOX_NAME (.devcontainer/docker-compose.yml). Bringing the
-# sandbox up while a container of the same name exists — running OR stopped —
-# would recreate it and can lose its bind-mounted .devcontainer/.env and
-# .hermes state. Names must be unique; refuse unless the operator explicitly
-# opts into replacing it with OH_REPLACE=1. `docker ps -a` covers stopped
-# containers too, so an idle prior install isn't silently overwritten. (A
-# leftover clone with NO container is safe: its .env/.hermes are reused, not
-# lost, so we don't block on the directory alone.)
 if [ "${OH_REPLACE:-}" != "1" ] && docker ps -a --format '{{.Names}}' 2>/dev/null | grep -Fxq "$SANDBOX_NAME"; then
   die "A sandbox named '$SANDBOX_NAME' already exists (a container with that name is present — running or stopped) — refusing to overwrite it and risk losing its .devcontainer/.env or .hermes state. Choose a unique name (re-run with SANDBOX_NAME=<name>), or pass OH_REPLACE=1 to rebuild this one in place."
 fi
 
 mkdir -p "$REPO_DIR/.devcontainer"
 
-# ─── Materialize .devcontainer/.env BEFORE configuring ───────────────
-# The installer's answers are written INTO this file, so it has to exist first.
-# .devcontainer/.env is gitignored; the .example is tracked, ships fully
-# commented, and is the schema document for every key. Peer impl: seedEnvFile()
-# in .oh/cli/src/lib/env-file.ts.
 ENV_FILE="$REPO_DIR/.devcontainer/.env"
 mkdir -p "$REPO_DIR/.devcontainer"
 if [ ! -f "$ENV_FILE" ]; then
@@ -401,17 +328,11 @@ else
   __ENV_WAS_NEW=0
 fi
 
-# Carry over a harness.yaml left by a pre-0.4.0 install, exactly once. The
-# migrator is self-contained and a no-op when there is no harness.yaml.
 if [ -f "$REPO_DIR/harness.yaml" ] && [ -f "$REPO_DIR/.oh/scripts/migrate-harness-yaml.sh" ]; then
   sh "$REPO_DIR/.oh/scripts/migrate-harness-yaml.sh" "$REPO_DIR"
 fi
 
-# Set one "KEY=value" line in .devcontainer/.env, UNCOMMENTING the template's
-# commented line in place so the surrounding prose keeps describing a key that
-# is now live. Appends only when the key is named nowhere. Same discipline as
-# setKeyInEnv() in the CLI and _env_set in migrate-harness-yaml.sh.
-_env_set() {   # $1 = key, $2 = value
+_env_set() {
   [ -n "${2:-}" ] || return 0
   awk -v key="$1" -v val="$2" '
     BEGIN { done = 0 }
@@ -425,12 +346,7 @@ _env_set() {   # $1 = key, $2 = value
 }
 
 # THE CONFIG WRITES ALWAYS RUN. They used to sit inside `if [ ! -f .env ]`, so
-# re-running the installer over an existing install wrote nothing. With .env as
-# the only configuration surface that would have made a re-run a total no-op.
-# Every write below is idempotent and edits one line, so an existing file keeps
-# its hand edits everywhere the installer does not have an answer.
 
-# Portable in-place sed: GNU sed uses -i, BSD/macOS requires -i ''
 _sedi() {
   if sed --version >/dev/null 2>&1; then
     sed -i "$@"
@@ -438,7 +354,6 @@ _sedi() {
     sed -i '' "$@"
   fi
 }
-# Escape sed replacement-string special chars for | delimiter (|, &, \)
 _sed_val() {
   printf '%s' "$1" \
     | sed 's/\\/\\\\/g' \
@@ -446,15 +361,11 @@ _sed_val() {
     | sed 's/&/\\&/g'
 }
 
-# Detect host values
 __TZ="$(cat /etc/timezone 2>/dev/null || echo America/Los_Angeles)"
 __GIT_NAME="$(git config --get user.name 2>/dev/null || true)"
 __GIT_EMAIL="$(git config --get user.email 2>/dev/null || true)"
 
 _env_set SANDBOX_NAME   "$SANDBOX_NAME"
-# Host detections only seed a FRESH file. On a re-run they would silently
-# overwrite a value the operator changed by hand, which the one-line diff would
-# not make obvious.
 if [ "$__ENV_WAS_NEW" = "1" ]; then
   _env_set TZ             "$__TZ"
   _env_set GIT_USER_NAME  "$__GIT_NAME"
@@ -463,7 +374,6 @@ fi
 
 unset __TZ __GIT_NAME __GIT_EMAIL
 
-# ─── Auto-detect host gh token ────────────────────────────────────────
 __GH_AUTOCONFIGURED=0
 if command -v gh >/dev/null 2>&1 && ! grep -qE '^GH_TOKEN=.+' "$ENV_FILE"; then
   if __GH_TOKEN_RAW="$(gh auth token 2>/dev/null)" && [ -n "$__GH_TOKEN_RAW" ]; then
@@ -481,20 +391,13 @@ if command -v gh >/dev/null 2>&1 && ! grep -qE '^GH_TOKEN=.+' "$ENV_FILE"; then
   fi
 fi
 
-# ─── Optional installs (extra agents/features — OFF by default) ──────
-# Each maps to an INSTALL_* build arg/env in .devcontainer/docker-compose.yml.
-# Enabling one rebuilds the image with that CLI; agent_browser also pulls
-# ~1 GB of Chromium. A pre-set INSTALL_* env var is honored (non-interactive
-# installs); otherwise we prompt — but only with a TTY, and --yes/--no keep
-# the lean default (nothing extra) rather than auto-enabling everything.
 banner "Optional installs (off by default)"
-_opt_install() {   # $1 = INSTALL_ suffix, $2 = human label
+_opt_install() {
   local __k="INSTALL_$1"
   if [ "${!__k:-}" = "true" ]; then
     _env_set "INSTALL_$1" true
     return 0
   fi
-  # Already enabled in an existing .env — leave the standing choice alone.
   if grep -qE "^INSTALL_$1=true" "$ENV_FILE"; then
     return 0
   fi
@@ -511,16 +414,8 @@ _opt_install DEEPAGENTS    "DeepAgents — LangChain multi-provider agent"
 _opt_install GROK_BUILD    "Grok Build — xAI terminal agent"
 _opt_install AGENT_BROWSER "agent-browser + Chromium (~1 GB)"
 
-# ─── Host Docker socket (OFF by default — security-sensitive) ────────
-# Mounting /var/run/docker.sock lets the agent drive Docker, but socket
-# access is effectively HOST ROOT (an agent can start a privileged container
-# that mounts the host filesystem). Off by default; a pre-set DOCKER_SOCKET
-# env honors non-interactive installs; --yes/--no keep the socket OFF.
-# docker-compose.sh reads this DOCKER_SOCKET key and applies the
-# docker-compose.docker-sock.yml overlay when truthy.
 banner "Host Docker socket (off by default)"
 if grep -qE '^DOCKER_SOCKET=' "$ENV_FILE"; then
-  # A standing choice, live in the file — never re-prompt over it.
   ok "DOCKER_SOCKET already set — leaving it alone"
 elif [ "${DOCKER_SOCKET:-}" = "true" ]; then
   _env_set DOCKER_SOCKET true
@@ -532,21 +427,15 @@ elif prompt_yn "Mount host Docker socket into the sandbox? (effectively host roo
   ok "DOCKER_SOCKET=true — host Docker socket will be mounted"
 fi
 
-# ─── 5. Bring up the sandbox ─────────────────────────────────────────
-# .devcontainer/.env was materialized and populated in step 4, before the config
-# prompts, so the answers had somewhere to land.
 
 banner "Building and starting sandbox"
 printf "${CYAN}==> Building image — ~10 min on cold cache, ~30s on warm cache. Compose output below.${NC}\n"
-# .oh/scripts/docker-compose.sh centralizes env-file + compose-overlay argv construction
-# and preserves each override path as a single literal argument.
 (
   cd "$REPO_DIR"
   "$REPO_DIR/.oh/scripts/docker-compose.sh" up -d --build
 )
 ok "Sandbox '$SANDBOX_NAME' started"
 
-# ─── Next Steps ──────────────────────────────────────────────────────
 printf "\n${GREEN}Installation complete!${NC}\n\n"
 printf "  ${CYAN}Configuration${NC}\n"
 printf "  ──────────────────────────────────────\n"

--- a/.oh/scripts/lib/session-runner.sh
+++ b/.oh/scripts/lib/session-runner.sh
@@ -1,238 +1,46 @@
 # shellcheck shell=bash
-#
-# .oh/scripts/lib/session-runner.sh — the runner ladder.
-#
-# A sourceable library that launches and supervises ONE long-lived agent
-# session through the ladder
-#
-#     herdr  ->  tmux  ->  foreground
-#
-# so that any executor (firstmate today, anything after it) detects, launches,
-# verifies, watches and tears a session down the same way instead of growing
-# its own private copy of the ladder.
-#
-# ---------------------------------------------------------------------------
-# Where this sits relative to the execution-boundary RFC
-# ---------------------------------------------------------------------------
-# `.oh/docs/rfcs/rfc-brain-hands-boundary.md` is the sole authority for the
-# Phase-0 brain/hands seam (see its AUTHORITY CLAUSE). This header CITES it and
-# deliberately does not restate it.
-#
-# The RFC landed with #733 (PR #736, merged 2026-08-13), so the path above
-# resolves. The clauses are quoted below anyway, so this header stays readable
-# without opening the RFC.
-#
-# Two clauses bind this library:
-#
-#   * Section 2 (brain/hands responsibility table) puts the iteration loop —
-#     ralph, and firstmate after it — on the BRAIN side: "It *invokes* hands; it
-#     is not hands." This ladder is therefore how the brain reaches a session
-#     HOST. It is not an execution target and must not grow into one.
-#   * Section 5 (workspace stance) makes `hostRoot === targetRoot` the ONLY
-#     supported Phase-0 mapping: "no consumer above the seam may translate a
-#     host path into an in-target path." This library never translates. When the
-#     execution-context gate finds the candidate runner's environment differs
-#     from the caller's, it REFUSES that runner rather than rewriting paths
-#     across the boundary.
-#
-# ---------------------------------------------------------------------------
 # CONTRACT: THE CALLER OWNS SHELL OPTIONS; THIS LIBRARY MUST NOT MUTATE THEM.
-# ---------------------------------------------------------------------------
 # There is deliberately NO `set -euo pipefail` at file scope. A file-scope
-# `set` in a sourced file silently rewrites the caller's option state for the
-# remainder of its execution, and shellcheck does not flag that. Strictness is
-# scoped inside the functions that need it, via `local -` (bash restores the
-# saved option set when the function returns).
-#
-# Note on `set -u` specifically: it is NOT used even function-scoped. In a
-# non-interactive shell an unbound expansion under `set -u` terminates the
-# whole shell — from a sourced library that means killing the CALLER. Argument
-# strictness is therefore expressed as explicit validation that RETURNS an
-# error, which is strictly safer than -u and never touches the caller.
-#
-# For the same reason, hard errors are reported as a non-zero RETURN plus a
-# message on stderr. A sourced library must never `exit` the caller's shell;
-# the caller decides what a hard error costs.
-#
-# ---------------------------------------------------------------------------
-# Public API
-# ---------------------------------------------------------------------------
-#   resolve_timeout_ms [slug]                     -> validated session budget (ms)
-#   runner_detect <slug> <worktree> [requested]   -> herdr|tmux|foreground on stdout
-#   runner_launch <mode> <slug> <worktree> <cmd>  -> launch; capture pane id / pid
-#   runner_pane_id                                -> the captured herdr pane id
-#   runner_verify_cwd <mode> <worktree>           -> herdr foreground_cwd check
-#   runner_alive <mode> <slug>                    -> 0 = live
-#   runner_watch <mode> <slug> <task_dir>         -> 0 = sentinel observed
-#   runner_teardown <mode> <slug>                 -> close the session
-#   runner_abort <mode> <slug> <task_dir> <why>   -> the single exit path
-#   runner_install_abort_trap <mode> <slug> <task_dir>
-#
-# Helpers other executors may reuse: runner_agent_name, runner_tmux_session,
-# runner_lock_path, runner_log_path, runner_session_log_path, runner_log.
-#
-# ---------------------------------------------------------------------------
-# Naming contract (PRD section 5)
-# ---------------------------------------------------------------------------
-#   herdr agent name   firstmate-<slug>
-#   tmux session       agent-firstmate-<slug>
-#   herdr log          /tmp/firstmate-<slug>.log
-#   tmux log           /tmp/agent-firstmate-<slug>.log
-#   lock               /tmp/firstmate-<slug>.lock   (atomic mkdir; the launch
-#                      claim itself is made by the executor, this library only
-#                      guarantees no exit path leaves the lock behind)
-#
-# ---------------------------------------------------------------------------
-# herdr 0.7.4 facts this file is pinned to (all live-verified 2026-08-12)
-# ---------------------------------------------------------------------------
-#   * `herdr status` prints `status: running` and `compatible: yes` under its
-#     `server:` block. There is no single "healthy" flag, so those two literals
-#     ARE the whole health predicate.
-#   * `herdr agent start <name> [...] --no-focus -- <argv...>` replies with an
-#     `agent_started` payload whose pane id is at `.result.agent.pane_id`.
-#     Observed shape (PRD section 15 Q0, captured 2026-08-12):
-#       {"result":{"agent":{"cwd":"/home/ryaneggz",
-#                           "foreground_cwd":"/home/ryaneggz",
-#                           "pane_id":"w5:p4", ...}},"type":"agent_started"}
-#     That is the ONE id this library captures; runner_verify_cwd, the
-#     `herdr wait output` watch and runner_teardown all consume it through the
-#     documented `runner_pane_id` accessor.
-#   * `herdr agent get <name>` is the liveness oracle: exit 0 (`agent_info`) =
-#     live, exit 1 (`agent_not_found`) = gone. It is REQUIRED here, not banned.
 #   * There is NO `agent stop` / `agent kill` verb — `herdr agent --help` lists
 #     only list/get/read/send/rename/focus/wait/start/attach/explain. Teardown
-#     is `herdr pane close <pane_id>`; a stop/kill verb would fail silently
-#     inside a trap.
-#   * herdr panes may be HOST processes. This was true of the deployment that
-#     built the gate: the operator's config directory was bind-mounted
-#     read-write into the container, so the container's herdr CLI read the HOST
-#     operator's herdr config — socket path and server address included —
-#     connected to the HOST's herdr server, and panes spawned outside the
-#     sandbox. A deployment defect, not a property of herdr; one of two
-#     host-root escape paths tracked under EPIC #731 as issue #756.
-#
-#     MIGRATION RESULT, observed 2026-08-13 after #756 closed. The trigger this
-#     note used to carry has been discharged; recording what the live re-probe
-#     actually showed rather than what it predicted:
-#
-#       - The config bind is gone. The herdr CLI now reaches an in-container
-#         server, `herdr agent start --cwd <container path>` is honoured
-#         instead of ignored, and the probe pane returns the caller's own
-#         environment. Caller and probe both read
-#         `host=<container> docker=yes worktree=yes`.
-#       - So the fingerprint comparison now PASSES where it used to fail. The
-#         gate stays regardless: it is a build-correctness guard whose job is to
-#         PROVE environment identity, not to encode one deployment's topology.
-#       - The prediction that the gate "stops rejecting herdr by itself" was
-#         WRONG, and closing #756 is what exposed why. A second defect had been
-#         masked by the first: the probe pane exited before its own read, so no
-#         fingerprint could ever be obtained and herdr was refused everywhere,
-#         including in a correct environment. Fixed in #761 by the keep-alive
-#         below — see RUNNER_PROBE_KEEPALIVE_SUFFIX.
-#
-#     The lesson worth keeping: a gate that is failing for one reason can hide a
-#     second reason it would fail anyway. Removing the cause does not prove the
-#     gate works — only re-probing does.
-#
-# ---------------------------------------------------------------------------
-# Deliberate deviations from the PRD sketch
-# ---------------------------------------------------------------------------
-#   * The foreground branch does NOT `exec`. `exec` would replace this shell
-#     and forfeit the exit-path contract (teardown -> lock removal ->
-#     FIRSTMATE-INCOMPLETE), so the command is run as a supervised child and
-#     watched by the same bounded poll tmux mode uses.
-#   * NO branch wraps the launched command in a `tee` log pipe. That pipe was
-#     removed on 2026-08-23 (spec-simplification US-002) because it makes the
-#     child's stdout a PIPE rather than a TTY, and an interactive agent session
-#     cannot run without a terminal. OBSERVED: the child started, printed only
-#     startup warnings, and never advanced. Logging that preserves the TTY:
-#     tmux mode uses `tmux pipe-pane`, herdr mode uses herdr's own pane capture
-#     (`herdr agent read`), and foreground mode inherits the caller's stdio and
-#     keeps no session log at all. Do not reintroduce a pipe or a redirect on
-#     the launched command — see the same rule in `.oh/scripts/firstmate.sh`.
 
-# --- constants --------------------------------------------------------------
 
-# The session budget default: 4 hours, in milliseconds (FR-6a). Every consumer
-# obtains the budget through resolve_timeout_ms and nowhere else.
 RUNNER_DEFAULT_TIMEOUT_MS=14400000
 
-# Guards resolve_timeout_ms against shell-arithmetic overflow on absurd input.
 RUNNER_MAX_TIMEOUT_DIGITS=15
 
-# Detection-probe ceiling. This is NOT the session budget: it bounds only the
-# short-lived fingerprint probe pane in runner_detect.
 RUNNER_PROBE_TIMEOUT_MS="${RUNNER_PROBE_TIMEOUT_MS:-15000}"
 
-# Poll cadence for the tmux/foreground watch, in seconds.
 RUNNER_POLL_INTERVAL_S="${RUNNER_POLL_INTERVAL_S:-5}"
 
-# Root for logs and the per-slug lock. Overridable for tests only; the shipped
-# default is /tmp, per the naming contract above.
 RUNNER_TMPDIR="${RUNNER_TMPDIR:-/tmp}"
 
-# Marker the fingerprint probe emits. Grepped out of pane output, so it must
-# not collide with anything a shell profile prints.
 RUNNER_FINGERPRINT_MARKER='FIRSTMATE-FINGERPRINT'
 
-# The environment fingerprint script. The SAME snippet runs in the probe pane
-# and locally, so "compared against the caller's own fingerprint gathered the
-# same way" is true by construction rather than by convention. $1 = worktree.
 # shellcheck disable=SC2016  # deliberately unexpanded: this is a script to be
-# evaluated inside the probe pane / a child shell, not here.
 RUNNER_PROBE_SCRIPT='wt="$1"; h="$(hostname 2>/dev/null || uname -n 2>/dev/null || echo unknown)"; d=no; [ -e /.dockerenv ] && d=yes; w=no; [ -d "$wt" ] && w=yes; printf "FIRSTMATE-FINGERPRINT host=%s docker=%s worktree=%s\n" "$h" "$d" "$w"'
 
-# The probe pane must OUTLIVE the read. herdr destroys a pane the moment its
-# command returns, and `herdr pane read` on a destroyed pane answers
-# `{"code":"pane_not_found"}` — so a probe that prints one line and exits races
-# its own reader and loses. The gate then reports "no fingerprint obtained" for
-# an environment that in fact matches, which makes the herdr rung unreachable
-# everywhere rather than only where the environment differs (#761).
-#
-# The keep-alive is a SUFFIX applied only to the pane invocation. It is never
-# folded into RUNNER_PROBE_SCRIPT, because that snippet also runs locally in
-# runner_local_fingerprint, and "the same snippet runs in the probe pane and
-# locally" is what makes the comparison true by construction rather than by
-# convention. A sleeping local fingerprint would also stall every caller.
-#
-# $2 is the keep-alive budget in seconds, passed positionally by
-# runner_probe_fingerprint. It is an upper bound, not a cost: the gate closes
-# the pane as soon as the read completes, on the match and the mismatch path
-# alike, so the sleep is cut short in every normal run.
 RUNNER_PROBE_KEEPALIVE_SUFFIX='; sleep "${2:-30}"'
 
-# Mutable state. Declared here so a caller running under `set -u` can read them
-# before the first launch.
 RUNNER_PANE_ID="${RUNNER_PANE_ID:-}"
 RUNNER_FG_PID="${RUNNER_FG_PID:-}"
 RUNNER_INELIGIBLE_REASON="${RUNNER_INELIGIBLE_REASON:-}"
 
-# --- naming helpers ---------------------------------------------------------
 
 runner_agent_name() { printf '%s\n' "firstmate-${1:-}"; }
 runner_tmux_session() { printf '%s\n' "agent-firstmate-${1:-}"; }
 runner_lock_path() { printf '%s\n' "$RUNNER_TMPDIR/firstmate-${1:-}.lock"; }
 
-# The firstmate log: where degrade reasons, rejections and teardowns are
-# recorded. Same file as the herdr-mode session log by design — one slug, one
-# narrative.
 runner_log_path() { printf '%s\n' "$RUNNER_TMPDIR/firstmate-${1:-}.log"; }
 
-# Where a mode's session output is captured. tmux mode gets its own name so a
-# tmux run and a herdr run of the same slug can never overwrite each other.
-#
-# tmux mode fills this file via `tmux pipe-pane`. herdr mode does NOT write it —
-# herdr owns its pane capture, and the path is returned only so a caller has one
-# name to talk about. foreground mode writes no session log: it inherits the
-# caller's stdio so the child keeps a TTY.
-runner_session_log_path() { # <mode> <slug>
+runner_session_log_path() {
   case "${1:-}" in
     tmux) printf '%s\n' "$RUNNER_TMPDIR/agent-firstmate-${2:-}.log" ;;
     *) printf '%s\n' "$RUNNER_TMPDIR/firstmate-${2:-}.log" ;;
   esac
 }
 
-runner_log() { # <slug> <message...>
+runner_log() {
   local slug="${1:-unknown}"
   shift || true
   local line="[session-runner] $*"
@@ -240,21 +48,11 @@ runner_log() { # <slug> <message...>
   printf '%s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$line" >>"$(runner_log_path "$slug")" 2>/dev/null || true
 }
 
-# --- session budget ---------------------------------------------------------
 
-# The ONLY source of the session budget. Every consumer — the herdr
-# `wait output --timeout`, the tmux poll ceiling and the foreground poll
-# ceiling — calls this, so a non-positive value can never reach herdr (making
-# its `--timeout 0` semantics unreachable by construction) and neither poll
-# loop can run unbounded or expire instantly.
-#
-# Accepts a POSIX integer > 0. Rejects 0, negative, non-numeric, empty and
-# absurdly large values: the default applies and the rejection is logged.
-resolve_timeout_ms() { # [slug]
+resolve_timeout_ms() {
   local slug="${1:-unknown}"
   local default_ms="$RUNNER_DEFAULT_TIMEOUT_MS"
 
-  # Unset is not a rejection — it is simply "use the default".
   if [ -z "${FIRSTMATE_TIMEOUT_MS+set}" ]; then
     printf '%s\n' "$default_ms"
     return 0
@@ -285,12 +83,8 @@ resolve_timeout_ms() { # [slug]
   printf '%s\n' "$((10#$raw))"
 }
 
-# --- herdr JSON helpers -----------------------------------------------------
 
-# Parses the pane id out of an `herdr agent start` reply. See the header for
-# the observed payload shape; `.result.agent.pane_id` is the field name, and
-# `.result.pane_id` is accepted as a defensive alternate.
-runner_parse_pane_id() { # <json>
+runner_parse_pane_id() {
   local json="${1:-}"
   [ -n "$json" ] || return 0
   if ! command -v jq >/dev/null 2>&1; then
@@ -299,8 +93,7 @@ runner_parse_pane_id() { # <json>
   printf '%s' "$json" | jq -r '.result.agent.pane_id // .result.pane_id // empty' 2>/dev/null
 }
 
-# Reads one field of one pane out of an `herdr pane list` reply.
-runner_pane_field() { # <json> <pane_id> <field>
+runner_pane_field() {
   local json="${1:-}" pane="${2:-}" field="${3:-}"
   [ -n "$json" ] && [ -n "$pane" ] && [ -n "$field" ] || return 0
   command -v jq >/dev/null 2>&1 || return 0
@@ -309,25 +102,9 @@ runner_pane_field() { # <json> <pane_id> <field>
       '.result.panes[]? | select(.pane_id == $p) | .[$f] // empty' 2>/dev/null
 }
 
-# The documented accessor for the pane id runner_launch captured. Every herdr
-# consumer in this file goes through it, so all of them provably use the same
-# id: runner_verify_cwd, the `herdr wait output` watch, and runner_teardown.
 runner_pane_id() { printf '%s\n' "${RUNNER_PANE_ID:-}"; }
 
-# Recovers the pane id from the server when this process did not launch the
-# session itself (e.g. `firstmate.sh --kill` in a fresh shell).
-# Best-effort lookup: "no such agent" is a normal answer, not an error.
-#
-# This function MUST return 0 in that case. Callers run under `set -euo
-# pipefail`, and `herdr agent get` exits 1 for a nonexistent agent, so under
-# pipefail the pipeline below returned 1 — which killed the caller at the
-# `pane="$(runner_resolve_pane_id ...)"` assignment inside runner_teardown.
-#
-# OBSERVED 2026-08-23: `firstmate.sh --kill <slug>` exited 1 with no output,
-# left the tmux session running, left the lock claimed, and appended no
-# FIRSTMATE-INCOMPLETE line — because teardown aborted on its FIRST branch.
-# Do not remove the trailing `|| true`.
-runner_resolve_pane_id() { # <slug>
+runner_resolve_pane_id() {
   local slug="${1:-}"
   command -v herdr >/dev/null 2>&1 || return 0
   command -v jq >/dev/null 2>&1 || return 0
@@ -336,23 +113,19 @@ runner_resolve_pane_id() { # <slug>
   return 0
 }
 
-# --- execution-context gate -------------------------------------------------
 
-runner_extract_fingerprint() { # stdin -> "host=... docker=... worktree=..."
+runner_extract_fingerprint() {
   grep -E "^$RUNNER_FINGERPRINT_MARKER " 2>/dev/null |
     tail -n 1 |
     sed -e "s/^$RUNNER_FINGERPRINT_MARKER //"
 }
 
-runner_local_fingerprint() { # <worktree>
+runner_local_fingerprint() {
   local -
   set -o pipefail
   bash -lc "$RUNNER_PROBE_SCRIPT" firstmate-probe "${1:-}" 2>/dev/null | runner_extract_fingerprint
 }
 
-# Seconds the probe pane must stay alive: the read window plus a margin. Derived
-# from the one timeout source so the two can never drift apart. Rejects empty,
-# non-numeric and absurdly small values back to a usable floor.
 runner_probe_keepalive_s() {
   local ms="${RUNNER_PROBE_TIMEOUT_MS:-15000}" s
   case "$ms" in '' | *[!0-9]*) ms=15000 ;; esac
@@ -361,17 +134,12 @@ runner_probe_keepalive_s() {
   printf '%s\n' "$s"
 }
 
-# The snippet the probe PANE runs: the shared fingerprint script plus the
-# keep-alive. Split out so both the tests and session-runner-ladder.sh can
-# assert on the composition instead of re-deriving it.
 runner_probe_pane_script() {
   local composed="${RUNNER_PROBE_SCRIPT}${RUNNER_PROBE_KEEPALIVE_SUFFIX}"
   printf '%s' "$composed"
 }
 
-# Names the fields that differ between two fingerprints, so the logged degrade
-# reason says WHICH field disagreed rather than only that something did.
-runner_fingerprint_diff() { # <caller_fp> <probe_fp>
+runner_fingerprint_diff() {
   local caller="${1:-}" probe="${2:-}" field diff=""
   for field in host docker worktree; do
     local a b
@@ -384,11 +152,7 @@ runner_fingerprint_diff() { # <caller_fp> <probe_fp>
   printf '%s\n' "${diff:-unknown}"
 }
 
-# Launches a probe pane, reads its environment fingerprint back, and closes the
-# pane again on BOTH verdicts. Echoes the probe's fingerprint; returns non-zero
-# when no fingerprint could be obtained. The pane is kept alive across the read
-# rather than being allowed to exit on its own — see RUNNER_PROBE_KEEPALIVE_SUFFIX.
-runner_probe_fingerprint() { # <slug> <worktree>
+runner_probe_fingerprint() {
   local -
   set -o pipefail
   local slug="${1:-}" worktree="${2:-}"
@@ -409,8 +173,6 @@ runner_probe_fingerprint() { # <slug> <worktree>
     --timeout "$RUNNER_PROBE_TIMEOUT_MS" >/dev/null 2>&1 || true
   probe_out="$(herdr pane read "$pane_id" --source recent --lines 200 2>/dev/null)" || probe_out=""
 
-  # The gate tears down its own probe pane regardless of verdict — no pane is
-  # left behind on either the match or the mismatch path.
   herdr pane close "$pane_id" >/dev/null 2>&1 || true
 
   fingerprint="$(printf '%s\n' "$probe_out" | runner_extract_fingerprint)"
@@ -422,19 +184,10 @@ runner_probe_fingerprint() { # <slug> <worktree>
   printf '%s\n' "$fingerprint"
 }
 
-# herdr eligibility: a zeroth nesting guard plus three conjuncts. Sets
-# RUNNER_INELIGIBLE_REASON whenever it returns non-zero.
-runner_herdr_eligible() { # <slug> <worktree>
+runner_herdr_eligible() {
   local slug="${1:-}" worktree="${2:-}"
   RUNNER_INELIGIBLE_REASON=""
 
-  # Zeroth — NESTING GUARD, evaluated BEFORE any probe pane is launched.
-  # HERDR_ENV / HERDR_PANE_ID are herdr 0.7.4's own in-pane markers (its
-  # embedded integration hook gates on exactly HERDR_ENV=1) and are inherited
-  # by every child of a pane. The permanent detection path must never itself
-  # nest a pane, so this rules herdr out without probing at all.
-  # Caveat: these markers do not cross a container boundary, so in a
-  # split-environment deployment the fingerprint gate below is the backstop.
   if [ "${HERDR_ENV:-}" = "1" ] || [ -n "${HERDR_PANE_ID:-}" ]; then
     RUNNER_INELIGIBLE_REASON="nesting guard: caller is inside a herdr pane (HERDR_ENV=${HERDR_ENV:-unset} HERDR_PANE_ID=${HERDR_PANE_ID:-unset}) — allow_nested=false policy, probe pane skipped"
     return 1
@@ -445,8 +198,6 @@ runner_herdr_eligible() { # <slug> <worktree>
     return 1
   fi
 
-  # Health predicate, pinned to two literal fields of `herdr status`. Anything
-  # else — including binary-up/server-down — is unhealthy.
   local status_out
   status_out="$(herdr status 2>/dev/null)" || status_out=""
   if ! printf '%s\n' "$status_out" | grep -q 'status: running' ||
@@ -455,10 +206,6 @@ runner_herdr_eligible() { # <slug> <worktree>
     return 1
   fi
 
-  # EXECUTION-CONTEXT GATE. herdr panes may execute on the host while this
-  # caller runs inside the sandbox; AGENTS.md requires all building and testing
-  # to happen INSIDE the sandbox, so same-environment execution must be proven,
-  # not assumed. Any mismatch makes herdr ineligible.
   local caller_fp probe_fp
   caller_fp="$(runner_local_fingerprint "$worktree")"
   if ! probe_fp="$(runner_probe_fingerprint "$slug" "$worktree")"; then
@@ -473,16 +220,8 @@ runner_herdr_eligible() { # <slug> <worktree>
   return 0
 }
 
-# --- the ladder -------------------------------------------------------------
 
-# Resolves the runner. Echoes herdr|tmux|foreground on stdout; every
-# diagnostic goes to stderr and the firstmate log, so `$(runner_detect ...)`
-# captures the mode and nothing else.
-#
-# An explicit request (third argument, or OH_RUNNER) that cannot be honoured is
-# a HARD ERROR — never a silent degrade, and in particular never a silent
-# host-side run.
-runner_detect() { # <slug> <worktree> [requested]
+runner_detect() {
   local slug="${1:-}" worktree="${2:-}" requested="${3:-${OH_RUNNER:-}}"
 
   case "$requested" in
@@ -534,21 +273,8 @@ runner_detect() { # <slug> <worktree> [requested]
   printf 'foreground\n'
 }
 
-# --- launch -----------------------------------------------------------------
 
-# Launches <cmd> in <worktree> under the resolved <mode>. The herdr branch
-# additionally passes --no-focus.
-#
-# NO branch redirects or pipes the launched command. The child must keep a TTY
-# or an interactive agent session will not start (see the deviations note at the
-# top of this file). tmux mode captures output with `tmux pipe-pane` AFTER the
-# session exists, which leaves the pane a terminal; herdr mode relies on herdr's
-# own pane capture; foreground mode inherits the caller's stdio.
-#
-# The cd is inside the launched command itself: runner flags that claim to set
-# a working directory frequently set only metadata while the shell starts
-# somewhere else, and that failure is silent.
-runner_launch() { # <mode> <slug> <worktree> <cmd>
+runner_launch() {
   local mode="${1:-}" slug="${2:-}" worktree="${3:-}" cmd="${4:-}"
   if [ -z "$mode" ] || [ -z "$slug" ] || [ -z "$worktree" ] || [ -z "$cmd" ]; then
     printf 'Error: runner_launch <mode> <slug> <worktree> <command> requires all four arguments.\n' >&2
@@ -559,8 +285,6 @@ runner_launch() { # <mode> <slug> <worktree> <cmd>
   log="$(runner_session_log_path "$mode" "$slug")"
   agent="$(runner_agent_name "$slug")"
   session="$(runner_tmux_session "$slug")"
-  # The cd is part of the launched command; the command itself is NEVER piped
-  # or redirected, so the child keeps its TTY.
   inner="cd $(printf '%q' "$worktree") && $cmd"
 
   case "$mode" in
@@ -580,9 +304,6 @@ runner_launch() { # <mode> <slug> <worktree> <cmd>
         printf 'Error: tmux new-session failed for %s.\n' "$session" >&2
         return 1
       fi
-      # Capture output WITHOUT taking the pane's TTY away. pipe-pane attaches to
-      # the pane after it exists, so the child still runs on a terminal. A
-      # failure here costs the log, never the session.
       if ! tmux pipe-pane -o -t "$session" "cat >> $(printf '%q' "$log")" 2>/dev/null; then
         runner_log "$slug" "launched tmux session $session, but pipe-pane logging to $log could not be attached"
       else
@@ -590,8 +311,6 @@ runner_launch() { # <mode> <slug> <worktree> <cmd>
       fi
       ;;
     foreground)
-      # Inherits this shell's stdio on purpose: that is the only way a
-      # foreground child keeps a TTY. It therefore writes no session log.
       bash -lc "$inner" &
       RUNNER_FG_PID=$!
       runner_log "$slug" "launched foreground child pid $RUNNER_FG_PID (stdio inherited; no session log)"
@@ -603,12 +322,7 @@ runner_launch() { # <mode> <slug> <worktree> <cmd>
   esac
 }
 
-# Verifies where the session ACTUALLY landed, by reading foreground_cwd back
-# out of `herdr pane list` for the pane id runner_launch captured.
-#
-# Its real job is detecting CROSS-ENVIRONMENT execution, not merely a lying
-# --cwd flag. A mismatch must never be "fixed" by loosening this check.
-runner_verify_cwd() { # <mode> <worktree>
+runner_verify_cwd() {
   local mode="${1:-}" worktree="${2:-}"
   [ "$mode" = "herdr" ] || return 0
 
@@ -633,16 +347,11 @@ runner_verify_cwd() { # <mode> <worktree>
   return 0
 }
 
-# --- liveness, watch, teardown ---------------------------------------------
 
-# Read-only liveness oracle. It never claims the launch slot — the executor's
-# atomic mkdir lock does that, because any read-only oracle leaves a
-# check-then-start TOCTOU window open.
-runner_alive() { # <mode> <slug>
+runner_alive() {
   local mode="${1:-}" slug="${2:-}"
   case "$mode" in
     herdr)
-      # The EXIT CODE is the oracle: 0 = agent_info (live), 1 = agent_not_found.
       herdr agent get "$(runner_agent_name "$slug")" >/dev/null 2>&1
       ;;
     tmux)
@@ -657,19 +366,13 @@ runner_alive() { # <mode> <slug>
   esac
 }
 
-runner_sentinel_present() { # <progress_file>
+runner_sentinel_present() {
   local progress="${1:-}"
   [ -n "$progress" ] && [ -f "$progress" ] || return 1
   grep -q '^STATUS: COMPLETE$' "$progress" 2>/dev/null
 }
 
-# Watches the session until the terminal sentinel appears or the session budget
-# expires. progress.txt is the AUTHORITY in every mode: herdr's `wait output`
-# match only triggers a re-read of the file.
-#
-# Returns 0 when the sentinel was observed. On expiry or on death without the
-# sentinel it runs the single exit path (runner_abort) and returns non-zero.
-runner_watch() { # <mode> <slug> <task_dir>
+runner_watch() {
   local mode="${1:-}" slug="${2:-}" task_dir="${3:-}"
   local progress="$task_dir/progress.txt"
   local budget_ms deadline now
@@ -687,9 +390,6 @@ runner_watch() { # <mode> <slug> <task_dir>
         return 0
       fi
     fi
-    # Mid-run herdr loss (or a match this file could not confirm) degrades the
-    # watch to file-polling the same progress.txt. The herdr server is never
-    # restarted.
     runner_log "$slug" "watch: herdr wait did not confirm the sentinel; polling $progress until the budget expires"
   fi
 
@@ -698,8 +398,6 @@ runner_watch() { # <mode> <slug> <task_dir>
       return 0
     fi
     if ! runner_alive "$mode" "$slug"; then
-      # Death without the sentinel — read the authority once more before
-      # calling it, in case the session wrote and exited between polls.
       if runner_sentinel_present "$progress"; then
         return 0
       fi
@@ -713,17 +411,13 @@ runner_watch() { # <mode> <slug> <task_dir>
   return 1
 }
 
-# Closes the session. herdr's teardown verb is `pane close` — 0.7.4 has no
 # `agent stop` / `agent kill`, and a nonexistent verb inside a trap would fail
-# silently.
-runner_teardown() { # <mode> <slug>
+runner_teardown() {
   local mode="${1:-}" slug="${2:-}"
   case "$mode" in
     herdr)
       local pane
       pane="$(runner_pane_id)" || pane=""
-      # `|| pane=""`: teardown is the single exit path and must never abort on a
-      # best-effort lookup under the caller's `set -e` (see runner_resolve_pane_id).
       [ -n "$pane" ] || pane="$(runner_resolve_pane_id "$slug")" || pane=""
       if [ -n "$pane" ]; then
         herdr pane close "$pane" >/dev/null 2>&1 || true
@@ -749,10 +443,7 @@ runner_teardown() { # <mode> <slug>
   return 0
 }
 
-# THE single exit path. Every non-success ending — budget expiry, launch
-# failure, operator abort — goes through here, so no path can leave the lock
-# behind (a stale lock would permanently wedge that slug).
-runner_abort() { # <mode> <slug> <task_dir> <reason>
+runner_abort() {
   local mode="${1:-}" slug="${2:-}" task_dir="${3:-}" reason="${4:-unspecified}"
 
   runner_teardown "$mode" "$slug"
@@ -772,10 +463,8 @@ runner_abort() { # <mode> <slug> <task_dir> <reason>
   return 0
 }
 
-# Routes operator abort (Ctrl-C / SIGTERM) through the same exit path.
-runner_install_abort_trap() { # <mode> <slug> <task_dir>
+runner_install_abort_trap() {
   local mode="${1:-}" slug="${2:-}" task_dir="${3:-}"
   # shellcheck disable=SC2064  # expanded now on purpose: the trap must capture
-  # this session's mode/slug/task_dir, not whatever they hold when it fires.
   trap "runner_abort $(printf '%q' "$mode") $(printf '%q' "$slug") $(printf '%q' "$task_dir") 'operator abort (signal)'; exit 130" INT TERM
 }

--- a/.oh/scripts/lib/task-contract.sh
+++ b/.oh/scripts/lib/task-contract.sh
@@ -1,33 +1,8 @@
 # shellcheck shell=bash
-#
-# .oh/scripts/lib/task-contract.sh — the shared task-folder contract.
-#
-# The slug regex and the four-file contract (prd.md, prd.json, prompt.md,
-# progress.txt) are the ONE interface every executor validates a task folder
-# against. This helper exists so the executors cannot silently diverge: an
-# executor sources it instead of growing its own private copy of the checks.
-#
-# ---------------------------------------------------------------------------
-# WORDING PROVENANCE
-# ---------------------------------------------------------------------------
-# The error and hint strings below are the canonical wording for a rejected task
-# folder, so an operator sees the SAME message whichever consumer rejected it.
-#
-# ---------------------------------------------------------------------------
-# CONTRACT: THE CALLER OWNS SHELL OPTIONS; THIS LIBRARY MUST NOT MUTATE THEM.
-# ---------------------------------------------------------------------------
-# There is deliberately no file-scope `set` here, for the same reason
-# `.oh/scripts/lib/session-runner.sh` has none: a `set` in a sourced file
-# silently rewrites the caller's option state for the rest of its execution,
-# which no linter flags. These functions RETURN non-zero on failure; a sourced
-# library must never `exit` the caller's shell.
 
-# The four-file contract, in canonical order.
 TASK_CONTRACT_FILES=(prd.md prd.json prompt.md progress.txt)
 
-# Per SPEC: kebab-case and shell-safe, because the slug becomes part of a
-# session name, a log path and a lock path.
-task_contract_validate_slug() { # <slug>
+task_contract_validate_slug() {
   local slug="${1:-}"
   if [[ ! "$slug" =~ ^[a-z0-9-]+$ ]]; then
     printf "Error: <taskdesc> must match ^[a-z0-9-]+\$ (got: '%s')\n" "$slug" >&2
@@ -36,9 +11,7 @@ task_contract_validate_slug() { # <slug>
   return 0
 }
 
-# The folder must exist AND carry all four files. A partial folder is a
-# scaffolding bug, not something an executor should launch against.
-task_contract_validate_dir() { # <task_dir>
+task_contract_validate_dir() {
   local task_dir="${1:-}" f
   if [ ! -d "$task_dir" ]; then
     printf 'Error: %s does not exist.\n' "$task_dir" >&2

--- a/.oh/scripts/link-providers.sh
+++ b/.oh/scripts/link-providers.sh
@@ -1,15 +1,8 @@
 #!/usr/bin/env bash
-# Create/repair the provider skill/agent/hook symlinks into the vendored .oh/
-# pack, and verify the pack is present. The skills/agents/hooks primitive pack is
-# vendored directly under .oh/ (no submodule), so there is nothing to fetch —
-# this script only wires the provider surfaces to it and validates the result.
 set -euo pipefail
 
 PROTECTED_PATHS_FILE=".claude/protected-paths.txt"
 
-# cc-safety-net destructive-command guard: pinned binary installed at image
-# build time (see .devcontainer/Dockerfile). Boot validation is presence +
-# version only — zero npm-registry access. See install-decision.md.
 CC_SAFETY_NET_PIN="1.0.6"
 
 required_files=(
@@ -63,10 +56,6 @@ case "$mode" in
 esac
 
 repo_root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
-# Inside a git checkout, git wins. Otherwise fall back to the project root
-# (OH_PROJECT_ROOT, else PWD) so `oh init`-equipped projects and standalone
-# trees — which are not git repos — still wire their providers instead of
-# crash-looping the sandbox boot. The real guard is the vendored pack below.
 if [ -z "$repo_root" ]; then
   repo_root="${OH_PROJECT_ROOT:-$PWD}"
 fi
@@ -171,11 +160,6 @@ check_protected_paths() {
 }
 
 check_cc_safety_net() {
-  # New check-kind: the required_* arrays above validate repo-relative files;
-  # cc-safety-net is a global binary on PATH, so it needs a presence + version
-  # check instead. Fails loudly via the shared `fail` path when the binary is
-  # missing or version-mismatched — UNLESS CC_SAFETY_NET_OFF=1, the kill-switch,
-  # which must never brick boot (downgrade to a warning and continue).
   local off="${CC_SAFETY_NET_OFF:-}" version
   if ! command -v cc-safety-net >/dev/null 2>&1; then
     if [ "$off" = "1" ]; then
@@ -211,13 +195,6 @@ check_links() {
     [ -x "$f" ] || fail "required pack executable missing or not executable: $f"
   done
 
-  # cc-safety-net enforcement is scoped to environments where the guard is
-  # actually enabled: the sandbox container exports CC_SAFETY_NET_STRICT=1 via
-  # docker-compose, and the Dockerfile guarantees the binary there. CI runners
-  # and pre-rebuild hosts also run this script (both --init and --check) but
-  # never set that marker — failing there would recreate the #639
-  # boot-adjacent failure class. The eval probe cc-safety-net-wiring.sh owns
-  # non-sandbox verification with proper SKIP semantics.
   if [ "${CC_SAFETY_NET_STRICT:-}" = "1" ]; then
     check_cc_safety_net
   else

--- a/.oh/scripts/locked-append.sh
+++ b/.oh/scripts/locked-append.sh
@@ -1,6 +1,4 @@
 #!/usr/bin/env bash
-# Append stdin to a target file, serializing whole-record writes with flock.
-# This is for the shared cron liveness trail (.oh/crons/.cron.log).
 set -euo pipefail
 
 usage() {

--- a/.oh/scripts/maintenance/restart-openharness-tmux.sh
+++ b/.oh/scripts/maintenance/restart-openharness-tmux.sh
@@ -1,29 +1,6 @@
 #!/usr/bin/env bash
-# restart-openharness-tmux.sh — clear the stale `system-cron` argv on the tmux server (issue #273).
-#
-# WHY THIS EXISTS
-#   The tmux *server* process permanently advertises the argv of the FIRST session that
-#   spawned it (historically `tmux new-session -d -s system-cron …`). tmux cannot rewrite a
-#   running server's argv, so the only way to clear the misleading string is a full
-#   `tmux kill-server` + relaunch of the durable session stack. The first new-session after
-#   the kill becomes the new server and defines its (clean) argv.
-#
-# WHY DETACHED
-#   `tmux kill-server` kills every session — INCLUDING the one the launcher runs in. This
-#   script is therefore meant to be launched DETACHED so it outlives the server it kills:
-#       setsid bash .oh/scripts/maintenance/restart-openharness-tmux.sh </dev/null >/tmp/oh-restart-273.boot.log 2>&1 &
-#   It is the spec-execute artifact for .oh/tasks/restart-openharness-tmux/ (see that PRD).
-#
-# SAFETY
-#   - flock single-instance + a done-sentinel make it a no-op on re-run.
-#   - It captures the LIVE session→(cwd,command) map BEFORE the kill and replays it, so it
-#     adapts to whatever is actually running; pinned fallbacks cover the two cron sessions.
-#   - Relaunch order puts the website origin before its tunnel and cron-system before its
-#     watchdog, so nothing races. The cron singleton lock (.oh/crons/.pid) self-heals on a dead
-#     pid (cron-runtime.ts acquireLock); we also clear it defensively.
-#   - It NEVER recreates the legacy `system-cron` session name (the watchdog self-exits on it).
 set -uo pipefail
-trap '' HUP   # survive the SIGHUP that the dying server sends to our (now-detached) group
+trap '' HUP
 
 HARNESS="${HARNESS:-${OH_PROJECT_ROOT:-/home/sandbox/harness}}"
 REPO="${OH_REPO:-mifunedev/openharness}"
@@ -31,20 +8,11 @@ ISSUE=273
 LOCK=/tmp/oh-restart-273.lock
 LOGF=/tmp/oh-restart-273.log
 MAP=/tmp/oh-restart-273.sessions.txt
-# Sentinel lives in /tmp, NOT under .oh/tasks/ — an untracked file in the tracked .oh/tasks/ tree
-# would make the weekly cleanup pre-flight (`git status --porcelain -- .oh/tasks/`) emit
-# BLOCKED-TASKS-WIP. /tmp survives `tmux kill-server` (only a container restart clears it,
-# which is not expected in the one-shot window). The heartbeat gate checks the same path.
 SENTINEL="/tmp/oh-restart-273.done"
 
-# Durable sessions to preserve across the restart. Transients (cron-<id>-*, agent-*,
-# the heartbeat's own session) are intentionally NOT relaunched.
 DURABLE_RE='^(cron-system|cron-watchdog|app-.*|expose-public-.*)$'
-# Fixed relaunch order: website origin before tunnel; cron-system before its watchdog.
 ORDER=(app-website app-website-preview app-orchestra expose-public-mifune cron-system cron-watchdog)
 
-# Canonical fallbacks (.devcontainer/entrypoint.sh) for the two cron sessions if live
-# capture misses them.
 fallback_cmd() {
   case "$1" in
     cron-system)   echo "cd $HARNESS && node --experimental-strip-types .oh/scripts/cron-runtime.ts 2>&1 | tee /tmp/cron-system.log" ;;
@@ -55,34 +23,26 @@ fallback_cmd() {
 
 log() { printf '[%s] %s\n' "$(date -Iseconds)" "$*" | tee -a "$LOGF" >&2; }
 
-# --- single-instance + idempotency guards ------------------------------------------------
 exec 9>"$LOCK" || { echo "cannot open lock $LOCK" >&2; exit 1; }
 if ! flock -n 9; then log "another restart holds the lock; exiting"; exit 0; fi
 if [[ -f "$SENTINEL" ]]; then log "sentinel present ($SENTINEL); already done — exiting"; exit 0; fi
 
 log "=== restart #273 begin (clears stale system-cron server argv) ==="
-# Grace window so the launching heartbeat agent can finish this pulse's memory/liveness
-# logging before we tear the server (and the agent's own session) down.
 sleep 8
 
-# --- capture the live durable session map BEFORE the kill --------------------------------
 : > "$MAP"
 tmux list-panes -a -F '#{session_name}|#{pane_current_path}|#{pane_start_command}' 2>/dev/null \
   | awk -F'|' -v re="$DURABLE_RE" '$1 ~ re { print }' > "$MAP" || true
 log "captured $(wc -l < "$MAP" | tr -d ' ') durable pane(s):"
 while IFS= read -r line; do log "  $line"; done < "$MAP"
-# The stale server argv uniquely uses the new-session `-s system-cron` form; the watchdog's
-# `tmux has-session -t system-cron` uses `-t`, so `-s system-cron` won't false-match it.
 if pgrep -af 'tmux' 2>/dev/null | grep -q -- '-s system-cron'; then
   log "pre-kill: tmux server still advertises stale '-s system-cron' argv (expected — about to clear it)"
 fi
 
-# --- kill the server (drops mifune.dev briefly) -----------------------------------------
 log "killing tmux server now"
 tmux kill-server 2>/dev/null || true
 sleep 2
 
-# Defensive: clear a singleton lock that names a now-dead runtime (cron-runtime also self-heals).
 if [[ -f "$HARNESS/.oh/crons/.pid" ]]; then
   oldpid="$(cat "$HARNESS/.oh/crons/.pid" 2>/dev/null || true)"
   if [[ -n "${oldpid:-}" ]] && ! kill -0 "$oldpid" 2>/dev/null; then
@@ -90,17 +50,12 @@ if [[ -f "$HARNESS/.oh/crons/.pid" ]]; then
   fi
 fi
 
-# --- relaunch durable sessions in dependency order --------------------------------------
 relaunch_one() {
   local s="$1" first=1 found=0 cwd cmd name
   while IFS='|' read -r name cwd cmd; do
     [[ "$name" == "$s" ]] || continue
     found=1
     [[ -z "${cwd:-}" ]] && cwd="$HARNESS"
-    # tmux reports `pane_start_command` WRAPPED in literal double-quotes when it contains shell
-    # metacharacters (verified against the live sessions). Strip one leading + one trailing
-    # quote so the replayed command is the bare `sh -c` string, not a quoted blob that sh would
-    # try to exec as a single filename.
     if [[ -n "${cmd:-}" ]]; then cmd="${cmd#\"}"; cmd="${cmd%\"}"; fi
     if [[ "$first" == 1 ]]; then
       if [[ -n "${cmd:-}" ]]; then tmux new-session -d -s "$s" -c "$cwd" "$cmd" || log "ERROR: new-session $s failed (rc=$?)"
@@ -121,9 +76,6 @@ relaunch_one() {
 
 for s in "${ORDER[@]}"; do
   if [[ "$s" == cron-watchdog ]]; then
-    # Wait for the cron RUNTIME (not just the session) to be alive and lock-holding before the
-    # watchdog, so the watchdog never double-launches it and we don't proceed past a crashed
-    # pane. `has-session` alone can't tell a live runtime from a pane holding a crash.
     for _ in $(seq 1 20); do
       if [[ -f "$HARNESS/.oh/crons/.pid" ]]; then
         rp="$(cat "$HARNESS/.oh/crons/.pid" 2>/dev/null || true)"
@@ -135,18 +87,13 @@ for s in "${ORDER[@]}"; do
   relaunch_one "$s"
 done
 
-# Any durable session present in the capture but not in ORDER (unexpected) — relaunch last.
 while IFS='|' read -r name _ _; do
   printf '%s\n' "${ORDER[@]}" | grep -qx "$name" && continue
   tmux has-session -t "$name" 2>/dev/null && continue
   relaunch_one "$name"
 done < "$MAP"
 
-# --- verify ------------------------------------------------------------------------------
 sleep 3
-# Expected = the sessions that were actually LIVE at capture (plus the always-on cron core),
-# NOT a fixed list — so a session that legitimately wasn't running (e.g. a transient
-# app-website-preview) is neither relaunched nor falsely flagged missing/degraded.
 mapfile -t expected < <(cut -d'|' -f1 "$MAP" | sort -u)
 for core in cron-system cron-watchdog; do
   printf '%s\n' "${expected[@]}" | grep -qx "$core" || expected+=("$core")
@@ -157,7 +104,6 @@ for s in "${expected[@]}"; do tmux has-session -t "$s" 2>/dev/null || missing+=(
 argv_clean="no"
 if ! pgrep -af 'tmux' 2>/dev/null | grep -q -- '-s system-cron'; then argv_clean="yes"; fi
 
-# Cron runtime must be ALIVE (a session existing is not enough — the pane could hold a crash).
 cron_alive="no"
 for _ in $(seq 1 15); do
   if [[ -f "$HARNESS/.oh/crons/.pid" ]]; then
@@ -167,10 +113,6 @@ for _ in $(seq 1 15); do
   sleep 1
 done
 
-# mifune.dev is INFORMATIONAL only. `npm run build` in the relaunched app-website can take
-# minutes and the named tunnel reconnects on its own, so a slow build must NOT mark the
-# restart degraded (that would falsely leave #273 open while the site is healthily building).
-# Poll ~2m and report whatever code we see.
 site="unchecked"
 if command -v curl >/dev/null 2>&1; then
   site="building"
@@ -181,14 +123,11 @@ if command -v curl >/dev/null 2>&1; then
   done
 fi
 
-# Success = the #273 goal (argv cleared) + the durable stack back + a LIVE cron runtime.
-# The public site returning is verified but does NOT gate success (it self-heals post-build).
 status="ok"
 [[ "${#missing[@]}" -gt 0 || "$argv_clean" != "yes" || "$cron_alive" != "yes" ]] && status="degraded"
 
 log "verify: status=$status missing=[${missing[*]:-none}] argv-cleared=$argv_clean cron-runtime-alive=$cron_alive mifune.dev=$site"
 
-# --- liveness + audit trail --------------------------------------------------------------
 if [[ -x "$HARNESS/.oh/scripts/locked-append.sh" ]]; then
   printf '[%s] restart-273: status=%s argv-cleared=%s cron-alive=%s missing=%s mifune=%s\n' \
     "$(date -Iseconds)" "$status" "$argv_clean" "$cron_alive" "${missing[*]:-none}" "$site" \
@@ -208,7 +147,6 @@ if command -v gh >/dev/null 2>&1; then
   fi
 fi
 
-# Mark done only on a clean restart so a degraded run can be retried.
 if [[ "$status" == "ok" ]]; then
   mkdir -p "$(dirname "$SENTINEL")"
   printf 'restart #273 completed %s\n' "$(date -Iseconds)" > "$SENTINEL"

--- a/.oh/scripts/migrate-harness-yaml.sh
+++ b/.oh/scripts/migrate-harness-yaml.sh
@@ -1,25 +1,5 @@
 #!/bin/sh
 # migrate-harness-yaml.sh — one-shot migration of a local harness.yaml into
-# .devcontainer/.env, run automatically by every lifecycle path.
-#
-# WHY THIS FILE IS SELF-CONTAINED. It carries its own copy of the awk parser
-# that used to live in .oh/scripts/harness-config.sh. That script is deleted in
-# the same release, so the whole harness.yaml compatibility story is ONE file:
-# delete this script in a later release and nothing else has to change.
-#
-# Behaviour, in order:
-#   1. No harness.yaml  -> exit 0. This is the steady state and costs one [ -f ].
-#   2. Seed .devcontainer/.env from .example.env when it is absent.
-#   3. Translate the 21 allowlisted section.key pairs into KEY=value.
-#   4. Set each key in .env, UNCOMMENTING THE TEMPLATE LINE IN PLACE when the
-#      key ships commented. harness.yaml won at runtime before this change, so a
-#      differing .env value is overwritten -- and both values are printed, so the
-#      change is visible rather than silent.
-#   5. compose.overrides -> merge into .oh/config.json composeOverrides[] via jq.
-#      Without jq the paths are printed for the operator instead of dropped.
-#   6. Remove the derived .devcontainer/.harness.yaml.env.
-#   7. mv harness.yaml harness.yaml.migrated -- idempotent, original preserved.
-#
 # Usage: migrate-harness-yaml.sh [repo-dir]     (default: the repo this lives in)
 
 set -eu
@@ -34,9 +14,6 @@ _env="$_root/.devcontainer/.env"
 _example="$_root/.devcontainer/.example.env"
 _config="$_root/.oh/config.json"
 
-# ── The parser (lifted from the deleted harness-config.sh) ────────────
-# mode=env               KEY=value for the allowlist
-# mode=compose-overrides one overlay path per line
 _parse() {
     awk -v mode="$1" -v sq="'" '
 BEGIN {
@@ -132,7 +109,6 @@ function clean_value(s) {
 _pairs=$(_parse env)
 _overrides=$(_parse compose-overrides)
 
-# ── Read one key out of .env, ignoring commented lines ────────────────
 _env_get() {
     [ -f "$_env" ] || return 0
     awk -F= -v key="$1" '
@@ -141,9 +117,6 @@ _env_get() {
     ' "$_env"
 }
 
-# ── Set one key in .env, uncommenting the template line in place ──────
-# Same discipline as the CLI writer: a commented `# KEY=default` line becomes
-# `KEY=value` at the SAME line index, so the file keeps its shape and prose.
 _env_set() {
     __k="$1"
     __v="$2"
@@ -166,7 +139,6 @@ _env_set() {
 printf 'harness.yaml migration\n'
 printf -- '----------------------\n'
 
-# ── 2. Seed .env when absent ──────────────────────────────────────────
 if [ ! -f "$_env" ]; then
     if [ -f "$_example" ]; then
         cp "$_example" "$_env"
@@ -179,10 +151,8 @@ if [ ! -f "$_env" ]; then
     fi
 fi
 
-# ── 3-4. Translate and write ──────────────────────────────────────────
 _count=0
 if [ -n "$_pairs" ]; then
-    # A value may contain spaces, so split on the FIRST '=' only.
     printf '%s\n' "$_pairs" | while IFS= read -r _pair; do
         [ -n "$_pair" ] || continue
         _key=${_pair%%=*}
@@ -194,7 +164,6 @@ if [ -n "$_pairs" ]; then
         elif [ "$_old" = "$_val" ]; then
             printf '  same    %s=%s\n' "$_key" "$_val"
         else
-            # harness.yaml won at runtime before, so the YAML value is kept.
             printf '  replace %s: %s -> %s\n' "$_key" "$_old" "$_val"
         fi
     done
@@ -202,7 +171,6 @@ if [ -n "$_pairs" ]; then
 fi
 [ "$_count" -gt 0 ] 2>/dev/null || printf '  (no set keys — nothing to carry over)\n'
 
-# ── 5. compose.overrides -> .oh/config.json composeOverrides[] ────────
 if [ -n "$_overrides" ]; then
     if command -v jq >/dev/null 2>&1; then
         [ -f "$_config" ] || printf '{}\n' > "$_config"
@@ -221,13 +189,11 @@ if [ -n "$_overrides" ]; then
     fi
 fi
 
-# ── 6. Drop the derived env-file ──────────────────────────────────────
 if [ -f "$_root/.devcontainer/.harness.yaml.env" ]; then
     rm -f "$_root/.devcontainer/.harness.yaml.env"
     printf '  remove  .devcontainer/.harness.yaml.env (derived — no longer used)\n'
 fi
 
-# ── 7. Retire the file ────────────────────────────────────────────────
 mv "$_yaml" "$_root/harness.yaml.migrated"
 printf '  rename  harness.yaml -> harness.yaml.migrated\n'
 printf -- '----------------------\n'

--- a/.oh/scripts/oh-path
+++ b/.oh/scripts/oh-path
@@ -1,28 +1,4 @@
 #!/bin/sh
-# oh-path — resolve a harness data directory deterministically.
-#
-# Usage:  oh-path <name> [--no-create]
-#   <name>   crons | evals | context | tasks | worktrees
-#            (or any <NAME>_DIR you define)
-#
-# Resolution precedence (first hit wins):
-#   1. environment override   <NAME>_DIR        (e.g. CRONS_DIR=.oh/crons)
-#   2. default                .oh/<name>
-#
-# The env var is read from the PROCESS environment. Inside the sandbox that is
-# populated by docker compose from .devcontainer/.env; on the host, export it in
-# the shell that runs the caller.
-#
-# The result is anchored to the REPO ROOT (the parent of this script's `.oh/`
-# directory), so it resolves identically no matter the caller's CWD. That is the
-# whole point: skills, crons, and sub-agents stop guessing where a directory
-# lives — they ask oh-path. To MOVE a directory in future, change ONE thing (the
-# <NAME>_DIR env var); every caller follows. No need to edit individual skills.
-#
-# Relative values are resolved against the repo root.
-# The directory is created (mkdir -p) unless --no-create. The absolute path is
-# printed on stdout. Mirrors the established CRONS_DIR pattern in
-# .oh/scripts/cron-runtime.ts + docker-compose.yml + entrypoint.sh.
 
 set -eu
 
@@ -44,20 +20,15 @@ for _arg in "$@"; do
 done
 [ -n "$_name" ] || { printf 'Usage: oh-path <name> [--no-create]\n' >&2; exit 2; }
 
-# Anchor to the repo root via this script's own location:
-#   <root>/.oh/scripts/oh-path  →  _root=<root>
 _script_dir=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd -P)
-_oh_dir=$(dirname -- "$_script_dir")      # <root>/.oh
-_root=$(dirname -- "$_oh_dir")            # <root>
+_oh_dir=$(dirname -- "$_script_dir")
+_root=$(dirname -- "$_oh_dir")
 
-# 1. environment override:  crons → CRONS_DIR, evals → EVALS_DIR, ...
 _envvar="$(printf '%s' "$_name" | tr 'a-z-' 'A-Z_')_DIR"
 eval "_dir=\${$_envvar:-}"
 
-# 2. default  .oh/<name>
 [ -n "$_dir" ] || _dir=".oh/$_name"
 
-# Resolve a relative value against the repo root. An absolute value is used verbatim.
 case "$_dir" in
     /*) ;;
     *) _dir="$_root/$_dir" ;;

--- a/.oh/scripts/promote-release-latest.sh
+++ b/.oh/scripts/promote-release-latest.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-# Promote the canonical release branch's immutable image to latest by digest.
 set -euo pipefail
 
 usage() {
@@ -104,8 +103,6 @@ if [[ -z "$digest" ]]; then
   exit 1
 fi
 
-# Address the immutable source by digest so latest never depends on a mutable
-# local tag or on a second registry tag lookup after the canonical-head check.
 docker buildx imagetools create --tag "$LATEST_IMAGE" "${VERSION_IMAGE}@${digest}"
 printf 'Promoted %s@%s to %s from canonical %s\n' \
   "$VERSION_IMAGE" "$digest" "$LATEST_IMAGE" "$canonical_branch"

--- a/.oh/scripts/provision-python.sh
+++ b/.oh/scripts/provision-python.sh
@@ -1,32 +1,4 @@
 #!/usr/bin/env bash
-# provision-python.sh — user-scoped uv/Python provisioning for the sandbox user.
-#
-# Why this exists
-# ---------------
-# uv keeps its managed interpreters, tool installs and cache under $HOME. When
-# any level of that tree is created by root (a Dockerfile `install -d` that only
-# chowns its final component, a Docker-created volume parent, a stray `sudo uv`),
-# the sandbox user cannot write into it and provisioning dies with:
-#
-#   error: failed to create directory /home/sandbox/.local/share/uv/python: Permission denied
-#
-# `sudo uv python install` is NOT a fix: it installs under /root/.local, and the
-# agent runs as `sandbox`. This script therefore does all of its work as the
-# target user, with HOME pinned to that user's home, and never touches /root.
-#
-# It is idempotent: every step is a no-op when already satisfied, so it is safe
-# to run from the image build, from every container boot, and by hand.
-#
-# Usage:
-#   provision-python.sh            # provision, then verify
-#   provision-python.sh --verify   # verify only; never installs
-#   provision-python.sh --print-env  # print the resolved env assignments
-#
-# Tunables (env):
-#   OH_PYTHON_VERSION            interpreter to manage        (default 3.11)
-#   OH_PYTHON_KERNEL_PACKAGES    space-separated pip specs     (default ipykernel)
-#   OH_PYTHON_KERNEL_HOME        venv location                 (default ~/.local/share/oh/kernel)
-#   OH_SANDBOX_USER              target user                   (default sandbox)
 
 set -euo pipefail
 
@@ -44,8 +16,6 @@ esac
 log()  { echo "[provision-python] $*"; }
 warn() { echo "[provision-python] WARNING: $*" >&2; }
 
-# An actionable error: say what failed, why it is not fixable with sudo, and the
-# exact command that repairs it.
 die() {
   echo "[provision-python] ERROR: $1" >&2
   shift
@@ -53,9 +23,6 @@ die() {
   exit 1
 }
 
-# ─── Re-exec as the sandbox user ────────────────────────────────────
-# Running as root would recreate the exact bug this script fixes. Drop
-# privileges first, and pin HOME so uv resolves user-scoped paths.
 if [ "$(id -u)" = "0" ]; then
   if ! id "$SANDBOX_USER" >/dev/null 2>&1; then
     die "user '$SANDBOX_USER' does not exist" \
@@ -64,9 +31,6 @@ if [ "$(id -u)" = "0" ]; then
   USER_HOME=$(getent passwd "$SANDBOX_USER" | cut -d: -f6)
   [ -n "$USER_HOME" ] || die "cannot resolve home directory for '$SANDBOX_USER'"
 
-  # Parents must exist and be user-owned BEFORE the drop, because after the drop
-  # there is no way to chown them. `install -d` applies -o/-g to the final
-  # component only, so every level is named explicitly, parents first.
   install -d -o "$SANDBOX_USER" -g "$SANDBOX_USER" \
     "$USER_HOME/.local" \
     "$USER_HOME/.local/bin" \
@@ -77,8 +41,6 @@ if [ "$(id -u)" = "0" ]; then
     "$USER_HOME/.cache" \
     "$USER_HOME/.cache/uv" 2>/dev/null || true
 
-  # Repair anything a previous root-owned run (or a root `uv`) left behind.
-  # Scoped to the uv/cache subtrees so unrelated home state is untouched.
   for d in "$USER_HOME/.local/share/uv" "$USER_HOME/.cache/uv"; do
     [ -d "$d" ] && chown -R "$(id -u "$SANDBOX_USER"):$(id -g "$SANDBOX_USER")" "$d" 2>/dev/null || true
   done
@@ -89,7 +51,6 @@ if [ "$(id -u)" = "0" ]; then
   exec su "$SANDBOX_USER" -s /bin/bash -c "HOME='$USER_HOME' '$0' $*"
 fi
 
-# ─── From here on we are the unprivileged target user ───────────────
 HOME="${HOME:-$(getent passwd "$(id -u)" | cut -d: -f6)}"
 export HOME
 
@@ -115,9 +76,6 @@ command -v uv >/dev/null 2>&1 || die \
   "the image installs it to /usr/local/bin/uv; rebuild the sandbox image:" \
   "  make sandbox"
 
-# ─── Writability preflight ──────────────────────────────────────────
-# Fail here with a precise repair command rather than letting uv emit a bare
-# "Permission denied" several layers down.
 check_writable() {
   local dir="$1"
   if [ ! -d "$dir" ]; then
@@ -143,17 +101,11 @@ for d in "$HOME/.local/share/uv" "$UV_PYTHON_INSTALL_DIR" "$HOME/.cache" "$UV_CA
   check_writable "$d"
 done
 
-# ─── Managed interpreter ────────────────────────────────────────────
 uv_python_path() {
   uv python find --managed-python "$PY_VERSION" 2>/dev/null | head -1
 }
 
 if [ "$MODE" = "provision" ]; then
-  # Unconditional: `uv python install` is itself idempotent (a fast no-op when
-  # the version is already managed), and running it every time is what proves
-  # the user-scoped install dir is writable. Do NOT gate it on `uv python find`
-  # — a system interpreter would satisfy the check while leaving the managed
-  # tree unprovisioned.
   log "ensuring managed Python $PY_VERSION in $UV_PYTHON_INSTALL_DIR"
   uv python install "$PY_VERSION" \
     || die "uv python install $PY_VERSION failed" \
@@ -173,7 +125,6 @@ case "$PY_PATH" in
                "  bash .oh/scripts/provision-python.sh" ;;
 esac
 
-# ─── Kernel environment ─────────────────────────────────────────────
 if [ "$MODE" = "provision" ]; then
   if [ ! -x "$KERNEL_PYTHON" ]; then
     log "creating kernel venv at $KERNEL_HOME"
@@ -182,7 +133,6 @@ if [ "$MODE" = "provision" ]; then
       || die "failed to create the kernel venv at $KERNEL_HOME"
   fi
 
-  # `uv pip install` is idempotent; already-satisfied specs resolve to a no-op.
   # shellcheck disable=SC2086 # KERNEL_PACKAGES is an intentional argv fragment.
   log "installing kernel packages: $KERNEL_PACKAGES"
   uv pip install --python "$KERNEL_PYTHON" $KERNEL_PACKAGES \
@@ -201,17 +151,14 @@ export PRIME_AGENT_KERNEL_PYTHON="\${PRIME_AGENT_KERNEL_PYTHON:-$KERNEL_PYTHON}"
 ENVEOF
 fi
 
-# ─── Verification ───────────────────────────────────────────────────
 [ -x "$KERNEL_PYTHON" ] || die \
   "kernel interpreter missing at $KERNEL_PYTHON" \
   "run: bash .oh/scripts/provision-python.sh"
 
-# ipykernel is the one hard requirement: without it the kernel cannot start.
 "$KERNEL_PYTHON" -c "import ipykernel" >/dev/null 2>&1 \
   || die "kernel environment is incomplete — ipykernel is not importable by $KERNEL_PYTHON" \
          "run: bash .oh/scripts/provision-python.sh"
 
-# Optional runtime packages: verified when requested, never silently assumed.
 for spec in $KERNEL_PACKAGES; do
   mod="${spec%%[<>=!\[]*}"
   mod="${mod//-/_}"

--- a/.oh/scripts/registry-portability.sh
+++ b/.oh/scripts/registry-portability.sh
@@ -1,47 +1,11 @@
 #!/usr/bin/env bash
-#
-# registry-portability.sh - portability linter for the published skill registry.
-#
-# Reads a checkout of the published registry and reports every reference that a
-# bare installer cannot resolve: harness-only paths, harness-only slash
-# commands, and citations of files the portable copy does not carry.
-#
-# The registry checkout is read-only. This script writes nothing under it.
-#
-# Usage:
-#   registry-portability.sh --registry <dir> [--allow <file>] [--strict-exceptions]
-#
-#   --registry <dir>       checkout of the published registry (required)
-#   --allow <file>         exceptions source; default <script dir>/registry-portability.md
-#   --strict-exceptions    make a stale exception entry fail the run
-#
-# Rules:
-#   OH-PATH        a harness-only path reference on the line.
-#   HARNESS-SKILL  a backticked slash command naming no folder under skills/.
-#   DANGLING-REF   a backticked references/<f>.md or scripts/<f>.sh that the
-#                  skill folder does not carry.
-#
-# Exceptions come from the single fenced block tagged allow inside the
-# exceptions file. Each entry is five pipe-separated fields:
-#   CLASS | RULE | <registry-relative path> | <12-hex line hash> | <reason>
-# CLASS is ALLOW (suppresses the finding) or KNOWN (labels it as triaged
-# without suppressing it). The key is the path, the rule, and the first 12 hex
-# characters of the sha256 of the trimmed source line.
-#
-# Exit codes:
-#   0  every finding was suppressed by an ALLOW entry, or there were none
-#   1  a finding survived, or a stale entry was found under --strict-exceptions
-#   2  the run could not be trusted: bad registry, empty scan, unreadable
-#      exceptions file. Never reported as a pass.
 
 set -euo pipefail
 export LC_ALL=C
 
 readonly PROG=registry-portability
 
-# --- constants ---------------------------------------------------------------
 
-# Filesystem roots a backticked absolute path names instead of a skill.
 readonly UNIX_ROOTS=" bin boot dev etc home lib media mnt opt proc root run sbin srv sys tmp usr var "
 readonly META_PREFIXES=(foo bar baz qux)
 
@@ -51,7 +15,6 @@ readonly RE_REF='^(references|scripts)/[A-Za-z0-9._-]+\.(md|sh)'
 readonly RE_NAME='^[a-z][a-z0-9-]*$'
 readonly RE_HASH='^[0-9a-f]{12}$'
 
-# --- helpers -----------------------------------------------------------------
 
 usage() {
   cat <<'EOF'
@@ -74,8 +37,6 @@ warn() {
   printf '%s: %s\n' "$PROG" "$1" >&2
 }
 
-# Strip leading and trailing whitespace. Result lands in TRIMMED; no subshell,
-# so this stays cheap enough to call once per line of every scanned file.
 TRIMMED=""
 trim() {
   local s=$1
@@ -84,7 +45,6 @@ trim() {
   TRIMMED=$s
 }
 
-# --- arguments ---------------------------------------------------------------
 
 REGISTRY=""
 ALLOW_FILE=""
@@ -141,10 +101,6 @@ if [[ ! -f $ALLOW_FILE ]]; then fatal "exceptions file not found: $ALLOW_FILE"; 
 WORKDIR=$(mktemp -d "${TMPDIR:-/tmp}/$PROG.XXXXXX")
 trap 'rm -rf "$WORKDIR"' EXIT
 
-# --- discover skill folders --------------------------------------------------
-# A plain glob over an already-validated directory. No process substitution:
-# a failure there is invisible to set -e and yields an empty list with status 0,
-# which is the exact fail-open this script exists to prevent.
 
 declare -a SKILL_DIRS=()
 declare -A SKILL_SET=()
@@ -157,9 +113,6 @@ done
 
 if (( ${#SKILL_DIRS[@]} == 0 )); then fatal "no skill folder under: $SKILLS_DIR"; fi
 
-# --- collect target files ----------------------------------------------------
-# find writes to a real file whose status is checked, and the reader loop is fed
-# by a redirect rather than a pipe, so the arrays it fills survive the loop.
 
 declare -a TARGET_FILE=()
 declare -a TARGET_BASE=()
@@ -178,10 +131,6 @@ if (( ${#TARGET_FILE[@]} == 0 )); then
   fatal "no *.md or *.sh file under any skill folder in: $SKILLS_DIR"
 fi
 
-# --- line hashes -------------------------------------------------------------
-# Hashes are computed one whole file at a time and cached: the trimmed lines are
-# written to a scratch directory and hashed in a single call, so a large file
-# costs one process rather than one per line.
 
 declare -A HASH_DONE=()
 declare -A LINE_HASH=()
@@ -216,8 +165,6 @@ ensure_hashes() {
   rm -rf "$dir" "$dir.sums"
 }
 
-# Result lands in HASH_RESULT. A command substitution would run the cache fill
-# in a subshell and throw the cache away with it.
 HASH_RESULT=""
 line_hash() {
   local rel=$1 lineno=$2
@@ -225,7 +172,6 @@ line_hash() {
   HASH_RESULT=${LINE_HASH["$rel:$lineno"]:-000000000000}
 }
 
-# --- rule helpers ------------------------------------------------------------
 
 is_skill_folder() {
   [[ -n ${SKILL_SET[$1]:-} ]]
@@ -243,8 +189,6 @@ is_placeholder() {
   return 1
 }
 
-# True when the token is already inside a harness path reported on this line, so
-# the same text is never reported twice.
 covered_by_oh_path() {
   local token=$1 seen
   if (( ${#OH_TOKENS[@]} == 0 )); then return 1; fi
@@ -254,7 +198,6 @@ covered_by_oh_path() {
   return 1
 }
 
-# --- scan --------------------------------------------------------------------
 
 declare -a FINDINGS=()
 declare -a OH_TOKENS=()
@@ -311,7 +254,6 @@ for index in "${!TARGET_FILE[@]}"; do
   done < "$file"
 done
 
-# --- exceptions --------------------------------------------------------------
 
 declare -A EXC_CLASS=()
 declare -a EXC_PATHS=()
@@ -388,7 +330,6 @@ if (( seen_block == 0 )); then
   fatal "no fenced block tagged allow in: $ALLOW_FILE"
 fi
 
-# --- report ------------------------------------------------------------------
 
 printf 'registry: %s\n' "$REGISTRY"
 printf 'exceptions: %s\n' "$ALLOW_FILE"
@@ -403,8 +344,6 @@ if (( ${#FINDINGS[@]} > 0 )); then
 else
   : > "$RAW"
 fi
-# Sorted by path, then line number, then rule, then token, and deduplicated on
-# that same tuple, so two runs over one tree print byte-identical output.
 if ! sort -t $'\t' -k1,1 -k2,2n -k3,3 -k4,4 -u "$RAW" > "$SORTED"; then
   fatal "cannot sort findings"
 fi
@@ -438,8 +377,6 @@ while IFS=$'\t' read -r rel_path lineno rule token; do
     "<ALLOW-or-KNOWN>" "$rule" "$rel_path" "$hash" "<reason>"
 done < "$SORTED"
 
-# Staleness is evaluated only against the file the entry names, never against
-# the whole tree, so an entry cannot be kept alive by an unrelated file.
 stale=0
 if (( ${#EXC_PATHS[@]} > 0 )); then
   for index in "${!EXC_PATHS[@]}"; do

--- a/.oh/scripts/release-reservation.mjs
+++ b/.oh/scripts/release-reservation.mjs
@@ -1,8 +1,3 @@
-// Pure SemVer reservation state machine used by the GitHub release bridge.
-//
-// The version is an input, not a derivation: the release workflow reads it from
-// root `package.json` and hands it in. This module performs no I/O and reads no
-// clock, so the same version reserves the same tag on every retry.
 
 export class ReleaseReservationError extends Error {
   constructor(code, message, options = {}) {
@@ -14,9 +9,6 @@ export class ReleaseReservationError extends Error {
   }
 }
 
-// Strict `MAJOR.MINOR.PATCH`. Leading zeros, prerelease identifiers, build
-// metadata, and a `v` prefix are all rejected: the `v` belongs to the tag name,
-// not to the version, and it is added in exactly one place (`releaseTagName`).
 const SEMVER_PATTERN = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
 
 export function parseSemVer(version) {
@@ -52,9 +44,6 @@ export async function reserveReleaseVersion({ attemptCreate, version }) {
       return { kind: "reused-draft", version: candidateVersion };
     case "same-sha-published":
       return { kind: "published-no-op", version: candidateVersion };
-    // The tag exists on a different commit, so this version already shipped.
-    // Under CalVer this advanced a `-N` suffix; under SemVer the version is a
-    // deliberate input, so the only correct answer is to report it and skip.
     case "foreign-collision":
       return { kind: "already-released", version: candidateVersion };
     case "invalid-state":

--- a/.oh/scripts/repo-orientation-benchmark-score.mjs
+++ b/.oh/scripts/repo-orientation-benchmark-score.mjs
@@ -1,6 +1,4 @@
 #!/usr/bin/env node
-// Score the repo-orientation A/B benchmark described by CB-004.
-// Usage: node scripts/repo-orientation-benchmark-score.mjs --manifest <tasks.json> --report <runs.json>
 
 import { readFileSync, statSync } from "node:fs";
 import path from "node:path";

--- a/.oh/scripts/reserve-github-release.mjs
+++ b/.oh/scripts/reserve-github-release.mjs
@@ -1,4 +1,3 @@
-// Reserve a retry-safe GitHub draft release by atomically creating its SemVer tag ref.
 
 import { appendFile } from "node:fs/promises";
 import { resolve } from "node:path";
@@ -8,10 +7,6 @@ import { parseSemVer, reserveReleaseVersion } from "./release-reservation.mjs";
 
 const GITHUB_API_VERSION = "2022-11-28";
 
-// The single place the `v` prefix is introduced. Every tag-shaped string in this
-// module derives from this helper, so the create path and the recovery path
-// cannot drift apart. The version itself stays bare everywhere else, including
-// the step outputs and the GHCR image tags.
 export function releaseTagName(version) {
   return `v${version}`;
 }
@@ -52,9 +47,6 @@ export async function reserveGitHubRelease({
   }
   if (!token) throw new Error("GITHUB_TOKEN is required");
 
-  // The version comes from root `package.json`, so it is identical across
-  // workflow retries and independent of both the push clock and the commit
-  // timestamp. Reject a malformed one before any GitHub state is touched.
   parseSemVer(releaseVersion);
 
   const repositoryUrl = `${apiUrl.replace(/\/$/, "")}/repos/${repository}`;
@@ -128,8 +120,6 @@ export async function reserveGitHubRelease({
   }
 
   async function findExactDraftRelease(tagName) {
-    // GitHub's release-by-tag endpoint excludes drafts. Authenticated listing
-    // is used only after the exact tag resolves to releaseSha.
     for (let page = 1; ; page += 1) {
       const result = await request(`/releases?per_page=100&page=${page}`);
       if (!result.response.ok) {
@@ -183,8 +173,6 @@ export async function reserveGitHubRelease({
       );
     }
 
-    // Another same-SHA run may win release creation after this run creates or
-    // observes the tag. Re-read only this exact candidate.
     const racedRelease = await recoverExactCandidateRelease(tagName);
     if (!racedRelease) {
       return {
@@ -200,8 +188,6 @@ export async function reserveGitHubRelease({
     version: releaseVersion,
     attemptCreate: async ({ candidateVersion }) => {
       const tagName = releaseTagName(candidateVersion);
-      // Creating the exact ref is the atomic version reservation. A crash after
-      // this succeeds is recoverable because a retry recognizes the same SHA.
       const createRef = await request("/git/refs", {
         method: "POST",
         body: JSON.stringify({ ref: `refs/tags/${tagName}`, sha: releaseSha }),
@@ -220,7 +206,6 @@ export async function reserveGitHubRelease({
           message: `GitHub reported a tag collision but the ref is absent (${errorMessage(createRef.body)})`,
         };
       }
-      // The tag exists on another commit, so this version already shipped.
       if (candidateSha !== releaseSha) return { kind: "foreign-collision" };
 
       const candidateRelease = await recoverExactCandidateRelease(tagName);
@@ -230,8 +215,6 @@ export async function reserveGitHubRelease({
     },
   });
 
-  // An already-released version has no release object of this run's own, and
-  // there is nothing left to publish. It is a clean skip, not a failure.
   if (reservation.kind === "already-released") {
     return {
       publishedNoop: true,

--- a/.oh/scripts/sandbox-boot-smoke.sh
+++ b/.oh/scripts/sandbox-boot-smoke.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-# sandbox-boot-smoke.sh — bounded CI smoke test for devcontainer boot health.
 
 set -euo pipefail
 
@@ -47,8 +46,6 @@ while [ "$(date +%s)" -le "$end" ]; do
   if [ -z "$cid" ]; then
     last_status="missing-container"
   else
-    # Prefer the exact healthcheck command wired into compose. Calling it via exec
-    # avoids waiting for Docker's start_period while still exercising the same check.
     # shellcheck disable=SC2086 # HEALTH_CMD intentionally splits into command argv.
     if docker exec "$cid" $HEALTH_CMD >/tmp/sandbox-boot-smoke-health.out 2>/tmp/sandbox-boot-smoke-health.err; then
       if ! docker exec -u sandbox "$cid" sh -lc \

--- a/.oh/scripts/sandbox-healthcheck.sh
+++ b/.oh/scripts/sandbox-healthcheck.sh
@@ -1,9 +1,4 @@
 #!/usr/bin/env bash
-# Healthcheck for the Open Harness sandbox container.
-#
-# Docker can keep the container process alive (`sleep infinity`) even when the
-# tmux-managed runtime services that make the sandbox useful have died. This
-# script reports those runtime failures through Docker/Compose health status.
 
 set -u
 

--- a/.oh/skills/audit/scripts/audit-evidence.sh
+++ b/.oh/skills/audit/scripts/audit-evidence.sh
@@ -1,6 +1,4 @@
 #!/usr/bin/env bash
-# Atomically publish target-correlated terminal evidence for audit-run.sh.
-# Usage: audit-evidence.sh complete <native-verdict-token>
 set -euo pipefail
 [[ ${1:-} == complete && $# -eq 2 ]] || { echo 'usage: audit-evidence.sh complete <native-verdict-token>' >&2; exit 64; }
 : "${AUDIT_RUN_ID:?AUDIT_RUN_ID is required}"

--- a/.oh/skills/audit/scripts/audit-run.sh
+++ b/.oh/skills/audit/scripts/audit-run.sh
@@ -1,17 +1,5 @@
 #!/usr/bin/env bash
-# Executable lifecycle and route bridge for one /audit target.
-# Usage: audit-run.sh <target> [target args] -- <route-driver> [driver options]
 set -euo pipefail
-# Bash started as an asynchronous job inherits SIGINT ignored. Re-exec once through
-# GNU env so direct and process-group launches can install reliable handlers.
-#
-# The "already re-exec'd" marker travels in ARGV, not the environment. It was
-# AUDIT_SIGNALS_RESET=1, which is exported and therefore inherited by every descendant:
-# a nested audit-run.sh -- a probe driving the boundary from inside an audit -- saw the
-# flag, skipped this re-exec, kept SIGINT ignored, and reported a signal-propagation
-# failure that described its caller rather than the repository. argv does not cross a
-# process boundary uninvited, so the marker cannot leak. An inherited env value is now
-# cleared and grants no skip.
 unset AUDIT_SIGNALS_RESET
 if [[ ${1:-} == --audit-signals-reset ]]; then
   shift
@@ -44,7 +32,6 @@ while (($#)); do
   if [[ $1 == -- ]]; then shift; command=("$@"); break; fi
   args+=("$1"); shift
 done
-# The bridge must remain open around actual route work; a preflight-only invocation is invalid.
 ((${#command[@]})) || usage
 repo_re='^[^/[:space:]]+/[^/[:space:]]+$'; number_re='^[1-9][0-9]*$'; uint_re='^[0-9]+$'
 value(){ (($2 < ${#args[@]})) && [[ -n ${args[$2]} && ${args[$2]} != --* ]]; }
@@ -185,8 +172,6 @@ trap 'forward_signal INT' INT
 trap 'forward_signal TERM' TERM
 trap 'forward_signal HUP' HUP
 cd "$AUDIT_ROOT"
-# The driver receives the validated target and target arguments verbatim after its own options.
-# AUDIT_ROUTE and AUDIT_TARGET_ARGS_JSON provide equivalent named/machine-readable bindings.
 if [[ ${AUDIT_FORCE_DIRECT:-} != 1 ]] && command -v setsid >/dev/null 2>&1; then
   env --default-signal=INT,TERM,HUP setsid -- "${command[@]}" "$target" "${args[@]}" & child_pid=$!; child_group=true
 else
@@ -199,8 +184,6 @@ if [[ -n $interrupted ]]; then
   wait "$child_pid" 2>/dev/null || true
   rc=$((128 + $(kill -l "$interrupted")))
 elif [[ $rc -eq 0 ]]; then
-  # Exit zero is only transport success. Completion requires atomic evidence
-  # produced by route work and correlated to this exact run, target, and argv.
   if [[ ! -f $AUDIT_EVIDENCE_PATH || -L $AUDIT_EVIDENCE_PATH ]] \
     || ! jq -e --arg id "$AUDIT_RUN_ID" --arg target "$target" --argjson args "$AUDIT_TARGET_ARGS_JSON" '
       .schemaVersion==1 and .runId==$id and .target==$target and .targetArgs==$args
@@ -215,9 +198,6 @@ elif [[ $rc -eq 0 ]]; then
 fi
 trap - INT TERM HUP
 if [[ $outer == true ]]; then
-  # The run record is REPORTED, never written. The `.oh/logs` tier this used to
-  # append to was deleted; a run's correlation data belongs in the operator's
-  # terminal, not in a file nobody reads back.
   finished_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
   state=complete; [[ $rc -eq 0 ]] || state=failed; [[ -z $interrupted ]] || state=interrupted
   printf 'audit -- run-id=%s target=%s state=%s verdict=%s exit=%s started=%s finished=%s\n' \

--- a/.oh/skills/audit/scripts/context-audit-runner.sh
+++ b/.oh/skills/audit/scripts/context-audit-runner.sh
@@ -1,9 +1,4 @@
 #!/usr/bin/env bash
-# /audit context runner — Tier-2 ablation harness
-# Usage:
-#   ./runner.sh --ablate <relative-path>   # e.g. .oh/context/IDENTITY.md
-#   ./runner.sh --baseline                 # record baseline probe outputs only
-#
 set -euo pipefail
 
 HARNESS="$(cd "${AUDIT_ROOT:-$(git rev-parse --show-toplevel)}" && pwd -P)"
@@ -15,15 +10,12 @@ trap 'rm -rf "$RESULTS"' EXIT
 source "$HARNESS/.oh/scripts/ablate.sh"
 ablate_recover
 
-# ── helpers ──────────────────────────────────────────────────────────────────
 
 extract_body() {
-  # Strip YAML frontmatter; print body (everything after closing ---)
   awk '/^---/{n++; if(n==2){p=1;next}} p{print}' "$1"
 }
 
 extract_markers() {
-  # Print one marker per line from probe frontmatter markers: list
   awk '/^markers:/{f=1;next} f && /^  - /{print substr($0,5)} f && /^[a-z]/{exit}' "$1"
 }
 
@@ -79,7 +71,6 @@ evaluate() {
   fi
 }
 
-# ── main ─────────────────────────────────────────────────────────────────────
 
 MODE="${1:-}"
 if [ -z "$MODE" ]; then
@@ -90,7 +81,6 @@ fi
 if [ "$MODE" = "--baseline" ]; then
   echo "=== Baseline probe run ==="
   run_probes "baseline"
-  # Ephemeral scratch, outside the repo. Nothing under .oh/ persists a run.
   OUT_DIR="${TMPDIR:-/tmp}/oh-context-audit/$TODAY"
   mkdir -p "$OUT_DIR"
   cp "$RESULTS"/baseline-*.txt "$OUT_DIR/"

--- a/.oh/skills/audit/scripts/implementation-gates.sh
+++ b/.oh/skills/audit/scripts/implementation-gates.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-# Executable production gates shared by /audit implementation fixtures and route.
 set -euo pipefail
 : "${AUDIT_ROOT:?AUDIT_ROOT is required}"
 AUDIT_ROOT=$(cd "$AUDIT_ROOT" && pwd -P)
@@ -27,8 +26,6 @@ case $mode in
       path="$AUDIT_ROOT/$artifact"
       resolved=$(realpath -e -- "$path" 2>/dev/null) \
         || { echo "FAIL gate1: required_artifact missing: $artifact" >&2; exit 1; }
-      # Exact canonical equality rejects '..', duplicate separators, and symlinks in
-      # any path component; the prefix check keeps every artifact below AUDIT_ROOT.
       [[ $resolved == "$AUDIT_ROOT/"* && $resolved == "$path" ]] \
         || { echo "FAIL gate1: required_artifact is non-canonical, symlinked, or outside AUDIT_ROOT: $artifact" >&2; exit 1; }
     done < <(jq -r '.artifact_contract.required_artifacts // [] | .[]' "$prd")
@@ -52,8 +49,6 @@ case $mode in
     snapshot_repo(){
       local out=$1 path rel
       {
-        # Git evidence covers index/worktree semantics. The filesystem walk also
-        # hashes ignored, untracked, and already-dirty content (excluding .git).
         git -C "$AUDIT_ROOT" status --porcelain=v1 -z --untracked-files=all
         git -C "$AUDIT_ROOT" diff --binary --no-ext-diff
         git -C "$AUDIT_ROOT" diff --cached --binary --no-ext-diff

--- a/.oh/skills/audit/scripts/pr-acquire.sh
+++ b/.oh/skills/audit/scripts/pr-acquire.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-# Private GitHub acquisition seam for /audit pr, prs, implementation, and fresh actions.
 set -euo pipefail
 usage() { echo 'usage: pr-acquire.sh <pr|prs> --repo owner/name [--pr N] [--label L] [--author A|--mine] [--base B] [--stale-days N]' >&2; exit 64; }
 mode=${1:-}; shift || true

--- a/.oh/skills/audit/scripts/pr-classify.sh
+++ b/.oh/skills/audit/scripts/pr-classify.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-# Pure, deterministic JSON classifier. No network, mutation, clock, or env defaults.
 set -euo pipefail
 jq -S -c '
 def fail_values: ["ACTION_REQUIRED","CANCELLED","ERROR","FAILURE","STARTUP_FAILURE","STALE","TIMED_OUT"];

--- a/.oh/skills/audit/scripts/route-driver.sh
+++ b/.oh/skills/audit/scripts/route-driver.sh
@@ -1,6 +1,4 @@
 #!/usr/bin/env bash
-# Canonical production bridge from audit-run.sh to a non-scriptable inline agent.
-# AUDIT_AGENT_COMMAND_JSON is a JSON argv array whose final argument will be the prompt.
 set -euo pipefail
 : "${AUDIT_ROOT:?AUDIT_ROOT is required}"
 : "${AUDIT_ROUTE:?AUDIT_ROUTE is required}"
@@ -25,11 +23,6 @@ prompt="$AUDIT_TMP_ROOT/route-prompt.txt"; output="$AUDIT_TMP_ROOT/route-output.
   cat "$AUDIT_ROUTE"
 } >"$prompt"
 rc=0
-# Launch the agent with the lifecycle identity SCRUBBED. Every binding it uses is already
-# in the prompt above as text; inheriting them as environment means the agent's own tool
-# calls (Gate 2 runs the probe suite) see an audit identity that is not theirs and grade
-# the caller instead of the tree. Observed twice: AUDIT_ROOT/AUDIT_RUN_ID and
-# AUDIT_SIGNALS_RESET each produced a green->red that reproduced on an unmodified base.
 env -u AUDIT_RUN_ID -u AUDIT_ROOT -u AUDIT_SIGNALS_RESET \
     -u AUDIT_TMP_ROOT -u AUDIT_EVIDENCE_PATH -u AUDIT_ROUTE -u AUDIT_TARGET \
     -u AUDIT_TARGET_ARGS_JSON -u AUDIT_AGENT_COMMAND_JSON \

--- a/.oh/skills/eval/run.sh
+++ b/.oh/skills/eval/run.sh
@@ -1,13 +1,7 @@
 #!/usr/bin/env bash
-# /eval runner — discover .oh/evals/probes/*.sh, run each against real state, and
-# write the .oh/evals/RESULTS.md benchmark scoreboard (overwrite-row-per-probe).
-# Exit-code oracle per probe: 0=PASS 1=REGRESSION 2=SKIPPED 124=TIMEOUT other=ERROR.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# The skill may be reached through agent-specific symlinks (`.claude/skills`) or
-# directly through the neutral `.oh/skills` source directory. Walk upward until the
-# repo's eval corpus is found instead of hard-coding a fixed depth.
 if [ -n "${AUDIT_ROOT:-}" ]; then
   ROOT="$(cd "$AUDIT_ROOT" && pwd -P)"
 else
@@ -34,26 +28,20 @@ while [ $# -gt 0 ]; do
   esac
 done
 
-# Temp-file handle for the atomic scoreboard write (assigned at the write block).
-# Initialized empty BEFORE the --ablate guard so the guarded EXIT trap is harmless
-# on the ablation exec path (the exec at run.sh:~49 replaces this shell entirely).
 tmp=""
 trap '[ -n "$tmp" ] && rm -f "$tmp"' EXIT
 
-# Recover through the single shared lock/sentinel state machine.
 # shellcheck source=.oh/scripts/ablate.sh
 source "$ROOT/.oh/scripts/ablate.sh"
 ablate_recover
 
-# --- ablation mode (M-1): run one probe with/without a target file via the shared
-#     swap/restore/trap mechanics in .oh/scripts/ablate.sh; reports LOAD-BEARING|PRUNABLE ---
 if [ -n "$ABLATE_TARGET" ]; then
   [ -n "$FILTER_PROBE" ] || { echo "--ablate requires --probe <id>" >&2; exit 64; }
   ABL_PROBE="$PROBES_DIR/$FILTER_PROBE.sh"
   [ -f "$ABL_PROBE" ] || { echo "no such probe: $FILTER_PROBE" >&2; exit 64; }
   case "$ABLATE_TARGET" in
-    /*) ABL_TGT="$ABLATE_TARGET" ;;                 # absolute — use as-is
-    *)  ABL_TGT="$ROOT/$ABLATE_TARGET" ;;           # relative — resolve against eval repo root, NOT cwd
+    /*) ABL_TGT="$ABLATE_TARGET" ;;
+    *)  ABL_TGT="$ROOT/$ABLATE_TARGET" ;;
   esac
   exec bash "$ROOT/.oh/scripts/ablate.sh" "$ABL_TGT" "$ABL_PROBE"
 fi
@@ -64,10 +52,6 @@ prior_row() {
 }
 prior_status() { prior_row "$1" | awk -F'|' '{gsub(/^[ \t]+|[ \t]+$/,"",$5); print $5}'; }
 
-# Capture the pre-write scoreboard ONCE. Carry-forward (prior_row) reads this
-# snapshot, never the live $RESULTS — so a filtered run can't erase untouched
-# rows, and a crash mid-write leaves the original file intact (atomic mv below).
-# set -e-safe: the [ -f ] short-circuits the cat so a missing file can't abort.
 RESULTS_ORIG=""
 [ -f "$RESULTS" ] && RESULTS_ORIG="$(cat "$RESULTS")"
 
@@ -96,7 +80,7 @@ for probe in "$PROBES_DIR"/*.sh; do
     124) status="TIMEOUT" ;;
     *) status="ERROR" ;;
   esac
-  reason="${reason%%$'\n'*}"   # first stderr line only
+  reason="${reason%%$'\n'*}"
 
   prior="$(prior_status "$id")"
   if [ -z "$prior" ]; then
@@ -106,7 +90,6 @@ for probe in "$PROBES_DIR"/*.sh; do
   else
     delta="${prior}->${status}"
   fi
-  # green->red is the recurrence signal; first run has no prior, so never fires
   if [ "$prior" = "PASS" ] && [ "$status" != "PASS" ] && [ "$status" != "SKIPPED" ]; then
     regressions+=("$id ($src): was PASS, now $status — ${reason:-no reason}")
   fi
@@ -119,10 +102,6 @@ for probe in "$PROBES_DIR"/*.sh; do
   ran=$((ran + 1))
 done
 
-# --- rewrite RESULTS.md: build the full scoreboard into a temp sibling file, then
-#     replace the live file in ONE atomic mv -f. New rows for probes run this
-#     invocation; carry prior rows (from the RESULTS_ORIG snapshot) for the rest.
-#     The temp path is a SIBLING of $RESULTS (same filesystem) so mv -f is atomic. ---
 tmp="$RESULTS.tmp.$$"
 cat > "$tmp" <<'HDR'
 # Probe results — benchmark scoreboard
@@ -151,7 +130,6 @@ printf '\n<!-- benchmark: pass-rate = PASS / (PASS + REGRESSION + TIMEOUT); SKIP
 mv -f "$tmp" "$RESULTS"
 tmp=""
 
-# --- summary to stdout: regressions first ---
 if [ "${#regressions[@]}" -gt 0 ]; then
   echo "REGRESSIONS (${#regressions[@]}):"
   for r in "${regressions[@]}"; do echo "  - $r"; done

--- a/.oh/skills/health-check/scripts/scope-preflight.sh
+++ b/.oh/skills/health-check/scripts/scope-preflight.sh
@@ -1,35 +1,4 @@
 #!/usr/bin/env bash
-# /health-check step 0 — classify the execution scope and the Docker endpoint ONCE,
-# so the skill branches instead of discovering the same failure nine times.
-#
-# Why this exists (issue #762, refs #756): the sandbox no longer has a host Docker
-# socket. It was removed deliberately as a host-root escape path. The `docker` CLI
-# is still installed, so every Docker step in the skill used to fail on its own with
-# the same 200-character connection error — nine times per invocation — while the
-# memory/disk/CPU steps kept reporting the CONTAINER's numbers under host framing.
-#
-# Contract:
-#   - stdout carries KEY=VALUE lines for the skill to branch on, plus AT MOST ONE
-#     human-readable SCOPE-NOTICE line. The KEY=VALUE lines select the branch; they
-#     are not the report.
-#   - Exit status is ALWAYS 0. A classification step that exits non-zero is itself
-#     the misleading-failure signal this script exists to remove.
-#   - DOCKER_TRIAGE=available requires a COMPLETED round-trip, never `[ -S path ]`
-#     alone: a socket file outlives an OOM-killed daemon, and a chmod-000 socket is
-#     unopenable while still passing every file test. Calling either "available"
-#     would reproduce the nine-failure wall in a shape no test covered.
-#   - The host-only branch makes ZERO daemon contact. `docker context inspect` may
-#     run during endpoint resolution because it reads local config and needs no
-#     daemon (verified: returns the endpoint with rc=0 while no daemon is running).
-#
-# Environment:
-#   HEALTH_CHECK_DOCKER_SOCK    Authoritative endpoint override. Bare path or URL.
-#                               The test knob, and the reason every branch here is
-#                               reachable under test rather than asserted in prose.
-#   HEALTH_CHECK_PROBE_TIMEOUT_S  Round-trip budget in seconds (default 5).
-#   DOCKER_HOST                 Honoured, and authoritative when set.
-#
-# NOTE: no `set -e`. Every failure below is a classification input, not an abort.
 set -uo pipefail
 
 SOCK_DEFAULT="/var/run/docker.sock"
@@ -40,10 +9,6 @@ probe_timeout="${HEALTH_CHECK_PROBE_TIMEOUT_S:-5}"
 case "$probe_timeout" in '' | *[!0-9]*) probe_timeout=5 ;; esac
 [ "$probe_timeout" -gt 0 ] 2>/dev/null || probe_timeout=5
 
-# --- endpoint helpers --------------------------------------------------------
-# The filesystem path a unix endpoint refers to, or empty for any other scheme.
-# A bare value with no scheme is a path (that is how DOCKER_HOST-less setups and
-# this script's own override are written).
 endpoint_path() {
   case "$1" in
     unix://*) printf '%s\n' "${1#unix://}" ;;
@@ -52,7 +17,6 @@ endpoint_path() {
   esac
 }
 
-# The `-H` form of an endpoint: schemes pass through, a bare path becomes unix://.
 endpoint_url() {
   case "$1" in
     *://*) printf '%s\n' "$1" ;;
@@ -60,10 +24,6 @@ endpoint_url() {
   esac
 }
 
-# --- 1. execution scope ------------------------------------------------------
-# /.dockerenv is the convention already used in this repo's runner fingerprint
-# (.oh/scripts/lib/session-runner.sh). /run/.containerenv covers podman, and the
-# cgroup read catches containers that ship neither marker file.
 scope="host"
 if [ -e /.dockerenv ] || [ -e /run/.containerenv ]; then
   scope="container"
@@ -71,17 +31,9 @@ elif [ -r /proc/1/cgroup ] && grep -qE '(docker|containerd|kubepods|libpod)' /pr
   scope="container"
 fi
 
-# --- 2. docker CLI -----------------------------------------------------------
-# Deliberately reported separately from the endpoint. Testing for the binary is
-# what made the old behaviour wrong: /usr/bin/docker is present in this sandbox
-# and proves nothing about reachability.
 docker_cli="absent"
 command -v docker >/dev/null 2>&1 && docker_cli="present"
 
-# --- 3. endpoint resolution --------------------------------------------------
-# An explicit override is AUTHORITATIVE and never falls through. If the operator
-# (or a test) names an endpoint, silently triaging a different one would answer a
-# question nobody asked. Only the implicit chain walks candidates.
 explicit=""
 if [ -n "${HEALTH_CHECK_DOCKER_SOCK:-}" ]; then
   explicit="$HEALTH_CHECK_DOCKER_SOCK"
@@ -93,9 +45,6 @@ endpoint=""
 if [ -n "$explicit" ]; then
   endpoint="$explicit"
 else
-  # `docker context` is how the real CLI resolves its endpoint when DOCKER_HOST is
-  # unset — Colima, OrbStack and rootless setups set a context, not always the env
-  # var. Narrow Go template, per this repo's deny-env-dump.sh inspect guard.
   ctx=""
   if [ "$docker_cli" = "present" ]; then
     ctx="$(timeout "$probe_timeout" docker context inspect \
@@ -104,8 +53,6 @@ else
   rootless=""
   [ -n "${XDG_RUNTIME_DIR:-}" ] && rootless="${XDG_RUNTIME_DIR}/docker.sock"
 
-  # First candidate that is actually a socket wins; otherwise keep the first
-  # candidate offered, so the notice can name a concrete endpoint.
   first=""
   for cand in "$ctx" "$SOCK_DEFAULT" "$rootless"; do
     [ -n "$cand" ] || continue
@@ -120,13 +67,10 @@ else
   [ -n "$endpoint" ] || endpoint="$SOCK_DEFAULT"
 fi
 
-# --- 4. triage ---------------------------------------------------------------
 triage=""
 reason=""
 ep_path="$(endpoint_path "$endpoint")"
 
-# Fast path: a unix endpoint with no socket present. Decided from the filesystem
-# alone, so the host-only branch contacts no daemon at all.
 if [ -n "$ep_path" ] && [ ! -S "$ep_path" ]; then
   triage="host-only"
   reason="no Docker socket at $ep_path"
@@ -134,10 +78,6 @@ elif [ "$docker_cli" = "absent" ]; then
   triage="host-only"
   reason="no docker CLI on PATH to reach $endpoint"
 else
-  # An endpoint exists (unix socket present, or a non-filesystem scheme such as
-  # tcp:// that no file test can settle). Spend exactly ONE round-trip on it.
-  # With an explicit override, target it directly. Without one, let the CLI resolve
-  # as it normally would, so context-supplied TLS settings are not dropped.
   rc=0
   if [ -n "$explicit" ]; then
     timeout "$probe_timeout" docker -H "$(endpoint_url "$endpoint")" \
@@ -153,16 +93,12 @@ else
   fi
 fi
 
-# --- 5. report ---------------------------------------------------------------
 printf 'SCOPE=%s\n' "$scope"
 printf 'DOCKER_CLI=%s\n' "$docker_cli"
 printf 'DOCKER_ENDPOINT=%s\n' "$endpoint"
 printf 'DOCKER_TRIAGE=%s\n' "$triage"
 printf 'METRICS_SCOPE=%s\n' "$scope"
 
-# Exactly one notice on both degraded branches, none when triage is available.
-# It carries the why, what was skipped, who runs the relocated procedure and where
-# it lives — a bare "docker unavailable" would leave the reader at a dead end.
 if [ "$triage" != "available" ]; then
   where="this container"
   [ "$scope" = "host" ] && where="this host"

--- a/.oh/skills/prompt-miner/scripts/__tests__/mine-traces.test.mjs
+++ b/.oh/skills/prompt-miner/scripts/__tests__/mine-traces.test.mjs
@@ -1,5 +1,3 @@
-// node --test suite for the prompt-miner engine. Pure node:test + node:assert —
-// no vitest/tsx. Run: node --test .claude/skills/prompt-miner/scripts/__tests__/
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import fs from "node:fs";
@@ -28,7 +26,6 @@ const HERE = path.dirname(fileURLToPath(import.meta.url));
 const ENGINE = path.join(HERE, "..", "mine-traces.mjs");
 const FIXTURES = path.join(HERE, "fixtures");
 
-// --- Claude string-vs-array human-prompt detection -------------------------
 
 test("Claude: string user content is a human prompt; array content is a tool_result", () => {
   const human = classifyLine(
@@ -84,7 +81,6 @@ test("Claude: <command-name>, isMeta, and non-external lines are excluded as met
   assert.equal(sdk.isHuman, false);
 });
 
-// --- nested is_error (Claude) vs toolResult.isError (Pi) -------------------
 
 test("Claude tool error is nested in the array; Pi error is on the toolResult message", () => {
   const claudeErr = classifyLine(
@@ -94,7 +90,6 @@ test("Claude tool error is nested in the array; Pi error is on the toolResult me
   assert.equal(claudeErr.kind, "tool_result");
   assert.equal(claudeErr.isError, true);
 
-  // Real Pi shape: message.isError
   const piErrFlat = classifyLine(
     { type: "message", message: { role: "toolResult", isError: true, content: [] } },
     "pi",
@@ -102,7 +97,6 @@ test("Claude tool error is nested in the array; Pi error is on the toolResult me
   assert.equal(piErrFlat.kind, "tool_result");
   assert.equal(piErrFlat.isError, true);
 
-  // Documented Pi shape: message.toolResult.isError
   const piErrNested = classifyLine(
     { type: "message", message: { role: "toolResult", toolResult: { isError: true } } },
     "pi",
@@ -126,7 +120,6 @@ test("Pi: type=message role=user is a human prompt with joined text blocks", () 
   assert.match(ev.text, /Create the baz module/);
 });
 
-// --- abandonment / incompleteness from last assistant stop -----------------
 
 test("abandonment via aborted; incompleteness via non-end_turn/stop; clean via end_turn", () => {
   const aborted = aggregateSession(
@@ -160,10 +153,8 @@ test("abandonment via aborted; incompleteness via non-end_turn/stop; clean via e
   assert.equal(clean.incomplete, 0);
 });
 
-// --- score-breakdown arithmetic on a known input ---------------------------
 
 test("score-breakdown arithmetic matches the documented formula", () => {
-  // Build: 2 human prompts (1 corrective), 1 tool error of 1 result, incomplete end.
   const events = [
     { kind: "human", isHuman: true, text: "Add the bar feature.", ts: "2026-01-01T00:00:00Z" },
     { kind: "assistant", stopReason: "tool_use", ts: "2026-01-01T00:01:00Z" },
@@ -172,13 +163,12 @@ test("score-breakdown arithmetic matches the documented formula", () => {
     { kind: "assistant", stopReason: "tool_use", ts: "2026-01-01T00:04:00Z" },
   ];
   const agg = aggregateSession(events, { sessionId: "k", harness: "claude" });
-  assert.equal(agg.toolErrorRate, 1); // 1/1
-  assert.equal(agg.correctionDensity, 0.5); // 1 corrective / 2 human
+  assert.equal(agg.toolErrorRate, 1);
+  assert.equal(agg.correctionDensity, 0.5);
   assert.equal(agg.incomplete, 1);
   assert.equal(agg.abandoned, 0);
 
   const { score, scoreBreakdown } = scoreSession(agg, DEFAULT_WEIGHTS, { hasBonus: false });
-  // 100 - 35*1 - 30*0.5 - 20*0 - 10*1 - 5*0 = 40
   assert.equal(score, 40);
   assert.equal(scoreBreakdown.penalties.toolErrorRate, 35);
   assert.equal(scoreBreakdown.penalties.correctionDensity, 15);
@@ -195,10 +185,9 @@ test("ground-truth bonus is added and the total is capped at 100", () => {
     { sessionId: "g", harness: "claude" },
   );
   const { score } = scoreSession(clean, DEFAULT_WEIGHTS, { hasBonus: true });
-  assert.equal(score, 100); // 100 + 15 capped at 100
+  assert.equal(score, 100);
 });
 
-// --- scoreUncapped: the uncensored sibling of score ------------------------
 
 test("scoreUncapped carries the uncensored total while score stays clamped at 100", () => {
   const clean = aggregateSession(
@@ -212,15 +201,10 @@ test("scoreUncapped carries the uncensored total while score stays clamped at 10
   assert.equal(scored.score, 100, "score is still clamped");
   assert.equal(scored.scoreUncapped, 115, "base 100 + bonus 15, uncensored");
   assert.ok(scored.scoreUncapped > 100, "the ceiling does not censor scoreUncapped");
-  // Sibling of score, not nested in the breakdown.
   assert.ok(!("scoreUncapped" in scored.scoreBreakdown), "not nested in scoreBreakdown");
 });
 
 test("a maximally-penalized session floors scoreUncapped at 0 without going negative", () => {
-  // Built as a literal agg: aggregateSession can never emit all five signals at
-  // their maximum at once (abandoned and incomplete are mutually exclusive, and
-  // correctionDensity counts follow-ups only, so it is (n-1)/n < 1). scoreSession
-  // is pure, so the worst case the weights permit is exercised directly.
   const worst = {
     toolErrorRate: 1,
     correctionDensity: 1,
@@ -229,14 +213,12 @@ test("a maximally-penalized session floors scoreUncapped at 0 without going nega
     turnBloat: 1,
   };
   const scored = scoreSession(worst, DEFAULT_WEIGHTS, { hasBonus: false });
-  // 100 - 35 - 30 - 20 - 10 - 5 = 0
   assert.equal(scored.scoreUncapped, 0, "lower bound is unaffected by the change");
   assert.equal(scored.score, 0);
   assert.ok(scored.scoreUncapped >= 0, "current weights cannot produce a negative");
 });
 
 test("scoreUncapped is emitted on both sessions[] and unranked[] of a fixture run", () => {
-  // --min-turns 4 splits the fixtures: the 3-turn session falls to unranked[].
   const out = execFileSync(
     "node",
     [ENGINE, "--dry-run", "--no-git", "--harness", "all", "--fixtures-dir", FIXTURES, "--min-turns", "4", "--now", "2026-06-19T00:00:00.000Z"],
@@ -263,7 +245,6 @@ test("sessions[] ranking still sorts on the clamped score, not scoreUncapped", (
   assert.deepEqual(data.sessions.map((s) => s.sessionId), expected);
 });
 
-// --- --no-git ground-truth stub path (bonus = 0) ---------------------------
 
 test("--no-git stubs the ground-truth bonus to 0 even when a PR URL is present", () => {
   const events = [
@@ -281,12 +262,10 @@ test("--no-git stubs the ground-truth bonus to 0 even when a PR URL is present",
   const stubbed = resolveGroundTruth(agg, { noGit: true });
   assert.equal(stubbed.hasBonus, false);
 
-  // With git enabled, the same PR URL earns the bonus (no git calls needed).
   const live = resolveGroundTruth(agg, { noGit: false, commitTimes: [] });
   assert.equal(live.hasBonus, true);
 });
 
-// --- redaction (line-level + block-level key) ------------------------------
 
 test("redact scrubs line-level tokens and a block-level PEM key body", () => {
   const pem = "-----BEGIN RSA PRIVATE KEY-----\nMIIabc123lineone\nlinetwoXYZ\n-----END RSA PRIVATE KEY-----";
@@ -309,7 +288,6 @@ test("redact scrubs line-level tokens and a block-level PEM key body", () => {
   assert.ok(out.includes("[REDACTED]"));
 });
 
-// --- --weights validation ---------------------------------------------------
 
 test("validateWeights rejects bad objects and accepts a complete one", () => {
   assert.throws(() => validateWeights("not-an-object"), /JSON object/);
@@ -322,7 +300,6 @@ test("validateWeights rejects bad objects and accepts a complete one", () => {
   assert.equal(ok.toolErrorRate, 50);
 });
 
-// --- feature extraction + session-type detection ---------------------------
 
 test("extractFeatures captures the documented marker keys", () => {
   const f = extractFeatures("Implement `foo` in src/foo.mjs per the acceptance criteria. See #42 and https://x.test/y");
@@ -343,7 +320,6 @@ test("detectSessionType classifies the first prompt", () => {
   assert.equal(detectSessionType("What does the wiki say about X?"), "query");
 });
 
-// --- session merge / no_human_prompt ---------------------------------------
 
 test("sessions with no human prompt are flagged no_human_prompt", () => {
   const agg = aggregateSession(
@@ -354,7 +330,6 @@ test("sessions with no human prompt are flagged no_human_prompt", () => {
   assert.equal(agg.firstHumanPrompt, null);
 });
 
-// --- integration: CLI dry-run over fixtures (+ malformed tolerance) ---------
 
 test("CLI --dry-run --no-git over fixtures: non-zero sessions and tool errors", () => {
   const out = execFileSync(
@@ -394,11 +369,7 @@ test("CLI rejects an unknown flag with a non-zero exit", () => {
   assert.throws(() => execFileSync("node", [ENGINE, "--bogus"], { encoding: "utf8", stdio: "pipe" }));
 });
 
-// --- weakness records (WH-<NNN>): shape, determinism, privacy ---------------
 
-// Synthetic sessions: tool_error fires in 2 of 3 (>= WEAKNESS_MIN_FREQUENCY),
-// so exactly one WH-001 record is produced. Ordering is intentionally jumbled
-// (sessionId z before a, harness pi before claude) to exercise the sorts.
 const SYNTH_SESSIONS = [
   { sessionId: "z-sess", harness: "pi", gitBranch: "feat/z", toolErrors: 1, incomplete: 0, abandoned: 0, scoreBreakdown: { signals: { correctionDensity: 0 } } },
   { sessionId: "a-sess", harness: "claude", gitBranch: "feat/a", toolErrors: 2, incomplete: 0, abandoned: 0, scoreBreakdown: { signals: { correctionDensity: 0 } } },
@@ -425,8 +396,6 @@ test("buildWeaknessRecords returns exactly the 7 metadata fields, all non-empty,
   assert.ok(typeof rec.recommended_repair_surface === "string" && rec.recommended_repair_surface.length > 0);
   assert.ok(Array.isArray(rec.affected_agents) && rec.affected_agents.length > 0);
   assert.ok(Array.isArray(rec.supporting_traces) && rec.supporting_traces.length > 0);
-  // Privacy: no promptText key on the record OR on any supporting trace; traces
-  // are session-id metadata only.
   assert.equal("promptText" in rec, false);
   for (const t of rec.supporting_traces) {
     assert.equal("promptText" in t, false);
@@ -438,7 +407,6 @@ test("buildWeaknessRecords is byte-identical across two calls and stable under i
   const a = JSON.stringify(buildWeaknessRecords(SYNTH_SESSIONS));
   const b = JSON.stringify(buildWeaknessRecords(SYNTH_SESSIONS));
   assert.equal(a, b, "two calls on the same input are byte-identical");
-  // WH-001 must not flip when the same sessions arrive in a different order.
   const shuffled = [SYNTH_SESSIONS[2], SYNTH_SESSIONS[0], SYNTH_SESSIONS[1]];
   assert.equal(JSON.stringify(buildWeaknessRecords(shuffled)), a, "stable under reorder");
 });
@@ -452,7 +420,6 @@ test("weakness records serialize no raw human-prompt substring from the fixtures
   const data = JSON.parse(out);
   assert.ok(Array.isArray(data.weaknesses) && data.weaknesses.length >= 1, ">= 1 WH record");
   const serialized = JSON.stringify(data.weaknesses);
-  // Distinctive human-prompt substrings that live verbatim in the fixture .jsonl.
   const humanPromptSubstrings = [
     "Implement the foo widget",
     "Add the bar feature",
@@ -465,20 +432,11 @@ test("weakness records serialize no raw human-prompt substring from the fixtures
   for (const w of data.weaknesses) assert.equal("promptText" in w, false);
 });
 
-// ---------------------------------------------------------------------------
-// #692 — window overlap semantics and sidechain exclusion
-// ---------------------------------------------------------------------------
 
 const T = (iso) => Date.parse(iso);
 const WINDOW = { start: T("2026-08-02T00:00:00Z"), end: T("2026-08-03T00:00:00Z") };
 
 test("withinWindow admits a session that STARTED before the window but was active inside it", () => {
-  // The regression this pins. Events are merged across resumed files keyed by
-  // sessionId, so a long-lived session keeps its ORIGINAL firstTs. The old
-  // implementation compared that single point against both bounds, so a session
-  // started 30h ago and worked in continuously was invisible to --hours 24 —
-  // and the daily cron runs a windowed query. Those resumed sessions are the
-  // high-signal ones.
   const resumed = { firstTs: T("2026-07-24T17:48:00Z"), lastTs: T("2026-08-02T20:00:00Z") };
   assert.equal(withinWindow(resumed, WINDOW), true);
 });
@@ -510,10 +468,6 @@ test("withinWindow rejects a session with no usable timestamps", () => {
 });
 
 test("classifyLine flags Claude sidechain records so they can be excluded", () => {
-  // Sidechain records carry the PARENT's sessionId and message.role "user", so
-  // without this flag a delegate briefing is counted as a human turn and
-  // corrupts correctionDensity / turnBloat / toolErrorRate for exactly the
-  // delegating sessions worth mining.
   const sidechain = classifyLine(
     {
       type: "user",
@@ -538,7 +492,6 @@ test("classifyLine flags Claude sidechain records so they can be excluded", () =
   );
   assert.equal(real.isSidechain, false);
 
-  // Absent/!== true must never be treated as sidechain.
   const weird = classifyLine(
     { type: "user", timestamp: "2026-08-02T12:00:00Z", sessionId: "s", isSidechain: "true", message: { role: "user", content: "x" } },
     "claude",
@@ -546,13 +499,10 @@ test("classifyLine flags Claude sidechain records so they can be excluded", () =
   assert.equal(weird.isSidechain, false);
 });
 
-// --- ceiling-saturation census (manifest + markdown) -----------------------
 
 test("computeCeilingSaturation counts the stored rounded score === 100, not scoreUncapped", () => {
   const census = computeCeilingSaturation([
-    // On the ceiling: the clamp censored 112.5 down to exactly 100.
     { sessionType: "impl", score: 100, scoreUncapped: 112.5 },
-    // NOT on the ceiling: 99.99 rounds to nothing else, it is simply below.
     { sessionType: "impl", score: 99.99, scoreUncapped: 99.99 },
     { sessionType: "other", score: 100, scoreUncapped: 100 },
   ]);
@@ -572,8 +522,6 @@ test("computeCeilingSaturation omits null session types and zero-session strata"
   assert.equal(census.cron.atCeiling, 0);
 });
 
-// A fixture dir carrying a noHumanPrompt session (assistant lines only → the
-// only way sessionType is null) next to the normal samples.
 function fixturesWithNoHumanSession() {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "pm-census-"));
   for (const f of fs.readdirSync(FIXTURES)) {
@@ -606,12 +554,10 @@ test("manifest.ceilingSaturation is built from rankable only and carries no null
   assert.ok(!("null" in census), "no null key in ceilingSaturation");
   for (const key of Object.keys(census)) assert.notEqual(key, "null");
 
-  // The census population is exactly sessions[] (rankable), not everything scanned.
   const totals = Object.values(census).reduce((n, c) => n + c.total, 0);
   assert.equal(totals, data.sessions.length);
   assert.ok(totals < data.manifest.sessionsScanned, "rankable is a strict subset here");
 
-  // Shape: every value is { atCeiling: int, total: int } and matches sessions[].
   const expected = {};
   for (const s of data.sessions) {
     expected[s.sessionType] ??= { atCeiling: 0, total: 0 };
@@ -637,13 +583,11 @@ test("the markdown report renders the census as flat bullets and adds no new hea
   assert.ok(census.length > 0, "at least one census bullet rendered");
   for (const l of census) assert.match(l, /^- ceilingSaturation\.[a-z]+: \d+\/\d+$/);
 
-  // The bullets live under the EXISTING ## Manifest heading.
   const manifestIdx = lines.indexOf("## Manifest");
   const nextHeadingIdx = lines.findIndex((l, i) => i > manifestIdx && l.startsWith("## "));
   const firstCensusIdx = lines.findIndex((l) => l.startsWith("- ceilingSaturation."));
   assert.ok(firstCensusIdx > manifestIdx && firstCensusIdx < nextHeadingIdx);
 
-  // No new heading of any level was introduced by the census.
   const headings = lines.filter((l) => /^#{1,6} /.test(l));
   assert.ok(!headings.some((h) => /ceiling/i.test(h)), "no census heading added");
   fs.rmSync(tmp, { recursive: true, force: true });

--- a/.oh/skills/prompt-miner/scripts/mine-traces.mjs
+++ b/.oh/skills/prompt-miner/scripts/mine-traces.mjs
@@ -1,25 +1,4 @@
 #!/usr/bin/env node
-// prompt-miner engine: parse Claude+Pi session traces, score each session by a
-// friction+ground-truth outcome proxy, extract prompt feature vectors, and emit a
-// ranked, redacted report (json + md). Zero npm deps; node v22 built-ins only.
-// The `git` binary is the single allowed external (ground-truth cross-ref), gated
-// behind --no-git. See references/scoring.md, references/markers.md,
-// references/report-schema.md for the contracts this engine implements.
-//
-// CLI-entrypoint detection is a BASENAME match on process.argv[1], NOT
-// `import.meta.url === pathToFileURL(argv[1])` — node resolves the symlink for
-// import.meta.url but not for argv[1], so the latter silently no-ops when the
-// script is invoked through the .claude/skills dir-symlink that SKILL.md Step 1
-// and the daily cron both prescribe (issue #663;
-// prompt-miner-engine-symlink-guard-bug). Same form as
-// rlm/scripts/query-context.mjs and weigh/scripts/score-trajectories.mjs.
-//
-// Known blast radius of the basename form, shared with both siblings: it trusts
-// the basename of argv[1] globally rather than file identity, so a DIFFERENT file
-// that happens to be named mine-traces.mjs and imports this module would run
-// main(). Nothing in this repo is so named. A realpath comparison would be both
-// symlink- and collision-safe, but adopting it here alone would leave three
-// sibling engines with three different guards; change all three together or none.
 
 import fs from "node:fs";
 import readline from "node:readline";
@@ -28,12 +7,7 @@ import os from "node:os";
 import process from "node:process";
 import { execFileSync } from "node:child_process";
 
-// ---------------------------------------------------------------------------
-// Constants & contracts
-// ---------------------------------------------------------------------------
 
-// Friction coefficients (the formula in references/scoring.md). Every key here is
-// REQUIRED when --weights is supplied; values must be finite, non-negative numbers.
 export const DEFAULT_WEIGHTS = Object.freeze({
   toolErrorRate: 35,
   correctionDensity: 30,
@@ -43,10 +17,8 @@ export const DEFAULT_WEIGHTS = Object.freeze({
   groundTruthBonus: 15,
 });
 
-// Turn-bloat reference point: assistantTurns beyond K saturate the penalty.
 export const TURN_BLOAT_K = 40;
 
-// Corrective-follow-up lexicon (highest-variance signal — see references/scoring.md).
 export const NEGATION_LEXICON = Object.freeze([
   "no",
   "wrong",
@@ -62,7 +34,6 @@ export const NEGATION_LEXICON = Object.freeze([
   "fix",
 ]);
 
-// Hedging lexicon for the prompt feature vector.
 const HEDGING_LEXICON = [
   "maybe",
   "perhaps",
@@ -77,7 +48,6 @@ const HEDGING_LEXICON = [
   "i guess",
 ];
 
-// Imperative verbs that mark an action-first prompt (startsImperative, impl type).
 const IMPERATIVE_VERBS = new Set([
   "add",
   "build",
@@ -112,7 +82,6 @@ const IMPERATIVE_VERBS = new Set([
   "design",
 ]);
 
-// The feature keys the marker step correlates against outcome.
 export const MARKER_FEATURE_KEYS = Object.freeze([
   "lenChars",
   "lenWords",
@@ -134,9 +103,6 @@ export const SCORE_MODEL =
 
 const PR_URL_RE = /github\.com\/[\w.-]+\/[\w.-]+\/pull\/\d+/i;
 
-// ---------------------------------------------------------------------------
-// Small helpers
-// ---------------------------------------------------------------------------
 
 export function clamp(value, lo, hi) {
   if (!Number.isFinite(value)) return lo;
@@ -147,7 +113,6 @@ function isPlainObject(value) {
   return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
-// Concatenate Claude/Pi content blocks into a single plain-text string.
 function blocksToText(content) {
   if (typeof content === "string") return content;
   if (!Array.isArray(content)) return "";
@@ -162,9 +127,6 @@ function blocksToText(content) {
   return parts.join("\n");
 }
 
-// ---------------------------------------------------------------------------
-// Weights
-// ---------------------------------------------------------------------------
 
 export function validateWeights(obj) {
   if (!isPlainObject(obj)) {
@@ -188,15 +150,7 @@ export function validateWeights(obj) {
   return { ...obj };
 }
 
-// ---------------------------------------------------------------------------
-// Line classification (pure, per single JSONL line)
-// ---------------------------------------------------------------------------
 
-// classifyLine normalizes ONE parsed JSONL object into a common event shape:
-//   { kind, ts, isError, stopReason, usage, text, isHuman, sessionId, gitBranch }
-// kind ∈ "human" | "assistant" | "tool_result" | "meta" | "other".
-// Session identity for Pi is resolved at the file layer (Pi message lines carry
-// none), so sessionId/gitBranch may be null here for Pi.
 export function classifyLine(line, harness) {
   const base = {
     kind: "other",
@@ -208,9 +162,6 @@ export function classifyLine(line, harness) {
     isHuman: false,
     sessionId: null,
     gitBranch: null,
-    // Claude marks subagent (delegate) traces with isSidechain: true. Those
-    // records carry the PARENT's sessionId, so they merge into the parent's
-    // bucket unless they are filtered out. See the exclusion in readTraceFile.
     isSidechain: false,
   };
   if (!isPlainObject(line)) return base;
@@ -233,7 +184,6 @@ export function classifyLine(line, harness) {
     if (line.type === "user" && msg) {
       const content = msg.content;
       if (typeof content === "string") {
-        // Real typed human prompt vs. meta/command wrappers.
         const isExternal = line.userType === "external";
         const notMeta = line.isMeta !== true;
         const roleUser = msg.role === "user";
@@ -250,7 +200,6 @@ export function classifyLine(line, harness) {
         return base;
       }
       if (Array.isArray(content)) {
-        // Array-valued user content = tool results, NOT a prompt. Errors are NESTED.
         base.kind = "tool_result";
         base.isError = content.some(
           (b) => isPlainObject(b) && b.type === "tool_result" && b.is_error === true,
@@ -261,16 +210,15 @@ export function classifyLine(line, harness) {
       return base;
     }
 
-    return base; // last-prompt, attachment, pr-link, ai-title, mode, etc.
+    return base;
   }
 
   if (harness === "pi") {
     base.ts = typeof line.timestamp === "string" ? line.timestamp : null;
     if (line.type === "session") {
-      // Carry session id so the file layer can resolve it.
       base.kind = "other";
       base.sessionId = typeof line.id === "string" ? line.id : null;
-      base.gitBranch = typeof line.cwd === "string" ? null : null; // Pi has no branch
+      base.gitBranch = typeof line.cwd === "string" ? null : null;
       return base;
     }
     if (line.type !== "message" || !isPlainObject(line.message)) return base;
@@ -292,8 +240,6 @@ export function classifyLine(line, harness) {
     }
     if (role === "toolResult") {
       base.kind = "tool_result";
-      // Real Pi traces put the flag at message.isError; the documented schema also
-      // allows message.toolResult.isError — accept either.
       const nested = isPlainObject(msg.toolResult) ? msg.toolResult.isError === true : false;
       base.isError = nested || msg.isError === true;
       return base;
@@ -304,9 +250,6 @@ export function classifyLine(line, harness) {
   return base;
 }
 
-// ---------------------------------------------------------------------------
-// Session aggregation (pure, over a merged list of normalized events)
-// ---------------------------------------------------------------------------
 
 function matchesLexicon(text, lexicon) {
   const lower = text.toLowerCase();
@@ -321,8 +264,6 @@ function matchesLexicon(text, lexicon) {
   return false;
 }
 
-// aggregateSession folds normalized events (already merged across resumed files for
-// one sessionId) into the per-session counts scoring needs.
 export function aggregateSession(events, meta = {}) {
   const humanPrompts = [];
   let assistantTurns = 0;
@@ -371,7 +312,6 @@ export function aggregateSession(events, meta = {}) {
 
   const clean = lastAssistantStop === "end_turn" || lastAssistantStop === "stop";
   const abandoned = lastAssistantStop === "aborted" ? 1 : 0;
-  // No clean final assistant turn (and not explicitly aborted) ⇒ incomplete.
   const incomplete = !clean && !abandoned ? 1 : 0;
   const turnBloat = clamp((assistantTurns - TURN_BLOAT_K) / TURN_BLOAT_K, 0, 1);
 
@@ -402,11 +342,7 @@ export function aggregateSession(events, meta = {}) {
   };
 }
 
-// ---------------------------------------------------------------------------
-// Scoring (pure: ground-truth resolution is injected)
-// ---------------------------------------------------------------------------
 
-// scoreSession applies the friction formula. groundTruth = { hasBonus, reason }.
 export function scoreSession(agg, weights = DEFAULT_WEIGHTS, groundTruth = { hasBonus: false }) {
   const w = weights;
   const penalties = {
@@ -425,10 +361,6 @@ export function scoreSession(agg, weights = DEFAULT_WEIGHTS, groundTruth = { has
     penalties.turnBloat;
   const bonus = groundTruth.hasBonus ? w.groundTruthBonus : 0;
   const score = clamp(base + bonus, 0, 100);
-  // The uncensored sibling of `score`. `base` is already capped at 100 by
-  // construction and `bonus` adds up to 15 more, so the clamped `score` is
-  // censored above 100 — an effect size computed on it reads a flattened upper
-  // tail. Marker effect sizes correlate against THIS field (references/markers.md).
   const scoreUncapped = base + bonus;
 
   return {
@@ -457,9 +389,6 @@ export function scoreSession(agg, weights = DEFAULT_WEIGHTS, groundTruth = { has
   };
 }
 
-// ---------------------------------------------------------------------------
-// Prompt feature extraction & session-type detection (pure)
-// ---------------------------------------------------------------------------
 
 function countMatches(text, re) {
   const m = text.match(re);
@@ -496,13 +425,6 @@ export function extractFeatures(text) {
   };
 }
 
-// Per-stratum census of how much of the RANKABLE population sits on the display
-// ceiling. `score` is clamped at 100, so a stratum whose sessions pile up there
-// has stopped discriminating — the operator can read that off the report instead
-// of recomputing it. Counts the STORED, rounded `score` field (not `scoreUncapped`,
-// not an unrounded intermediate), because that is the number the report displays.
-// Session types with no rankable sessions are omitted; a null type cannot appear,
-// because `rankable` excludes noHumanPrompt sessions (the only null-type records).
 export function computeCeilingSaturation(records) {
   const census = {};
   for (const r of records) {
@@ -530,23 +452,9 @@ export function detectSessionType(text) {
   return "other";
 }
 
-// ---------------------------------------------------------------------------
-// Weakness records (pure) — cluster repeated harness-level failure signals into
-// metadata-only WH-<NNN> records. A weakness record NEVER carries prompt text in
-// ANY mode (not even --include-prompt-text); supporting_traces holds session-id
-// metadata only. See references/report-schema.md and rfc-selfimprove-roadmap.md
-// items 4 + 6 (the likely_harness_layer / recommended_repair_surface vocab).
-// ---------------------------------------------------------------------------
 
-// A single occurrence is not a pattern: a signal must recur in at least this many
-// sessions before it earns a weakness record.
 export const WEAKNESS_MIN_FREQUENCY = 2;
 
-// Fixed failure-signal taxonomy. Declaration order is the deterministic tiebreak
-// when two clusters share a frequency, so WH-001 never flips across identical
-// runs. `likely_harness_layer` and `recommended_repair_surface` use the exact
-// RFC item 4 + 6 enum terms (harness layer: artifact contract | audit gate |
-// handoff | terminal status; repair surface: skill rule | probe | verifier).
 const WEAKNESS_SIGNALS = Object.freeze([
   {
     key: "tool_error",
@@ -578,10 +486,6 @@ const WEAKNESS_SIGNALS = Object.freeze([
   },
 ]);
 
-// buildWeaknessRecords clusters sessions by the fixed failure-signal taxonomy and
-// emits one metadata-only WH-<NNN> record per signal met by >= minFrequency
-// sessions. Pure + deterministic: clusters sort by frequency desc then taxonomy
-// order, so WH-001 is stable across byte-identical inputs.
 export function buildWeaknessRecords(sessions, opts = {}) {
   const list = Array.isArray(sessions) ? sessions : [];
   const total = list.length;
@@ -595,10 +499,8 @@ export function buildWeaknessRecords(sessions, opts = {}) {
     const matched = list.filter((s) => signal.match(s));
     if (matched.length < minFrequency) continue;
 
-    // affected agents: distinct harness values, sorted (deterministic).
     const affected_agents = [...new Set(matched.map((s) => s?.harness).filter(Boolean))].sort();
 
-    // supporting traces: session-id METADATA ONLY — never prompt text, in any mode.
     const supporting_traces = matched
       .map((s) => ({
         sessionId: s?.sessionId ?? null,
@@ -619,7 +521,6 @@ export function buildWeaknessRecords(sessions, opts = {}) {
     });
   }
 
-  // Deterministic ordering: frequency desc, then taxonomy declaration order asc.
   clusters.sort((a, b) => b.count - a.count || a.order - b.order);
 
   return clusters.map((c, i) => ({
@@ -633,30 +534,21 @@ export function buildWeaknessRecords(sessions, opts = {}) {
   }));
 }
 
-// ---------------------------------------------------------------------------
-// Redaction (pure)
-// ---------------------------------------------------------------------------
 
 export function redact(text) {
   if (typeof text !== "string") return text;
   let out = text;
-  // Block-level first: PEM key bodies (multiline) then long base64/hex runs.
   out = out.replace(/-----BEGIN [A-Z0-9 ]*KEY-----[\s\S]*?-----END [A-Z0-9 ]*KEY-----/g, "[REDACTED]");
-  // Line-level token shapes (run before the generic >=40 run so they read cleanly).
   out = out.replace(/sk-ant-[A-Za-z0-9_-]+/g, "[REDACTED]");
   out = out.replace(/sk-[A-Za-z0-9_-]+/g, "[REDACTED]");
   out = out.replace(/github_pat_[A-Za-z0-9_]+/g, "[REDACTED]");
   out = out.replace(/\bgh[opsu]_[A-Za-z0-9]+/g, "[REDACTED]");
   out = out.replace(/\bAKIA[0-9A-Z]{12,}/g, "[REDACTED]");
   out = out.replace(/Bearer\s+[A-Za-z0-9._~+/=-]+/g, "Bearer [REDACTED]");
-  // Generic high-entropy runs (≥40 base64/hex chars) last.
   out = out.replace(/[A-Za-z0-9+/=]{40,}/g, "[REDACTED]");
   return out;
 }
 
-// ---------------------------------------------------------------------------
-// CLI parsing
-// ---------------------------------------------------------------------------
 
 const USAGE = `usage: mine-traces.mjs [options]
   --harness all|claude|pi   (default all)
@@ -796,9 +688,6 @@ export function parseArgs(argv) {
   return args;
 }
 
-// ---------------------------------------------------------------------------
-// File enumeration & windowing (impure)
-// ---------------------------------------------------------------------------
 
 function expandHome(p) {
   if (p.startsWith("~")) return path.join(os.homedir(), p.slice(1));
@@ -838,7 +727,6 @@ function listFiles(dir, predicate) {
   return out;
 }
 
-// Returns [{file, harness}]. Fixtures override real traces when --fixtures-dir set.
 function enumerateFiles(args) {
   if (args.fixturesDir) {
     const dir = expandHome(args.fixturesDir);
@@ -862,18 +750,13 @@ function enumerateFiles(args) {
   return result;
 }
 
-// Pi filename: <ts>_<uuid>.jsonl → uuid segment is the session id fallback.
 function piSessionIdFromFile(file) {
   const base = path.basename(file).replace(/\.jsonl$/, "");
   const idx = base.indexOf("_");
   return idx >= 0 ? base.slice(idx + 1) : base;
 }
 
-// ---------------------------------------------------------------------------
-// Ground-truth (git)
-// ---------------------------------------------------------------------------
 
-// Fetch origin/development once and return a list of commit unix-timestamps.
 function loadGitCommitTimes() {
   try {
     execFileSync("git", ["fetch", "origin", "development", "--depth=200"], {
@@ -881,7 +764,6 @@ function loadGitCommitTimes() {
       timeout: 60000,
     });
   } catch {
-    // best-effort fetch; fall through to whatever ref exists locally
   }
   try {
     const out = execFileSync("git", ["log", "--format=%ct", "origin/development", "-n", "200"], {
@@ -909,12 +791,8 @@ export function resolveGroundTruth(agg, { noGit, commitTimes = [] }) {
   return { hasBonus: false, reason: "none" };
 }
 
-// ---------------------------------------------------------------------------
-// Pipeline (impure): read → aggregate → score → feature → rank → report
-// ---------------------------------------------------------------------------
 
 async function readFileEvents(file, harness, store, counters) {
-  // Pi: resolve one sessionId per file (from a `session` line or filename).
   let piSessionId = harness === "pi" ? piSessionIdFromFile(file) : null;
 
   const events = [];
@@ -935,14 +813,6 @@ async function readFileEvents(file, harness, store, counters) {
       piSessionId = ev.sessionId;
     }
     if (ev.kind === "other" && !ev.sessionId) continue;
-    // Exclude subagent (sidechain) turns from the parent session's feature
-    // vector. `listFiles` recurses, so <session-id>/subagents/agent-*.jsonl is
-    // already ingested, and every line there carries the PARENT's sessionId
-    // with message.role "user"/"assistant". Left in, a delegate briefing is
-    // counted as a HUMAN turn, which inflates the human-prompt denominator and
-    // corrupts turnBloat / correctionDensity / toolErrorRate for exactly the
-    // delegating sessions most worth mining (#692). Measured on the live
-    // corpus: 45,167 sidechain lines vs 42,679 non-sidechain — the majority.
     if (ev.isSidechain) {
       counters.sidechainTurnsExcluded += 1;
       continue;
@@ -950,7 +820,6 @@ async function readFileEvents(file, harness, store, counters) {
     events.push(ev);
   }
 
-  // Group into the store, keyed by sessionId (merge resumed sessions across files).
   if (harness === "claude") {
     for (const ev of events) {
       const sid = ev.sessionId;
@@ -968,22 +837,11 @@ async function readFileEvents(file, harness, store, counters) {
   }
 }
 
-// A session is in-window when its ACTIVITY SPAN OVERLAPS the window — not when
-// it happens to START inside it.
-//
-// The old form compared a single point (`agg.firstTs || agg.lastTs`) against
-// both bounds. Because events are merged across resumed files keyed by
-// sessionId, a long-lived session keeps its ORIGINAL firstTs, so a session
-// started 30h ago and worked in continuously ever since was invisible to
-// `--hours 24` — and the daily cron runs `--hours 24`. Those resumed sessions
-// are the high-signal ones (#692).
 export function withinWindow(agg, window) {
   if (!window.start && !window.end) return true;
   const start = agg.firstTs || agg.lastTs;
   const end = agg.lastTs || agg.firstTs;
   if (!start || !end) return false;
-  // Overlap test: the session ended before the window opened, or began after
-  // it closed → out. Anything else intersects.
   if (window.start && end < window.start) return false;
   if (window.end && start > window.end) return false;
   return true;
@@ -1011,7 +869,6 @@ async function run(args) {
     await readFileEvents(file, harness, store, counters);
   }
 
-  // Aggregate + score every session.
   const commitTimes = args.noGit ? [] : loadGitCommitTimes();
   let sessions = [];
   for (const bucket of store.values()) {
@@ -1055,7 +912,6 @@ async function run(args) {
     sessions.push(record);
   }
 
-  // Window filter, then last-n (most-recent firstTs), then ranking.
   sessions = sessions.filter((s) => withinWindow({ firstTs: s.window.firstTs, lastTs: s.window.lastTs }, window));
   const sessionsScanned = sessions.length;
   const toolErrorsTotal = sessions.reduce((sum, s) => sum + s.toolErrors, 0);
@@ -1066,8 +922,6 @@ async function run(args) {
   const rankable = sessions.filter((s) => !s.noHumanPrompt && s.turns >= args.minTurns);
   rankable.sort((a, b) => b.score - a.score || String(a.sessionId).localeCompare(String(b.sessionId)));
 
-  // Weakness records cluster harness-level failure signals across ALL in-window
-  // sessions (ranked + unranked) — metadata only, never prompt text.
   const weaknesses = buildWeaknessRecords(sessions);
 
   const manifest = {
@@ -1101,9 +955,6 @@ async function run(args) {
   return { dataset, manifest, rankable, utcDate };
 }
 
-// ---------------------------------------------------------------------------
-// Report rendering
-// ---------------------------------------------------------------------------
 
 function renderMarkdown(dataset, top) {
   const { manifest, sessions, weaknesses = [] } = dataset;
@@ -1117,8 +968,6 @@ function renderMarkdown(dataset, top) {
   lines.push(`- window: ${manifest.window.start || "(open)"} → ${manifest.window.end || "(open)"}`);
   lines.push(`- sessionsScanned: ${manifest.sessionsScanned}`);
   lines.push(`- sessionsRanked: ${manifest.sessionsRanked}`);
-  // Flat bullets under the EXISTING ## Manifest heading — no new heading, so the
-  // report's section structure is unchanged. Sorted by type for a stable diff.
   for (const [type, c] of Object.entries(manifest.ceilingSaturation || {}).sort(([a], [b]) =>
     a.localeCompare(b),
   )) {
@@ -1145,8 +994,6 @@ function renderMarkdown(dataset, top) {
   lines.push(sep);
   for (const s of sessions.slice(-top).reverse()) lines.push(fmtRow(s));
   lines.push("");
-  // Weakness records: metadata-only WH-<NNN> clusters. No prompt text is
-  // rendered — only the fixed taxonomy summary + session-id counts.
   lines.push("## Weakness records");
   lines.push("");
   if (!weaknesses.length) {
@@ -1174,9 +1021,6 @@ function writeReports(outDir, utcDate, dataset, top) {
   return { jsonPath, mdPath };
 }
 
-// ---------------------------------------------------------------------------
-// main
-// ---------------------------------------------------------------------------
 
 async function main() {
   let args;
@@ -1218,7 +1062,6 @@ async function main() {
   );
 }
 
-// Basename-match entrypoint detection (symlink-safe; see header note).
 if (path.basename(process.argv[1] || "") === "mine-traces.mjs") {
   main();
 }

--- a/.oh/skills/retro/scripts/check-identity-duplicates.sh
+++ b/.oh/skills/retro/scripts/check-identity-duplicates.sh
@@ -1,9 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Reads proposed IDENTITY lines from stdin and reports lines whose lesson text
-# already appears in .oh/context/IDENTITY.md. Exact enough to catch
-# double-writes without making subjective semantic judgments.
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 ROOT=$(cd "$SCRIPT_DIR/../../../.." && pwd)
 IDENTITY_FILE="$ROOT/.oh/context/IDENTITY.md"
@@ -11,36 +8,19 @@ IDENTITY_FILE="$ROOT/.oh/context/IDENTITY.md"
 status=0
 while IFS= read -r line; do
   [[ -n "$line" ]] || continue
-  # Strip common bullet/date prefixes and metadata after the first bracket tag.
   normalized=$(printf '%s' "$line" \
     | sed -E 's/^- +//' \
     | sed -E 's/^\*\*[0-9]{4}-[0-9]{2}-[0-9]{2}\*\*: //' \
     | sed -E 's/^[0-9]{4}-[0-9]{2}-[0-9]{2}: //' \
     | sed -E 's/ \[[^]]+\].*$//')
   [[ -n "$normalized" ]] || continue
-  # Pass 1 — exact (fixed-string, case-insensitive). Cheap and certain.
   if [[ -f "$IDENTITY_FILE" ]] && grep -Fqi -- "$normalized" "$IDENTITY_FILE"; then
     echo "DUPLICATE: $line" >&2
     status=1
     continue
   fi
 
-  # Pass 2 — REPHRASED. `grep -Fqi` alone only catches a byte-identical restatement, so
-  # reordering a clause or swapping two words slipped a duplicate straight through, which
-  # is how the same lesson lands three times in different words. Compare content-word
-  # SETS instead: reduce both sides to lowercase words, drop stopwords and anything
-  # shorter than 4 characters, and flag when a high proportion of the proposal's distinct
-  # content words already co-occur in a single existing entry.
-  #
-  # Deliberately still not semantic: this is a set-overlap heuristic, not a judgment about
-  # meaning. It reports a candidate for a human to confirm — the propose-then-confirm gate
-  # is what decides.
   if [[ -f "$IDENTITY_FILE" ]]; then
-    # thresh/minhits calibrated against the real file, both directions: a human
-    # rephrasing of an existing entry scored 0.56 and a synthetic one reusing the entry's
-    # own content words scored 0.82, while 8 lessons from domains this harness has never
-    # recorded topped out at 0.20. 0.50 sits in that gap with margin on both sides. The
-    # hit floor stops a 5-word proposal from matching on two incidental words.
     hit=$(printf '%s\n' "$normalized" | awk -v thresh=0.50 -v minhits=5 '
       function words(str, out,   n, i, w, arr) {
         n = split(tolower(str), arr, /[^a-z0-9]+/)

--- a/.oh/skills/retro/scripts/validate-retro-report.sh
+++ b/.oh/skills/retro/scripts/validate-retro-report.sh
@@ -28,7 +28,6 @@ if [[ "$last_line" != 'STATUS: RETRO-DONE' ]]; then
   exit 1
 fi
 
-# Validate table rows enough to catch skipped evidence/verdict/confidence fields.
 awk -F'|' '
   /^\|[[:space:]]*[A-Z0-9-]+[[:space:]]*\|/ {
     id=$2; gsub(/^[[:space:]]+|[[:space:]]+$/, "", id)
@@ -47,7 +46,6 @@ awk -F'|' '
   END { if (rows < 1) { print "REGRESSION: no hypothesis rows" > "/dev/stderr"; exit 1 } }
 ' "$REPORT"
 
-# Every IDENTITY promotion candidate must carry a triage tag and a probe id.
 if grep -q '^Proposed IDENTITY.md addition(s):' "$REPORT"; then
   while IFS= read -r cand; do
     [[ "$cand" == "- none" ]] && continue

--- a/.oh/skills/rlm/scripts/__tests__/query-context.test.mjs
+++ b/.oh/skills/rlm/scripts/__tests__/query-context.test.mjs
@@ -1,6 +1,3 @@
-// node --test suite for the rlm query-context primitive. Pure node:test +
-// node:assert — no vitest/tsx. Run:
-//   node --test .oh/skills/rlm/scripts/__tests__/query-context.test.mjs
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import fs from "node:fs";
@@ -24,7 +21,6 @@ const HERE = path.dirname(fileURLToPath(import.meta.url));
 const SCRIPT = path.join(HERE, "..", "query-context.mjs");
 const FIXTURE = path.join(HERE, "fixtures", "big-sample.txt");
 
-// Run the CLI and parse its JSON stdout.
 function runCli(extraArgs) {
   const out = execFileSync("node", [SCRIPT, FIXTURE, ...extraArgs], { encoding: "utf8" });
   return JSON.parse(out);
@@ -32,10 +28,8 @@ function runCli(extraArgs) {
 
 const FIXTURE_BUF = fs.readFileSync(FIXTURE);
 const FIXTURE_LINES = FIXTURE_BUF.toString("utf8").split("\n");
-// split() on a trailing-newline file yields a trailing "" element; drop it.
 if (FIXTURE_LINES[FIXTURE_LINES.length - 1] === "") FIXTURE_LINES.pop();
 
-// --- chunk map (--map) ------------------------------------------------------
 
 test("--map returns ONLY the chunk map: line ranges + byte offsets, no content", () => {
   const out = runCli(["--map"]);
@@ -43,12 +37,10 @@ test("--map returns ONLY the chunk map: line ranges + byte offsets, no content",
   assert.equal(out.totalLines, FIXTURE_LINES.length);
   assert.equal(out.totalBytes, FIXTURE_BUF.length);
 
-  // No content anywhere in map mode.
   assert.ok(!("slice" in out), "no slice in --map output");
   assert.ok(!("grep" in out), "no grep in --map output");
   for (const c of out.chunkMap) assert.ok(!("content" in c), "chunk carries no content");
 
-  // 600 lines / default chunk 100 = 6 chunks, contiguous & covering the whole file.
   assert.equal(out.chunkSize, DEFAULT_CHUNK_SIZE);
   assert.equal(out.chunkMap.length, Math.ceil(FIXTURE_LINES.length / DEFAULT_CHUNK_SIZE));
   assert.equal(out.chunkMap[0].startLine, 1);
@@ -60,12 +52,10 @@ test("--map returns ONLY the chunk map: line ranges + byte offsets, no content",
     assert.equal(out.chunkMap[i].startLine, out.chunkMap[i - 1].endLine + 1, "line ranges are contiguous");
   }
 
-  // And the raw stdout must not leak file content.
   const raw = execFileSync("node", [SCRIPT, FIXTURE, "--map"], { encoding: "utf8" });
   assert.ok(!raw.includes("lorem ipsum"), "map mode never emits file content");
 });
 
-// --- line slice -------------------------------------------------------------
 
 test("--slice L1:L2 returns the addressed line span with correct offsets, untruncated", () => {
   const out = runCli(["--slice", "10:20"]);
@@ -74,11 +64,9 @@ test("--slice L1:L2 returns the addressed line span with correct offsets, untrun
   assert.equal(out.slice.truncated, false);
   assert.equal(out.slice.bytesOmitted, 0);
 
-  // Content equals exactly lines 10..20 of the fixture (+ trailing newlines).
   const expected = `${FIXTURE_LINES.slice(9, 20).join("\n")}\n`;
   assert.equal(out.slice.content, expected);
 
-  // Byte offsets line up with the buffer.
   assert.equal(
     FIXTURE_BUF.toString("utf8", out.slice.startByte, out.slice.endByte),
     out.slice.content,
@@ -86,13 +74,11 @@ test("--slice L1:L2 returns the addressed line span with correct offsets, untrun
   assert.ok(out.slice.returnedBytes <= MAX_SLICE_BYTES, "well under the guard");
 });
 
-// --- grep with match locations ----------------------------------------------
 
 test("--grep reports match locations as {line, col} (+ byteOffset, chunkIndex)", () => {
   const out = runCli(["--grep", "NEEDLE"]);
   assert.equal(out.grep.pattern, "NEEDLE");
 
-  // Recompute expected NEEDLE locations directly from the fixture.
   const expected = [];
   FIXTURE_LINES.forEach((text, idx) => {
     const col = text.indexOf("NEEDLE");
@@ -107,16 +93,13 @@ test("--grep reports match locations as {line, col} (+ byteOffset, chunkIndex)",
     assert.equal(m.line, expected[i].line);
     assert.equal(m.col, expected[i].col);
     assert.equal(typeof m.byteOffset, "number");
-    // byteOffset points at the literal match in the buffer.
     assert.equal(FIXTURE_BUF.toString("utf8", m.byteOffset, m.byteOffset + 6), "NEEDLE");
     assert.equal(m.chunkIndex, Math.floor((m.line - 1) / DEFAULT_CHUNK_SIZE));
   });
 });
 
-// --- max-bytes guard --------------------------------------------------------
 
 test("max-bytes guard: a whole-file slice is truncated, never the full blob (default cap)", () => {
-  // Default mode (no flags) addresses the WHOLE 46KB file; the 32KB guard bounds it.
   const out = runCli([]);
   assert.ok(FIXTURE_BUF.length > MAX_SLICE_BYTES, "fixture sanity: exceeds the cap");
   assert.equal(out.slice.truncated, true, "oversized slice is truncated");
@@ -136,12 +119,10 @@ test("max-bytes guard: --max-bytes override truncates at a line boundary", () =>
   assert.equal(out.slice.truncated, true);
   assert.ok(out.slice.returnedBytes <= 4096, "respects the overridden cap");
   assert.ok(out.slice.bytesOmitted > 0);
-  // Truncation is line-aligned: content ends on a newline (no partial line).
   assert.ok(out.slice.content.endsWith("\n"), "truncated at a line boundary");
   assert.ok(out.slice.endLine < 600, "stopped before the requested end");
 });
 
-// --- pure-function unit checks ----------------------------------------------
 
 test("buildLineIndex byte spans include the newline and reproduce the file", () => {
   const buf = Buffer.from("alpha\nbeta\ngamma\n", "utf8");
@@ -149,7 +130,6 @@ test("buildLineIndex byte spans include the newline and reproduce the file", () 
   assert.equal(lines.length, 3);
   assert.equal(lines[0].text, "alpha");
   assert.equal(buf.toString("utf8", lines[0].start, lines[0].end), "alpha\n");
-  // Concatenating spans reproduces the buffer exactly.
   const joined = lines.map((l) => buf.toString("utf8", l.start, l.end)).join("");
   assert.equal(joined, buf.toString("utf8"));
 });
@@ -182,7 +162,6 @@ test("analyze --map carries no content; analyze grep counts matches", () => {
   assert.equal(g.matchCount, 3, "two on line 3, one on line 2");
 });
 
-// --- CLI argument validation ------------------------------------------------
 
 test("parseSlice / parseArgs reject malformed input", () => {
   assert.throws(() => parseSlice("10-20"), /L1:L2/);

--- a/.oh/skills/rlm/scripts/query-context.mjs
+++ b/.oh/skills/rlm/scripts/query-context.mjs
@@ -1,38 +1,15 @@
 #!/usr/bin/env node
-// rlm query-context primitive: address a large artifact WITHOUT ingesting it.
-// Given <path> [--grep <re>] [--slice L1:L2] [--chunk <size>] [--map] it returns
-// (as JSON to stdout) the addressed slice + a chunk map (per-chunk line range and
-// byte offsets; for --grep, match locations as {line, col}). The anti-context-rot
-// move: the root agent ADDRESSES context instead of dumping the whole file into its
-// window. Pure, zero npm deps; node v22 built-ins only.
-//
-// A hard max-bytes guard (MAX_SLICE_BYTES, overridable via --max-bytes) ensures a
-// slice/grep result is NEVER an unbounded blob: when a requested span exceeds the
-// cap it is truncated at a line boundary, `truncated: true` is set, and `bytesOmitted`
-// reports how much was withheld. --map returns ONLY the chunk map (no content).
-//
-// CLI-entrypoint detection is a BASENAME match on process.argv[1] (ends with
-// query-context.mjs), NOT `import.meta.url === pathToFileURL(argv[1])` — the latter
-// silently no-ops when the script is invoked through the .claude/skills dir-symlink
-// (prompt-miner-engine-symlink-guard-bug).
 
 import fs from "node:fs";
 import path from "node:path";
 import process from "node:process";
 
-// ---------------------------------------------------------------------------
-// Constants & contracts
-// ---------------------------------------------------------------------------
 
-// Hard ceiling on the bytes any single slice/grep result may return. The guard
-// truncates at a line boundary once a span would exceed this, so the tool can
-// never hand back an unbounded blob (the whole point of context-as-environment).
-export const MAX_SLICE_BYTES = 32 * 1024; // 32 KiB
+export const MAX_SLICE_BYTES = 32 * 1024;
 
-// Default chunk size (in lines) when --chunk is not supplied.
 export const DEFAULT_CHUNK_SIZE = 100;
 
-const NEWLINE = 0x0a; // '\n'
+const NEWLINE = 0x0a;
 
 const USAGE = `usage: query-context.mjs <path> [options]
   --grep <re>        report match locations ({line, col, byteOffset}) for a regex
@@ -45,14 +22,7 @@ const USAGE = `usage: query-context.mjs <path> [options]
 Output is JSON on stdout. A slice/grep result is capped at the max-bytes guard:
 when exceeded it is truncated at a line boundary with truncated:true + bytesOmitted.`;
 
-// ---------------------------------------------------------------------------
-// Line indexing (pure: Buffer -> per-line byte ranges)
-// ---------------------------------------------------------------------------
 
-// buildLineIndex scans the buffer for newline BYTES (0x0a) so byte offsets stay
-// correct for multibyte UTF-8 content. Each entry's [start, end) byte span INCLUDES
-// the trailing newline, so concatenating consecutive lines reproduces the file
-// exactly. `text` is the line content WITHOUT its trailing newline (for grep cols).
 export function buildLineIndex(buf) {
   const lines = [];
   let start = 0;
@@ -68,17 +38,12 @@ export function buildLineIndex(buf) {
   return lines;
 }
 
-// ---------------------------------------------------------------------------
-// Chunk map (pure)
-// ---------------------------------------------------------------------------
 
-// buildChunkMap partitions the line index into fixed-size chunks and reports each
-// chunk's 1-based inclusive line range and absolute byte offsets — never any content.
 export function buildChunkMap(lines, chunkSize) {
   const size = Math.max(1, Math.floor(chunkSize));
   const chunks = [];
   for (let lo = 0; lo < lines.length; lo += size) {
-    const hi = Math.min(lo + size, lines.length); // exclusive line index
+    const hi = Math.min(lo + size, lines.length);
     const startByte = lines[lo].start;
     const endByte = lines[hi - 1].end;
     chunks.push({
@@ -94,14 +59,7 @@ export function buildChunkMap(lines, chunkSize) {
   return chunks;
 }
 
-// ---------------------------------------------------------------------------
-// Bounded slice (pure: enforces the max-bytes guard at a line boundary)
-// ---------------------------------------------------------------------------
 
-// buildBoundedSlice returns the byte span for the inclusive 0-based line range
-// [loIdx, hiIdx], truncated at a line boundary so returnedBytes <= maxBytes. A
-// single first line larger than the cap is hard-cut at the byte cap. The result
-// always satisfies returnedBytes <= maxBytes — never an unbounded blob.
 export function buildBoundedSlice(buf, lines, loIdx, hiIdx, maxBytes = MAX_SLICE_BYTES) {
   const cap = Math.max(1, Math.floor(maxBytes));
   const startByte = lines[loIdx].start;
@@ -109,7 +67,7 @@ export function buildBoundedSlice(buf, lines, loIdx, hiIdx, maxBytes = MAX_SLICE
   const requestedBytes = requestedEndByte - startByte;
 
   let endByte = startByte;
-  let lastLineIdx = loIdx - 1; // -1 relative => 0 lines returned (only on hard-cut)
+  let lastLineIdx = loIdx - 1;
   let truncated = false;
 
   for (let i = loIdx; i <= hiIdx; i += 1) {
@@ -117,7 +75,6 @@ export function buildBoundedSlice(buf, lines, loIdx, hiIdx, maxBytes = MAX_SLICE
     if (cumulative > cap) {
       truncated = true;
       if (i === loIdx) {
-        // Even the first line overflows the cap → hard byte cut (partial line).
         endByte = startByte + cap;
         lastLineIdx = loIdx;
       }
@@ -143,15 +100,7 @@ export function buildBoundedSlice(buf, lines, loIdx, hiIdx, maxBytes = MAX_SLICE
   };
 }
 
-// ---------------------------------------------------------------------------
-// Grep (pure: regex match locations, capped by the max-bytes guard)
-// ---------------------------------------------------------------------------
 
-// grepLines runs the regex per line and reports every match as {line, col,
-// byteOffset, chunkIndex, text}. col is a 1-based CHARACTER column within the line;
-// byteOffset is the absolute byte position of the match. The cumulative bytes of the
-// returned match `text` previews are capped at maxBytes — once exceeded, further
-// matches are withheld (truncated:true + bytesOmitted), so the result is bounded.
 export function grepLines(lines, pattern, chunkSize, maxBytes = MAX_SLICE_BYTES) {
   const cap = Math.max(1, Math.floor(maxBytes));
   const size = Math.max(1, Math.floor(chunkSize));
@@ -184,7 +133,6 @@ export function grepLines(lines, pattern, chunkSize, maxBytes = MAX_SLICE_BYTES)
           text: preview,
         });
       }
-      // Guard against zero-width matches looping forever.
       if (m.index === re.lastIndex) re.lastIndex += 1;
     }
   }
@@ -200,13 +148,7 @@ export function grepLines(lines, pattern, chunkSize, maxBytes = MAX_SLICE_BYTES)
   };
 }
 
-// ---------------------------------------------------------------------------
-// Analysis (pure: Buffer + options -> the output record)
-// ---------------------------------------------------------------------------
 
-// analyze is the pure core the CLI wraps: given the file buffer and parsed options
-// it produces the JSON-able result object. No I/O here (the caller reads the file),
-// so it is fully unit-testable.
 export function analyze(buf, opts) {
   const chunkSize = opts.chunk != null ? opts.chunk : DEFAULT_CHUNK_SIZE;
   const maxBytes = opts.maxBytes != null ? opts.maxBytes : MAX_SLICE_BYTES;
@@ -222,7 +164,6 @@ export function analyze(buf, opts) {
     chunkMap,
   };
 
-  // --map is exclusive: ONLY the chunk map, never any content.
   if (opts.map) {
     out.mode = "map";
     return out;
@@ -233,8 +174,6 @@ export function analyze(buf, opts) {
     out.grep = grepLines(lines, opts.grep, chunkSize, maxBytes);
   }
 
-  // Default (no --grep, no --slice) addresses the WHOLE file as a slice — which the
-  // guard then bounds, so even a bare `query-context <bigfile>` is never unbounded.
   if (opts.slice || opts.grep == null) {
     if (lines.length === 0) {
       out.mode = out.mode || "slice";
@@ -262,15 +201,11 @@ export function analyze(buf, opts) {
   return out;
 }
 
-// Clamp a 1-based line number into the file's range.
 function clampLine(n, total) {
   if (!Number.isFinite(n)) return 1;
   return Math.min(Math.max(1, Math.floor(n)), total);
 }
 
-// ---------------------------------------------------------------------------
-// CLI parsing (pure)
-// ---------------------------------------------------------------------------
 
 export function parseArgs(argv) {
   const args = {
@@ -341,9 +276,6 @@ export function parseSlice(raw) {
   return { from, to };
 }
 
-// ---------------------------------------------------------------------------
-// main (impure: reads the file, prints JSON)
-// ---------------------------------------------------------------------------
 
 function main() {
   let args;
@@ -373,7 +305,6 @@ function main() {
   process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
 }
 
-// Basename-match entrypoint detection (symlink-safe; see header note).
 if (path.basename(process.argv[1] || "") === "query-context.mjs") {
   main();
 }

--- a/.oh/skills/ste/scripts/ste-check.sh
+++ b/.oh/skills/ste/scripts/ste-check.sh
@@ -1,13 +1,4 @@
 #!/usr/bin/env bash
-# ste-check.sh — report controlled-language violations in Markdown prose.
-#
-# The script reads files. The script writes no file. The script reports each
-# finding on one line as `file:line: RULE-ID message`.
-#
-# Exit codes:
-#   0  every scanned line passed every detector
-#   1  the script reported at least one finding
-#   2  the caller passed an invalid argument
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -90,9 +81,6 @@ done
 findings=0
 blocks_matched=0
 for f in "${files[@]}"; do
-  # A leading `---` is YAML frontmatter only when a closing `---` follows it.
-  # Without this pre-pass a document that opens with a horizontal rule looks
-  # like unterminated frontmatter, and the whole file would be skipped clean.
   has_front=0
   if [ "$(head -n 1 "$f")" = "---" ] \
      && awk 'NR>1 && $0=="---"{found=1; exit} END{exit !found}' "$f"; then
@@ -305,7 +293,6 @@ for f in "${files[@]}"; do
     printf 'ste-check: failed to scan %s\n' "$f" >&2
     exit 2
   }
-  # The awk program prints findings first and one summary line last.
   summary=$(printf '%s\n' "$count" | tail -n 1)
   case "$summary" in
     '##STE## '*) : ;;
@@ -317,8 +304,6 @@ for f in "${files[@]}"; do
   blocks_matched=$(( blocks_matched + file_blocks ))
 done
 
-# A --blocks tag that matches no fence would otherwise pass vacuously, which
-# makes any "--blocks after must exit 0" assertion satisfiable by a typo.
 if [ "$blocks_set" -eq 1 ] && [ "$blocks_matched" -eq 0 ]; then
   printf 'ste-check: no fenced block tagged "%s" in %d file(s); nothing was scanned\n' \
     "$blocks" "${#files[@]}" >&2
@@ -331,9 +316,6 @@ if [ "$findings" -gt 0 ]; then
   exit 1
 fi
 
-# A clean exit reads as approval, so it carries its own residual. Two defects in
-# the 10-question check are NOT machine-detectable here, and both were measured
-# escaping a green run: see SKILL.md and ste-checker-contract.sh section 7.
 printf 'ste-check: no findings in %d file(s). Two defects escape every detector: a condition that trails the action it guards (question 4), and a sentence that opens with a pronoun naming no antecedent (question 7). Run the 10-question check in %s/SKILL.md.\n' \
   "${#files[@]}" "$SKILL_ROOT" >&2
 exit 0

--- a/.oh/skills/weigh/scripts/__tests__/score-trajectories.test.mjs
+++ b/.oh/skills/weigh/scripts/__tests__/score-trajectories.test.mjs
@@ -1,5 +1,3 @@
-// node --test suite for the weigh scorer. Pure node:test + node:assert — no
-// vitest/tsx. Run: node --test .oh/skills/weigh/scripts/__tests__/
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import path from "node:path";
@@ -23,7 +21,6 @@ const HERE = path.dirname(fileURLToPath(import.meta.url));
 const SCORER = path.join(HERE, "..", "score-trajectories.mjs");
 const FIXTURE = path.join(HERE, "fixtures", "cohort-sample.json");
 
-// A reusable cohort matching the fixture (so unit tests don't read the file).
 const COHORT = [
   { id: "t-alpha", costTokens: 1200, evalRc: 0, auditVerdict: "PASS", clusterId: "c1", clusterSize: 3, judgeScore: 0.9 },
   { id: "t-bravo", costTokens: 2400, evalRc: 0, auditVerdict: null, clusterId: "c1", clusterSize: 3, judgeScore: 0.7 },
@@ -31,7 +28,6 @@ const COHORT = [
   { id: "t-delta", costTokens: 1500, evalRc: 1, auditVerdict: "FAIL", clusterId: "c3", clusterSize: 1, judgeScore: 0.3 },
 ];
 
-// --- frozen contract --------------------------------------------------------
 
 test("DEFAULT_WEIGHTS is frozen, has the exact keys, and sums to 100", () => {
   assert.ok(Object.isFrozen(DEFAULT_WEIGHTS));
@@ -58,7 +54,6 @@ test("TRAJECTORY_SCHEMA is a named JSON-Schema describing the trajectory record"
   assert.deepEqual(TRAJECTORY_SCHEMA.required, ["id"]);
 });
 
-// --- weight() normalization + breakdown reconstructability ------------------
 
 test("weight() normalizes each sub-signal to [0,1]", () => {
   const ctx = cohortStats(COHORT);
@@ -67,12 +62,10 @@ test("weight() normalizes each sub-signal to [0,1]", () => {
   for (const k of WEIGHT_KEYS) {
     assert.ok(s[k] >= 0 && s[k] <= 1, `signal ${k} in [0,1]`);
   }
-  // consistency = clusterSize/N = 3/4; evalPass(0)=1; auditPass(PASS)=1; judge=0.9
   assert.equal(s.consistency, 0.75);
   assert.equal(s.evalPass, 1);
   assert.equal(s.auditPass, 1);
   assert.equal(s.judge, 0.9);
-  // cost cohort-relative: alpha=1200, min=800, max=2400 → 1-(400/1600)=0.75
   assert.equal(s.cost, 0.75);
 });
 
@@ -86,7 +79,6 @@ test("weightBreakdown is fully reconstructable (contributions = weight*signal, s
     sum += bd.contributions[k];
   }
   assert.ok(Math.abs(sum - bd.rawWeight) < 1e-9, "contributions sum to rawWeight");
-  // alpha hand-computed: 30*.75 + 20*1 + 15*1 + 10*.75 + 25*.9 = 87.5
   assert.equal(r.weight, 87.5);
 });
 
@@ -99,15 +91,13 @@ test("evalPass/auditPass/judge default mappings (null/skipped → neutral)", () 
   assert.equal(weight({ id: "e", auditVerdict: "PASS" }, ctx).weightBreakdown.signals.auditPass, 1);
   assert.equal(weight({ id: "f", auditVerdict: "FAIL" }, ctx).weightBreakdown.signals.auditPass, 0);
   assert.equal(weight({ id: "g", auditVerdict: null }, ctx).weightBreakdown.signals.auditPass, 0.5);
-  // judge disabled (null) → neutral 0.5
   assert.equal(weight({ id: "h", judgeScore: null }, ctx).weightBreakdown.signals.judge, 0.5);
 });
 
-// --- the hard eligibility floor ---------------------------------------------
 
 test("hard floor: evalRc===1 || auditVerdict==='FAIL' marks a trajectory ineligible", () => {
   const ctx = cohortStats(COHORT);
-  const delta = weight(COHORT[3], ctx); // evalRc:1 AND FAIL
+  const delta = weight(COHORT[3], ctx);
   assert.equal(delta.eligible, false);
   assert.equal(delta.floorViolated, true);
   assert.equal(delta.floorCause, "eval-regression+audit-fail");
@@ -128,12 +118,10 @@ test("--soft converts the hard floor into a down-weight (eligible, scaled weight
   assert.equal(hard.eligible, false);
   assert.equal(soft.eligible, true);
   assert.equal(soft.weightBreakdown.softFactor, SOFT_FLOOR_FACTOR);
-  // soft.weight is the raw weight scaled by SOFT_FLOOR_FACTOR (within display rounding)
   assert.ok(soft.weight < hard.weightBreakdown.rawWeight, "soft weight is down-weighted");
   assert.ok(Math.abs(soft.weight - hard.weightBreakdown.rawWeight * SOFT_FLOOR_FACTOR) < 1e-3);
 });
 
-// --- selection methods ------------------------------------------------------
 
 test("select best-of-n (default) picks the argmax eligible — never the floor-breaker", () => {
   const r = select(COHORT);
@@ -148,7 +136,6 @@ test("select best-of-n (default) picks the argmax eligible — never the floor-b
 
 test("select vote picks the largest self-consistency cluster's best member", () => {
   const r = select(COHORT, { method: "vote" });
-  // c1 (alpha+bravo) is the largest eligible cluster; best member = alpha.
   assert.equal(r.selected, "t-alpha");
   assert.equal(r.cluster.size, 2);
   assert.notEqual(r.selected, "t-delta");
@@ -159,7 +146,6 @@ test("select softmax returns a normalized distribution and an argmax selection",
   assert.equal(r.selected, "t-alpha");
   const total = r.distribution.reduce((s, d) => s + d.p, 0);
   assert.ok(Math.abs(total - 1) < 1e-6, "softmax distribution sums to ~1");
-  // the floor-breaker is excluded from the distribution
   assert.ok(!r.distribution.some((d) => d.id === "t-delta"));
 });
 
@@ -174,7 +160,6 @@ test("select rejects an unknown method", () => {
   assert.throws(() => select(COHORT, { method: "bogus" }), /unknown --method/);
 });
 
-// --- NO-SELECTION shape (all-floor-fail cohort) -----------------------------
 
 test("select returns the explicit NO-SELECTION shape when nothing is eligible", () => {
   const allFail = [
@@ -192,7 +177,6 @@ test("select returns the explicit NO-SELECTION shape when nothing is eligible", 
   ]);
 });
 
-// --- judge:0 full determinism ----------------------------------------------
 
 test("judge:0 yields a fully deterministic, judge-free weight (identical across runs)", () => {
   const w0 = { ...DEFAULT_WEIGHTS, judge: 0 };
@@ -200,17 +184,14 @@ test("judge:0 yields a fully deterministic, judge-free weight (identical across 
   const b = select(COHORT, { weights: w0 });
   assert.equal(a.selected, b.selected);
   assert.equal(a.selected, "t-alpha");
-  // every judge contribution is exactly 0 → the judge signal cannot move the pick
   for (const row of a.scored) {
     assert.equal(row.weightBreakdown.contributions.judge, 0);
   }
-  // a wildly different judgeScore on the same deterministic signals changes nothing
   const tampered = COHORT.map((t) => ({ ...t, judgeScore: 0 }));
   const c = select(tampered, { weights: w0 });
   assert.equal(c.selected, "t-alpha");
 });
 
-// --- validateWeights() rejections -------------------------------------------
 
 test("validateWeights rejects non-object/missing/negative/non-finite/unknown-key", () => {
   assert.throws(() => validateWeights("not-an-object"), /JSON object/);
@@ -234,7 +215,6 @@ test("clamp coerces non-finite to lo and bounds the range", () => {
   assert.equal(clamp(0.4, 0, 1), 0.4);
 });
 
-// --- CLI: absent --now throws + exits 1 -------------------------------------
 
 test("CLI throws and exits non-zero when --now is absent (no Date.now() fallback)", () => {
   assert.throws(

--- a/.oh/skills/weigh/scripts/score-trajectories.mjs
+++ b/.oh/skills/weigh/scripts/score-trajectories.mjs
@@ -1,51 +1,23 @@
 #!/usr/bin/env node
-// weigh engine: the harness-owned weighted-trajectory scorer. Given a cohort of
-// candidate trajectories (the Workflow tool *proposes* them; this scorer *owns the
-// weight function that picks among them*), normalize each sub-signal to [0,1],
-// weight by a frozen, tunable DEFAULT_WEIGHTS vector, apply the hard eligibility
-// floor, and select/aggregate via best-of-n | vote | softmax | synthesis.
-//
-// PURE: zero npm deps (node v22 built-ins only), and ZERO impurity — no `git`, no
-// `Date.now()`, no model call. `--now <ts>` is REQUIRED (it stamps the report's
-// generatedAt); there is no Date.now() fallback, which keeps the scorer perfectly
-// deterministic for the eval probe and unit tests. See references/scoring.md for
-// the contract this engine implements.
 
 import fs from "node:fs";
 import process from "node:process";
 
-// ---------------------------------------------------------------------------
-// Constants & contracts
-// ---------------------------------------------------------------------------
 
-// Deterministic-first frozen weights (sum 100). 75 of the 100 are signals WE own
-// (consistency + evalPass + auditPass + cost); `judge` is the one model-side
-// coefficient — set it to 0 for a fully deterministic, judge-free weight. Every
-// key here is REQUIRED when --weights is supplied; values must be finite and
-// non-negative. See references/scoring.md.
 export const DEFAULT_WEIGHTS = Object.freeze({
-  consistency: 30, // self-consistency cluster membership   ┐
-  evalPass: 20, //    /eval regression floor                 │ 75 = signals WE own
-  auditPass: 15, //   /audit promotability verdict           │  (deterministic)
-  cost: 10, //        token-cost efficiency (cheaper→higher) ┘
-  judge: 25, //       model-judge verifier — set 0 → fully deterministic weight
+  consistency: 30,
+  evalPass: 20,
+  auditPass: 15,
+  cost: 10,
+  judge: 25,
 });
 
-// The weight keys, in canonical order (single source for iteration + the probe).
 export const WEIGHT_KEYS = Object.freeze(Object.keys(DEFAULT_WEIGHTS));
 
-// The four selection methods this scorer supports.
 export const SELECTION_METHODS = Object.freeze(["best-of-n", "vote", "softmax", "synthesis"]);
 
-// In --soft mode, a floor-violating trajectory stays eligible but its weight is
-// scaled by this factor (a down-weight, not an exclusion) so a least-bad pick is
-// allowed while still ranking below any clean trajectory of comparable signals.
 export const SOFT_FLOOR_FACTOR = 0.25;
 
-// TRAJECTORY_SCHEMA — the single source of truth for the trajectory record shape.
-// US-002's sampling step cites this so spawned agents emit structured output the
-// scorer can consume. It is a named JSON-Schema object (draft 2020-12); the scorer
-// does not runtime-validate against it (zero-dep), it is the published contract.
 export const TRAJECTORY_SCHEMA = Object.freeze({
   $schema: "https://json-schema.org/draft/2020-12/schema",
   $id: "https://openharness.dev/weigh/trajectory.schema.json",
@@ -110,9 +82,6 @@ const USAGE = `usage: score-trajectories.mjs --cohort <path> --now <ts> [options
   --dry-run         print the resolved config + cohort preview; do not select
   -h | --help`;
 
-// ---------------------------------------------------------------------------
-// Small helpers
-// ---------------------------------------------------------------------------
 
 export function clamp(value, lo, hi) {
   if (!Number.isFinite(value)) return lo;
@@ -129,19 +98,13 @@ function round(value, dp = 4) {
   return Math.round(value * f) / f;
 }
 
-// Accept an array cohort or a { trajectories: [...] } wrapper; return the list.
 function asTrajectoryList(cohort) {
   if (Array.isArray(cohort)) return cohort;
   if (isPlainObject(cohort) && Array.isArray(cohort.trajectories)) return cohort.trajectories;
   throw new Error("cohort must be an array of trajectories or { trajectories: [...] }");
 }
 
-// ---------------------------------------------------------------------------
-// Weights
-// ---------------------------------------------------------------------------
 
-// validateWeights mirrors prompt-miner semantics: must be an object; every key
-// present; finite non-negative; any unknown key is an error.
 export function validateWeights(obj) {
   if (!isPlainObject(obj)) {
     throw new Error("--weights must be a JSON object");
@@ -163,12 +126,7 @@ export function validateWeights(obj) {
   return { ...obj };
 }
 
-// ---------------------------------------------------------------------------
-// Cohort statistics (pure)
-// ---------------------------------------------------------------------------
 
-// cohortStats computes the cohort-relative context weight() needs: N, and the
-// min/max token cost over the trajectories that declare a finite costTokens.
 export function cohortStats(cohort) {
   const list = asTrajectoryList(cohort);
   const n = list.length;
@@ -178,12 +136,7 @@ export function cohortStats(cohort) {
   return { n, minCost, maxCost };
 }
 
-// ---------------------------------------------------------------------------
-// Sub-signal normalization + weight (pure)
-// ---------------------------------------------------------------------------
 
-// Returns the floor-violation cause string for a trajectory, or null if clean.
-// A trajectory may break the floor two ways at once; both are reported, joined.
 function floorCause(traj) {
   const causes = [];
   if (traj.evalRc === 1) causes.push("eval-regression");
@@ -191,12 +144,6 @@ function floorCause(traj) {
   return causes.length ? causes.join("+") : null;
 }
 
-// weight() scores ONE trajectory against the cohort context `ctx` (from
-// cohortStats). Each sub-signal is normalized to [0,1]; the weighted sum (Σ W.k ·
-// signal_k) is the raw weight. Emits a fully reconstructable weightBreakdown
-// (raw signals, normalized signals, per-term contributions, weights used). The
-// hard floor (evalRc===1 || auditVerdict==='FAIL') sets eligible=false; --soft
-// (opts.soft) instead keeps it eligible and scales the weight by SOFT_FLOOR_FACTOR.
 export function weight(traj, ctx, weights = DEFAULT_WEIGHTS, opts = {}) {
   if (!isPlainObject(traj)) throw new Error("weight(): trajectory must be an object");
   const w = weights;
@@ -205,29 +152,21 @@ export function weight(traj, ctx, weights = DEFAULT_WEIGHTS, opts = {}) {
   const maxCost = ctx && Number.isFinite(ctx.maxCost) ? ctx.maxCost : 0;
   const soft = opts.soft === true;
 
-  // --- raw signals -----------------------------------------------------------
   const clusterSize = Number.isFinite(traj.clusterSize) ? traj.clusterSize : 1;
   const judgeScore = Number.isFinite(traj.judgeScore) ? traj.judgeScore : null;
   const costTokens = Number.isFinite(traj.costTokens) ? traj.costTokens : null;
   const evalRc = traj.evalRc;
   const auditVerdict = traj.auditVerdict ?? null;
 
-  // --- normalize each sub-signal to [0,1] ------------------------------------
-  // consistency: cluster membership as a fraction of the cohort.
   const consistency = clamp(clusterSize / n, 0, 1);
-  // judge: verifier score, neutral 0.5 when the judge is disabled (null).
   const judge = clamp(judgeScore ?? 0.5, 0, 1);
-  // evalPass: 0 PASS → 1.0 · 2|null SKIPPED/NA → 0.5 · 1 REGRESSION → 0.0.
   const evalPass = evalRc === 0 ? 1 : evalRc === 1 ? 0 : 0.5;
-  // auditPass: PASS → 1.0 · null NA → 0.5 · FAIL → 0.0.
   const auditPass = auditVerdict === "PASS" ? 1 : auditVerdict === "FAIL" ? 0 : 0.5;
-  // cost: cohort-relative; cheapest → 1, most expensive → 0; neutral 0.5 if absent.
   const cost =
     costTokens === null ? 0.5 : clamp(1 - (costTokens - minCost) / Math.max(maxCost - minCost, 1), 0, 1);
 
   const signals = { consistency, evalPass, auditPass, cost, judge };
 
-  // --- weighted sum (per-term contributions kept full-precision) -------------
   const contributions = {};
   let rawWeight = 0;
   for (const k of WEIGHT_KEYS) {
@@ -238,8 +177,6 @@ export function weight(traj, ctx, weights = DEFAULT_WEIGHTS, opts = {}) {
 
   const cause = floorCause(traj);
   const floorViolated = cause !== null;
-  // Hard floor (default): eligibility excludes floor-violators. --soft: everyone
-  // is eligible, but a violator's weight is scaled down (least-bad pick allowed).
   const eligible = soft ? true : !floorViolated;
   const finalWeight = soft && floorViolated ? rawWeight * SOFT_FLOOR_FACTOR : rawWeight;
 
@@ -261,20 +198,11 @@ export function weight(traj, ctx, weights = DEFAULT_WEIGHTS, opts = {}) {
   };
 }
 
-// ---------------------------------------------------------------------------
-// Selection (pure)
-// ---------------------------------------------------------------------------
 
-// Deterministic argmax over scored rows: highest weight wins; ties broken by id
-// ascending so the result is reproducible (no Math.random anywhere in the scorer).
 function argmaxRow(rows) {
   return [...rows].sort((a, b) => b.weight - a.weight || String(a.id).localeCompare(String(b.id)))[0];
 }
 
-// select() scores the whole cohort with weight(), applies the eligibility floor,
-// and picks/aggregates per `method`. When NOTHING is eligible it returns the
-// explicit NO-SELECTION shape — never a silent least-bad pick.
-//   opts: { method, weights, soft, k, tau }
 export function select(cohort, opts = {}) {
   const list = asTrajectoryList(cohort);
   const weights = opts.weights || DEFAULT_WEIGHTS;
@@ -294,7 +222,6 @@ export function select(cohort, opts = {}) {
 
   const eligible = scored.filter((r) => r.eligible);
   if (eligible.length === 0) {
-    // Honest 3-state: no eligible trajectory → name the floor that killed them.
     return { selected: null, reason: "NO-SELECTION", method, weights: { ...weights }, soft, floorViolations, scored };
   }
 
@@ -305,8 +232,6 @@ export function select(cohort, opts = {}) {
   }
 
   if (method === "vote") {
-    // Largest self-consistency cluster among eligible (by member count); tie → the
-    // cluster whose best member has the max weight. Selected = that best member.
     const clusters = new Map();
     for (const r of eligible) {
       const traj = list.find((t) => t.id === r.id);
@@ -332,8 +257,6 @@ export function select(cohort, opts = {}) {
   }
 
   if (method === "softmax") {
-    // Deterministic softmax distribution over eligible weights (temperature tau).
-    // Selection is the argmax of the distribution (no random sampling → pure).
     const maxW = Math.max(...eligible.map((r) => r.weight));
     const exps = eligible.map((r) => Math.exp((r.weight - maxW) / tau));
     const sum = exps.reduce((a, b) => a + b, 0) || 1;
@@ -343,7 +266,6 @@ export function select(cohort, opts = {}) {
     return { ...base, selected: distribution[0].id, tau, distribution };
   }
 
-  // synthesis: return the top-K eligible (by weight) for a synth agent to graft.
   const ranked = [...eligible].sort((a, b) => b.weight - a.weight || String(a.id).localeCompare(String(b.id)));
   const topRows = ranked.slice(0, Math.min(k, ranked.length));
   return {
@@ -354,9 +276,6 @@ export function select(cohort, opts = {}) {
   };
 }
 
-// ---------------------------------------------------------------------------
-// CLI parsing (pure)
-// ---------------------------------------------------------------------------
 
 export function parseArgs(argv) {
   const args = {
@@ -431,7 +350,6 @@ export function parseArgs(argv) {
   return args;
 }
 
-// Resolve --now (unix-seconds or ISO) into an ISO timestamp WITHOUT Date.now().
 function resolveNow(now) {
   if (now == null || now === "") throw new Error("--now <ts> is required (no Date.now() fallback)");
   const ms = /^\d+$/.test(String(now)) ? Number(now) * 1000 : Date.parse(now);
@@ -439,9 +357,6 @@ function resolveNow(now) {
   return new Date(ms).toISOString();
 }
 
-// ---------------------------------------------------------------------------
-// main (impure: reads the cohort file, writes stdout)
-// ---------------------------------------------------------------------------
 
 function main(argv) {
   let args;
@@ -452,7 +367,6 @@ function main(argv) {
     process.exit(64);
   }
 
-  // --now is REQUIRED — there is NO Date.now() fallback (purity + determinism).
   let generatedAt;
   try {
     generatedAt = resolveNow(args.now);
@@ -491,7 +405,6 @@ function main(argv) {
   };
 
   if (args.dryRun) {
-    // --dry-run: show the resolved config + cohort preview; do NOT select.
     process.stdout.write(
       `${JSON.stringify(
         { dryRun: true, ...config, trajectoryIds: list.map((t) => (t ? t.id : null)) },
@@ -513,11 +426,6 @@ function main(argv) {
   process.stdout.write(`${JSON.stringify({ ...config, ...result }, null, 2)}\n`);
 }
 
-// CLI-entrypoint detection: BASENAME match — process.argv[1] ends with
-// score-trajectories.mjs. Do NOT use `import.meta.url === pathToFileURL(argv[1])`:
-// node resolves the symlink for import.meta.url but not for argv[1] when this is
-// invoked through the `.claude/skills` → `.oh/skills` symlink, so the guard
-// silently no-ops (see memory: prompt-miner-engine-symlink-guard-bug).
 if ((process.argv[1] || "").endsWith("score-trajectories.mjs")) {
   main(process.argv.slice(2));
 }

--- a/.oh/tasks/ste-controlled-language/verify.sh
+++ b/.oh/tasks/ste-controlled-language/verify.sh
@@ -1,10 +1,4 @@
 #!/usr/bin/env bash
-# verify.sh — assert every acceptance criterion for issue #750.
-#
-# Every checker assertion compares the exit code and fails this script on a
-# mismatch. Nothing here prints an exit code without acting on it.
-#
-# Exit 0 when every check passes. Exit 1 when any check fails.
 set -uo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
@@ -18,20 +12,19 @@ pass() { printf '  PASS  %s\n' "$1"; }
 fail() { printf '  FAIL  %s\n' "$1" >&2; FAILURES=$((FAILURES + 1)); }
 head2() { printf '\n== %s\n' "$1"; }
 
-expect_eq() { # label actual expected
+expect_eq() {
   if [ "$2" = "$3" ]; then pass "$1 = $2"; else fail "$1 = $2, expected $3"; fi
 }
-expect_ge() { # label actual minimum
+expect_ge() {
   if [ "$2" -ge "$3" ] 2>/dev/null; then pass "$1 = $2 (min $3)"; else fail "$1 = $2, expected at least $3"; fi
 }
-expect_rc() { # label expected-rc command...
+expect_rc() {
   local label="$1" want="$2"; shift 2
   "$@" >/dev/null 2>&1
   local got=$?
   if [ "$got" -eq "$want" ]; then pass "$label -> rc=$got"; else fail "$label -> rc=$got, expected $want"; fi
 }
 
-# --------------------------------------------------------------------------
 head2 "US-004  checker script"
 [ -f "$CHECK" ] && pass "$CHECK exists" || fail "$CHECK missing"
 [ -x "$CHECK" ] && pass "$CHECK is executable" || fail "$CHECK is not executable"
@@ -45,13 +38,9 @@ expect_rc "missing file" 2 bash "$CHECK" /nonexistent/ste-fixture.md
 expect_rc "directory argument" 2 bash "$CHECK" "$SKILL"
 expect_rc "bad --max-words" 2 bash "$CHECK" --max-words abc "$SKILL/SKILL.md"
 
-# The four fail-open shapes the PR audit on #751 found. Each exited 0 while
-# scanning little or nothing. A linter that passes by reading nothing is worse
-# than no linter, because the green exit is read as proof.
 FIX=$(mktemp -d); trap 'rm -rf "$FIX"' EXIT
 printf 'Intro.\n\n```bash\ncode\nThe runner basically utilizes things.\n' > "$FIX/unclosed.md"
 expect_rc "unclosed fence must not exempt the rest of the file" 1 bash "$CHECK" "$FIX/unclosed.md"
-# The checker exits 1 here by design; pipefail would otherwise mask the grep.
 { bash "$CHECK" "$FIX/unclosed.md" 2>/dev/null || true; } | command grep -q ' FENCE ' \
   && pass "unclosed fence reports a FENCE finding" || fail "unclosed fence is not reported"
 printf -- '---\nThe runner basically utilizes things.\nMore prose that basically utilizes things.\n' > "$FIX/rule.md"
@@ -69,18 +58,15 @@ expect_rc "PASSIVE stays silent on non-participles ending in ed" 0 bash "$CHECK"
 printf 'Read the guide at www.example.com/things/various for more.\n' > "$FIX/url.md"
 expect_rc "a bare hostname is stripped before matching" 0 bash "$CHECK" "$FIX/url.md"
 
-# The probe that keeps every assertion above enforced after merge.
 PROBE=.oh/evals/probes/ste-checker-contract.sh
 [ -x "$PROBE" ] && pass "$PROBE is executable" || fail "$PROBE missing or not executable"
 expect_rc "the checker-contract probe passes" 0 bash "$PROBE"
 
-# The checker must not write to the file it scans.
 BEFORE_SUM=$(md5sum "$SKILL/references/examples.md" | cut -d' ' -f1)
 bash "$CHECK" --blocks before "$SKILL/references/examples.md" >/dev/null 2>&1
 AFTER_SUM=$(md5sum "$SKILL/references/examples.md" | cut -d' ' -f1)
 expect_eq "examples.md unchanged by a scan" "$AFTER_SUM" "$BEFORE_SUM"
 
-# --------------------------------------------------------------------------
 head2 "US-001  references/rules.md"
 expect_eq "rules.md '## ' headings" "$(command grep -c '^## ' "$SKILL/references/rules.md")" 10
 expect_eq "rules.md '### ' rules"    "$(command grep -c '^### ' "$SKILL/references/rules.md")" 53
@@ -95,8 +81,6 @@ for claim in 'Not the ASD-STE100 controlled dictionary' \
   command grep -qiF "$claim" "$SKILL/references/dictionary.md" \
     && pass "dictionary states: $claim" || fail "dictionary omits: $claim"
 done
-# Every word in both mapped columns must be backticked. That is what lets the
-# file name a banned word and still pass its own checker.
 BADROW=$(command grep -n '^| ' "$SKILL/references/dictionary.md" \
   | command grep -vE '^[0-9]+:\| (Do not use|-+)' \
   | command grep -vE '^[0-9]+:\|---' \
@@ -122,14 +106,12 @@ expect_rc "checker on examples.md (narrative)"  0 bash "$CHECK" "$SKILL/referenc
 expect_rc "checker --blocks after (must pass)"  0 bash "$CHECK" --blocks after  "$SKILL/references/examples.md"
 expect_rc "checker --blocks before (must FAIL)" 1 bash "$CHECK" --blocks before "$SKILL/references/examples.md"
 
-# The before blocks are the regression fixture: every detector class must fire.
 FOUND=$(bash "$CHECK" --blocks before "$SKILL/references/examples.md" 2>/dev/null | awk '{print $2}' | sort -u)
 for cls in HEDGE VAGUE PASSIVE LONG COMPOUND WORD; do
   printf '%s\n' "$FOUND" | command grep -qx "$cls" \
     && pass "detector $cls fires on the fixture" || fail "detector $cls never fires"
 done
 
-# --------------------------------------------------------------------------
 head2 "US-005  SKILL.md"
 LINES=$(wc -l < "$SKILL/SKILL.md")
 if [ "$LINES" -lt 500 ]; then pass "SKILL.md = $LINES lines (< 500)"; else fail "SKILL.md = $LINES lines, cap 500"; fi
@@ -147,13 +129,11 @@ done
 for link in 'references/rules.md' 'references/dictionary.md' 'references/examples.md' 'scripts/ste-check.sh'; do
   command grep -qF "$link" "$SKILL/SKILL.md" && pass "SKILL.md links $link" || fail "SKILL.md omits $link"
 done
-# Frontmatter allow-list: name, description, allowed-tools, compatibility, license, metadata.
 BADKEYS=$(awk 'NR==1&&$0=="---"{f=1;next} f&&$0=="---"{exit} f&&/^[a-zA-Z][a-zA-Z0-9_-]*:/{sub(/:.*/,"");print}' "$SKILL/SKILL.md" \
   | command grep -vE '^(name|description|allowed-tools|compatibility|license|metadata)$')
 if [ -z "$BADKEYS" ]; then pass "frontmatter keys inside the allow-list"; else fail "frontmatter keys outside allow-list: $BADKEYS"; fi
 expect_rc "checker on SKILL.md (self-application)" 0 bash "$CHECK" "$SKILL/SKILL.md"
 
-# --------------------------------------------------------------------------
 head2 "authoring conventions"
 for f in "$SKILL"/references/*.md; do
   n=$(wc -l < "$f")
@@ -168,10 +148,7 @@ XLINK=$(command grep -nE '(rules|dictionary|examples)\.md' "$SKILL"/references/*
   | command grep -vE '^[^:]*/(rules|dictionary|examples)\.md:[0-9]+:.*') || true
 if [ -z "$XLINK" ]; then pass "no reference-to-reference cross-links"; else fail "cross-links found: $XLINK"; fi
 
-# --------------------------------------------------------------------------
 head2 "legacy reference tokens"
-# Read the pattern from the probe itself so this check never drifts from it,
-# and so the literal tokens never appear in this file.
 PAT=$(sed -n "s/^pat='\(.*\)'$/\1/p" .oh/evals/probes/audit-stale-references.sh | head -1)
 if [ -z "$PAT" ]; then
   fail "could not read the legacy-token pattern from the probe"
@@ -180,14 +157,12 @@ else
   if [ -z "$HITS" ]; then pass "no legacy tokens in the new files"; else fail "legacy tokens: $HITS"; fi
 fi
 
-# --------------------------------------------------------------------------
 head2 "US-006  wiring"
 command grep -q '^| `/ste` |' AGENTS.md && pass "AGENTS.md holds the /ste row" || fail "AGENTS.md has no /ste row"
 expect_eq "AGENTS.md /ste rows" "$(command grep -c '^| `/ste` |' AGENTS.md)" 1
 awk '/^## \[Unreleased\]/{u=1} u&&/^### Added/{a=1;next} a&&/^## \[/{exit} a&&/openharness\/issues\/750/{found=1} END{exit !found}' CHANGELOG.md \
   && pass "CHANGELOG '### Added' links issue 750" || fail "CHANGELOG '### Added' does not link issue 750"
 
-# --------------------------------------------------------------------------
 head2 "US-007  remote routing guard"
 if git rev-parse --verify -q upstream/development >/dev/null 2>&1; then
   BASE=upstream/development
@@ -212,7 +187,6 @@ else
   fail "no base ref to diff against"
 fi
 
-# --------------------------------------------------------------------------
 printf '\n'
 if [ "$FAILURES" -eq 0 ]; then
   printf 'VERIFY: all checks passed\n'

--- a/.oh/templates/full/.codex/hooks/deny-env-dump.sh
+++ b/.oh/templates/full/.codex/hooks/deny-env-dump.sh
@@ -1,7 +1,4 @@
 #!/usr/bin/env bash
-# Codex wrapper for the shared Claude Bash secret-exposure guard.
-# Codex PreToolUse currently cannot surface "ask" decisions, so convert those
-# to deny to preserve the no-approval-prompt default without failing open.
 set -euo pipefail
 
 root=$(git rev-parse --show-toplevel)

--- a/.oh/templates/full/.codex/hooks/deny-local-settings.sh
+++ b/.oh/templates/full/.codex/hooks/deny-local-settings.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-# Codex file-tool guard for operator-owned settings.local.json files.
 set -euo pipefail
 
 input=$(cat)

--- a/.oh/templates/full/.pi/bridge-recovery/__tests__/recovery.test.ts
+++ b/.oh/templates/full/.pi/bridge-recovery/__tests__/recovery.test.ts
@@ -1,9 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import factory from "../index";
 
-// Fire-the-handler test harness (mirrors .pi/extensions/__tests__/path-guard.test.ts):
-// .pi/** is NOT CI-typechecked, so we exercise the extension by invoking its
-// registered handlers, never by importing pi itself.
 type Handler = (event: unknown, ctx?: unknown) => Promise<unknown> | unknown;
 
 function makePi() {
@@ -47,7 +44,7 @@ describe("slack bridge codex retry-recovery", () => {
     factory(pi);
     const messages = [slackUser("[📱 @Ryan via slack]: Links?"), assistantError(STALE)];
     await fire("agent_end", { messages });
-    await fire("agent_end", { messages }); // our retry hit the same error -> give up
+    await fire("agent_end", { messages });
     expect(sendUserMessage).toHaveBeenCalledOnce();
   });
 

--- a/.oh/templates/full/.pi/bridge-recovery/index.ts
+++ b/.oh/templates/full/.pi/bridge-recovery/index.ts
@@ -1,30 +1,6 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 
-// Standalone Codex retry-recovery for the pi-messenger-bridge Slack session.
-//
-// The npm bridge (pi-messenger-bridge) chains Codex turns through the
-// openai-codex Responses provider's connection-scoped `previous_response_id`.
-// When that id goes stale the provider returns HTTP 400
-// `previous_response_not_found`, clears its own cached continuation, and
-// re-throws WITHOUT retrying — so a real Slack turn dies with `willRetry:false`
-// and the user gets no reply. The npm package has no recovery hook (the custom
-// extension's recovery from harness PR #283 was dropped in the npm swap).
-//
-// This extension is co-loaded ALONGSIDE the bridge (a 2nd `--extension` in
-// .devcontainer/client-slack-supervise.sh) — it does NOT patch node_modules. It
-// owns the `agent_end` event (the bridge does not hook it, so no collision): on
-// a recoverable provider-state error whose failed turn was Slack-originated, it
-// re-injects that user text ONCE. The failed request already cleared the stale
-// id, so the retry starts a fresh chain and succeeds; the bridge's
-// `pendingRemoteChat` survives the errored turn, so the recovered reply is still
-// delivered to Slack. See issue #282 / PR #482.
-//
-// It lives OUTSIDE .pi/extensions/ so pi's one-level `./extensions` auto-discovery
-// never loads it implicitly (which would double-register the agent_end handler).
 
-// Inbound Slack turns are stamped by the bridge as
-//   `[📱 @<user> via <transport>]: <text>`  (pi-messenger-bridge dist/index.js)
-// The legacy custom extension used `[Slack #<channel>] <user>: <text>`.
 const SLACK_PREFIX_RE = /^\[(📱 |Slack #)/;
 const RECOVERABLE_RE = /previous_response_not_found|previous response .*not found/i;
 
@@ -42,9 +18,6 @@ function textOf(m: AnyMsg | undefined): string {
     .trim();
 }
 
-// The most recent user message — but only if THIS bridge originated it (carries
-// the Slack prefix). Returns undefined for non-Slack turns so we never re-inject
-// a message the bridge did not send.
 function lastSlackUserText(messages: AnyMsg[]): string | undefined {
   for (let i = messages.length - 1; i >= 0; i--) {
     const t = textOf(messages[i]);
@@ -53,8 +26,6 @@ function lastSlackUserText(messages: AnyMsg[]): string | undefined {
   return undefined;
 }
 
-// Tolerant across event shapes: the recoverable error may surface on the last
-// assistant message (extension AgentEndEvent) or at the event top level.
 function isRecoverable(event: any, messages: AnyMsg[]): boolean {
   if (RECOVERABLE_RE.test(String(event?.errorMessage ?? ""))) return true;
   return messages.some(
@@ -63,8 +34,6 @@ function isRecoverable(event: any, messages: AnyMsg[]): boolean {
 }
 
 export default function (pi: ExtensionAPI): void {
-  // One-retry-per-episode guard, keyed on the failed text: if our re-injected
-  // turn hits the same recoverable error, we stop (don't loop forever).
   let lastRetriedText: string | undefined;
 
   const reset = () => {
@@ -77,18 +46,17 @@ export default function (pi: ExtensionAPI): void {
     const messages: AnyMsg[] = Array.isArray(event?.messages) ? event.messages : [];
 
     if (!isRecoverable(event, messages)) {
-      lastRetriedText = undefined; // clean / non-recoverable turn — reset guard
+      lastRetriedText = undefined;
       return;
     }
 
     const failedText = lastSlackUserText(messages);
     if (!failedText) {
-      lastRetriedText = undefined; // not bridge-originated — leave it alone
+      lastRetriedText = undefined;
       return;
     }
 
     if (lastRetriedText === failedText) {
-      // Our retry hit the same error — recovery exhausted, stop here.
       lastRetriedText = undefined;
       console.error("[slack-recovery] previous_response_not_found recovery exhausted; giving up on this turn");
       return;
@@ -97,8 +65,6 @@ export default function (pi: ExtensionAPI): void {
     lastRetriedText = failedText;
     console.error("[slack-recovery] stale previous_response_id — re-injecting the failed Slack turn once");
     try {
-      // followUp queues it as the next user message (matches how the bridge
-      // itself delivers inbound Slack messages), starting a fresh Codex chain.
       pi.sendUserMessage(failedText, { deliverAs: "followUp" });
     } catch (err) {
       console.error("[slack-recovery] re-inject failed:", err);

--- a/.oh/templates/full/.pi/extensions/__tests__/path-guard.test.ts
+++ b/.oh/templates/full/.pi/extensions/__tests__/path-guard.test.ts
@@ -71,7 +71,6 @@ describe("path-guard extension", () => {
     expect(captured.commands.has("guard")).toBe(true);
   });
 
-  // Fix #1: hasUI guard tests
   describe("headless mode (hasUI === false)", () => {
     it("does not call confirm for write on sensitive path in headless mode", async () => {
       const { ctx } = makeCtx(async () => false, false);
@@ -110,7 +109,6 @@ describe("path-guard extension", () => {
       const { ctx } = makeCtx(async () => false);
       const result = await fire(
         captured.toolCallHandlers,
-        // Fix #5: canonical key is `path` (verified from pi write.ts writeSchema)
         { toolName: "write", input: { path } },
         ctx,
       );
@@ -175,7 +173,6 @@ describe("path-guard extension", () => {
       expect(result).toBeUndefined();
     });
 
-    // Fix #4: capitalized tool names still fire the guard (toLowerCase normalization)
     it("fires guard for capitalized tool names (Write, Edit)", async () => {
       for (const toolName of ["Write", "Edit"]) {
         const { ctx } = makeCtx(async () => false);
@@ -218,7 +215,6 @@ describe("path-guard extension", () => {
       expect(result).toMatchObject({ block: true });
     });
 
-    // Fix #2: case-insensitive RISKY_BASH — uppercase variants must still trigger
     it.each([
       ["RM -RF /tmp/x"],
       ["Sudo apt update"],
@@ -234,7 +230,6 @@ describe("path-guard extension", () => {
       expect(result).toMatchObject({ block: true });
     });
 
-    // Fix #3: bare > /dev/... redirection without leading colon
     it.each([
       ["> /dev/sda"],
       ["dd if=/dev/zero > /dev/sdb"],
@@ -284,7 +279,6 @@ describe("path-guard extension", () => {
       expect(body).toContain("...");
     });
 
-    // Fix #4: capitalized Bash tool name still fires the guard
     it("fires guard for capitalized tool name Bash", async () => {
       const { ctx } = makeCtx(async () => false);
       const result = await fire(

--- a/.oh/templates/full/.pi/extensions/codex-stale-response-retry.ts
+++ b/.oh/templates/full/.pi/extensions/codex-stale-response-retry.ts
@@ -1,15 +1,5 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 
-// Recover non-Slack Pi turns that fail because the Codex Responses provider
-// reused stale WebSocket continuation state (`previous_response_id`).
-//
-// Installed pi-ai@0.79.9 clears that stale continuation after the failed
-// request, but the failed user turn is lost because the agent-level retry
-// classifier does not treat `previous_response_not_found` as retryable. This
-// project-local extension re-queues the same user text once, so the next request
-// is sent with a fresh/full context. Slack-originated messages are deliberately
-// skipped: the dedicated `.pi/bridge-recovery/` extension owns those because it
-// is co-loaded with pi-messenger-bridge and preserves Slack reply delivery state.
 
 const SLACK_PREFIX_RE = /^\[(📱 |Slack #)/;
 const RECOVERABLE_RE = /previous_response_not_found|previous response .*not found/i;

--- a/.oh/templates/full/.pi/extensions/path-guard.ts
+++ b/.oh/templates/full/.pi/extensions/path-guard.ts
@@ -13,10 +13,6 @@ export function isSensitivePath(p: string): boolean {
   return SENSITIVE_PATHS.some((re) => re.test(p));
 }
 
-// Fix #2: All regexes now carry the `i` flag for case-insensitive matching.
-// Fix #3: Block-device redirection regex updated to match bare `> /dev/...`
-//         without requiring a leading `:` (shell colon-truncate idiom).
-//         nvme devices use numeric suffixes (nvme0n1), disk\d+ likewise.
 const RISKY_BASH = [
   /\brm\s+-rf\b/i,
   /\bsudo\b/i,
@@ -25,15 +21,8 @@ const RISKY_BASH = [
   /(^|\s)>\s*\/dev\/(sd[a-z]|nvme\d*|hd[a-z]|disk\d+)\b/i,
 ];
 
-// Tool names confirmed lowercase from pi source:
-// packages/coding-agent/src/core/tools/index.ts:
-//   export type ToolName = "read" | "bash" | "edit" | "write" | "grep" | "find" | "ls";
 const MUTATING_TOOLS = new Set(["write", "edit"]);
 
-// Canonical input key for write and edit is `path` (verified from pi source):
-//   write.ts: const writeSchema = Type.Object({ path: Type.String(...), content: ... });
-//   edit.ts:  const editSchema = Type.Object({ path: Type.String(...), edits: ... });
-// Fallbacks retained for forward-compatibility with any future schema changes.
 function pickPath(input: Record<string, unknown> | undefined): string | undefined {
   if (!input) return undefined;
   for (const key of ["path", "file_path", "target", "filename"]) {
@@ -45,13 +34,8 @@ function pickPath(input: Record<string, unknown> | undefined): string | undefine
 
 export default function (pi: ExtensionAPI) {
   pi.on("tool_call", async (event, ctx) => {
-    // Fix #1: Guard against headless/RPC mode where ctx.ui is unavailable.
-    // Mirrors the pattern in mifune-banner.ts.
     if (!ctx.hasUI) return;
 
-    // Fix #4: Defensive toLowerCase normalization on toolName. Pi uses
-    // lowercase names (confirmed from index.ts ToolName union), but this
-    // costs nothing and protects against future renames.
     const toolName = event.toolName?.toLowerCase() ?? "";
 
     if (MUTATING_TOOLS.has(toolName)) {
@@ -67,8 +51,6 @@ export default function (pi: ExtensionAPI) {
     }
 
     if (toolName === "bash") {
-      // Interactive TUI sessions already put the operator in the loop. Avoid
-      // interrupting those sessions with a second in-tree confirmation modal.
       if (ctx.mode === "tui") return;
 
       const cmd = (event.input as { command?: string } | undefined)?.command ?? "";

--- a/.pi/bridge-recovery/__tests__/recovery.test.ts
+++ b/.pi/bridge-recovery/__tests__/recovery.test.ts
@@ -1,9 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import factory from "../index";
 
-// Fire-the-handler test harness (mirrors .pi/extensions/__tests__/path-guard.test.ts):
-// .pi/** is NOT CI-typechecked, so we exercise the extension by invoking its
-// registered handlers, never by importing pi itself.
 type Handler = (event: unknown, ctx?: unknown) => Promise<unknown> | unknown;
 
 function makePi() {
@@ -47,7 +44,7 @@ describe("slack bridge codex retry-recovery", () => {
     factory(pi);
     const messages = [slackUser("[📱 @Ryan via slack]: Links?"), assistantError(STALE)];
     await fire("agent_end", { messages });
-    await fire("agent_end", { messages }); // our retry hit the same error -> give up
+    await fire("agent_end", { messages });
     expect(sendUserMessage).toHaveBeenCalledOnce();
   });
 

--- a/.pi/bridge-recovery/index.ts
+++ b/.pi/bridge-recovery/index.ts
@@ -1,30 +1,6 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 
-// Standalone Codex retry-recovery for the pi-messenger-bridge Slack session.
-//
-// The npm bridge (pi-messenger-bridge) chains Codex turns through the
-// openai-codex Responses provider's connection-scoped `previous_response_id`.
-// When that id goes stale the provider returns HTTP 400
-// `previous_response_not_found`, clears its own cached continuation, and
-// re-throws WITHOUT retrying — so a real Slack turn dies with `willRetry:false`
-// and the user gets no reply. The npm package has no recovery hook (the custom
-// extension's recovery from harness PR #283 was dropped in the npm swap).
-//
-// This extension is co-loaded ALONGSIDE the bridge (a 2nd `--extension` in
-// .devcontainer/client-slack-supervise.sh) — it does NOT patch node_modules. It
-// owns the `agent_end` event (the bridge does not hook it, so no collision): on
-// a recoverable provider-state error whose failed turn was Slack-originated, it
-// re-injects that user text ONCE. The failed request already cleared the stale
-// id, so the retry starts a fresh chain and succeeds; the bridge's
-// `pendingRemoteChat` survives the errored turn, so the recovered reply is still
-// delivered to Slack. See issue #282 / PR #482.
-//
-// It lives OUTSIDE .pi/extensions/ so pi's one-level `./extensions` auto-discovery
-// never loads it implicitly (which would double-register the agent_end handler).
 
-// Inbound Slack turns are stamped by the bridge as
-//   `[📱 @<user> via <transport>]: <text>`  (pi-messenger-bridge dist/index.js)
-// The legacy custom extension used `[Slack #<channel>] <user>: <text>`.
 const SLACK_PREFIX_RE = /^\[(📱 |Slack #)/;
 const RECOVERABLE_RE = /previous_response_not_found|previous response .*not found/i;
 
@@ -42,9 +18,6 @@ function textOf(m: AnyMsg | undefined): string {
     .trim();
 }
 
-// The most recent user message — but only if THIS bridge originated it (carries
-// the Slack prefix). Returns undefined for non-Slack turns so we never re-inject
-// a message the bridge did not send.
 function lastSlackUserText(messages: AnyMsg[]): string | undefined {
   for (let i = messages.length - 1; i >= 0; i--) {
     const t = textOf(messages[i]);
@@ -53,8 +26,6 @@ function lastSlackUserText(messages: AnyMsg[]): string | undefined {
   return undefined;
 }
 
-// Tolerant across event shapes: the recoverable error may surface on the last
-// assistant message (extension AgentEndEvent) or at the event top level.
 function isRecoverable(event: any, messages: AnyMsg[]): boolean {
   if (RECOVERABLE_RE.test(String(event?.errorMessage ?? ""))) return true;
   return messages.some(
@@ -63,8 +34,6 @@ function isRecoverable(event: any, messages: AnyMsg[]): boolean {
 }
 
 export default function (pi: ExtensionAPI): void {
-  // One-retry-per-episode guard, keyed on the failed text: if our re-injected
-  // turn hits the same recoverable error, we stop (don't loop forever).
   let lastRetriedText: string | undefined;
 
   const reset = () => {
@@ -77,18 +46,17 @@ export default function (pi: ExtensionAPI): void {
     const messages: AnyMsg[] = Array.isArray(event?.messages) ? event.messages : [];
 
     if (!isRecoverable(event, messages)) {
-      lastRetriedText = undefined; // clean / non-recoverable turn — reset guard
+      lastRetriedText = undefined;
       return;
     }
 
     const failedText = lastSlackUserText(messages);
     if (!failedText) {
-      lastRetriedText = undefined; // not bridge-originated — leave it alone
+      lastRetriedText = undefined;
       return;
     }
 
     if (lastRetriedText === failedText) {
-      // Our retry hit the same error — recovery exhausted, stop here.
       lastRetriedText = undefined;
       console.error("[slack-recovery] previous_response_not_found recovery exhausted; giving up on this turn");
       return;
@@ -97,8 +65,6 @@ export default function (pi: ExtensionAPI): void {
     lastRetriedText = failedText;
     console.error("[slack-recovery] stale previous_response_id — re-injecting the failed Slack turn once");
     try {
-      // followUp queues it as the next user message (matches how the bridge
-      // itself delivers inbound Slack messages), starting a fresh Codex chain.
       pi.sendUserMessage(failedText, { deliverAs: "followUp" });
     } catch (err) {
       console.error("[slack-recovery] re-inject failed:", err);

--- a/.pi/extensions/__tests__/path-guard.test.ts
+++ b/.pi/extensions/__tests__/path-guard.test.ts
@@ -71,7 +71,6 @@ describe("path-guard extension", () => {
     expect(captured.commands.has("guard")).toBe(true);
   });
 
-  // Fix #1: hasUI guard tests
   describe("headless mode (hasUI === false)", () => {
     it("does not call confirm for write on sensitive path in headless mode", async () => {
       const { ctx } = makeCtx(async () => false, false);
@@ -110,7 +109,6 @@ describe("path-guard extension", () => {
       const { ctx } = makeCtx(async () => false);
       const result = await fire(
         captured.toolCallHandlers,
-        // Fix #5: canonical key is `path` (verified from pi write.ts writeSchema)
         { toolName: "write", input: { path } },
         ctx,
       );
@@ -175,7 +173,6 @@ describe("path-guard extension", () => {
       expect(result).toBeUndefined();
     });
 
-    // Fix #4: capitalized tool names still fire the guard (toLowerCase normalization)
     it("fires guard for capitalized tool names (Write, Edit)", async () => {
       for (const toolName of ["Write", "Edit"]) {
         const { ctx } = makeCtx(async () => false);

--- a/.pi/extensions/codex-stale-response-retry.ts
+++ b/.pi/extensions/codex-stale-response-retry.ts
@@ -1,15 +1,5 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 
-// Recover non-Slack Pi turns that fail because the Codex Responses provider
-// reused stale WebSocket continuation state (`previous_response_id`).
-//
-// Installed pi-ai@0.79.9 clears that stale continuation after the failed
-// request, but the failed user turn is lost because the agent-level retry
-// classifier does not treat `previous_response_not_found` as retryable. This
-// project-local extension re-queues the same user text once, so the next request
-// is sent with a fresh/full context. Slack-originated messages are deliberately
-// skipped: the dedicated `.pi/bridge-recovery/` extension owns those because it
-// is co-loaded with pi-messenger-bridge and preserves Slack reply delivery state.
 
 const SLACK_PREFIX_RE = /^\[(📱 |Slack #)/;
 const RECOVERABLE_RE = /previous_response_not_found|previous response .*not found/i;

--- a/.pi/extensions/path-guard.ts
+++ b/.pi/extensions/path-guard.ts
@@ -7,11 +7,6 @@ export const SENSITIVE_PATHS: RegExp[] = [
   /\.pem$/,
   /\.key$/,
   /(^|\/)id_(rsa|ed25519|ecdsa)$/,
-  // Operator-only configuration directory (repo root and $HOME). Anchored to a
-  // whole path segment so ordinary tool config (jest.config.js, .configrc) is
-  // untouched. Mirrors the `.config/` tier in .oh/hooks/deny-secret-paths.sh —
-  // note this extension only covers write/edit in interactive mode, so the
-  // deterministic hooks remain the enforcing layer.
   /(^|\/)\.config(\/|$)/,
 ];
 
@@ -19,22 +14,9 @@ export function isSensitivePath(p: string): boolean {
   return SENSITIVE_PATHS.some((re) => re.test(p));
 }
 
-// Destructive-bash guarding is now owned by cc-safety-net (the pinned pi
-// extension from the `npm:cc-safety-net` package): it deterministically parses
-// and denies `rm -rf`, `git reset --hard`, `git push --force`, block-device
-// redirection, and related destructive intent across every mode, including
-// headless. This extension therefore no longer inspects bash commands — it
-// guards sensitive-path writes/edits only.
 
-// Tool names confirmed lowercase from pi source:
-// packages/coding-agent/src/core/tools/index.ts:
-//   export type ToolName = "read" | "bash" | "edit" | "write" | "grep" | "find" | "ls";
 const MUTATING_TOOLS = new Set(["write", "edit"]);
 
-// Canonical input key for write and edit is `path` (verified from pi source):
-//   write.ts: const writeSchema = Type.Object({ path: Type.String(...), content: ... });
-//   edit.ts:  const editSchema = Type.Object({ path: Type.String(...), edits: ... });
-// Fallbacks retained for forward-compatibility with any future schema changes.
 function pickPath(input: Record<string, unknown> | undefined): string | undefined {
   if (!input) return undefined;
   for (const key of ["path", "file_path", "target", "filename"]) {
@@ -46,13 +28,8 @@ function pickPath(input: Record<string, unknown> | undefined): string | undefine
 
 export default function (pi: ExtensionAPI) {
   pi.on("tool_call", async (event, ctx) => {
-    // Fix #1: Guard against headless/RPC mode where ctx.ui is unavailable.
-    // Mirrors the pattern in mifune-banner.ts.
     if (!ctx.hasUI) return;
 
-    // Fix #4: Defensive toLowerCase normalization on toolName. Pi uses
-    // lowercase names (confirmed from index.ts ToolName union), but this
-    // costs nothing and protects against future renames.
     const toolName = event.toolName?.toLowerCase() ?? "";
 
     if (MUTATING_TOOLS.has(toolName)) {

--- a/.pi/install/install-langfuse.sh
+++ b/.pi/install/install-langfuse.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-# Install the pinned pi-langfuse fork with the patched OpenTelemetry dependency.
 set -euo pipefail
 
 PI_LANGFUSE_VERSION="1.5.9"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Update policy and release automation live in [`/git`](.claude/skills/git/SKILL.m
 
 ## [Unreleased]
 
+### Changed
+- Strip explanatory comments from all tracked code — `.ts`/`.mjs`/`.sh`/`.py` plus `oh-path`, the Dockerfile, the Makefile and `.zshrc` — leaving only machine-read directives ([#837](https://github.com/mifunedev/openharness/pull/837)).
+
 ### Fixed
 - The `development` issue closer never fired: `pull_request_target` resolves the workflow from the **default** branch (`main`), where the file does not exist. Swapped to `pull_request` ([#841](https://github.com/mifunedev/openharness/issues/841)).
 - **`uv python install` now works as the `sandbox` user without `sudo`.** `install -d -o sandbox -g sandbox .../uv/tools` chowns the final component only, so the intermediate `.../share/uv` stayed `root:root`.

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,8 @@
-# Open Harness — Makefile
-# Override sandbox name: make shell SANDBOX_NAME=mycontainer
-# Connect to a different running container: make shell portfolio-advisor
-# Connect as a specific user: make shell some-container SHELL_USER=postgres
 
 -include .devcontainer/.env
 
 COMPOSE           := .oh/scripts/docker-compose.sh
 
-# SANDBOX_NAME comes from the `-include .devcontainer/.env` above; fallback openharness.
-# Command-line "make ... SANDBOX_NAME=x" overrides all assignments automatically.
 SANDBOX_NAME      := $(or $(SANDBOX_NAME),openharness)
 
 SHELL_USER        ?= sandbox
@@ -21,7 +15,6 @@ ifeq ($(firstword $(MAKECMDGOALS)),shell)
   endif
 endif
 
-# `make gateway <pi|hermes>` — forward the backend as a positional word.
 ifeq ($(firstword $(MAKECMDGOALS)),gateway)
   GATEWAY_ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
   $(foreach a,$(GATEWAY_ARGS),$(eval $a:;@:))


### PR DESCRIPTION
## What this does

Removes explanatory prose from every tracked code file. Code is the source of
truth; comments were a second, unverified source that drifts.

**216 files touched. 6,639 lines deleted, 176 re-added as trailing-comment
rewrites — a net 6,463 comment lines removed.** No code changed.

Of the 4,014 comment lines that survived the first pass, **751 remain**, and
**710 of those are machine-read directives**:

| Category | Lines | Why it survives |
|---|---|---|
| Shebangs | 158 | the file will not execute without it |
| `# shellcheck …` | 34 | CI Boot Path Lint turns red without it |
| Probe `tier:`/`source:`/`desc:` | 514 | `run.sh` greps these to build `RESULTS.md`; they are data |
| `eslint-disable` | 4 | lint pragma |
| **Prose a test or probe greps for** | **39** | each proven necessary — see below |

## Scope

All tracked `.ts`/`.mjs`/`.sh`/`.py`, templates and tests included, **plus four
code files the four-extension glob missed**:

| File | Removed |
|---|---|
| `.oh/scripts/oh-path` — a `#!/bin/sh` script with no extension | 51 |
| `.devcontainer/Dockerfile` | 77 |
| `.oh/install/.zshrc` | 14 |
| `Makefile` | 7 |

`oh-path` is the only extensionless script in the repo (every tracked file was
checked for a shebang). Config files — `.tmux.conf`, `.codex/config.toml` — are
treated like the YAML/JSON that was out of scope.

## How the keep-set was built

Nothing is preserved on a guess. The process is failure-driven:

1. Strip **every** comment except shebangs, shellcheck, probe headers, eslint.
2. Run the full suite and all 105 probes.
3. For each failure, mine what it actually demands — `toContain`/`toMatch`
   arguments, `indexOf` operands, the literal head of any comment-anchored
   regex, and each probe's `grep`/`awk` patterns — from the **oracle's source**,
   because vitest truncates long expectations and some assertions name no string
   at all (a regex anchor fails as `expected null not to be null`).
4. Restore only the comment lines carrying those strings, then repeat.

Two filters keep this honest:

- **A needle that also appears in the file's code is satisfied without the
  comment.** Only comment-exclusive strings make a comment load-bearing.
- **Needles are scoped to the files their oracle reads**, so one test's strings
  cannot shield look-alike comments elsewhere in the repo.

The effect of each filter, measured:

| Keep-set | Lines kept |
|---|---|
| Original heuristic (first push) | 4,014 |
| Failure-driven, whole blocks | 2,528 |
| + needle must be comment-exclusive | 2,150 |
| + no block expansion | 602 |
| + needles scoped to their oracle's files | 51 |
| + drop contentless `# ─────` rulers | **39** |

## Language-aware, never regex-over-lines

| Language | Parser |
|---|---|
| shell | `mvdan-sh` — the shfmt parser |
| TS/JS | the TypeScript parser (`createSourceFile`) |
| Python | stdlib `tokenize` |
| Dockerfile / Makefile / `.zshrc` | line-wise: only a line whose first character is `#` |

So heredoc bodies, string literals and regex literals are never mistaken for
comments. `run.sh`'s `<<'HDR'` markdown body is untouched, and the Makefile's
11 `## ` help annotations — which `make help` parses with awk — all survive,
including the tab-indented recipe containing `##`.

## Verification

| # | Gate | Result |
|---|---|---|
| 1 | File modes | **PASS** — `git diff --summary \| grep mode` empty; filesystem exec bits also compared against the git index, identical |
| 2 | `shellcheck` | **PASS** — both CI globs exit 0; across all 159 tracked `.sh` the finding codes are identical to baseline (5 pre-existing). `oh-path` also `sh -n` clean |
| 3 | `bash .oh/skills/eval/run.sh` | **PASS** — per-probe status identical to baseline for all 105 probes; runner exits 0 |
| 4 | `pnpm typecheck && pnpm test` | **PASS** — typecheck clean; 758 passed, same single pre-existing failure as baseline |
| 5 | No code changed | **PASS** — 195 modified files verified by stripping all comments from both the original and the result and comparing the residue: `0 with code changes` |
| 6 | `RESULTS.md` | **PASS** — all 105 probes still carry a tier and a source |
| — | Idempotency | **PASS** — a second run changes 0 files |

### Baseline corrections

Two figures in the task brief did not match the repo, so the gates were run
against measured baselines instead:

- **Probes.** The brief expected 100 PASS / 4 SKIPPED. On the untouched tree
  this branch was cut from, the real baseline is **99 PASS / 1 REGRESSION /
  5 SKIPPED** — `audit-run-root-contract` already fails and
  `oh-init-headless-config` already skips here, both environment-related.
- **Tests.** They run from the repo root (`.oh/cli/package.json` has no `test`
  script), and the baseline is **758 passing plus one pre-existing failure**
  (`cron-runtime.test.ts:420`, failing on the untouched tree).

`sandbox-boot-smoke.test.ts` failed once during verification and passed 3/3 in
isolation and on a full re-run — it is load-sensitive (its timeout resolves to
`0s` under parallel load), not caused by this change.

## What this fixes from the first push

The first pass used a string-matching heuristic. It kept 4,014 lines, and
**1,214 of those across 131 files were orphaned fragments** — single lines left
behind from comment blocks whose opening lines were stripped, so the surviving
text read as a non-sequitur:

```
PROBE_DIR="$ROOT/.oh/evals/probes"

# would silently check a per-worktree empty ledger (the exact defect US-007 fixed).
MEM_DIR="$(sh "$ROOT/.oh/scripts/oh-path" memory --no-create ...)"
```

That is down to **23 lines across 12 files**, and every one is now a line an
oracle greps for rather than a random middle line of a paragraph. Some still
read as a truncated sentence — that is the cost of keeping exactly the asserted
line and nothing more, and it is the honest trade for "code is truth".

## Could not verify

- **`shellcheck` is not installed in this sandbox** and `apt-get` is not
  permitted. It was obtained as a pinned binary via the `shellcheck` npm wrapper
  (v0.11.0); CI installs its own from apt, so gate 2 is proved against 0.11.0,
  not CI's exact build.
- Probes that need the network or Docker (`debugmcp-availability`,
  `next-dev-prod`, `registry-portability`, `oh-init-headless-config`) SKIP here
  and so exercise nothing.
- Nothing ran inside a real provisioned container. The boot path — including the
  newly-stripped `Dockerfile` and `entrypoint.sh` — is covered only by
  shellcheck, `bash -n`, and the tests that read those scripts.

## Rebase note

This branch needs a rebase once `feat/remove-memory-tier` lands. **The fix is to
re-run the scratchpad script over the rebased tree, not to resolve conflicts by
hand.** The script is idempotent and its keep-set is content-addressed (comment
text, not line numbers), so re-running reproduces this diff exactly.
