### PR TITLE
fix: surface persistent-red probes in the eval summary

### DIFF
--- a/.oh/skills/eval/run.sh
+++ b/.oh/skills/eval/run.sh
@@ -74,6 +74,7 @@ RESULTS_ORIG=""
 now="$(date -u +'%Y-%m-%d %H:%M')"
 declare -A NEWROW
 regressions=()
+stuck=()
 ran=0
 
 shopt -s nullglob
@@ -108,6 +109,9 @@ for probe in "$PROBES_DIR"/*.sh; do
   # green->red is the recurrence signal; first run has no prior, so never fires
   if [ "$prior" = "PASS" ] && [ "$status" != "PASS" ] && [ "$status" != "SKIPPED" ]; then
     regressions+=("$id ($src): was PASS, now $status — ${reason:-no reason}")
+  fi
+  if [ "$status" != "PASS" ] && [ "$status" != "SKIPPED" ] && [ "$prior" != "PASS" ]; then
+    stuck+=("$id ($src): $status, delta=$delta — ${reason:-no reason}")
   fi
 
   NEWROW[$id]="| $id | $tier | $now | $status | $src |"
@@ -151,6 +155,10 @@ tmp=""
 if [ "${#regressions[@]}" -gt 0 ]; then
   echo "REGRESSIONS (${#regressions[@]}):"
   for r in "${regressions[@]}"; do echo "  - $r"; done
+fi
+if [ "${#stuck[@]}" -gt 0 ]; then
+  echo "PERSISTENT RED (${#stuck[@]}) — not gating, no green->red delta:"
+  for r in "${stuck[@]}"; do echo "  - $r"; done
 fi
 echo "ran $ran probe(s); wrote $RESULTS"
 if [ "${#regressions[@]}" -gt 0 ]; then exit 1; fi


### PR DESCRIPTION
## The gap

A probe that is red **without** a green→red delta never enters `regressions[]`, so it never gates. That is deliberate — `eval-gate.sh` (tier A) asserts the gate keys on the delta and the runner's exit code, *never* on the bare presence of a `REGRESSION` row, and `.oh/skills/spec/references/execute.md:283` explains why: a probe already red on the base must not block a PR that did not cause it.

**That policy is correct and this PR does not touch it.**

The actual gap is that such a probe was also never *mentioned*. `audit-run-root-contract` sat red through two repair attempts (`d6a1c18c`, `a734c2b4`) while every run printed a clean summary and exited 0. The `run.sh:108` comment — *"first run has no prior, so never fires"* — describes the gating rule, but nothing ever told the operator a red row was sitting there.

## The change

`run.sh` collects those rows into `stuck[]` and prints a `PERSISTENT RED` section after `REGRESSIONS`. Eight added lines, one file. **The exit contract is untouched — only `regressions[]` gates.**

The two buckets are disjoint by construction: `regressions[]` requires `prior = PASS`, `stuck[]` requires `prior != PASS`.

## Verification by rejection

With a temporary always-red fixture probe:

| Case | Reported under | Exit |
|---|---|---|
| Born red (`prior` empty, `delta=new-fail`) | `PERSISTENT RED` | 0 |
| Steady red (`prior=REGRESSION`, `delta=unchanged`) | `PERSISTENT RED` | 0 |
| A PASS probe forced red (`delta=PASS->REGRESSION`) | `REGRESSIONS` | **1** |

The third row is the one that matters: a real regression still gates, still exits 1, and produced **no** `PERSISTENT RED` line — the new bucket cannot swallow a genuine failure.

Observed output:

```
PERSISTENT RED (1) — not gating, no green->red delta:
  - zz-temp-red-fixture (temporary rejection fixture): REGRESSION, delta=unchanged — REGRESSION: deliberately red fixture
ran 97 probe(s); wrote .oh/evals/RESULTS.md
```

Fixture removed. `eval-gate`, `eval-runner-exit`, `eval-ci-gate` and `eval-runs-once-per-cycle` all still PASS.

**One non-obvious constraint:** `eval-runner-exit` reads `tail -n 12` of `run.sh` and requires the `regressions[@] … -gt 0 … exit 1` guard to stay co-located at the exit point. The new block is placed *above* that guard so the window still matches — verified explicitly.

## Diff scope

One file. `RESULTS.md` is deliberately **not** included: running the suite rewrites every row's timestamp, and no status changed, so committing it would be pure noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
