### PR TITLE
FROM fix/841-close-issues-trigger TO development

### DIFF
--- a/.github/workflows/close-issues-on-development.yml
+++ b/.github/workflows/close-issues-on-development.yml
@@ -5,17 +5,20 @@ name: "Close linked issues on development merge"
 # pull request targets `development`, so `Closes #N` never fires on its own. This
 # workflow closes those issues instead, and leaves the default branch alone.
 #
-# The trigger is `pull_request_target`, not `pull_request`: a `pull_request` run
-# started by a fork receives a read-only token, so `issues: write` would be
-# unusable and a fork pull request would never close its issue.
-# `pull_request_target` runs the base-branch workflow with a writable token.
-# The usual `pull_request_target` hazard is running untrusted head-branch code.
-# This workflow never does that: `actions/checkout` takes its default ref, which
-# is the base branch, and the only author-controlled values (the title and the
-# body) reach the script through `env` as plain strings.
+# The trigger is `pull_request`, NOT `pull_request_target`. `pull_request_target`
+# resolves the workflow file from the repository DEFAULT branch, which is `main`,
+# where this file does not exist — so it would never fire for a pull request into
+# `development`. `pull_request` resolves the workflow from the pull request's merge
+# context, so this file on `development` runs for pull requests targeting it.
+#
+# Known limit: a `pull_request` run started from a FORK receives a read-only
+# token, so a fork pull request cannot close its issue and the run fails on the
+# `issues.update` call. Every pull request in this repository is same-repo, where
+# the token is writable. Covering forks needs this workflow on the default branch
+# under `pull_request_target`; do that only when `main` carries the file.
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - closed
     branches:
@@ -37,9 +40,12 @@ jobs:
     runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
 
     steps:
-      - name: Checkout base branch
+      # Only `.oh/scripts/closing-keywords.mjs` is needed, and it is never executed
+      # as a build step — it is imported and called with the title and the body.
+      - name: Checkout the base branch
         uses: actions/checkout@v7
         with:
+          ref: ${{ github.event.pull_request.base.ref }}
           persist-credentials: false
 
       - name: Close each referenced issue

--- a/.oh/docs/contributing.md
+++ b/.oh/docs/contributing.md
@@ -155,7 +155,8 @@ one keyword per issue. A bare `#42` links the issue but does not close it.
 When the pull request merges into `development`, the workflow
 [`.github/workflows/close-issues-on-development.yml`](../../.github/workflows/close-issues-on-development.yml)
 closes each referenced issue as `completed`. Closing the pull request without
-merging it closes no issue.
+merging it closes no issue. A pull request opened from a fork gets a read-only
+token, so close its issue by hand.
 
 Create the PR:
 

--- a/.oh/evals/RESULTS.md
+++ b/.oh/evals/RESULTS.md
@@ -6,102 +6,102 @@ probe id; git history is the time series.** Schema and exit-code semantics are i
 
 | probe | tier | last-run (UTC) | status | source |
 |-------|------|----------------|--------|--------|
-| ablate-state-machine | A | 2026-08-26 20:01 | PASS | issue #645 — one locked versioned ablation recovery owner |
-| advisor-monitored-loop | A | 2026-08-26 20:01 | PASS | conversation 2026-06-19 (issue #257); rewritten by spec-simplification US-002 |
-| agent-browser-cli | A | 2026-08-26 20:01 | PASS | retro lesson 2026-06-07 (agent-browser 0.8.5 CLI) |
-| artifact-contract-audit | A | 2026-08-26 20:01 | PASS | issue #583/#645 — production /audit implementation Gate 1 behavior |
-| audit-dispatcher-contract | A | 2026-08-26 20:01 | PASS | issue #645 — audit consolidation public taxonomy |
-| audit-implementation-behavior | A | 2026-08-26 20:01 | PASS | issue #645 — implementation root/repo/browser behavior |
-| audit-pr-acquire | A | 2026-08-26 20:01 | PASS | issue #645 — production PR acquisition behavior |
-| audit-pr-classifier | A | 2026-08-26 20:01 | PASS | issue #645 — deterministic focused and queue PR classifier |
-| audit-run-root-contract | A | 2026-08-26 20:01 | PASS | issue #645 — executable immutable audit root/run correlation |
-| audit-shellcheck-coverage | A | 2026-08-26 20:01 | PASS | issue #645 — private audit scripts require release and CI lint coverage |
-| audit-stale-references | A | 2026-08-26 20:01 | PASS | issue #645 — clean-breaking audit migration |
-| boot-lint-glob | A | 2026-08-26 20:01 | PASS | issue #90, issue #120 |
-| builder-skill-consolidation | A | 2026-08-26 20:01 | PASS | issue #643 — consolidate artifact builders behind one /builder dispatcher |
-| capability-benchmark-schema | A | 2026-08-26 20:01 | PASS | issue #167 — capability benchmark instrument |
-| cc-safety-net-wiring | A | 2026-08-26 20:01 | PASS | .oh/tasks/cc-safety-net/prd.json US-007 2026-07-19 |
-| changelog-entry-length | A | 2026-08-26 20:01 | PASS | conversation 2026-08-24 — CHANGELOG.md grew to 259KB of bullet prose because "one line" was unquantified |
-| cleanup-tasks-scoped-guard | A | 2026-08-26 20:01 | PASS | issue #85 |
-| cleanup-tasks-worktree-grooming | A | 2026-08-26 20:01 | PASS | issue #168; issue #327 |
-| close-issues-on-development | A | 2026-08-26 20:01 | PASS | issue #841 (closing keywords never fire because the default branch is main) 2026-08-26 |
-| codex-stale-response-retry | A | 2026-08-26 20:01 | PASS | issue #506 — Codex previous_response_not_found RCA |
-| compose-config-path-parity | A | 2026-08-26 20:01 | PASS | ? |
-| context-tier-size-budget | A | 2026-08-26 20:01 | PASS | .oh/tasks/spec-simplification/ (issue #816, US-007) — the always-on tier was 85,256 B |
-| cron-claude-codex-fallback | A | 2026-08-26 20:01 | PASS | conversation 2026-06-12 (default Codex fallback for crons) |
-| cron-watchdog | A | 2026-08-26 20:01 | PASS | issues #130/#453 (cron runtime watchdog + legacy system-cron reaping) 2026-06-19 |
-| curl-bash-safe-alternatives | A | 2026-08-26 20:01 | PASS | vet-run/vet integration — public curl|bash examples need review-first alternatives |
-| datasets-schema | A | 2026-08-26 20:01 | PASS | issue #196 — .oh/evals/datasets verifiable trajectory corpus (Repo2RLEnv-inspired) |
-| debugmcp-availability | A | 2026-08-26 20:01 | SKIPPED | issue #297 — DebugMCP MCP debug-server availability |
-| delegate-model-effort-policy | A | 2026-08-26 20:01 | PASS | conversation 2026-07-11 (delegate model inheritance and thinking policy) |
-| devtcp-hook | A | 2026-08-26 20:01 | PASS | retro lesson 2026-06-10 (zsh /dev/tcp) |
-| docker-inspect-env-guard | A | 2026-08-26 20:01 | PASS | operator directive 2026-08-08 (agents keep the docker socket, but must |
-| docs-build-fast-path | A | 2026-08-26 20:01 | PASS | #455 — docs builds must stay out of fast harness/eval/release gates; #536 — docs site externalized to openharness-web; docs markdown relocated to .oh/docs/ |
-| drift-check-cron-staleness-glob | A | 2026-08-26 20:01 | PASS | issue #98; issue #225 (restart-required cron frontmatter/config drift) |
-| entrypoint-pnpm-manifest-fingerprint | A | 2026-08-26 20:01 | PASS | issue #521 (manifest-aware sandbox installs) 2026-07-01 |
-| env-schema-parity | A | 2026-08-26 20:01 | PASS | ? |
-| eval-ci-gate | A | 2026-08-26 20:01 | PASS | #103 — eval probe suite gated in CI |
-| eval-gate | A | 2026-08-26 20:01 | PASS | retro lesson 2026-06-11 (eval-gate) |
-| eval-results-atomic | A | 2026-08-26 20:01 | PASS | issue #83 (eval-results-atomic-write) |
-| eval-runner-exit | A | 2026-08-26 20:01 | PASS | retro lesson 2026-06-11 (eval-runner-exit) #29 |
-| eval-runs-once-per-cycle | A | 2026-08-26 20:01 | PASS | .oh/tasks/spec-simplification/ (issue #816, US-006) — /eval ran 3x per cycle on the |
-| execution-target-contract | A | 2026-08-26 20:01 | PASS | issue #733 (ExecutionTarget contract + Docker Compose adapter) 2026-08-10 |
-| executor-kill-clears-session | A | 2026-08-26 20:01 | PASS | .oh/tasks/spec-simplification/ (issue #816, US-002) — OBSERVED 2026-08-23: |
-| executor-launch-interactive | A | 2026-08-26 20:01 | PASS | .oh/tasks/spec-simplification/ (issue #816, US-002) — OBSERVED 2026-08-23: the build |
-| firstmate-executor-contract | A | 2026-08-26 20:01 | PASS | .oh/tasks/spec-simplification/ (issue #816, US-002) — one build executor, no toggle |
-| get-oh-bootstrap | A | 2026-08-26 20:01 | PASS | get-oh.sh bootstrap — the Node-bootstrapping host-side path to the standalone `oh` CLI (also on npm as @mifune/openharness; see oh-npm-package.sh) |
-| git-skill | A | 2026-08-26 20:01 | PASS | conversation 2026-06-15 — rules are not always supported; git workflow must be the /git skill |
-| harness-audit-empty-output-gate | A | 2026-08-26 20:01 | PASS | issue #246 — /audit harness must fail closed on empty auditor outputs |
-| harness-ci-core-paths | A | 2026-08-26 20:01 | PASS | #165 — core sandbox config files must trigger harness CI |
-| harness-ci-hooks-paths | A | 2026-08-26 20:01 | PASS | issue #202 — credential/security hook changes must trigger harness CI |
-| harness-yaml-migration | A | 2026-08-26 20:01 | PASS | ? |
-| health-check-docker-stats | A | 2026-08-26 20:01 | PASS | retro lesson 2026-06-10 (docker stats vs ps Size) |
-| health-check-socket-degrade | A | 2026-08-26 20:01 | PASS | issue #762 (refs #756) — /health-check degrades to one statement, not nine failures |
-| heartbeat-logging-contract | A | 2026-08-26 20:01 | PASS | issue #447 (heartbeat log append hardening) 2026-06-18 |
-| make-oh-lifecycle-parity | A | 2026-08-26 20:01 | PASS | the Makefile/oh surface-gap consolidation — two front doors onto |
-| markitdown-wiki-ingest | A | 2026-08-26 20:01 | PASS | issue #649 — pinned local-document normalization contract for /wiki ingest |
-| next-dev-prod | A | 2026-08-26 20:01 | SKIPPED | retro lesson 2026-06-04 |
-| oh-devcontainer-restructure | A | 2026-08-26 20:01 | PASS | consolidate devcontainer — .oh/devcontainer/ folded back into .devcontainer/ |
-| oh-image-only-deploy | A | 2026-08-26 20:01 | PASS | .oh/tasks/image-only-deploy/prd.json US-004 (issue #609, Flavor B image-only deploy) |
-| oh-init-headless-config | A | 2026-08-26 20:01 | PASS | ? |
-| oh-init-scaffold | A | 2026-08-26 20:01 | PASS | issue #531 Phase 2 |
-| oh-npm-package | A | 2026-08-26 20:01 | PASS | npm publish path for the standalone `oh` CLI (@mifune/openharness) — alternative to get-oh.sh |
-| oh-payload-manifest | A | 2026-08-26 20:01 | PASS | issue #531 follow-on (.oh payload manifest — oh update ships a declared allowlist) |
-| oh-sandbox-image-mode | A | 2026-08-26 20:01 | PASS | conversation 2026-07-05 (basic Docker deployment — prebuilt-image mode) |
-| oh-shipped-repo-overridable | A | 2026-08-26 20:01 | PASS | issue #531 follow-on (de-hardcode residual — shipped .oh shell scripts keep the upstream repo overridable) |
-| oh-standalone-lifecycle | A | 2026-08-26 20:01 | PASS | issue #564 |
-| oh-update | A | 2026-08-26 20:01 | PASS | issue #531 Phase 3 (oh update — upgrade only the .oh control plane) |
-| operator-config-guard | A | 2026-08-26 20:01 | PASS | operator directives 2026-08-06 (.config/ and settings.local.json are operator-only) |
-| pnpm-audit-ci-gate | A | 2026-08-26 20:01 | PASS | issue #171 — pnpm security audits must run in CI |
-| post-bridge-publish-confirmation | A | 2026-08-26 20:01 | PASS | #523 — post-bridge live publishing requires an explicit final confirmation gate |
-| prd-output-path-contract | A | 2026-08-26 20:01 | PASS | retro lesson 2026-06-19 |
-| project-root-seam | A | 2026-08-26 20:01 | PASS | issue #531 Phase 1 (OH_PROJECT_ROOT project-root seam) 2026-06-26 |
-| prompt-miner-schema-compat | A | 2026-08-26 20:01 | PASS | issue #253 — prompt-miner JSONL schema-drift guard |
-| prompt-miner-symlink-entrypoint | A | 2026-08-26 20:01 | PASS | issue #663 — prompt-miner engine no-ops via the documented .claude/skills symlink |
-| prompt-miner-weakness-record | A | 2026-08-26 20:01 | PASS | issue #580 — prompt-miner weakness-record (WH-xxx) cluster output |
-| protected-path-deletion | A | 2026-08-26 20:01 | PASS | .oh/tasks/spec-simplification/ (issue #816, US-001) — the critique gate was deleted, |
-| protected-paths-resolve | A | 2026-08-26 20:01 | PASS | issue #753 — .claude/protected-paths.txt named 7 paths that did not exist. |
-| registry-portability-gate | A | 2026-08-26 20:01 | PASS | issue #758 |
-| registry-portability | A | 2026-08-26 20:01 | SKIPPED | issue #758 |
-| repo-map-contract | A | 2026-08-26 20:01 | PASS | issue #464 — repo map must optimize orientation without adding a tree dependency or unmeasured performance claims |
-| retro-deterministic-contract | A | 2026-08-26 20:01 | PASS | issue #443 — /retro deterministic output and self-contained helper contract |
-| rl-delegation-write-worker | A | 2026-08-26 20:01 | PASS | retro lesson 2026-06-10 (rl-delegation) #57 |
-| rlm-context-budget | A | 2026-08-26 20:01 | PASS | .oh/tasks/rlm-weighted-trajectories/prd.json US-006 |
-| runtime-preflight-gate | A | 2026-08-26 20:01 | PASS | issue #806 § B1 (open sandbox.substrate vs sandbox.runtime selector); |
-| sandbox-boot-guard-ci | A | 2026-08-26 20:01 | PASS | issue #449 (sandbox image build CI guard) 2026-06-19 |
-| session-runner-ladder | A | 2026-08-26 20:01 | PASS | .oh/tasks/firstmate-executor/ (issue #746) — the shared herdr -> tmux -> foreground runner ladder and its safety gates |
-| skill-paths | A | 2026-08-26 20:01 | PASS | issue #43 — stale path references; extended by issue #69 — apps/->packages/ rename guard |
-| skills-dir-clean | A | 2026-08-26 20:01 | PASS | conversation 2026-06-29 — Pi parses every top-level `.md` in the skills |
-| skills-vendored | A | 2026-08-26 20:01 | PASS | absorb .mifune submodule into .oh — the skills/agents/hooks pack is vendored |
-| slack-admin-command-surface | A | 2026-08-26 20:01 | PASS | issue #354 — Slack bridge docs must distinguish Pi /msg-bridge commands from Slack DM admin text handlers |
-| spec-family-contract | A | 2026-08-26 20:01 | PASS | conversation 2026-06-19 (spec-* family split, issue #265); consolidated into /spec dispatcher 2026-06-23 (one skill, args); |
-| spec-ready-finalization | A | 2026-08-26 20:01 | PASS | issue #134 — the build path must finalize ready PRs after gates, not stop at a draft |
-| ste-checker-contract | A | 2026-08-26 20:01 | PASS | issue #750 PR audit — the /ste checker had four fail-open paths (unclosed |
-| submitted-by-trailers | A | 2026-08-26 20:01 | PASS | conversation 2026-06-12 (commit attribution trailers); repointed by |
-| sync-skill-contract | A | 2026-08-26 20:01 | PASS | issue #331 — /sync dispatcher skill (bidirectional origin↔upstream sync) |
-| tool-catalog-boundary | A | 2026-08-26 20:01 | PASS | agent-browser's exclusion from the harness catalog (#821) and the |
-| weigh-scorer-contract | A | 2026-08-26 20:01 | PASS | .oh/tasks/rlm-weighted-trajectories/prd.json US-003 (2026-06-27) |
-| wiki-readme-index | A | 2026-08-26 20:01 | PASS | issue #132 — wiki README index drift guard |
-| workflow-boundaries | A | 2026-08-26 20:01 | PASS | conversation 2026-06-19 (workflow consolidation, issue #259) |
+| ablate-state-machine | A | 2026-08-26 20:20 | PASS | issue #645 — one locked versioned ablation recovery owner |
+| advisor-monitored-loop | A | 2026-08-26 20:20 | PASS | conversation 2026-06-19 (issue #257); rewritten by spec-simplification US-002 |
+| agent-browser-cli | A | 2026-08-26 20:20 | PASS | retro lesson 2026-06-07 (agent-browser 0.8.5 CLI) |
+| artifact-contract-audit | A | 2026-08-26 20:20 | PASS | issue #583/#645 — production /audit implementation Gate 1 behavior |
+| audit-dispatcher-contract | A | 2026-08-26 20:20 | PASS | issue #645 — audit consolidation public taxonomy |
+| audit-implementation-behavior | A | 2026-08-26 20:20 | PASS | issue #645 — implementation root/repo/browser behavior |
+| audit-pr-acquire | A | 2026-08-26 20:20 | PASS | issue #645 — production PR acquisition behavior |
+| audit-pr-classifier | A | 2026-08-26 20:20 | PASS | issue #645 — deterministic focused and queue PR classifier |
+| audit-run-root-contract | A | 2026-08-26 20:20 | PASS | issue #645 — executable immutable audit root/run correlation |
+| audit-shellcheck-coverage | A | 2026-08-26 20:20 | PASS | issue #645 — private audit scripts require release and CI lint coverage |
+| audit-stale-references | A | 2026-08-26 20:20 | PASS | issue #645 — clean-breaking audit migration |
+| boot-lint-glob | A | 2026-08-26 20:20 | PASS | issue #90, issue #120 |
+| builder-skill-consolidation | A | 2026-08-26 20:20 | PASS | issue #643 — consolidate artifact builders behind one /builder dispatcher |
+| capability-benchmark-schema | A | 2026-08-26 20:20 | PASS | issue #167 — capability benchmark instrument |
+| cc-safety-net-wiring | A | 2026-08-26 20:20 | PASS | .oh/tasks/cc-safety-net/prd.json US-007 2026-07-19 |
+| changelog-entry-length | A | 2026-08-26 20:20 | PASS | conversation 2026-08-24 — CHANGELOG.md grew to 259KB of bullet prose because "one line" was unquantified |
+| cleanup-tasks-scoped-guard | A | 2026-08-26 20:20 | PASS | issue #85 |
+| cleanup-tasks-worktree-grooming | A | 2026-08-26 20:20 | PASS | issue #168; issue #327 |
+| close-issues-on-development | A | 2026-08-26 20:20 | PASS | issue #841 (closing keywords never fire because the default branch is main) 2026-08-26 |
+| codex-stale-response-retry | A | 2026-08-26 20:20 | PASS | issue #506 — Codex previous_response_not_found RCA |
+| compose-config-path-parity | A | 2026-08-26 20:20 | PASS | ? |
+| context-tier-size-budget | A | 2026-08-26 20:20 | PASS | .oh/tasks/spec-simplification/ (issue #816, US-007) — the always-on tier was 85,256 B |
+| cron-claude-codex-fallback | A | 2026-08-26 20:20 | PASS | conversation 2026-06-12 (default Codex fallback for crons) |
+| cron-watchdog | A | 2026-08-26 20:20 | PASS | issues #130/#453 (cron runtime watchdog + legacy system-cron reaping) 2026-06-19 |
+| curl-bash-safe-alternatives | A | 2026-08-26 20:20 | PASS | vet-run/vet integration — public curl|bash examples need review-first alternatives |
+| datasets-schema | A | 2026-08-26 20:20 | PASS | issue #196 — .oh/evals/datasets verifiable trajectory corpus (Repo2RLEnv-inspired) |
+| debugmcp-availability | A | 2026-08-26 20:20 | SKIPPED | issue #297 — DebugMCP MCP debug-server availability |
+| delegate-model-effort-policy | A | 2026-08-26 20:20 | PASS | conversation 2026-07-11 (delegate model inheritance and thinking policy) |
+| devtcp-hook | A | 2026-08-26 20:20 | PASS | retro lesson 2026-06-10 (zsh /dev/tcp) |
+| docker-inspect-env-guard | A | 2026-08-26 20:20 | PASS | operator directive 2026-08-08 (agents keep the docker socket, but must |
+| docs-build-fast-path | A | 2026-08-26 20:20 | PASS | #455 — docs builds must stay out of fast harness/eval/release gates; #536 — docs site externalized to openharness-web; docs markdown relocated to .oh/docs/ |
+| drift-check-cron-staleness-glob | A | 2026-08-26 20:20 | PASS | issue #98; issue #225 (restart-required cron frontmatter/config drift) |
+| entrypoint-pnpm-manifest-fingerprint | A | 2026-08-26 20:20 | PASS | issue #521 (manifest-aware sandbox installs) 2026-07-01 |
+| env-schema-parity | A | 2026-08-26 20:20 | PASS | ? |
+| eval-ci-gate | A | 2026-08-26 20:20 | PASS | #103 — eval probe suite gated in CI |
+| eval-gate | A | 2026-08-26 20:20 | PASS | retro lesson 2026-06-11 (eval-gate) |
+| eval-results-atomic | A | 2026-08-26 20:20 | PASS | issue #83 (eval-results-atomic-write) |
+| eval-runner-exit | A | 2026-08-26 20:20 | PASS | retro lesson 2026-06-11 (eval-runner-exit) #29 |
+| eval-runs-once-per-cycle | A | 2026-08-26 20:20 | PASS | .oh/tasks/spec-simplification/ (issue #816, US-006) — /eval ran 3x per cycle on the |
+| execution-target-contract | A | 2026-08-26 20:20 | PASS | issue #733 (ExecutionTarget contract + Docker Compose adapter) 2026-08-10 |
+| executor-kill-clears-session | A | 2026-08-26 20:20 | PASS | .oh/tasks/spec-simplification/ (issue #816, US-002) — OBSERVED 2026-08-23: |
+| executor-launch-interactive | A | 2026-08-26 20:20 | PASS | .oh/tasks/spec-simplification/ (issue #816, US-002) — OBSERVED 2026-08-23: the build |
+| firstmate-executor-contract | A | 2026-08-26 20:20 | PASS | .oh/tasks/spec-simplification/ (issue #816, US-002) — one build executor, no toggle |
+| get-oh-bootstrap | A | 2026-08-26 20:20 | PASS | get-oh.sh bootstrap — the Node-bootstrapping host-side path to the standalone `oh` CLI (also on npm as @mifune/openharness; see oh-npm-package.sh) |
+| git-skill | A | 2026-08-26 20:20 | PASS | conversation 2026-06-15 — rules are not always supported; git workflow must be the /git skill |
+| harness-audit-empty-output-gate | A | 2026-08-26 20:20 | PASS | issue #246 — /audit harness must fail closed on empty auditor outputs |
+| harness-ci-core-paths | A | 2026-08-26 20:20 | PASS | #165 — core sandbox config files must trigger harness CI |
+| harness-ci-hooks-paths | A | 2026-08-26 20:20 | PASS | issue #202 — credential/security hook changes must trigger harness CI |
+| harness-yaml-migration | A | 2026-08-26 20:20 | PASS | ? |
+| health-check-docker-stats | A | 2026-08-26 20:20 | PASS | retro lesson 2026-06-10 (docker stats vs ps Size) |
+| health-check-socket-degrade | A | 2026-08-26 20:20 | PASS | issue #762 (refs #756) — /health-check degrades to one statement, not nine failures |
+| heartbeat-logging-contract | A | 2026-08-26 20:20 | PASS | issue #447 (heartbeat log append hardening) 2026-06-18 |
+| make-oh-lifecycle-parity | A | 2026-08-26 20:20 | PASS | the Makefile/oh surface-gap consolidation — two front doors onto |
+| markitdown-wiki-ingest | A | 2026-08-26 20:20 | PASS | issue #649 — pinned local-document normalization contract for /wiki ingest |
+| next-dev-prod | A | 2026-08-26 20:20 | SKIPPED | retro lesson 2026-06-04 |
+| oh-devcontainer-restructure | A | 2026-08-26 20:20 | PASS | consolidate devcontainer — .oh/devcontainer/ folded back into .devcontainer/ |
+| oh-image-only-deploy | A | 2026-08-26 20:20 | PASS | .oh/tasks/image-only-deploy/prd.json US-004 (issue #609, Flavor B image-only deploy) |
+| oh-init-headless-config | A | 2026-08-26 20:20 | PASS | ? |
+| oh-init-scaffold | A | 2026-08-26 20:20 | PASS | issue #531 Phase 2 |
+| oh-npm-package | A | 2026-08-26 20:20 | PASS | npm publish path for the standalone `oh` CLI (@mifune/openharness) — alternative to get-oh.sh |
+| oh-payload-manifest | A | 2026-08-26 20:20 | PASS | issue #531 follow-on (.oh payload manifest — oh update ships a declared allowlist) |
+| oh-sandbox-image-mode | A | 2026-08-26 20:20 | PASS | conversation 2026-07-05 (basic Docker deployment — prebuilt-image mode) |
+| oh-shipped-repo-overridable | A | 2026-08-26 20:20 | PASS | issue #531 follow-on (de-hardcode residual — shipped .oh shell scripts keep the upstream repo overridable) |
+| oh-standalone-lifecycle | A | 2026-08-26 20:20 | PASS | issue #564 |
+| oh-update | A | 2026-08-26 20:20 | PASS | issue #531 Phase 3 (oh update — upgrade only the .oh control plane) |
+| operator-config-guard | A | 2026-08-26 20:20 | PASS | operator directives 2026-08-06 (.config/ and settings.local.json are operator-only) |
+| pnpm-audit-ci-gate | A | 2026-08-26 20:20 | PASS | issue #171 — pnpm security audits must run in CI |
+| post-bridge-publish-confirmation | A | 2026-08-26 20:20 | PASS | #523 — post-bridge live publishing requires an explicit final confirmation gate |
+| prd-output-path-contract | A | 2026-08-26 20:20 | PASS | retro lesson 2026-06-19 |
+| project-root-seam | A | 2026-08-26 20:20 | PASS | issue #531 Phase 1 (OH_PROJECT_ROOT project-root seam) 2026-06-26 |
+| prompt-miner-schema-compat | A | 2026-08-26 20:20 | PASS | issue #253 — prompt-miner JSONL schema-drift guard |
+| prompt-miner-symlink-entrypoint | A | 2026-08-26 20:20 | PASS | issue #663 — prompt-miner engine no-ops via the documented .claude/skills symlink |
+| prompt-miner-weakness-record | A | 2026-08-26 20:20 | PASS | issue #580 — prompt-miner weakness-record (WH-xxx) cluster output |
+| protected-path-deletion | A | 2026-08-26 20:20 | PASS | .oh/tasks/spec-simplification/ (issue #816, US-001) — the critique gate was deleted, |
+| protected-paths-resolve | A | 2026-08-26 20:20 | PASS | issue #753 — .claude/protected-paths.txt named 7 paths that did not exist. |
+| registry-portability-gate | A | 2026-08-26 20:20 | PASS | issue #758 |
+| registry-portability | A | 2026-08-26 20:20 | SKIPPED | issue #758 |
+| repo-map-contract | A | 2026-08-26 20:20 | PASS | issue #464 — repo map must optimize orientation without adding a tree dependency or unmeasured performance claims |
+| retro-deterministic-contract | A | 2026-08-26 20:20 | PASS | issue #443 — /retro deterministic output and self-contained helper contract |
+| rl-delegation-write-worker | A | 2026-08-26 20:20 | PASS | retro lesson 2026-06-10 (rl-delegation) #57 |
+| rlm-context-budget | A | 2026-08-26 20:20 | PASS | .oh/tasks/rlm-weighted-trajectories/prd.json US-006 |
+| runtime-preflight-gate | A | 2026-08-26 20:20 | PASS | issue #806 § B1 (open sandbox.substrate vs sandbox.runtime selector); |
+| sandbox-boot-guard-ci | A | 2026-08-26 20:20 | PASS | issue #449 (sandbox image build CI guard) 2026-06-19 |
+| session-runner-ladder | A | 2026-08-26 20:20 | PASS | .oh/tasks/firstmate-executor/ (issue #746) — the shared herdr -> tmux -> foreground runner ladder and its safety gates |
+| skill-paths | A | 2026-08-26 20:20 | PASS | issue #43 — stale path references; extended by issue #69 — apps/->packages/ rename guard |
+| skills-dir-clean | A | 2026-08-26 20:20 | PASS | conversation 2026-06-29 — Pi parses every top-level `.md` in the skills |
+| skills-vendored | A | 2026-08-26 20:20 | PASS | absorb .mifune submodule into .oh — the skills/agents/hooks pack is vendored |
+| slack-admin-command-surface | A | 2026-08-26 20:20 | PASS | issue #354 — Slack bridge docs must distinguish Pi /msg-bridge commands from Slack DM admin text handlers |
+| spec-family-contract | A | 2026-08-26 20:20 | PASS | conversation 2026-06-19 (spec-* family split, issue #265); consolidated into /spec dispatcher 2026-06-23 (one skill, args); |
+| spec-ready-finalization | A | 2026-08-26 20:20 | PASS | issue #134 — the build path must finalize ready PRs after gates, not stop at a draft |
+| ste-checker-contract | A | 2026-08-26 20:20 | PASS | issue #750 PR audit — the /ste checker had four fail-open paths (unclosed |
+| submitted-by-trailers | A | 2026-08-26 20:20 | PASS | conversation 2026-06-12 (commit attribution trailers); repointed by |
+| sync-skill-contract | A | 2026-08-26 20:20 | PASS | issue #331 — /sync dispatcher skill (bidirectional origin↔upstream sync) |
+| tool-catalog-boundary | A | 2026-08-26 20:20 | PASS | agent-browser's exclusion from the harness catalog (#821) and the |
+| weigh-scorer-contract | A | 2026-08-26 20:20 | PASS | .oh/tasks/rlm-weighted-trajectories/prd.json US-003 (2026-06-27) |
+| wiki-readme-index | A | 2026-08-26 20:20 | PASS | issue #132 — wiki README index drift guard |
+| workflow-boundaries | A | 2026-08-26 20:20 | PASS | conversation 2026-06-19 (workflow consolidation, issue #259) |
 
 <!-- benchmark: pass-rate = PASS / (PASS + REGRESSION + TIMEOUT); SKIPPED excluded -->

--- a/.oh/evals/probes/close-issues-on-development.sh
+++ b/.oh/evals/probes/close-issues-on-development.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 # tier: A
 # source: issue #841 (closing keywords never fire because the default branch is main) 2026-08-26
-# desc: the development-merge issue closer must stay merged-only, development-only, and least-privilege.
+# desc: the development-merge issue closer must stay merged-only, development-only, least-privilege,
+#       and on the pull_request trigger — pull_request_target resolves from the default branch,
+#       where this workflow does not exist, so it would never fire.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
@@ -24,7 +26,7 @@ missing=()
 has() { grep -Fq -- "$1" <<<"$text" || missing+=("$2"); }
 has_regex() { grep -Eq -- "$1" <<<"$text" || missing+=("$2"); }
 
-has_regex '^[[:space:]]*pull_request_target:[[:space:]]*$' "pull_request_target trigger"
+has_regex '^[[:space:]]*pull_request:[[:space:]]*$' "pull_request trigger"
 has_regex '^[[:space:]]*-[[:space:]]*closed[[:space:]]*$' "closed event type"
 has_regex '^[[:space:]]*-[[:space:]]*development[[:space:]]*$' "development branch filter"
 has 'if: github.event.pull_request.merged == true' "merged-only guard"
@@ -36,9 +38,16 @@ has 'state_reason: "completed"' "completed state reason"
 has 'PR_TITLE: ${{ github.event.pull_request.title }}' "title passed through env"
 has 'PR_BODY: ${{ github.event.pull_request.body }}' "body passed through env"
 
-# pull_request_target grants a writable token, so the workflow must never run
-# head-branch code. `actions/checkout` takes its default (base) ref: any explicit
-# head ref would turn this into an arbitrary-code-execution surface.
+# pull_request_target resolves the workflow from the DEFAULT branch (main), where
+# this file does not exist — it would never fire. This is the bug the trigger swap
+# fixed; the probe keeps it from coming back.
+if grep -Eq '^[[:space:]]*pull_request_target:' <<<"$text"; then
+  echo "REGRESSION close-issues-on-development must not use pull_request_target: it resolves from the default branch, where this workflow does not exist" >&2
+  exit 1
+fi
+
+# The workflow must never run head-branch code: it checks out the base ref and
+# only imports the parser. An explicit head ref would make this an ACE surface.
 if grep -Eq 'ref:[[:space:]]*\$\{\{[[:space:]]*github\.event\.pull_request\.head' <<<"$text"; then
   echo "REGRESSION close-issues-on-development must not check out the pull request head ref" >&2
   exit 1

--- a/.oh/skills/git/SKILL.md
+++ b/.oh/skills/git/SKILL.md
@@ -84,8 +84,8 @@ Example: `FROM feat/42-slack-thread-replies TO development`
 > each referenced issue as `completed` (#841).
 >
 > The trailer is therefore load-bearing — write it on every PR. Close by hand only when the
-> automation cannot see the merge (a direct push, a merge into another branch, or a PR whose
-> body carried no trailer):
+> automation cannot see the merge (a direct push, a merge into another branch, a PR whose
+> body carried no trailer, or a PR opened from a **fork**, which gets a read-only token):
 >
 > ```bash
 > gh issue close <N> --repo <owner/name> --comment "Merged in #<PR>."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Update policy and release automation live in [`/git`](.claude/skills/git/SKILL.m
 ## [Unreleased]
 
 ### Fixed
+- The `development` issue closer never fired: `pull_request_target` resolves the workflow from the **default** branch (`main`), where the file does not exist. Swapped to `pull_request` ([#841](https://github.com/mifunedev/openharness/issues/841)).
 - **`uv python install` now works as the `sandbox` user without `sudo`.** `install -d -o sandbox -g sandbox .../uv/tools` chowns the final component only, so the intermediate `.../share/uv` stayed `root:root`.
 - Root cause detail: `uv python install` writes `.../uv/python`, a sibling of `tools` inside that root-owned directory, so it failed with `Permission denied`. Every level is now named explicitly, parents first.
 - The boot-time ownership repair now covers the uv tree. The UID-sync sweep only rewrites paths owned by the *old* sandbox UID, so a root-owned uv directory was never repaired. Existing containers self-heal on restart.


### PR DESCRIPTION
Closes #841

## The bug

The workflow merged in #848 **could never run.**

`pull_request_target` resolves the workflow file from the repository's **default** branch. That branch is `main`, which does not carry `.github/workflows/close-issues-on-development.yml` — the file exists only on `development`. So no run was ever registered for a PR into `development`.

I picked `pull_request_target` to cover fork PRs, which get a read-only token under `pull_request`. That trade bought fork support at the cost of the feature working at all.

The evidence was available before #848 merged and I misread it as a bootstrap artifact:

```
$ gh run list --workflow=close-issues-on-development.yml
HTTP 404: workflow close-issues-on-development.yml not found on the default branch
```

and no run fired when #848 itself merged.

## The fix

Swap to `pull_request`, which resolves the workflow from the PR's merge context — so the file on `development` runs for PRs targeting `development`. This is exactly how `ci-harness.yml` fires today.

The fork limit is now stated rather than designed around: a fork PR gets a read-only token and cannot close its issue. Every PR in this repository is same-repo. Covering forks needs this file on the default branch under `pull_request_target`, which is a separate change to `main`.

Checkout is pinned to `github.event.pull_request.base.ref` explicitly. The workflow imports the parser and calls it with the title and body; it never executes head-branch code.

## Guard

The probe now fails on the `pull_request_target` trigger **by name**, with the reason in the message, so this cannot come back silently:

```
REGRESSION close-issues-on-development must not use pull_request_target:
it resolves from the default branch, where this workflow does not exist
```

Mutation-tested: reintroducing the trigger fails the probe.

## Verification

| Check | Result |
|---|---|
| `bash .oh/skills/eval/run.sh` | 97 probes, 0 regressions |
| New trigger guard, mutation-tested | reintroducing `pull_request_target` fails it |
| Script body against a mocked octokit | merged / no-keyword / already-closed / reference-is-a-PR unchanged |
| `.oh/scripts/closing-keywords.mjs` | untouched; its 22 tests still pass |

## This PR is the live test

The body carries `Closes #841`. Merging it into `development` is the positive-path validation the issue's § Validation asks for — **if #841 closes on merge, the feature works.** If it does not, the trigger is still wrong and the issue stays open on its own.
