### PR TITLE
fix: audit probe read an unreaped zombie as a surviving orphan

### DIFF
--- a/.oh/evals/RESULTS.md
+++ b/.oh/evals/RESULTS.md
@@ -6,101 +6,101 @@ probe id; git history is the time series.** Schema and exit-code semantics are i
 
 | probe | tier | last-run (UTC) | status | source |
 |-------|------|----------------|--------|--------|
-| ablate-state-machine | A | 2026-08-26 18:31 | PASS | issue #645 — one locked versioned ablation recovery owner |
-| advisor-monitored-loop | A | 2026-08-26 18:31 | PASS | conversation 2026-06-19 (issue #257); rewritten by spec-simplification US-002 |
-| agent-browser-cli | A | 2026-08-26 18:31 | PASS | retro lesson 2026-06-07 (agent-browser 0.8.5 CLI) |
-| artifact-contract-audit | A | 2026-08-26 18:31 | PASS | issue #583/#645 — production /audit implementation Gate 1 behavior |
-| audit-dispatcher-contract | A | 2026-08-26 18:31 | PASS | issue #645 — audit consolidation public taxonomy |
-| audit-implementation-behavior | A | 2026-08-26 18:31 | PASS | issue #645 — implementation root/repo/browser behavior |
-| audit-pr-acquire | A | 2026-08-26 18:31 | PASS | issue #645 — production PR acquisition behavior |
-| audit-pr-classifier | A | 2026-08-26 18:31 | PASS | issue #645 — deterministic focused and queue PR classifier |
-| audit-run-root-contract | A | 2026-08-26 18:31 | REGRESSION | issue #645 — executable immutable audit root/run correlation |
-| audit-shellcheck-coverage | A | 2026-08-26 18:31 | PASS | issue #645 — private audit scripts require release and CI lint coverage |
-| audit-stale-references | A | 2026-08-26 18:31 | PASS | issue #645 — clean-breaking audit migration |
-| boot-lint-glob | A | 2026-08-26 18:31 | PASS | issue #90, issue #120 |
-| builder-skill-consolidation | A | 2026-08-26 18:31 | PASS | issue #643 — consolidate artifact builders behind one /builder dispatcher |
-| capability-benchmark-schema | A | 2026-08-26 18:31 | PASS | issue #167 — capability benchmark instrument |
-| cc-safety-net-wiring | A | 2026-08-26 18:31 | PASS | .oh/tasks/cc-safety-net/prd.json US-007 2026-07-19 |
-| changelog-entry-length | A | 2026-08-26 18:31 | PASS | conversation 2026-08-24 — CHANGELOG.md grew to 259KB of bullet prose because "one line" was unquantified |
-| cleanup-tasks-scoped-guard | A | 2026-08-26 18:31 | PASS | issue #85 |
-| cleanup-tasks-worktree-grooming | A | 2026-08-26 18:31 | PASS | issue #168; issue #327 |
-| codex-stale-response-retry | A | 2026-08-26 18:31 | PASS | issue #506 — Codex previous_response_not_found RCA |
-| compose-config-path-parity | A | 2026-08-26 18:31 | PASS | ? |
-| context-tier-size-budget | A | 2026-08-26 18:31 | PASS | .oh/tasks/spec-simplification/ (issue #816, US-007) — the always-on tier was 85,256 B |
-| cron-claude-codex-fallback | A | 2026-08-26 18:31 | PASS | conversation 2026-06-12 (default Codex fallback for crons) |
-| cron-watchdog | A | 2026-08-26 18:31 | PASS | issues #130/#453 (cron runtime watchdog + legacy system-cron reaping) 2026-06-19 |
-| curl-bash-safe-alternatives | A | 2026-08-26 18:31 | PASS | vet-run/vet integration — public curl|bash examples need review-first alternatives |
-| datasets-schema | A | 2026-08-26 18:31 | PASS | issue #196 — .oh/evals/datasets verifiable trajectory corpus (Repo2RLEnv-inspired) |
-| debugmcp-availability | A | 2026-08-26 18:31 | SKIPPED | issue #297 — DebugMCP MCP debug-server availability |
-| delegate-model-effort-policy | A | 2026-08-26 18:31 | PASS | conversation 2026-07-11 (delegate model inheritance and thinking policy) |
-| devtcp-hook | A | 2026-08-26 18:31 | PASS | retro lesson 2026-06-10 (zsh /dev/tcp) |
-| docker-inspect-env-guard | A | 2026-08-26 18:31 | PASS | operator directive 2026-08-08 (agents keep the docker socket, but must |
-| docs-build-fast-path | A | 2026-08-26 18:31 | PASS | #455 — docs builds must stay out of fast harness/eval/release gates; #536 — docs site externalized to openharness-web; docs markdown relocated to .oh/docs/ |
-| drift-check-cron-staleness-glob | A | 2026-08-26 18:31 | PASS | issue #98; issue #225 (restart-required cron frontmatter/config drift) |
-| entrypoint-pnpm-manifest-fingerprint | A | 2026-08-26 18:31 | PASS | issue #521 (manifest-aware sandbox installs) 2026-07-01 |
-| env-schema-parity | A | 2026-08-26 18:31 | PASS | ? |
-| eval-ci-gate | A | 2026-08-26 18:31 | PASS | #103 — eval probe suite gated in CI |
-| eval-gate | A | 2026-08-26 18:31 | PASS | retro lesson 2026-06-11 (eval-gate) |
-| eval-results-atomic | A | 2026-08-26 18:31 | PASS | issue #83 (eval-results-atomic-write) |
-| eval-runner-exit | A | 2026-08-26 18:31 | PASS | retro lesson 2026-06-11 (eval-runner-exit) #29 |
-| eval-runs-once-per-cycle | A | 2026-08-26 18:31 | PASS | .oh/tasks/spec-simplification/ (issue #816, US-006) — /eval ran 3x per cycle on the |
-| execution-target-contract | A | 2026-08-26 18:31 | PASS | issue #733 (ExecutionTarget contract + Docker Compose adapter) 2026-08-10 |
-| executor-kill-clears-session | A | 2026-08-26 18:31 | PASS | .oh/tasks/spec-simplification/ (issue #816, US-002) — OBSERVED 2026-08-23: |
-| executor-launch-interactive | A | 2026-08-26 18:31 | PASS | .oh/tasks/spec-simplification/ (issue #816, US-002) — OBSERVED 2026-08-23: the build |
-| firstmate-executor-contract | A | 2026-08-26 18:31 | PASS | .oh/tasks/spec-simplification/ (issue #816, US-002) — one build executor, no toggle |
-| get-oh-bootstrap | A | 2026-08-26 18:31 | PASS | get-oh.sh bootstrap — the Node-bootstrapping host-side path to the standalone `oh` CLI (also on npm as @mifune/openharness; see oh-npm-package.sh) |
-| git-skill | A | 2026-08-26 18:31 | PASS | conversation 2026-06-15 — rules are not always supported; git workflow must be the /git skill |
-| harness-audit-empty-output-gate | A | 2026-08-26 18:31 | PASS | issue #246 — /audit harness must fail closed on empty auditor outputs |
-| harness-ci-core-paths | A | 2026-08-26 18:31 | PASS | #165 — core sandbox config files must trigger harness CI |
-| harness-ci-hooks-paths | A | 2026-08-26 18:31 | PASS | issue #202 — credential/security hook changes must trigger harness CI |
-| harness-yaml-migration | A | 2026-08-26 18:31 | PASS | ? |
-| health-check-docker-stats | A | 2026-08-26 18:31 | PASS | retro lesson 2026-06-10 (docker stats vs ps Size) |
-| health-check-socket-degrade | A | 2026-08-26 18:31 | PASS | issue #762 (refs #756) — /health-check degrades to one statement, not nine failures |
-| heartbeat-logging-contract | A | 2026-08-26 18:31 | PASS | issue #447 (heartbeat log append hardening) 2026-06-18 |
-| make-oh-lifecycle-parity | A | 2026-08-26 18:31 | PASS | the Makefile/oh surface-gap consolidation — two front doors onto |
-| markitdown-wiki-ingest | A | 2026-08-26 18:31 | PASS | issue #649 — pinned local-document normalization contract for /wiki ingest |
-| next-dev-prod | A | 2026-08-26 18:31 | SKIPPED | retro lesson 2026-06-04 |
-| oh-devcontainer-restructure | A | 2026-08-26 18:31 | PASS | consolidate devcontainer — .oh/devcontainer/ folded back into .devcontainer/ |
-| oh-image-only-deploy | A | 2026-08-26 18:31 | PASS | .oh/tasks/image-only-deploy/prd.json US-004 (issue #609, Flavor B image-only deploy) |
-| oh-init-headless-config | A | 2026-08-26 18:31 | SKIPPED | ? |
-| oh-init-scaffold | A | 2026-08-26 18:31 | PASS | issue #531 Phase 2 |
-| oh-npm-package | A | 2026-08-26 18:31 | PASS | npm publish path for the standalone `oh` CLI (@mifune/openharness) — alternative to get-oh.sh |
-| oh-payload-manifest | A | 2026-08-26 18:31 | PASS | issue #531 follow-on (.oh payload manifest — oh update ships a declared allowlist) |
-| oh-sandbox-image-mode | A | 2026-08-26 18:31 | PASS | conversation 2026-07-05 (basic Docker deployment — prebuilt-image mode) |
-| oh-shipped-repo-overridable | A | 2026-08-26 18:31 | PASS | issue #531 follow-on (de-hardcode residual — shipped .oh shell scripts keep the upstream repo overridable) |
-| oh-standalone-lifecycle | A | 2026-08-26 18:31 | PASS | issue #564 |
-| oh-update | A | 2026-08-26 18:31 | PASS | issue #531 Phase 3 (oh update — upgrade only the .oh control plane) |
-| operator-config-guard | A | 2026-08-26 18:31 | PASS | operator directives 2026-08-06 (.config/ and settings.local.json are operator-only) |
-| pnpm-audit-ci-gate | A | 2026-08-26 18:31 | PASS | issue #171 — pnpm security audits must run in CI |
-| post-bridge-publish-confirmation | A | 2026-08-26 18:31 | PASS | #523 — post-bridge live publishing requires an explicit final confirmation gate |
-| prd-output-path-contract | A | 2026-08-26 18:31 | PASS | retro lesson 2026-06-19 |
-| project-root-seam | A | 2026-08-26 18:31 | PASS | issue #531 Phase 1 (OH_PROJECT_ROOT project-root seam) 2026-06-26 |
-| prompt-miner-schema-compat | A | 2026-08-26 18:31 | PASS | issue #253 — prompt-miner JSONL schema-drift guard |
-| prompt-miner-symlink-entrypoint | A | 2026-08-26 18:31 | PASS | issue #663 — prompt-miner engine no-ops via the documented .claude/skills symlink |
-| prompt-miner-weakness-record | A | 2026-08-26 18:31 | PASS | issue #580 — prompt-miner weakness-record (WH-xxx) cluster output |
-| protected-path-deletion | A | 2026-08-26 18:31 | PASS | .oh/tasks/spec-simplification/ (issue #816, US-001) — the critique gate was deleted, |
-| protected-paths-resolve | A | 2026-08-26 18:31 | PASS | issue #753 — .claude/protected-paths.txt named 7 paths that did not exist. |
-| registry-portability-gate | A | 2026-08-26 18:31 | PASS | issue #758 |
-| registry-portability | A | 2026-08-26 18:31 | SKIPPED | issue #758 |
-| repo-map-contract | A | 2026-08-26 18:31 | PASS | issue #464 — repo map must optimize orientation without adding a tree dependency or unmeasured performance claims |
-| retro-deterministic-contract | A | 2026-08-26 18:31 | PASS | issue #443 — /retro deterministic output and self-contained helper contract |
-| rl-delegation-write-worker | A | 2026-08-26 18:31 | PASS | retro lesson 2026-06-10 (rl-delegation) #57 |
-| rlm-context-budget | A | 2026-08-26 18:31 | PASS | .oh/tasks/rlm-weighted-trajectories/prd.json US-006 |
-| runtime-preflight-gate | A | 2026-08-26 18:31 | PASS | issue #806 § B1 (open sandbox.substrate vs sandbox.runtime selector); |
-| sandbox-boot-guard-ci | A | 2026-08-26 18:31 | PASS | issue #449 (sandbox image build CI guard) 2026-06-19 |
-| session-runner-ladder | A | 2026-08-26 18:31 | PASS | .oh/tasks/firstmate-executor/ (issue #746) — the shared herdr -> tmux -> foreground runner ladder and its safety gates |
-| skill-paths | A | 2026-08-26 18:31 | PASS | issue #43 — stale path references; extended by issue #69 — apps/->packages/ rename guard |
-| skills-dir-clean | A | 2026-08-26 18:31 | PASS | conversation 2026-06-29 — Pi parses every top-level `.md` in the skills |
-| skills-vendored | A | 2026-08-26 18:31 | PASS | absorb .mifune submodule into .oh — the skills/agents/hooks pack is vendored |
-| slack-admin-command-surface | A | 2026-08-26 18:31 | PASS | issue #354 — Slack bridge docs must distinguish Pi /msg-bridge commands from Slack DM admin text handlers |
-| spec-family-contract | A | 2026-08-26 18:31 | PASS | conversation 2026-06-19 (spec-* family split, issue #265); consolidated into /spec dispatcher 2026-06-23 (one skill, args); |
-| spec-ready-finalization | A | 2026-08-26 18:31 | PASS | issue #134 — the build path must finalize ready PRs after gates, not stop at a draft |
-| ste-checker-contract | A | 2026-08-26 18:31 | PASS | issue #750 PR audit — the /ste checker had four fail-open paths (unclosed |
-| submitted-by-trailers | A | 2026-08-26 18:31 | PASS | conversation 2026-06-12 (commit attribution trailers); repointed by |
-| sync-skill-contract | A | 2026-08-26 18:31 | PASS | issue #331 — /sync dispatcher skill (bidirectional origin↔upstream sync) |
-| tool-catalog-boundary | A | 2026-08-26 18:31 | PASS | agent-browser's exclusion from the harness catalog (#821) and the |
-| weigh-scorer-contract | A | 2026-08-26 18:31 | PASS | .oh/tasks/rlm-weighted-trajectories/prd.json US-003 (2026-06-27) |
-| wiki-readme-index | A | 2026-08-26 18:31 | PASS | issue #132 — wiki README index drift guard |
-| workflow-boundaries | A | 2026-08-26 18:31 | PASS | conversation 2026-06-19 (workflow consolidation, issue #259) |
+| ablate-state-machine | A | 2026-08-26 18:54 | PASS | issue #645 — one locked versioned ablation recovery owner |
+| advisor-monitored-loop | A | 2026-08-26 18:54 | PASS | conversation 2026-06-19 (issue #257); rewritten by spec-simplification US-002 |
+| agent-browser-cli | A | 2026-08-26 18:54 | PASS | retro lesson 2026-06-07 (agent-browser 0.8.5 CLI) |
+| artifact-contract-audit | A | 2026-08-26 18:54 | PASS | issue #583/#645 — production /audit implementation Gate 1 behavior |
+| audit-dispatcher-contract | A | 2026-08-26 18:54 | PASS | issue #645 — audit consolidation public taxonomy |
+| audit-implementation-behavior | A | 2026-08-26 18:54 | PASS | issue #645 — implementation root/repo/browser behavior |
+| audit-pr-acquire | A | 2026-08-26 18:54 | PASS | issue #645 — production PR acquisition behavior |
+| audit-pr-classifier | A | 2026-08-26 18:54 | PASS | issue #645 — deterministic focused and queue PR classifier |
+| audit-run-root-contract | A | 2026-08-26 18:54 | PASS | issue #645 — executable immutable audit root/run correlation |
+| audit-shellcheck-coverage | A | 2026-08-26 18:54 | PASS | issue #645 — private audit scripts require release and CI lint coverage |
+| audit-stale-references | A | 2026-08-26 18:54 | PASS | issue #645 — clean-breaking audit migration |
+| boot-lint-glob | A | 2026-08-26 18:54 | PASS | issue #90, issue #120 |
+| builder-skill-consolidation | A | 2026-08-26 18:54 | PASS | issue #643 — consolidate artifact builders behind one /builder dispatcher |
+| capability-benchmark-schema | A | 2026-08-26 18:54 | PASS | issue #167 — capability benchmark instrument |
+| cc-safety-net-wiring | A | 2026-08-26 18:54 | PASS | .oh/tasks/cc-safety-net/prd.json US-007 2026-07-19 |
+| changelog-entry-length | A | 2026-08-26 18:54 | PASS | conversation 2026-08-24 — CHANGELOG.md grew to 259KB of bullet prose because "one line" was unquantified |
+| cleanup-tasks-scoped-guard | A | 2026-08-26 18:54 | PASS | issue #85 |
+| cleanup-tasks-worktree-grooming | A | 2026-08-26 18:54 | PASS | issue #168; issue #327 |
+| codex-stale-response-retry | A | 2026-08-26 18:54 | PASS | issue #506 — Codex previous_response_not_found RCA |
+| compose-config-path-parity | A | 2026-08-26 18:54 | PASS | ? |
+| context-tier-size-budget | A | 2026-08-26 18:54 | PASS | .oh/tasks/spec-simplification/ (issue #816, US-007) — the always-on tier was 85,256 B |
+| cron-claude-codex-fallback | A | 2026-08-26 18:54 | PASS | conversation 2026-06-12 (default Codex fallback for crons) |
+| cron-watchdog | A | 2026-08-26 18:54 | PASS | issues #130/#453 (cron runtime watchdog + legacy system-cron reaping) 2026-06-19 |
+| curl-bash-safe-alternatives | A | 2026-08-26 18:54 | PASS | vet-run/vet integration — public curl|bash examples need review-first alternatives |
+| datasets-schema | A | 2026-08-26 18:54 | PASS | issue #196 — .oh/evals/datasets verifiable trajectory corpus (Repo2RLEnv-inspired) |
+| debugmcp-availability | A | 2026-08-26 18:54 | SKIPPED | issue #297 — DebugMCP MCP debug-server availability |
+| delegate-model-effort-policy | A | 2026-08-26 18:54 | PASS | conversation 2026-07-11 (delegate model inheritance and thinking policy) |
+| devtcp-hook | A | 2026-08-26 18:54 | PASS | retro lesson 2026-06-10 (zsh /dev/tcp) |
+| docker-inspect-env-guard | A | 2026-08-26 18:54 | PASS | operator directive 2026-08-08 (agents keep the docker socket, but must |
+| docs-build-fast-path | A | 2026-08-26 18:54 | PASS | #455 — docs builds must stay out of fast harness/eval/release gates; #536 — docs site externalized to openharness-web; docs markdown relocated to .oh/docs/ |
+| drift-check-cron-staleness-glob | A | 2026-08-26 18:54 | PASS | issue #98; issue #225 (restart-required cron frontmatter/config drift) |
+| entrypoint-pnpm-manifest-fingerprint | A | 2026-08-26 18:54 | PASS | issue #521 (manifest-aware sandbox installs) 2026-07-01 |
+| env-schema-parity | A | 2026-08-26 18:54 | PASS | ? |
+| eval-ci-gate | A | 2026-08-26 18:54 | PASS | #103 — eval probe suite gated in CI |
+| eval-gate | A | 2026-08-26 18:54 | PASS | retro lesson 2026-06-11 (eval-gate) |
+| eval-results-atomic | A | 2026-08-26 18:54 | PASS | issue #83 (eval-results-atomic-write) |
+| eval-runner-exit | A | 2026-08-26 18:54 | PASS | retro lesson 2026-06-11 (eval-runner-exit) #29 |
+| eval-runs-once-per-cycle | A | 2026-08-26 18:54 | PASS | .oh/tasks/spec-simplification/ (issue #816, US-006) — /eval ran 3x per cycle on the |
+| execution-target-contract | A | 2026-08-26 18:54 | PASS | issue #733 (ExecutionTarget contract + Docker Compose adapter) 2026-08-10 |
+| executor-kill-clears-session | A | 2026-08-26 18:54 | PASS | .oh/tasks/spec-simplification/ (issue #816, US-002) — OBSERVED 2026-08-23: |
+| executor-launch-interactive | A | 2026-08-26 18:54 | PASS | .oh/tasks/spec-simplification/ (issue #816, US-002) — OBSERVED 2026-08-23: the build |
+| firstmate-executor-contract | A | 2026-08-26 18:54 | PASS | .oh/tasks/spec-simplification/ (issue #816, US-002) — one build executor, no toggle |
+| get-oh-bootstrap | A | 2026-08-26 18:54 | PASS | get-oh.sh bootstrap — the Node-bootstrapping host-side path to the standalone `oh` CLI (also on npm as @mifune/openharness; see oh-npm-package.sh) |
+| git-skill | A | 2026-08-26 18:54 | PASS | conversation 2026-06-15 — rules are not always supported; git workflow must be the /git skill |
+| harness-audit-empty-output-gate | A | 2026-08-26 18:54 | PASS | issue #246 — /audit harness must fail closed on empty auditor outputs |
+| harness-ci-core-paths | A | 2026-08-26 18:54 | PASS | #165 — core sandbox config files must trigger harness CI |
+| harness-ci-hooks-paths | A | 2026-08-26 18:54 | PASS | issue #202 — credential/security hook changes must trigger harness CI |
+| harness-yaml-migration | A | 2026-08-26 18:54 | PASS | ? |
+| health-check-docker-stats | A | 2026-08-26 18:54 | PASS | retro lesson 2026-06-10 (docker stats vs ps Size) |
+| health-check-socket-degrade | A | 2026-08-26 18:54 | PASS | issue #762 (refs #756) — /health-check degrades to one statement, not nine failures |
+| heartbeat-logging-contract | A | 2026-08-26 18:54 | PASS | issue #447 (heartbeat log append hardening) 2026-06-18 |
+| make-oh-lifecycle-parity | A | 2026-08-26 18:54 | PASS | the Makefile/oh surface-gap consolidation — two front doors onto |
+| markitdown-wiki-ingest | A | 2026-08-26 18:54 | PASS | issue #649 — pinned local-document normalization contract for /wiki ingest |
+| next-dev-prod | A | 2026-08-26 18:54 | SKIPPED | retro lesson 2026-06-04 |
+| oh-devcontainer-restructure | A | 2026-08-26 18:54 | PASS | consolidate devcontainer — .oh/devcontainer/ folded back into .devcontainer/ |
+| oh-image-only-deploy | A | 2026-08-26 18:54 | PASS | .oh/tasks/image-only-deploy/prd.json US-004 (issue #609, Flavor B image-only deploy) |
+| oh-init-headless-config | A | 2026-08-26 18:54 | SKIPPED | ? |
+| oh-init-scaffold | A | 2026-08-26 18:54 | PASS | issue #531 Phase 2 |
+| oh-npm-package | A | 2026-08-26 18:54 | PASS | npm publish path for the standalone `oh` CLI (@mifune/openharness) — alternative to get-oh.sh |
+| oh-payload-manifest | A | 2026-08-26 18:54 | PASS | issue #531 follow-on (.oh payload manifest — oh update ships a declared allowlist) |
+| oh-sandbox-image-mode | A | 2026-08-26 18:54 | PASS | conversation 2026-07-05 (basic Docker deployment — prebuilt-image mode) |
+| oh-shipped-repo-overridable | A | 2026-08-26 18:54 | PASS | issue #531 follow-on (de-hardcode residual — shipped .oh shell scripts keep the upstream repo overridable) |
+| oh-standalone-lifecycle | A | 2026-08-26 18:54 | PASS | issue #564 |
+| oh-update | A | 2026-08-26 18:54 | PASS | issue #531 Phase 3 (oh update — upgrade only the .oh control plane) |
+| operator-config-guard | A | 2026-08-26 18:54 | PASS | operator directives 2026-08-06 (.config/ and settings.local.json are operator-only) |
+| pnpm-audit-ci-gate | A | 2026-08-26 18:54 | PASS | issue #171 — pnpm security audits must run in CI |
+| post-bridge-publish-confirmation | A | 2026-08-26 18:54 | PASS | #523 — post-bridge live publishing requires an explicit final confirmation gate |
+| prd-output-path-contract | A | 2026-08-26 18:54 | PASS | retro lesson 2026-06-19 |
+| project-root-seam | A | 2026-08-26 18:54 | PASS | issue #531 Phase 1 (OH_PROJECT_ROOT project-root seam) 2026-06-26 |
+| prompt-miner-schema-compat | A | 2026-08-26 18:54 | PASS | issue #253 — prompt-miner JSONL schema-drift guard |
+| prompt-miner-symlink-entrypoint | A | 2026-08-26 18:54 | PASS | issue #663 — prompt-miner engine no-ops via the documented .claude/skills symlink |
+| prompt-miner-weakness-record | A | 2026-08-26 18:54 | PASS | issue #580 — prompt-miner weakness-record (WH-xxx) cluster output |
+| protected-path-deletion | A | 2026-08-26 18:54 | PASS | .oh/tasks/spec-simplification/ (issue #816, US-001) — the critique gate was deleted, |
+| protected-paths-resolve | A | 2026-08-26 18:54 | PASS | issue #753 — .claude/protected-paths.txt named 7 paths that did not exist. |
+| registry-portability-gate | A | 2026-08-26 18:54 | PASS | issue #758 |
+| registry-portability | A | 2026-08-26 18:54 | SKIPPED | issue #758 |
+| repo-map-contract | A | 2026-08-26 18:54 | PASS | issue #464 — repo map must optimize orientation without adding a tree dependency or unmeasured performance claims |
+| retro-deterministic-contract | A | 2026-08-26 18:54 | PASS | issue #443 — /retro deterministic output and self-contained helper contract |
+| rl-delegation-write-worker | A | 2026-08-26 18:54 | PASS | retro lesson 2026-06-10 (rl-delegation) #57 |
+| rlm-context-budget | A | 2026-08-26 18:54 | PASS | .oh/tasks/rlm-weighted-trajectories/prd.json US-006 |
+| runtime-preflight-gate | A | 2026-08-26 18:54 | PASS | issue #806 § B1 (open sandbox.substrate vs sandbox.runtime selector); |
+| sandbox-boot-guard-ci | A | 2026-08-26 18:54 | PASS | issue #449 (sandbox image build CI guard) 2026-06-19 |
+| session-runner-ladder | A | 2026-08-26 18:54 | PASS | .oh/tasks/firstmate-executor/ (issue #746) — the shared herdr -> tmux -> foreground runner ladder and its safety gates |
+| skill-paths | A | 2026-08-26 18:54 | PASS | issue #43 — stale path references; extended by issue #69 — apps/->packages/ rename guard |
+| skills-dir-clean | A | 2026-08-26 18:54 | PASS | conversation 2026-06-29 — Pi parses every top-level `.md` in the skills |
+| skills-vendored | A | 2026-08-26 18:54 | PASS | absorb .mifune submodule into .oh — the skills/agents/hooks pack is vendored |
+| slack-admin-command-surface | A | 2026-08-26 18:54 | PASS | issue #354 — Slack bridge docs must distinguish Pi /msg-bridge commands from Slack DM admin text handlers |
+| spec-family-contract | A | 2026-08-26 18:54 | PASS | conversation 2026-06-19 (spec-* family split, issue #265); consolidated into /spec dispatcher 2026-06-23 (one skill, args); |
+| spec-ready-finalization | A | 2026-08-26 18:54 | PASS | issue #134 — the build path must finalize ready PRs after gates, not stop at a draft |
+| ste-checker-contract | A | 2026-08-26 18:54 | PASS | issue #750 PR audit — the /ste checker had four fail-open paths (unclosed |
+| submitted-by-trailers | A | 2026-08-26 18:54 | PASS | conversation 2026-06-12 (commit attribution trailers); repointed by |
+| sync-skill-contract | A | 2026-08-26 18:54 | PASS | issue #331 — /sync dispatcher skill (bidirectional origin↔upstream sync) |
+| tool-catalog-boundary | A | 2026-08-26 18:54 | PASS | agent-browser's exclusion from the harness catalog (#821) and the |
+| weigh-scorer-contract | A | 2026-08-26 18:54 | PASS | .oh/tasks/rlm-weighted-trajectories/prd.json US-003 (2026-06-27) |
+| wiki-readme-index | A | 2026-08-26 18:54 | PASS | issue #132 — wiki README index drift guard |
+| workflow-boundaries | A | 2026-08-26 18:54 | PASS | conversation 2026-06-19 (workflow consolidation, issue #259) |
 
 <!-- benchmark: pass-rate = PASS / (PASS + REGRESSION + TIMEOUT); SKIPPED excluded -->

--- a/.oh/evals/probes/audit-run-root-contract.sh
+++ b/.oh/evals/probes/audit-run-root-contract.sh
@@ -32,6 +32,11 @@ chmod +x "$tmp/complete-driver" "$tmp/.oh/skills/audit/scripts/audit-evidence.sh
 git -C "$tmp" init -q; git -C "$tmp" config user.email test@example.invalid; git -C "$tmp" config user.name test
 git -C "$tmp" add .; git -C "$tmp" commit -qm init
 fail(){ echo "REGRESSION: $*" >&2; exit 1; }
+still_running(){
+  local st
+  st=$(ps -o stat= -p "$1" 2>/dev/null | tr -d '[:space:]')
+  [[ -n $st && ${st#Z} == "$st" ]]
+}
 export TMPDIR="$tmpdir"
 # Invalid usage creates neither temp state nor log.
 set +e; usage_out=$(CRON_WORKTREE="$tmp" CRON_LOG_ROOT="$tmp" bash "$RUN" nope 2>&1); usage_rc=$?; set -e
@@ -143,7 +148,7 @@ for sig in INT TERM HUP; do
   set +e; wait "$wrapper"; signal_rc=$?; set -e
   expected=$((128 + $(kill -l "$sig")))
   [[ $signal_rc -eq $expected && -f "$tmp/${sig,,}-seen" ]] || fail "$sig not propagated/interrupted rc wrong"
-  for pid in "$driver_pid" "$grandchild_pid"; do kill -0 "$pid" 2>/dev/null && fail "orphaned $sig route child $pid"; done
+  for pid in "$driver_pid" "$grandchild_pid"; do still_running "$pid" && fail "orphaned $sig route child $pid"; done
   rec_line=$(grep '^audit -- run-id=' "$tmp/sig-rec" | tail -1)
   [[ $rec_line == *state=interrupted* && $rec_line == *"exit=$expected"* ]] || fail "$sig interrupted lifecycle not reported nonzero"
 done
@@ -162,6 +167,6 @@ driver_pid=$(<"$tmp/pids-seen")
 kill -INT "$wrapper"
 set +e; wait "$wrapper"; signal_rc=$?; set -e
 [[ $signal_rc -eq 130 && -f "$tmp/int-seen" ]] || fail 'direct SIGINT not propagated/interrupted'
-kill -0 "$driver_pid" 2>/dev/null && fail 'direct route child survived SIGINT'
+still_running "$driver_pid" && fail 'direct route child survived SIGINT'
 [[ ! -e "$tmp/.oh/logs" ]] || fail 'the run reported into a file instead of stderr'
 echo 'PASS: executable audit evidence/root/run-record/argument/INT/TERM/HUP contract' >&2


### PR DESCRIPTION
## The bug

`audit-run-root-contract.sh` asserted "no orphaned route child" with `kill -0`, which returns **success for a zombie** — a process that is already dead but not yet reaped.

The signal fixture spawns a grandchild that deliberately ignores INT/TERM, to prove `audit-run.sh`'s escalation ladder reaps it anyway. Traced end to end:

- `setsid` does not fork, so `$!` **is** the session leader and the pgid is correct
- `kill -INT -PGID` reaches the whole group
- The driver exits; the grandchild survives INT and TERM **by design**
- `SIGKILL` is sent and **works** — the process dies

Then `ps` shows it as `ZN  [sleep] <defunct>`, reparented to PID 1. Dead, but unreaped.

```
pid=642   kill -0: SUCCEEDS   ps -o stat=: [ZN]
 642    1 ZN   [sleep] <defunct>
```

**Why it was green on CI and red in the sandbox.** GitHub runners have a reaping init, so the pid vanishes and the probe passes — CI run 33000262005 logged `audit-run-root-contract  PASS  REGRESSION->PASS`. This sandbox's PID 1 is `/init.krun` (a MicroSandbox microVM init) which does not reap: **749 zombies are currently parented to it**, unrelated to any probe. `.devcontainer/docker-compose.yml:94` requests `init: true`, but this execution environment is not that Docker path.

**`audit-run.sh` is correct and unchanged.** The escalation ladder does its job; the probe's liveness test did not.

## The fix

```bash
still_running(){
  local st
  st=$(ps -o stat= -p "$1" 2>/dev/null | tr -d '[:space:]')
  [[ -n $st && ${st#Z} == "$st" ]]
}
```

Empty `ps` output means fully reaped; a status beginning `Z` means dead-but-unreaped; anything else means running. Called as the **left operand of `&&`** at both sites, preserving the `set -e` safety the original `kill -0 ... && fail` shape relied on.

Two call sites: the INT/TERM/HUP loop and the `AUDIT_FORCE_DIRECT=1` fallback.

## Verification by rejection — both directions

The direction that matters is the second one: a "fix" that merely mutes the assertion would be worthless.

| Case | Before | After |
|---|---|---|
| Zombie (dead, unreaped) | ✗ false positive | ✓ passes |
| Escalation genuinely broken | ✗ fails | ✗ **still fails** |

For the second row I neutralized `terminate_child`'s `kill -TERM` and `kill -KILL`, re-ran the probe, and it failed with `REGRESSION: orphaned INT route child 1067`. `audit-run.sh` was then fully restored — `git diff --exit-code` on it is clean, and it is not in this PR's diff.

- Suite: **96 probes, 92 PASS / 0 REGRESSION / 4 SKIPPED** (was 91 PASS / 1 REGRESSION). First fully-green run.
- `eval-gate`, `eval-runner-exit`, `eval-ci-gate`, `eval-runs-once-per-cycle` all still PASS.
- Diff is exactly two files. `RESULTS.md`'s churn is the timestamp refresh `run.sh` writes on every run; I verified the only **status** change across all 96 rows is this probe's `REGRESSION → PASS`.

## Deliberately not in this PR

`run.sh:109` gates only on a `prior = PASS` transition, so a steady-red probe is invisible to CI. That looks like a hole, and it is **not** — it is deliberate policy, asserted by the tier-A `eval-gate.sh` probe and documented at `.oh/skills/spec/references/execute.md:283-286`: a probe already red on the base branch must not block a PR that did not cause it. Gating on the bare presence of a `REGRESSION` row would turn `eval-gate` red.

The genuine gap there is **reporting**, not gating — steady-red is never surfaced, which is how this probe survived two prior repair attempts (`d6a1c18c`, `a734c2b4`) while CI stayed green. That is a report-only change and belongs in its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
