### PR TITLE
FROM feat/841-close-issues-on-development TO development

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,28 @@
+<!--
+Title format (literal): FROM <source-branch> TO <target-branch>
+Example:                FROM feat/42-slack-thread-replies TO development
+-->
+
+Closes #<issue-number>
+
+<!--
+Put a closing keyword — Closes, Fixes or Resolves — in this body or in the title,
+one per issue. When this PR merges into `development`, the
+`close-issues-on-development` workflow closes each referenced issue as completed.
+A bare `#42` links the issue but does not close it.
+-->
+
+## Summary
+
+<!-- What changed, and why. Rationale and rejected alternatives belong here. -->
+
+## Verification
+
+<!-- The commands you ran and what they proved. -->
+
+## Checklist
+
+- [ ] Base branch is `development`
+- [ ] Title is `FROM <source-branch> TO <target-branch>`
+- [ ] Closing keyword links every issue this PR completes
+- [ ] `CHANGELOG.md` has an `## [Unreleased]` entry, or this is a pure chore

--- a/.github/workflows/close-issues-on-development.yml
+++ b/.github/workflows/close-issues-on-development.yml
@@ -1,0 +1,108 @@
+name: "Close linked issues on development merge"
+
+# GitHub applies a closing keyword automatically only when a pull request merges
+# into the repository default branch. The default branch here is `main` and every
+# pull request targets `development`, so `Closes #N` never fires on its own. This
+# workflow closes those issues instead, and leaves the default branch alone.
+#
+# The trigger is `pull_request_target`, not `pull_request`: a `pull_request` run
+# started by a fork receives a read-only token, so `issues: write` would be
+# unusable and a fork pull request would never close its issue.
+# `pull_request_target` runs the base-branch workflow with a writable token.
+# The usual `pull_request_target` hazard is running untrusted head-branch code.
+# This workflow never does that: `actions/checkout` takes its default ref, which
+# is the base branch, and the only author-controlled values (the title and the
+# body) reach the script through `env` as plain strings.
+
+on:
+  pull_request_target:
+    types:
+      - closed
+    branches:
+      - development
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: close-issues-on-development-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  close-linked-issues:
+    name: Close referenced issues
+    # A pull request that closes without merging must not close any issue.
+    if: github.event.pull_request.merged == true
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
+
+    steps:
+      - name: Checkout base branch
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Close each referenced issue
+        uses: actions/github-script@v7
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        with:
+          script: |
+            const path = require("path");
+            const { pathToFileURL } = require("url");
+            const parserPath = path.join(
+              process.env.GITHUB_WORKSPACE,
+              ".oh",
+              "scripts",
+              "closing-keywords.mjs",
+            );
+            const { parseClosingRefs } = await import(pathToFileURL(parserPath).href);
+
+            const [owner, repo] = process.env.GITHUB_REPOSITORY.split("/");
+            const prNumber = Number(process.env.PR_NUMBER);
+            if (!Number.isSafeInteger(prNumber) || prNumber <= 0) {
+              throw new Error(`invalid pull request number: ${process.env.PR_NUMBER}`);
+            }
+
+            const issueNumbers = parseClosingRefs(process.env.PR_TITLE, process.env.PR_BODY);
+            if (issueNumbers.length === 0) {
+              core.info(`PR #${prNumber} carries no closing keyword. Nothing to close.`);
+              return;
+            }
+            core.info(`PR #${prNumber} references: ${issueNumbers.map((n) => `#${n}`).join(", ")}`);
+
+            // One bad reference must not hide the rest, so collect the failures
+            // and report them after every issue has had its turn.
+            const failures = [];
+
+            for (const issue_number of issueNumbers) {
+              try {
+                const { data: issue } = await github.rest.issues.get({ owner, repo, issue_number });
+
+                if (issue.pull_request) {
+                  core.info(`Skipping #${issue_number}: it is a pull request, not an issue.`);
+                  continue;
+                }
+                if (issue.state === "closed") {
+                  core.info(`Skipping #${issue_number}: already closed.`);
+                  continue;
+                }
+
+                await github.rest.issues.update({
+                  owner,
+                  repo,
+                  issue_number,
+                  state: "closed",
+                  state_reason: "completed",
+                });
+                core.info(`Closed #${issue_number} as completed (merged in #${prNumber}).`);
+              } catch (error) {
+                failures.push(`#${issue_number}: ${error.message}`);
+              }
+            }
+
+            if (failures.length > 0) {
+              throw new Error(`failed to close ${failures.length} issue(s): ${failures.join("; ")}`);
+            }

--- a/.oh/docs/contributing.md
+++ b/.oh/docs/contributing.md
@@ -142,11 +142,20 @@ Example:
 FROM feat/42-slack-thread-replies TO development
 ```
 
-Link the issue in the body:
+Link the issue in the title or the body with a closing keyword:
 
 ```
 Closes #42
 ```
+
+`Closes`, `Fixes` and `Resolves` all work, and each grammatical variant works
+(`Closed`, `Fixed`, `Resolved`). List every issue the pull request completes —
+one keyword per issue. A bare `#42` links the issue but does not close it.
+
+When the pull request merges into `development`, the workflow
+[`.github/workflows/close-issues-on-development.yml`](../../.github/workflows/close-issues-on-development.yml)
+closes each referenced issue as `completed`. Closing the pull request without
+merging it closes no issue.
 
 Create the PR:
 

--- a/.oh/evals/RESULTS.md
+++ b/.oh/evals/RESULTS.md
@@ -6,101 +6,102 @@ probe id; git history is the time series.** Schema and exit-code semantics are i
 
 | probe | tier | last-run (UTC) | status | source |
 |-------|------|----------------|--------|--------|
-| ablate-state-machine | A | 2026-08-26 18:54 | PASS | issue #645 — one locked versioned ablation recovery owner |
-| advisor-monitored-loop | A | 2026-08-26 18:54 | PASS | conversation 2026-06-19 (issue #257); rewritten by spec-simplification US-002 |
-| agent-browser-cli | A | 2026-08-26 18:54 | PASS | retro lesson 2026-06-07 (agent-browser 0.8.5 CLI) |
-| artifact-contract-audit | A | 2026-08-26 18:54 | PASS | issue #583/#645 — production /audit implementation Gate 1 behavior |
-| audit-dispatcher-contract | A | 2026-08-26 18:54 | PASS | issue #645 — audit consolidation public taxonomy |
-| audit-implementation-behavior | A | 2026-08-26 18:54 | PASS | issue #645 — implementation root/repo/browser behavior |
-| audit-pr-acquire | A | 2026-08-26 18:54 | PASS | issue #645 — production PR acquisition behavior |
-| audit-pr-classifier | A | 2026-08-26 18:54 | PASS | issue #645 — deterministic focused and queue PR classifier |
-| audit-run-root-contract | A | 2026-08-26 18:54 | PASS | issue #645 — executable immutable audit root/run correlation |
-| audit-shellcheck-coverage | A | 2026-08-26 18:54 | PASS | issue #645 — private audit scripts require release and CI lint coverage |
-| audit-stale-references | A | 2026-08-26 18:54 | PASS | issue #645 — clean-breaking audit migration |
-| boot-lint-glob | A | 2026-08-26 18:54 | PASS | issue #90, issue #120 |
-| builder-skill-consolidation | A | 2026-08-26 18:54 | PASS | issue #643 — consolidate artifact builders behind one /builder dispatcher |
-| capability-benchmark-schema | A | 2026-08-26 18:54 | PASS | issue #167 — capability benchmark instrument |
-| cc-safety-net-wiring | A | 2026-08-26 18:54 | PASS | .oh/tasks/cc-safety-net/prd.json US-007 2026-07-19 |
-| changelog-entry-length | A | 2026-08-26 18:54 | PASS | conversation 2026-08-24 — CHANGELOG.md grew to 259KB of bullet prose because "one line" was unquantified |
-| cleanup-tasks-scoped-guard | A | 2026-08-26 18:54 | PASS | issue #85 |
-| cleanup-tasks-worktree-grooming | A | 2026-08-26 18:54 | PASS | issue #168; issue #327 |
-| codex-stale-response-retry | A | 2026-08-26 18:54 | PASS | issue #506 — Codex previous_response_not_found RCA |
-| compose-config-path-parity | A | 2026-08-26 18:54 | PASS | ? |
-| context-tier-size-budget | A | 2026-08-26 18:54 | PASS | .oh/tasks/spec-simplification/ (issue #816, US-007) — the always-on tier was 85,256 B |
-| cron-claude-codex-fallback | A | 2026-08-26 18:54 | PASS | conversation 2026-06-12 (default Codex fallback for crons) |
-| cron-watchdog | A | 2026-08-26 18:54 | PASS | issues #130/#453 (cron runtime watchdog + legacy system-cron reaping) 2026-06-19 |
-| curl-bash-safe-alternatives | A | 2026-08-26 18:54 | PASS | vet-run/vet integration — public curl|bash examples need review-first alternatives |
-| datasets-schema | A | 2026-08-26 18:54 | PASS | issue #196 — .oh/evals/datasets verifiable trajectory corpus (Repo2RLEnv-inspired) |
-| debugmcp-availability | A | 2026-08-26 18:54 | SKIPPED | issue #297 — DebugMCP MCP debug-server availability |
-| delegate-model-effort-policy | A | 2026-08-26 18:54 | PASS | conversation 2026-07-11 (delegate model inheritance and thinking policy) |
-| devtcp-hook | A | 2026-08-26 18:54 | PASS | retro lesson 2026-06-10 (zsh /dev/tcp) |
-| docker-inspect-env-guard | A | 2026-08-26 18:54 | PASS | operator directive 2026-08-08 (agents keep the docker socket, but must |
-| docs-build-fast-path | A | 2026-08-26 18:54 | PASS | #455 — docs builds must stay out of fast harness/eval/release gates; #536 — docs site externalized to openharness-web; docs markdown relocated to .oh/docs/ |
-| drift-check-cron-staleness-glob | A | 2026-08-26 18:54 | PASS | issue #98; issue #225 (restart-required cron frontmatter/config drift) |
-| entrypoint-pnpm-manifest-fingerprint | A | 2026-08-26 18:54 | PASS | issue #521 (manifest-aware sandbox installs) 2026-07-01 |
-| env-schema-parity | A | 2026-08-26 18:54 | PASS | ? |
-| eval-ci-gate | A | 2026-08-26 18:54 | PASS | #103 — eval probe suite gated in CI |
-| eval-gate | A | 2026-08-26 18:54 | PASS | retro lesson 2026-06-11 (eval-gate) |
-| eval-results-atomic | A | 2026-08-26 18:54 | PASS | issue #83 (eval-results-atomic-write) |
-| eval-runner-exit | A | 2026-08-26 18:54 | PASS | retro lesson 2026-06-11 (eval-runner-exit) #29 |
-| eval-runs-once-per-cycle | A | 2026-08-26 18:54 | PASS | .oh/tasks/spec-simplification/ (issue #816, US-006) — /eval ran 3x per cycle on the |
-| execution-target-contract | A | 2026-08-26 18:54 | PASS | issue #733 (ExecutionTarget contract + Docker Compose adapter) 2026-08-10 |
-| executor-kill-clears-session | A | 2026-08-26 18:54 | PASS | .oh/tasks/spec-simplification/ (issue #816, US-002) — OBSERVED 2026-08-23: |
-| executor-launch-interactive | A | 2026-08-26 18:54 | PASS | .oh/tasks/spec-simplification/ (issue #816, US-002) — OBSERVED 2026-08-23: the build |
-| firstmate-executor-contract | A | 2026-08-26 18:54 | PASS | .oh/tasks/spec-simplification/ (issue #816, US-002) — one build executor, no toggle |
-| get-oh-bootstrap | A | 2026-08-26 18:54 | PASS | get-oh.sh bootstrap — the Node-bootstrapping host-side path to the standalone `oh` CLI (also on npm as @mifune/openharness; see oh-npm-package.sh) |
-| git-skill | A | 2026-08-26 18:54 | PASS | conversation 2026-06-15 — rules are not always supported; git workflow must be the /git skill |
-| harness-audit-empty-output-gate | A | 2026-08-26 18:54 | PASS | issue #246 — /audit harness must fail closed on empty auditor outputs |
-| harness-ci-core-paths | A | 2026-08-26 18:54 | PASS | #165 — core sandbox config files must trigger harness CI |
-| harness-ci-hooks-paths | A | 2026-08-26 18:54 | PASS | issue #202 — credential/security hook changes must trigger harness CI |
-| harness-yaml-migration | A | 2026-08-26 18:54 | PASS | ? |
-| health-check-docker-stats | A | 2026-08-26 18:54 | PASS | retro lesson 2026-06-10 (docker stats vs ps Size) |
-| health-check-socket-degrade | A | 2026-08-26 18:54 | PASS | issue #762 (refs #756) — /health-check degrades to one statement, not nine failures |
-| heartbeat-logging-contract | A | 2026-08-26 18:54 | PASS | issue #447 (heartbeat log append hardening) 2026-06-18 |
-| make-oh-lifecycle-parity | A | 2026-08-26 18:54 | PASS | the Makefile/oh surface-gap consolidation — two front doors onto |
-| markitdown-wiki-ingest | A | 2026-08-26 18:54 | PASS | issue #649 — pinned local-document normalization contract for /wiki ingest |
-| next-dev-prod | A | 2026-08-26 18:54 | SKIPPED | retro lesson 2026-06-04 |
-| oh-devcontainer-restructure | A | 2026-08-26 18:54 | PASS | consolidate devcontainer — .oh/devcontainer/ folded back into .devcontainer/ |
-| oh-image-only-deploy | A | 2026-08-26 18:54 | PASS | .oh/tasks/image-only-deploy/prd.json US-004 (issue #609, Flavor B image-only deploy) |
-| oh-init-headless-config | A | 2026-08-26 18:54 | SKIPPED | ? |
-| oh-init-scaffold | A | 2026-08-26 18:54 | PASS | issue #531 Phase 2 |
-| oh-npm-package | A | 2026-08-26 18:54 | PASS | npm publish path for the standalone `oh` CLI (@mifune/openharness) — alternative to get-oh.sh |
-| oh-payload-manifest | A | 2026-08-26 18:54 | PASS | issue #531 follow-on (.oh payload manifest — oh update ships a declared allowlist) |
-| oh-sandbox-image-mode | A | 2026-08-26 18:54 | PASS | conversation 2026-07-05 (basic Docker deployment — prebuilt-image mode) |
-| oh-shipped-repo-overridable | A | 2026-08-26 18:54 | PASS | issue #531 follow-on (de-hardcode residual — shipped .oh shell scripts keep the upstream repo overridable) |
-| oh-standalone-lifecycle | A | 2026-08-26 18:54 | PASS | issue #564 |
-| oh-update | A | 2026-08-26 18:54 | PASS | issue #531 Phase 3 (oh update — upgrade only the .oh control plane) |
-| operator-config-guard | A | 2026-08-26 18:54 | PASS | operator directives 2026-08-06 (.config/ and settings.local.json are operator-only) |
-| pnpm-audit-ci-gate | A | 2026-08-26 18:54 | PASS | issue #171 — pnpm security audits must run in CI |
-| post-bridge-publish-confirmation | A | 2026-08-26 18:54 | PASS | #523 — post-bridge live publishing requires an explicit final confirmation gate |
-| prd-output-path-contract | A | 2026-08-26 18:54 | PASS | retro lesson 2026-06-19 |
-| project-root-seam | A | 2026-08-26 18:54 | PASS | issue #531 Phase 1 (OH_PROJECT_ROOT project-root seam) 2026-06-26 |
-| prompt-miner-schema-compat | A | 2026-08-26 18:54 | PASS | issue #253 — prompt-miner JSONL schema-drift guard |
-| prompt-miner-symlink-entrypoint | A | 2026-08-26 18:54 | PASS | issue #663 — prompt-miner engine no-ops via the documented .claude/skills symlink |
-| prompt-miner-weakness-record | A | 2026-08-26 18:54 | PASS | issue #580 — prompt-miner weakness-record (WH-xxx) cluster output |
-| protected-path-deletion | A | 2026-08-26 18:54 | PASS | .oh/tasks/spec-simplification/ (issue #816, US-001) — the critique gate was deleted, |
-| protected-paths-resolve | A | 2026-08-26 18:54 | PASS | issue #753 — .claude/protected-paths.txt named 7 paths that did not exist. |
-| registry-portability-gate | A | 2026-08-26 18:54 | PASS | issue #758 |
-| registry-portability | A | 2026-08-26 18:54 | SKIPPED | issue #758 |
-| repo-map-contract | A | 2026-08-26 18:54 | PASS | issue #464 — repo map must optimize orientation without adding a tree dependency or unmeasured performance claims |
-| retro-deterministic-contract | A | 2026-08-26 18:54 | PASS | issue #443 — /retro deterministic output and self-contained helper contract |
-| rl-delegation-write-worker | A | 2026-08-26 18:54 | PASS | retro lesson 2026-06-10 (rl-delegation) #57 |
-| rlm-context-budget | A | 2026-08-26 18:54 | PASS | .oh/tasks/rlm-weighted-trajectories/prd.json US-006 |
-| runtime-preflight-gate | A | 2026-08-26 18:54 | PASS | issue #806 § B1 (open sandbox.substrate vs sandbox.runtime selector); |
-| sandbox-boot-guard-ci | A | 2026-08-26 18:54 | PASS | issue #449 (sandbox image build CI guard) 2026-06-19 |
-| session-runner-ladder | A | 2026-08-26 18:54 | PASS | .oh/tasks/firstmate-executor/ (issue #746) — the shared herdr -> tmux -> foreground runner ladder and its safety gates |
-| skill-paths | A | 2026-08-26 18:54 | PASS | issue #43 — stale path references; extended by issue #69 — apps/->packages/ rename guard |
-| skills-dir-clean | A | 2026-08-26 18:54 | PASS | conversation 2026-06-29 — Pi parses every top-level `.md` in the skills |
-| skills-vendored | A | 2026-08-26 18:54 | PASS | absorb .mifune submodule into .oh — the skills/agents/hooks pack is vendored |
-| slack-admin-command-surface | A | 2026-08-26 18:54 | PASS | issue #354 — Slack bridge docs must distinguish Pi /msg-bridge commands from Slack DM admin text handlers |
-| spec-family-contract | A | 2026-08-26 18:54 | PASS | conversation 2026-06-19 (spec-* family split, issue #265); consolidated into /spec dispatcher 2026-06-23 (one skill, args); |
-| spec-ready-finalization | A | 2026-08-26 18:54 | PASS | issue #134 — the build path must finalize ready PRs after gates, not stop at a draft |
-| ste-checker-contract | A | 2026-08-26 18:54 | PASS | issue #750 PR audit — the /ste checker had four fail-open paths (unclosed |
-| submitted-by-trailers | A | 2026-08-26 18:54 | PASS | conversation 2026-06-12 (commit attribution trailers); repointed by |
-| sync-skill-contract | A | 2026-08-26 18:54 | PASS | issue #331 — /sync dispatcher skill (bidirectional origin↔upstream sync) |
-| tool-catalog-boundary | A | 2026-08-26 18:54 | PASS | agent-browser's exclusion from the harness catalog (#821) and the |
-| weigh-scorer-contract | A | 2026-08-26 18:54 | PASS | .oh/tasks/rlm-weighted-trajectories/prd.json US-003 (2026-06-27) |
-| wiki-readme-index | A | 2026-08-26 18:54 | PASS | issue #132 — wiki README index drift guard |
-| workflow-boundaries | A | 2026-08-26 18:54 | PASS | conversation 2026-06-19 (workflow consolidation, issue #259) |
+| ablate-state-machine | A | 2026-08-26 20:01 | PASS | issue #645 — one locked versioned ablation recovery owner |
+| advisor-monitored-loop | A | 2026-08-26 20:01 | PASS | conversation 2026-06-19 (issue #257); rewritten by spec-simplification US-002 |
+| agent-browser-cli | A | 2026-08-26 20:01 | PASS | retro lesson 2026-06-07 (agent-browser 0.8.5 CLI) |
+| artifact-contract-audit | A | 2026-08-26 20:01 | PASS | issue #583/#645 — production /audit implementation Gate 1 behavior |
+| audit-dispatcher-contract | A | 2026-08-26 20:01 | PASS | issue #645 — audit consolidation public taxonomy |
+| audit-implementation-behavior | A | 2026-08-26 20:01 | PASS | issue #645 — implementation root/repo/browser behavior |
+| audit-pr-acquire | A | 2026-08-26 20:01 | PASS | issue #645 — production PR acquisition behavior |
+| audit-pr-classifier | A | 2026-08-26 20:01 | PASS | issue #645 — deterministic focused and queue PR classifier |
+| audit-run-root-contract | A | 2026-08-26 20:01 | PASS | issue #645 — executable immutable audit root/run correlation |
+| audit-shellcheck-coverage | A | 2026-08-26 20:01 | PASS | issue #645 — private audit scripts require release and CI lint coverage |
+| audit-stale-references | A | 2026-08-26 20:01 | PASS | issue #645 — clean-breaking audit migration |
+| boot-lint-glob | A | 2026-08-26 20:01 | PASS | issue #90, issue #120 |
+| builder-skill-consolidation | A | 2026-08-26 20:01 | PASS | issue #643 — consolidate artifact builders behind one /builder dispatcher |
+| capability-benchmark-schema | A | 2026-08-26 20:01 | PASS | issue #167 — capability benchmark instrument |
+| cc-safety-net-wiring | A | 2026-08-26 20:01 | PASS | .oh/tasks/cc-safety-net/prd.json US-007 2026-07-19 |
+| changelog-entry-length | A | 2026-08-26 20:01 | PASS | conversation 2026-08-24 — CHANGELOG.md grew to 259KB of bullet prose because "one line" was unquantified |
+| cleanup-tasks-scoped-guard | A | 2026-08-26 20:01 | PASS | issue #85 |
+| cleanup-tasks-worktree-grooming | A | 2026-08-26 20:01 | PASS | issue #168; issue #327 |
+| close-issues-on-development | A | 2026-08-26 20:01 | PASS | issue #841 (closing keywords never fire because the default branch is main) 2026-08-26 |
+| codex-stale-response-retry | A | 2026-08-26 20:01 | PASS | issue #506 — Codex previous_response_not_found RCA |
+| compose-config-path-parity | A | 2026-08-26 20:01 | PASS | ? |
+| context-tier-size-budget | A | 2026-08-26 20:01 | PASS | .oh/tasks/spec-simplification/ (issue #816, US-007) — the always-on tier was 85,256 B |
+| cron-claude-codex-fallback | A | 2026-08-26 20:01 | PASS | conversation 2026-06-12 (default Codex fallback for crons) |
+| cron-watchdog | A | 2026-08-26 20:01 | PASS | issues #130/#453 (cron runtime watchdog + legacy system-cron reaping) 2026-06-19 |
+| curl-bash-safe-alternatives | A | 2026-08-26 20:01 | PASS | vet-run/vet integration — public curl|bash examples need review-first alternatives |
+| datasets-schema | A | 2026-08-26 20:01 | PASS | issue #196 — .oh/evals/datasets verifiable trajectory corpus (Repo2RLEnv-inspired) |
+| debugmcp-availability | A | 2026-08-26 20:01 | SKIPPED | issue #297 — DebugMCP MCP debug-server availability |
+| delegate-model-effort-policy | A | 2026-08-26 20:01 | PASS | conversation 2026-07-11 (delegate model inheritance and thinking policy) |
+| devtcp-hook | A | 2026-08-26 20:01 | PASS | retro lesson 2026-06-10 (zsh /dev/tcp) |
+| docker-inspect-env-guard | A | 2026-08-26 20:01 | PASS | operator directive 2026-08-08 (agents keep the docker socket, but must |
+| docs-build-fast-path | A | 2026-08-26 20:01 | PASS | #455 — docs builds must stay out of fast harness/eval/release gates; #536 — docs site externalized to openharness-web; docs markdown relocated to .oh/docs/ |
+| drift-check-cron-staleness-glob | A | 2026-08-26 20:01 | PASS | issue #98; issue #225 (restart-required cron frontmatter/config drift) |
+| entrypoint-pnpm-manifest-fingerprint | A | 2026-08-26 20:01 | PASS | issue #521 (manifest-aware sandbox installs) 2026-07-01 |
+| env-schema-parity | A | 2026-08-26 20:01 | PASS | ? |
+| eval-ci-gate | A | 2026-08-26 20:01 | PASS | #103 — eval probe suite gated in CI |
+| eval-gate | A | 2026-08-26 20:01 | PASS | retro lesson 2026-06-11 (eval-gate) |
+| eval-results-atomic | A | 2026-08-26 20:01 | PASS | issue #83 (eval-results-atomic-write) |
+| eval-runner-exit | A | 2026-08-26 20:01 | PASS | retro lesson 2026-06-11 (eval-runner-exit) #29 |
+| eval-runs-once-per-cycle | A | 2026-08-26 20:01 | PASS | .oh/tasks/spec-simplification/ (issue #816, US-006) — /eval ran 3x per cycle on the |
+| execution-target-contract | A | 2026-08-26 20:01 | PASS | issue #733 (ExecutionTarget contract + Docker Compose adapter) 2026-08-10 |
+| executor-kill-clears-session | A | 2026-08-26 20:01 | PASS | .oh/tasks/spec-simplification/ (issue #816, US-002) — OBSERVED 2026-08-23: |
+| executor-launch-interactive | A | 2026-08-26 20:01 | PASS | .oh/tasks/spec-simplification/ (issue #816, US-002) — OBSERVED 2026-08-23: the build |
+| firstmate-executor-contract | A | 2026-08-26 20:01 | PASS | .oh/tasks/spec-simplification/ (issue #816, US-002) — one build executor, no toggle |
+| get-oh-bootstrap | A | 2026-08-26 20:01 | PASS | get-oh.sh bootstrap — the Node-bootstrapping host-side path to the standalone `oh` CLI (also on npm as @mifune/openharness; see oh-npm-package.sh) |
+| git-skill | A | 2026-08-26 20:01 | PASS | conversation 2026-06-15 — rules are not always supported; git workflow must be the /git skill |
+| harness-audit-empty-output-gate | A | 2026-08-26 20:01 | PASS | issue #246 — /audit harness must fail closed on empty auditor outputs |
+| harness-ci-core-paths | A | 2026-08-26 20:01 | PASS | #165 — core sandbox config files must trigger harness CI |
+| harness-ci-hooks-paths | A | 2026-08-26 20:01 | PASS | issue #202 — credential/security hook changes must trigger harness CI |
+| harness-yaml-migration | A | 2026-08-26 20:01 | PASS | ? |
+| health-check-docker-stats | A | 2026-08-26 20:01 | PASS | retro lesson 2026-06-10 (docker stats vs ps Size) |
+| health-check-socket-degrade | A | 2026-08-26 20:01 | PASS | issue #762 (refs #756) — /health-check degrades to one statement, not nine failures |
+| heartbeat-logging-contract | A | 2026-08-26 20:01 | PASS | issue #447 (heartbeat log append hardening) 2026-06-18 |
+| make-oh-lifecycle-parity | A | 2026-08-26 20:01 | PASS | the Makefile/oh surface-gap consolidation — two front doors onto |
+| markitdown-wiki-ingest | A | 2026-08-26 20:01 | PASS | issue #649 — pinned local-document normalization contract for /wiki ingest |
+| next-dev-prod | A | 2026-08-26 20:01 | SKIPPED | retro lesson 2026-06-04 |
+| oh-devcontainer-restructure | A | 2026-08-26 20:01 | PASS | consolidate devcontainer — .oh/devcontainer/ folded back into .devcontainer/ |
+| oh-image-only-deploy | A | 2026-08-26 20:01 | PASS | .oh/tasks/image-only-deploy/prd.json US-004 (issue #609, Flavor B image-only deploy) |
+| oh-init-headless-config | A | 2026-08-26 20:01 | PASS | ? |
+| oh-init-scaffold | A | 2026-08-26 20:01 | PASS | issue #531 Phase 2 |
+| oh-npm-package | A | 2026-08-26 20:01 | PASS | npm publish path for the standalone `oh` CLI (@mifune/openharness) — alternative to get-oh.sh |
+| oh-payload-manifest | A | 2026-08-26 20:01 | PASS | issue #531 follow-on (.oh payload manifest — oh update ships a declared allowlist) |
+| oh-sandbox-image-mode | A | 2026-08-26 20:01 | PASS | conversation 2026-07-05 (basic Docker deployment — prebuilt-image mode) |
+| oh-shipped-repo-overridable | A | 2026-08-26 20:01 | PASS | issue #531 follow-on (de-hardcode residual — shipped .oh shell scripts keep the upstream repo overridable) |
+| oh-standalone-lifecycle | A | 2026-08-26 20:01 | PASS | issue #564 |
+| oh-update | A | 2026-08-26 20:01 | PASS | issue #531 Phase 3 (oh update — upgrade only the .oh control plane) |
+| operator-config-guard | A | 2026-08-26 20:01 | PASS | operator directives 2026-08-06 (.config/ and settings.local.json are operator-only) |
+| pnpm-audit-ci-gate | A | 2026-08-26 20:01 | PASS | issue #171 — pnpm security audits must run in CI |
+| post-bridge-publish-confirmation | A | 2026-08-26 20:01 | PASS | #523 — post-bridge live publishing requires an explicit final confirmation gate |
+| prd-output-path-contract | A | 2026-08-26 20:01 | PASS | retro lesson 2026-06-19 |
+| project-root-seam | A | 2026-08-26 20:01 | PASS | issue #531 Phase 1 (OH_PROJECT_ROOT project-root seam) 2026-06-26 |
+| prompt-miner-schema-compat | A | 2026-08-26 20:01 | PASS | issue #253 — prompt-miner JSONL schema-drift guard |
+| prompt-miner-symlink-entrypoint | A | 2026-08-26 20:01 | PASS | issue #663 — prompt-miner engine no-ops via the documented .claude/skills symlink |
+| prompt-miner-weakness-record | A | 2026-08-26 20:01 | PASS | issue #580 — prompt-miner weakness-record (WH-xxx) cluster output |
+| protected-path-deletion | A | 2026-08-26 20:01 | PASS | .oh/tasks/spec-simplification/ (issue #816, US-001) — the critique gate was deleted, |
+| protected-paths-resolve | A | 2026-08-26 20:01 | PASS | issue #753 — .claude/protected-paths.txt named 7 paths that did not exist. |
+| registry-portability-gate | A | 2026-08-26 20:01 | PASS | issue #758 |
+| registry-portability | A | 2026-08-26 20:01 | SKIPPED | issue #758 |
+| repo-map-contract | A | 2026-08-26 20:01 | PASS | issue #464 — repo map must optimize orientation without adding a tree dependency or unmeasured performance claims |
+| retro-deterministic-contract | A | 2026-08-26 20:01 | PASS | issue #443 — /retro deterministic output and self-contained helper contract |
+| rl-delegation-write-worker | A | 2026-08-26 20:01 | PASS | retro lesson 2026-06-10 (rl-delegation) #57 |
+| rlm-context-budget | A | 2026-08-26 20:01 | PASS | .oh/tasks/rlm-weighted-trajectories/prd.json US-006 |
+| runtime-preflight-gate | A | 2026-08-26 20:01 | PASS | issue #806 § B1 (open sandbox.substrate vs sandbox.runtime selector); |
+| sandbox-boot-guard-ci | A | 2026-08-26 20:01 | PASS | issue #449 (sandbox image build CI guard) 2026-06-19 |
+| session-runner-ladder | A | 2026-08-26 20:01 | PASS | .oh/tasks/firstmate-executor/ (issue #746) — the shared herdr -> tmux -> foreground runner ladder and its safety gates |
+| skill-paths | A | 2026-08-26 20:01 | PASS | issue #43 — stale path references; extended by issue #69 — apps/->packages/ rename guard |
+| skills-dir-clean | A | 2026-08-26 20:01 | PASS | conversation 2026-06-29 — Pi parses every top-level `.md` in the skills |
+| skills-vendored | A | 2026-08-26 20:01 | PASS | absorb .mifune submodule into .oh — the skills/agents/hooks pack is vendored |
+| slack-admin-command-surface | A | 2026-08-26 20:01 | PASS | issue #354 — Slack bridge docs must distinguish Pi /msg-bridge commands from Slack DM admin text handlers |
+| spec-family-contract | A | 2026-08-26 20:01 | PASS | conversation 2026-06-19 (spec-* family split, issue #265); consolidated into /spec dispatcher 2026-06-23 (one skill, args); |
+| spec-ready-finalization | A | 2026-08-26 20:01 | PASS | issue #134 — the build path must finalize ready PRs after gates, not stop at a draft |
+| ste-checker-contract | A | 2026-08-26 20:01 | PASS | issue #750 PR audit — the /ste checker had four fail-open paths (unclosed |
+| submitted-by-trailers | A | 2026-08-26 20:01 | PASS | conversation 2026-06-12 (commit attribution trailers); repointed by |
+| sync-skill-contract | A | 2026-08-26 20:01 | PASS | issue #331 — /sync dispatcher skill (bidirectional origin↔upstream sync) |
+| tool-catalog-boundary | A | 2026-08-26 20:01 | PASS | agent-browser's exclusion from the harness catalog (#821) and the |
+| weigh-scorer-contract | A | 2026-08-26 20:01 | PASS | .oh/tasks/rlm-weighted-trajectories/prd.json US-003 (2026-06-27) |
+| wiki-readme-index | A | 2026-08-26 20:01 | PASS | issue #132 — wiki README index drift guard |
+| workflow-boundaries | A | 2026-08-26 20:01 | PASS | conversation 2026-06-19 (workflow consolidation, issue #259) |
 
 <!-- benchmark: pass-rate = PASS / (PASS + REGRESSION + TIMEOUT); SKIPPED excluded -->

--- a/.oh/evals/probes/close-issues-on-development.sh
+++ b/.oh/evals/probes/close-issues-on-development.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# tier: A
+# source: issue #841 (closing keywords never fire because the default branch is main) 2026-08-26
+# desc: the development-merge issue closer must stay merged-only, development-only, and least-privilege.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+WORKFLOW="$ROOT/.github/workflows/close-issues-on-development.yml"
+PARSER="$ROOT/.oh/scripts/closing-keywords.mjs"
+
+if [[ ! -f "$WORKFLOW" ]]; then
+  echo "REGRESSION close-issues-on-development workflow missing" >&2
+  exit 1
+fi
+
+if [[ ! -f "$PARSER" ]]; then
+  echo "REGRESSION closing-keyword parser missing: .oh/scripts/closing-keywords.mjs" >&2
+  exit 1
+fi
+
+text="$(cat "$WORKFLOW")"
+missing=()
+
+has() { grep -Fq -- "$1" <<<"$text" || missing+=("$2"); }
+has_regex() { grep -Eq -- "$1" <<<"$text" || missing+=("$2"); }
+
+has_regex '^[[:space:]]*pull_request_target:[[:space:]]*$' "pull_request_target trigger"
+has_regex '^[[:space:]]*-[[:space:]]*closed[[:space:]]*$' "closed event type"
+has_regex '^[[:space:]]*-[[:space:]]*development[[:space:]]*$' "development branch filter"
+has 'if: github.event.pull_request.merged == true' "merged-only guard"
+has_regex '^[[:space:]]*contents:[[:space:]]*read[[:space:]]*$' "read-only contents permission"
+has_regex '^[[:space:]]*issues:[[:space:]]*write[[:space:]]*$' "issues write permission"
+has 'persist-credentials: false' "checkout token persistence disabled"
+has 'closing-keywords.mjs' "shared parser wired in"
+has 'state_reason: "completed"' "completed state reason"
+has 'PR_TITLE: ${{ github.event.pull_request.title }}' "title passed through env"
+has 'PR_BODY: ${{ github.event.pull_request.body }}' "body passed through env"
+
+# pull_request_target grants a writable token, so the workflow must never run
+# head-branch code. `actions/checkout` takes its default (base) ref: any explicit
+# head ref would turn this into an arbitrary-code-execution surface.
+if grep -Eq 'ref:[[:space:]]*\$\{\{[[:space:]]*github\.event\.pull_request\.head' <<<"$text"; then
+  echo "REGRESSION close-issues-on-development must not check out the pull request head ref" >&2
+  exit 1
+fi
+
+# Author-controlled strings must reach the script through env, never through
+# template interpolation inside the script body.
+if grep -Eq '^[[:space:]]+.*\$\{\{[[:space:]]*github\.event\.pull_request\.(title|body)' <<<"$(sed -n '/script: |/,$p' <<<"$text")"; then
+  echo "REGRESSION close-issues-on-development interpolates PR title/body into the script body" >&2
+  exit 1
+fi
+
+if grep -Eq 'permissions:[[:space:]]*write-all|contents:[[:space:]]*write|packages:[[:space:]]*write|pull-requests:[[:space:]]*write' <<<"$text"; then
+  echo "REGRESSION close-issues-on-development exceeds contents:read + issues:write" >&2
+  exit 1
+fi
+
+if (( ${#missing[@]} )); then
+  printf 'REGRESSION close-issues-on-development contract missing: %s\n' "${missing[*]}" >&2
+  exit 1
+fi
+
+echo "PASS close-issues-on-development closes referenced issues only on a merged development PR, under contents:read + issues:write" >&2
+exit 0

--- a/.oh/scripts/__tests__/closing-keywords.test.ts
+++ b/.oh/scripts/__tests__/closing-keywords.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const MODULE_PATH = path.join(__dirname, "..", "closing-keywords.mjs");
+
+const { parseClosingRefs } = (await import(MODULE_PATH)) as {
+  parseClosingRefs: (title?: string | null, body?: string | null) => number[];
+};
+
+describe("parseClosingRefs", () => {
+  it("reads a closing keyword from the title", () => {
+    expect(parseClosingRefs("Closes #841", "")).toEqual([841]);
+  });
+
+  it("reads a closing keyword from the body", () => {
+    expect(parseClosingRefs("FROM feat/841 TO development", "Closes #841")).toEqual([841]);
+  });
+
+  it.each([
+    "close",
+    "closes",
+    "closed",
+    "fix",
+    "fixes",
+    "fixed",
+    "resolve",
+    "resolves",
+    "resolved",
+  ])("accepts the keyword %s", (keyword) => {
+    expect(parseClosingRefs("", `${keyword} #42`)).toEqual([42]);
+  });
+
+  it("ignores keyword case", () => {
+    expect(parseClosingRefs("", "CLOSES #1\nReSoLvEd #2")).toEqual([1, 2]);
+  });
+
+  it("accepts a colon between the keyword and the reference", () => {
+    expect(parseClosingRefs("", "Closes: #5")).toEqual([5]);
+  });
+
+  it("returns every uniquely referenced issue", () => {
+    expect(parseClosingRefs("Closes #3", "Fixes #7\nResolves #11")).toEqual([3, 7, 11]);
+  });
+
+  it("deduplicates repeated references", () => {
+    expect(parseClosingRefs("Closes #9", "Fixes #9\nResolved: #9")).toEqual([9]);
+  });
+
+  it("ignores a bare issue reference", () => {
+    expect(parseClosingRefs("", "Related to #123 and #124")).toEqual([]);
+  });
+
+  it("ignores a cross-repository reference", () => {
+    expect(parseClosingRefs("", "Closes owner/repo#5")).toEqual([]);
+  });
+
+  it("ignores an issue URL", () => {
+    expect(parseClosingRefs("", "Closes https://github.com/mifunedev/openharness/issues/5")).toEqual(
+      [],
+    );
+  });
+
+  it("returns nothing when no keyword is present", () => {
+    expect(parseClosingRefs("FROM feat/x TO development", "Adds a workflow.")).toEqual([]);
+  });
+
+  it("returns nothing for empty input", () => {
+    expect(parseClosingRefs(null, undefined)).toEqual([]);
+  });
+
+  it("rejects issue number zero", () => {
+    expect(parseClosingRefs("", "Closes #0")).toEqual([]);
+  });
+
+  it("does not match a keyword glued to another word", () => {
+    expect(parseClosingRefs("", "pre-closes #5\nunfixes #6")).toEqual([]);
+  });
+});

--- a/.oh/scripts/closing-keywords.mjs
+++ b/.oh/scripts/closing-keywords.mjs
@@ -1,0 +1,39 @@
+// Parse GitHub closing keywords out of a pull request title and body.
+//
+// GitHub applies `Closes #N` automatically only when a pull request merges into the
+// repository default branch. This repository's default branch is `main` while every
+// pull request targets `development`, so the trailer never fires on its own. The
+// workflow `.github/workflows/close-issues-on-development.yml` closes the issues
+// instead, and it uses this module to decide which issues those are.
+//
+// This file holds no GitHub API calls so the parsing rules stay unit-testable.
+
+// The nine keywords GitHub honours, an optional colon, then a same-repository
+// issue reference. The lookbehind rejects `owner/repo#5` and `word-closes #5`, so
+// only issues in this repository match. A bare `#5` never matches: a keyword is
+// required.
+const CLOSING_REFERENCE =
+  /(?<![\w/-])(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s*:?\s+#(\d+)\b/gi;
+
+/**
+ * Extract the issue numbers a pull request asks to close.
+ *
+ * @param {string | null | undefined} title Pull request title.
+ * @param {string | null | undefined} body Pull request body.
+ * @returns {number[]} Unique issue numbers, ascending.
+ */
+export function parseClosingRefs(title, body) {
+  const text = [title, body].filter((part) => typeof part === "string").join("\n");
+  const found = new Set();
+
+  for (const match of text.matchAll(CLOSING_REFERENCE)) {
+    const number = Number(match[1]);
+    if (Number.isSafeInteger(number) && number > 0) {
+      found.add(number);
+    }
+  }
+
+  return [...found].sort((a, b) => a - b);
+}
+
+export default parseClosingRefs;

--- a/.oh/skills/git/SKILL.md
+++ b/.oh/skills/git/SKILL.md
@@ -71,16 +71,21 @@ Example: `FROM feat/42-slack-thread-replies TO development`
 
 ## PR Bodies
 
-- Link issue: `Closes #<issue#>` (or `Fixes`/`Resolves`)
+- Link issue: `Closes #<issue#>` (or `Fixes`/`Resolves`) in the PR title or body
 - Target default target branch (`development` → `main` → `master`, whichever exists)
 
-> **`Closes #N` does NOT auto-close the issue in this repo — close it by hand after every
-> merge.** GitHub honors a closing trailer only on merge into the **default** branch. PRs
-> here target `development` while the default branch is `main`, so the trailer registers as
-> a `referenced` timeline event and nothing else. Verified on #759 (whose `closed` event
-> carries `commit=none`) and independently on #753 from PR #757. Keep writing the trailer —
-> it is the machine-readable link a reader follows — but treat the close as a separate
-> manual step:
+> **`Closes #N` closes the issue on merge into `development` — the workflow does it, not
+> GitHub.** GitHub honors a closing trailer only on merge into the **default** branch. PRs
+> here target `development` while the default branch is `main`, so GitHub records the
+> trailer as a `referenced` timeline event and nothing else. Verified on #759 (whose
+> `closed` event carries `commit=none`) and independently on #753 from PR #757.
+> `.github/workflows/close-issues-on-development.yml` closes the gap: on a **merged** PR
+> into `development` it parses the title and body for the nine closing keywords and closes
+> each referenced issue as `completed` (#841).
+>
+> The trailer is therefore load-bearing — write it on every PR. Close by hand only when the
+> automation cannot see the merge (a direct push, a merge into another branch, or a PR whose
+> body carried no trailer):
 >
 > ```bash
 > gh issue close <N> --repo <owner/name> --comment "Merged in #<PR>."
@@ -281,5 +286,6 @@ Let `$BASE` = default target branch (detected per rule above).
 4. Commit with `<type>: <description>`
 5. `git push -u origin <branch>` → then `/ci-status` (if skill exists)
 6. `gh pr create --base $BASE --title "FROM <branch> TO $BASE" --body "Closes #<issue#>"`
-7. After the merge, **close the issue manually** — `Closes #N` does not fire when the PR
-   targets a non-default branch (see § PR Bodies): `gh issue close <issue#> --repo <owner/name>`
+7. After the merge, confirm the issue closed. The `close-issues-on-development` workflow
+   closes it from the `Closes #N` trailer (see § PR Bodies). If the merge bypassed a PR into
+   `development`, close it by hand: `gh issue close <issue#> --repo <owner/name>`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,21 @@ Update policy and release automation live in [`/git`](.claude/skills/git/SKILL.m
 - `ENV UV_PYTHON_INSTALL_DIR` and `ENV UV_CACHE_DIR` pin uv's managed-interpreter and cache trees under `/home/sandbox`, so nothing falls back to `/root`.
 - `ARG INSTALL_PYTHON_KERNEL=true` (with `ARG OH_PYTHON_VERSION=3.11`) bakes the interpreter and kernel venv into the image as `sandbox`, so a fresh boot needs no network.
 - The entrypoint re-runs the same idempotent script every boot behind `OH_PROVISION_PYTHON` (default `true`), non-fatally.
+- Close linked issues on merge into `development`: `.github/workflows/close-issues-on-development.yml` reads closing keywords from a merged PR and closes each issue ([#841](https://github.com/mifunedev/openharness/issues/841)).
+- Add `.github/pull_request_template.md` — title format, closing-keyword reminder, CHANGELOG checkbox ([#841](https://github.com/mifunedev/openharness/issues/841)).
+- Add the `close-issues-on-development` eval probe: the closer stays merged-only, development-only, and capped at `contents: read` + `issues: write` ([#841](https://github.com/mifunedev/openharness/issues/841)).
+
+### Removed
+- **Remove the `.oh/memory` tier entirely.** Code is the source of truth. The directory, its tracked `README.md`, the `MEMORY.md` ledger, and dated session logs are gone as a concept — not relocated.
+- **Remove file logging from the harness.** No skill, cron, or script writes a run log under `.oh/`. Runs report to the terminal; the only durable trail left is `.oh/crons/.cron.log`, the cron liveness line.
+- Remove the seeder `.oh/scripts/ensure-memory-file.sh`, its boot pre-create block, `MEMORY_DIR` from both compose files and both `.example.env` templates, and the `memory` name from `.oh/scripts/oh-path`.
+- Remove `AUDIT_LOG_ROOT` entirely. It existed only to resolve a shared log root, so `audit-run.sh` now validates and exports one root, and `route-driver.sh` scrubs one fewer variable.
+- Remove `.oh/skills/retro/references/memory-protocol.md`, `.oh/skills/retro/scripts/{render-log-entry.sh,memory-audit.py}`, and `.oh/skills/prompt-miner/scripts/render-log-entry.sh`.
+- Remove the Memory-Improvement-Protocol log step from 20 skills. `oh init` no longer seeds `.oh/memory/`.
+- Remove 9 eval probes whose subject no longer exists, plus the `probe-memory.md` context-ablation probe. See the PR body for the list.
+- **Remove the `workspace/` template directory.** It held two tracked files (`AGENTS.md` and a `CLAUDE.md` symlink) and never was the container's working directory — `workspaceFolder` is and stays the repo root.
+- Remove the Dockerfile `COPY workspace/`, the `workspace/**` CI path filters, the eight `workspace/*` gitignore rules, and the `workspace/README.md` stub `oh init` used to scaffold.
+- Remove the `workspace` scope from `/audit skills`; `all` now means the root scope alone.
 
 ### Changed
 - **`/retro` becomes report-only.** It keeps the scientific pass and promotes only to `.oh/context/IDENTITY.md` behind its propose-then-confirm gate. It writes no log.


### PR DESCRIPTION
Closes #841

## Problem

GitHub applies a closing trailer only when the pull request merges into the repository **default** branch. That branch is `main` here while every pull request targets `development`, so `Closes #N` registered as a `referenced` timeline event and the issue stayed open. `/git` encoded the workaround: "close it by hand after every merge."

## What this ships

`.github/workflows/close-issues-on-development.yml` — runs on a **closed** pull request against `development`, continues only when `merged == true`, reads the nine closing keywords from the title and the body, and closes each referenced issue with `state_reason: completed`. Permissions are `contents: read` + `issues: write` and nothing else.

Parsing lives in `.oh/scripts/closing-keywords.mjs`, not inline in the workflow, so vitest can prove every guardrail without a live merge.

`.oh/evals/probes/close-issues-on-development.sh` locks the contract so a later edit cannot quietly weaken it.

## Why `pull_request_target`, not `pull_request`

A `pull_request` run started from a fork receives a read-only token, so `issues: write` would be unusable and a fork pull request would never close its issue. `pull_request_target` runs the base-branch workflow with a writable token.

The usual `pull_request_target` hazard is running head-branch code. This workflow never does:

- `actions/checkout` takes its default ref, which is the **base** branch, with `persist-credentials: false`.
- The only author-controlled values — the title and the body — reach the script through `env` as plain strings, never interpolated into the script body.

The probe fails the build if either property is weakened, and rejects any escalation past `contents: read` + `issues: write`.

## Verification

| Check | Result |
|---|---|
| `vitest .oh/scripts/__tests__/closing-keywords.test.ts` | 22/22 pass |
| Full `vitest run` | 780 tests; the one `init.test.ts` failure was an RPC worker timeout under load and passes in isolation |
| `pnpm run typecheck` | clean |
| `bash .oh/skills/eval/run.sh` | 97 probes, 0 regressions |
| New probe mutation-tested | flipping `merged == true`, `issues: write`, and `persist-credentials: false` each fails it |
| Script body against a mocked octokit | merged / no-keyword / already-closed / reference-is-a-PR paths all behave |

## Acceptance criteria

- [x] `Closes #<open issue>` in the title or body closes that issue on merge into `development`
- [x] `Fixes` and `Resolves` behave equivalently (all nine keyword variants covered)
- [x] Multiple references close every uniquely referenced issue (deduplicated)
- [x] Closing an unmerged PR closes nothing — `if: github.event.pull_request.merged == true`
- [x] Merging without a closing keyword closes nothing
- [x] A PR into another branch does not trigger the workflow — `branches: [development]`
- [x] Issues close with the `completed` state reason
- [x] Permissions limited to `contents: read` + `issues: write`
- [x] Contributor documentation and a new PR template tell authors where to put the keyword
- [x] Default branch unchanged
- [x] A bare `#123` is not a closing instruction; `owner/repo#5` is out of scope

## Left unverified

The issue's § Validation asks for a live test PR. That is only possible once this workflow is itself on `development` — the workflow cannot fire for its own PR. **Post-merge check:** open a throwaway issue plus a test PR into `development`, confirm the positive path, then confirm the unmerged and no-keyword guardrails.

## Guarded against

`gh` pushes here use a token without the `workflow` scope, so this branch was pushed over SSH. Unrelated to the change, but worth knowing for the next workflow edit.
