### PR TITLE
fix: run the cron tmux wrapper test in a non-login shell

### DIFF
--- a/.oh/scripts/__tests__/cron-runtime.test.ts
+++ b/.oh/scripts/__tests__/cron-runtime.test.ts
@@ -350,7 +350,7 @@ describe("buildTmuxWrapper", () => {
       agentBin: opts.agentBin,
       promptFile,
     });
-    const result = spawnSync("bash", ["-lc", command], {
+    const result = spawnSync("bash", ["-c", command], {
       env: { ...process.env, PATH: `${binDir}:${process.env.PATH ?? ""}` },
       encoding: "utf-8",
     });


### PR DESCRIPTION
## The bug

`buildTmuxWrapper`'s suite spawned the generated command with **`bash -lc`**. A login shell sources the profile files, which rebuild `PATH` from scratch and discard the `binDir` prefix the test injects:

```
$ PATH="/tmp/pathtest:$PATH" bash -lc 'command -v claude; echo "PATH[0]=${PATH%%:*}"'
/usr/bin/claude
PATH[0]=/home/sandbox/.local/bin      # shim prefix gone

$ PATH="/tmp/pathtest:$PATH" bash -c  'command -v claude; echo "PATH[0]=${PATH%%:*}"'
/tmp/pathtest/claude
PATH[0]=/tmp/pathtest                 # shim wins
```

So a bare `agentBin` like `"claude"` resolved to whatever real binary the machine has installed instead of the shim the test wrote. It got exit `0` from the real binary rather than the shimmed `9`.

**Why it looked environment-dependent:** CI images have no `claude`, so the shim survived and the suite passed. Any box with `/usr/bin/claude` — every sandbox in this project — failed. A test that is green on CI and red on the developer's machine is worse than a failing one, because CI stops being evidence.

**Why only the Claude case failed:** the sibling non-Claude test passes an *absolute* path (`path.join(tmp, "pi-agent")`), which no `PATH` rewrite can shadow.

## The fix

One token: `-lc` → `-c`.

Production never runs this wrapper through a login shell either — `buildTmuxWrapper`'s output is handed to `tmux new-session` (`cron-runtime.ts:865`). Only `buildCronAgentCommand` runs under `bash -lc` (`:974`), and that is not what this suite spawns. The test was asserting against a shell the code under test never sees.

## Verification

- **By rejection:** reintroducing the `exit $status; rm -f` ordering defect in `buildTmuxWrapper` fails **both** cleanup tests (2 failed / 101 passed). Restored, both pass. The guard still has teeth — this is not a test weakened into passing.
- `pnpm test:scripts`: **758/758 pass.** It was 757/758 before; this was the last red test in the repo.
- `pnpm run typecheck`: clean.
- Eval suite: 96 probes, 91 PASS / 1 REGRESSION / 4 SKIPPED — unchanged. The regression is `audit-run-root-contract`, red before this branch and unrelated.

## Noticed, not fixed

`.gitignore:25` is `**/node_modules/` with a trailing slash, so it matches directories only. A `node_modules` **symlink** at the repo root is not ignored and can be staged by `git add -A`. Out of scope here; flagging it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
