### PR TITLE
FROM fix/861-in-sandbox-live-install TO development

### DIFF
--- a/.oh/cli/README.md
+++ b/.oh/cli/README.md
@@ -72,6 +72,12 @@ oh tool list                    # what is present, and what is installable
 oh tool install agent-browser   # asks before the ~1 GB Chromium download
 ```
 
+`oh harness` and `oh tool` also run **inside** the sandbox, where they install
+into the current environment instead of driving the container over Docker
+Compose. Detection is automatic (`/.dockerenv` plus `SANDBOX_NAME`); override it
+with `OH_EXECUTION_TARGET=local` or `OH_EXECUTION_TARGET=docker-compose`.
+`oh sandbox` and `oh runtime install` remain host-only and say so.
+
 ## Commands
 
 | Command | What it does |

--- a/.oh/cli/src/__tests__/harness.test.ts
+++ b/.oh/cli/src/__tests__/harness.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { copyFileSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
+
+vi.mock("node:os", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:os")>();
+  return { ...actual, userInfo: () => ({ ...actual.userInfo(), username: "sandbox", uid: 1000 }) };
+});
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import {

--- a/.oh/cli/src/__tests__/harness.test.ts
+++ b/.oh/cli/src/__tests__/harness.test.ts
@@ -437,3 +437,37 @@ describe("runHarnessStatus", () => {
     expect(text(err)).toContain('unknown harness "emacs"');
   });
 });
+
+describe("oh harness — inside the sandbox", () => {
+  const INSIDE: NodeJS.ProcessEnv = { OH_EXECUTION_TARGET: "local" };
+
+  it("installs live instead of skipping the install", async () => {
+    const root = makeRepo();
+    const { calls, run } = makeRunner((cmd) =>
+      cmd === "opencode" ? { status: 1, stdout: "", stderr: "" } : undefined,
+    );
+    const { io, out } = makeIo();
+    expect(await runHarnessInstall("opencode", { cwd: root, run, env: INSIDE }, io)).toBe(0);
+    expect(text(out)).not.toContain("skipping the live install");
+    expect(calls.some((c) => c.cmd === "sudo" && c.args.includes("opencode-ai"))).toBe(true);
+    expect(readEnv(root)).toMatch(/^INSTALL_OPENCODE=true$/m);
+  });
+
+  it("verifies as the sandbox user, never through sudo", async () => {
+    const root = makeRepo();
+    const { calls, run } = makeRunner();
+    const { io } = makeIo();
+    expect(await runHarnessList({ cwd: root, run, env: INSIDE }, io)).toBe(0);
+    expect(calls.some((c) => c.cmd === "sudo")).toBe(false);
+    expect(calls.some((c) => c.cmd === "claude" && c.args.includes("--version"))).toBe(true);
+  });
+
+  it("reports real INSTALLED values without a docker inspect", async () => {
+    const root = makeRepo();
+    const { calls, run } = makeRunner();
+    const { io, out } = makeIo();
+    expect(await runHarnessStatus("claude-code", { cwd: root, run, env: INSIDE }, io)).toBe(0);
+    expect(calls.some((c) => isInspect(c.cmd, c.args))).toBe(false);
+    expect(text(out)).not.toContain("INSTALLED is `?`");
+  });
+});

--- a/.oh/cli/src/__tests__/lifecycle.test.ts
+++ b/.oh/cli/src/__tests__/lifecycle.test.ts
@@ -40,6 +40,7 @@ afterEach(() => {
     rmSync(cleanups.pop()!, { recursive: true, force: true });
   }
   vi.restoreAllMocks();
+  vi.unstubAllEnvs();
 });
 
 function makeRepo(): string {
@@ -605,5 +606,26 @@ describe("help surfaces", () => {
     expect(gateway).toContain("oh gateway <pi|hermes>");
     expect(gateway).toContain("gateway.sh");
     expect(gateway).toContain("OH_PROJECT_ROOT");
+  });
+});
+
+describe("lifecycle inside the sandbox", () => {
+  it("refuses to provision the sandbox from inside it", async () => {
+    vi.stubEnv("OH_EXECUTION_TARGET", "local");
+    const root = makeRepo();
+    addScript(root, "docker-compose.sh");
+    const { calls, run } = makeRunner();
+    const { io, err } = makeIo();
+    expect(await runSandbox({ cwd: root, run }, io)).toBe(1);
+    expect(err.join("")).toContain("already inside the sandbox");
+    expect(calls.length).toBe(0);
+  });
+
+  it("opens a shell locally instead of exec-ing into a container", () => {
+    vi.stubEnv("OH_EXECUTION_TARGET", "local");
+    const root = makeRepo();
+    const { calls, run } = makeRunner();
+    expect(runShell({ cwd: root, run }, makeIo().io)).toBe(0);
+    expect(calls[0].cmd).toBe("zsh");
   });
 });

--- a/.oh/cli/src/__tests__/lifecycle.test.ts
+++ b/.oh/cli/src/__tests__/lifecycle.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
+
+vi.mock("node:os", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:os")>();
+  return { ...actual, userInfo: () => ({ ...actual.userInfo(), username: "sandbox", uid: 1000 }) };
+});
 import { join } from "node:path";
 import {
   runGateway,

--- a/.oh/cli/src/__tests__/local-target.test.ts
+++ b/.oh/cli/src/__tests__/local-target.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from "vitest";
+import {
+  HostOnlyError,
+  LocalExecutionTarget,
+  resolveExecutionTarget,
+  runningInsideSandbox,
+  SANDBOX_MARKER_FILE,
+  type LifecycleRunner,
+  type RunResult,
+} from "../lib/execution/index.js";
+
+
+interface RecordedCall {
+  cmd: string;
+  args: string[];
+  stdio: string;
+}
+
+function makeRunner(
+  reply: (cmd: string, args: string[]) => RunResult | undefined = () => undefined,
+): { calls: RecordedCall[]; run: LifecycleRunner } {
+  const calls: RecordedCall[] = [];
+  const run: LifecycleRunner = (cmd, args, opts) => {
+    calls.push({ cmd, args: [...args], stdio: opts.stdio });
+    return reply(cmd, args) ?? { status: 0, stdout: "", stderr: "" };
+  };
+  return { calls, run };
+}
+
+function target(uid: number, run: LifecycleRunner): LocalExecutionTarget {
+  return new LocalExecutionTarget({
+    projectRoot: "/workspace",
+    run,
+    env: {},
+    identity: () => (uid === 0 ? { name: "root", uid: 0 } : { name: "sandbox", uid }),
+  });
+}
+
+describe("runningInsideSandbox", () => {
+  const present = (p: string): boolean => p === SANDBOX_MARKER_FILE;
+  const absent = (): boolean => false;
+
+  it("is true when the container marker and SANDBOX_NAME are both present", () => {
+    expect(runningInsideSandbox({ SANDBOX_NAME: "openharness" }, present)).toBe(true);
+  });
+
+  it("is false on a host without the container marker", () => {
+    expect(runningInsideSandbox({ SANDBOX_NAME: "openharness" }, absent)).toBe(false);
+  });
+
+  it("is false inside a container that is not an Open Harness sandbox", () => {
+    expect(runningInsideSandbox({}, present)).toBe(false);
+  });
+
+  it("honours OH_EXECUTION_TARGET=local on a host", () => {
+    expect(runningInsideSandbox({ OH_EXECUTION_TARGET: "local" }, absent)).toBe(true);
+  });
+
+  it("honours OH_EXECUTION_TARGET=docker-compose inside the sandbox", () => {
+    expect(
+      runningInsideSandbox(
+        { OH_EXECUTION_TARGET: "docker-compose", SANDBOX_NAME: "openharness" },
+        present,
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("resolveExecutionTarget", () => {
+  it("returns the local target inside the sandbox", () => {
+    const t = resolveExecutionTarget({
+      projectRoot: "/workspace",
+      container: "openharness",
+      env: { OH_EXECUTION_TARGET: "local" },
+    });
+    expect(t.kind).toBe("local");
+  });
+
+  it("returns the docker compose target on the host", () => {
+    const t = resolveExecutionTarget({
+      projectRoot: "/workspace",
+      container: "openharness",
+      env: { OH_EXECUTION_TARGET: "docker-compose" },
+    });
+    expect(t.kind).toBe("docker-compose");
+  });
+});
+
+describe("LocalExecutionTarget", () => {
+  it("is always ready and can exec", async () => {
+    const { run } = makeRunner();
+    const t = target(1001, run);
+    expect(await t.status()).toBe("ready");
+    expect([...(await t.capabilities())]).toContain("exec");
+  });
+
+  it("runs the argv directly for the current user", async () => {
+    const { calls, run } = makeRunner();
+    const r = await target(1001, run).exec({
+      argv: ["claude", "--version"],
+      user: "sandbox",
+      stdio: "capture",
+    });
+    expect(r.exitCode).toBe(0);
+    expect(calls).toEqual([{ cmd: "claude", args: ["--version"], stdio: "capture" }]);
+  });
+
+  it("runs the argv directly when no user is requested", async () => {
+    const { calls, run } = makeRunner();
+    await target(1001, run).exec({ argv: ["bash", "-lc", "true"], stdio: "capture" });
+    expect(calls[0].cmd).toBe("bash");
+  });
+
+  it("wraps a root request in sudo when the caller is not root", async () => {
+    const { calls, run } = makeRunner();
+    await target(1001, run).exec({
+      argv: ["npm", "install", "-g", "x"],
+      user: "root",
+      stdio: "inherit",
+    });
+    expect(calls[0]).toEqual({
+      cmd: "sudo",
+      args: ["--", "npm", "install", "-g", "x"],
+      stdio: "inherit",
+    });
+  });
+
+  it("uses non-interactive sudo for captured root execs", async () => {
+    const { calls, run } = makeRunner();
+    await target(1001, run).exec({ argv: ["id"], user: "root", stdio: "capture" });
+    expect(calls[0]).toEqual({ cmd: "sudo", args: ["-n", "--", "id"], stdio: "capture" });
+  });
+
+  it("does not wrap a root request when the caller is already root", async () => {
+    const { calls, run } = makeRunner();
+    await target(0, run).exec({ argv: ["id"], user: "root", stdio: "capture" });
+    expect(calls[0].cmd).toBe("id");
+  });
+
+  it("drops privileges with gosu when root asks for another user", async () => {
+    const { calls, run } = makeRunner();
+    await target(0, run).exec({ argv: ["id"], user: "sandbox", stdio: "capture" });
+    expect(calls[0]).toEqual({ cmd: "gosu", args: ["sandbox", "id"], stdio: "capture" });
+  });
+
+  it("reports a missing binary as exit 127 instead of a spawn failure", async () => {
+    const { run } = makeRunner(() => ({ status: null, error: { code: "ENOENT" } }));
+    const r = await target(1001, run).exec({ argv: ["nope"], stdio: "capture" });
+    expect(r.exitCode).toBe(127);
+  });
+
+  it("refuses to provision the sandbox from inside it", async () => {
+    const { run } = makeRunner();
+    await expect(target(1001, run).provision()).rejects.toBeInstanceOf(HostOnlyError);
+  });
+
+  it("refuses to destroy the sandbox from inside it", async () => {
+    const { run } = makeRunner();
+    await expect(target(1001, run).destroy()).rejects.toBeInstanceOf(HostOnlyError);
+  });
+
+  it("attaches by running the argv with inherited stdio", () => {
+    const { calls, run } = makeRunner();
+    expect(target(1001, run).attach({ argv: ["zsh"], user: "sandbox" })).toBe(0);
+    expect(calls[0]).toEqual({ cmd: "zsh", args: [], stdio: "inherit" });
+  });
+});

--- a/.oh/cli/src/__tests__/runtime.test.ts
+++ b/.oh/cli/src/__tests__/runtime.test.ts
@@ -465,3 +465,27 @@ describe("oh runtime never writes configuration", () => {
     expect(readFileSync(join(root, ".devcontainer", ".env"), "utf8")).toBe(before);
   });
 });
+
+describe("oh runtime — inside the sandbox", () => {
+  const INSIDE: NodeJS.ProcessEnv = { OH_EXECUTION_TARGET: "local" };
+
+  it("refuses to install a runtime from inside the sandbox", async () => {
+    const root = makeRepo();
+    const { calls, run } = makeRunner();
+    const { io, err } = makeIo();
+    expect(
+      await runRuntimeInstall("microsandbox", { cwd: root, run, env: INSIDE }, io),
+    ).toBe(1);
+    expect(err.join("")).toContain("must run on the host");
+    expect(calls.length).toBe(0);
+  });
+
+  it("reports host-scope checks as unmeasured instead of measuring the container", async () => {
+    const root = makeRepo();
+    const { calls, run } = makeRunner();
+    const { io, out } = makeIo();
+    expect(await runRuntimeStatus("docker", { cwd: root, run, env: INSIDE }, io)).toBe(0);
+    expect(calls.some((c) => c.cmd === "docker" && c.args[0] === "version")).toBe(false);
+    expect(out.join("")).toContain("?");
+  });
+});

--- a/.oh/cli/src/__tests__/tool.test.ts
+++ b/.oh/cli/src/__tests__/tool.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { copyFileSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
+
+vi.mock("node:os", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:os")>();
+  return { ...actual, userInfo: () => ({ ...actual.userInfo(), username: "sandbox", uid: 1000 }) };
+});
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import {

--- a/.oh/cli/src/__tests__/tool.test.ts
+++ b/.oh/cli/src/__tests__/tool.test.ts
@@ -338,3 +338,61 @@ describe("oh tool install — the other exits", () => {
     expect(calls.length).toBe(0);
   });
 });
+
+describe("oh tool — inside the sandbox", () => {
+  const INSIDE: NodeJS.ProcessEnv = { OH_EXECUTION_TARGET: "local" };
+
+  const inBox = (extra: (cmd: string, args: string[]) => RunResult | undefined = () => undefined) =>
+    makeRunner((cmd, args) => {
+      const custom = extra(cmd, args);
+      if (custom) return custom;
+      if (cmd === "bash" && args.join(" ").includes("command -v agent-browser")) {
+        return { status: 1, stdout: "", stderr: "" };
+      }
+      return undefined;
+    });
+
+  it("lists real INSTALLED values without a docker inspect", async () => {
+    const root = makeRepo();
+    const { calls, run } = inBox();
+    const { io, out } = makeIo();
+    expect(await runToolList({ cwd: root, run, env: INSIDE }, io)).toBe(0);
+    expect(calls.some((c) => isInspect(c.cmd, c.args))).toBe(false);
+    const text = out.join("");
+    expect(text).not.toContain("INSTALLED is `?`");
+    expect(text).not.toContain("oh sandbox");
+  });
+
+  it("installs live instead of skipping the install", async () => {
+    const root = makeRepo();
+    const { calls, run } = inBox();
+    const { io, out } = makeIo(true);
+    expect(await runToolInstall("agent-browser", { cwd: root, run, env: INSIDE }, io)).toBe(0);
+    expect(out.join("")).not.toContain("skipping the live install");
+    expect(
+      calls.some((c) => c.cmd === "bash" && c.args.some((a) => a.includes("--with-deps"))),
+    ).toBe(true);
+    expect(flagLine(root)).toMatch(/^INSTALL_AGENT_BROWSER=true$/);
+  });
+
+  it("reports an already-installed tool without running the installer", async () => {
+    const root = makeRepo();
+    const { calls, run } = inBox((cmd, args) =>
+      cmd === "bash" && args.join(" ").includes("command -v agent-browser")
+        ? { status: 0, stdout: "", stderr: "" }
+        : undefined,
+    );
+    const { io, out } = makeIo(true);
+    expect(await runToolInstall("agent-browser", { cwd: root, run, env: INSIDE }, io)).toBe(0);
+    expect(out.join("")).toContain("already installed");
+    expect(calls.some((c) => c.args.some((a) => a.includes("--with-deps")))).toBe(false);
+  });
+
+  it("verifies as the sandbox user, never through sudo", async () => {
+    const root = makeRepo();
+    const { calls, run } = inBox();
+    const { io } = makeIo();
+    await runToolStatus("gh", { cwd: root, run, env: INSIDE }, io);
+    expect(calls.some((c) => c.cmd === "sudo")).toBe(false);
+  });
+});

--- a/.oh/cli/src/commands/harness.ts
+++ b/.oh/cli/src/commands/harness.ts
@@ -32,6 +32,7 @@ export interface HarnessOptions {
   cwd?: string;
   run?: LifecycleRunner;
   json?: boolean;
+  env?: NodeJS.ProcessEnv;
 }
 
 export interface HarnessInstallOptions extends HarnessOptions {
@@ -52,9 +53,18 @@ function isReachable(status: string): boolean {
   return status === "ready" || status === "starting";
 }
 
-function targetFor(root: string, run: LifecycleRunner): ExecutionTarget {
+function targetFor(
+  root: string,
+  run: LifecycleRunner,
+  env?: NodeJS.ProcessEnv,
+): ExecutionTarget {
   const name = configuredContainerName(root) ?? DEFAULT_CONTAINER_NAME;
-  return resolveExecutionTarget({ projectRoot: root, container: name, run });
+  return resolveExecutionTarget({
+    projectRoot: root,
+    container: name,
+    run,
+    ...(env ? { env } : {}),
+  });
 }
 
 async function probeInstalled(
@@ -64,7 +74,7 @@ async function probeInstalled(
   try {
     const r = await target.exec({
       argv: [...entry.verifyArgv],
-      user: entry.installUser,
+      user: "sandbox",
       stdio: "capture",
     });
     return r.exitCode === 0;
@@ -77,10 +87,11 @@ async function probeInstalled(
 async function collectStates(
   root: string,
   run: LifecycleRunner,
+  env?: NodeJS.ProcessEnv,
   only?: HarnessEntry,
 ): Promise<HarnessState[]> {
   const entries = only ? [only] : [...HARNESS_CATALOG];
-  const target = targetFor(root, run);
+  const target = targetFor(root, run, env);
 
   let reachable = false;
   try {
@@ -135,7 +146,7 @@ function renderTable(states: HarnessState[], io: HarnessIO): void {
 export async function runHarnessList(opts: HarnessOptions, io: HarnessIO): Promise<number> {
   const run = opts.run ?? spawnRunner;
   const root = resolveProjectRoot(opts.cwd);
-  const states = await collectStates(root, run);
+  const states = await collectStates(root, run, opts.env);
   if (opts.json) {
     io.stdout(`${JSON.stringify(states, null, 2)}\n`);
   } else {
@@ -164,7 +175,7 @@ export async function runHarnessStatus(
     if (!only) return unknownHarness(name, io);
   }
 
-  const states = await collectStates(root, run, only);
+  const states = await collectStates(root, run, opts.env, only);
   if (opts.json) {
     io.stdout(`${JSON.stringify(only ? states[0] : states, null, 2)}\n`);
   } else {
@@ -205,7 +216,7 @@ export async function runHarnessInstall(
 
   if (opts.persistOnly) return 0;
 
-  const target = targetFor(root, run);
+  const target = targetFor(root, run, opts.env);
   let status: string;
   try {
     status = await target.status();

--- a/.oh/cli/src/commands/lifecycle.ts
+++ b/.oh/cli/src/commands/lifecycle.ts
@@ -3,7 +3,9 @@ import { join } from "node:path";
 import {
   ExecutionExitError,
   ExecutionSpawnError,
+  HostOnlyError,
   resolveExecutionTarget,
+  runningInsideSandbox,
 } from "../lib/execution/index.js";
 import {
   assertSpawned,
@@ -98,6 +100,10 @@ function configuredImage(root: string): string | undefined {
 export async function runSandbox(opts: SandboxOptions, io: LifecycleIO): Promise<number> {
   const run = opts.run ?? spawnRunner;
   const root = resolveProjectRoot(opts.cwd);
+  if (runningInsideSandbox()) {
+    io.stderr(`${new HostOnlyError("`oh sandbox`").message}\n`);
+    return 1;
+  }
   seedConfig(root, io);
   await maybePromptDockerSocket(root, io);
   requireLifecycleScript(root, "docker-compose.sh");
@@ -127,6 +133,10 @@ export async function runSandbox(opts: SandboxOptions, io: LifecycleIO): Promise
     return 0;
   } catch (err) {
     if (err instanceof ExecutionExitError) return err.exitCode;
+    if (err instanceof HostOnlyError) {
+      io.stderr(`${err.message}\n`);
+      return 1;
+    }
     throw err;
   }
 }

--- a/.oh/cli/src/commands/runtime.ts
+++ b/.oh/cli/src/commands/runtime.ts
@@ -27,6 +27,7 @@ export interface RuntimeOptions {
   cwd?: string;
   run?: LifecycleRunner;
   json?: boolean;
+  env?: NodeJS.ProcessEnv;
 }
 
 export interface RuntimeInstallOptions extends RuntimeOptions {
@@ -61,9 +62,18 @@ function isReachable(status: string): boolean {
   return status === "ready" || status === "starting";
 }
 
-function targetFor(root: string, run: LifecycleRunner): ExecutionTarget {
+function targetFor(
+  root: string,
+  run: LifecycleRunner,
+  env?: NodeJS.ProcessEnv,
+): ExecutionTarget {
   const name = configuredContainerName(root) ?? DEFAULT_CONTAINER_NAME;
-  return resolveExecutionTarget({ projectRoot: root, container: name, run });
+  return resolveExecutionTarget({
+    projectRoot: root,
+    container: name,
+    run,
+    ...(env ? { env } : {}),
+  });
 }
 
 function requiredOf(check: PreflightCheck): string {
@@ -89,6 +99,7 @@ async function runCheck(
   check: PreflightCheck,
   run: LifecycleRunner,
   targetReachable: boolean,
+  hostMeasurable: boolean,
 ): Promise<CheckResult> {
   const base = {
     id: check.id,
@@ -102,6 +113,7 @@ async function runCheck(
   let stdout: string;
 
   if (check.scope === "host") {
+    if (!hostMeasurable) return unmeasured(check);
     const argv = [...check.probeArgv];
     const r = run(argv[0], argv.slice(1), { stdio: "capture" });
     if (r.status === null || r.status === undefined) return { ...base, found: "?", ok: null };
@@ -153,7 +165,7 @@ async function probeInstalled(
   try {
     const r = await target.exec({
       argv: [...entry.verifyArgv],
-      user: entry.installUser ?? "sandbox",
+      user: "sandbox",
       stdio: "capture",
     });
     return r.exitCode === 0;
@@ -173,10 +185,12 @@ function verdict(checks: CheckResult[]): boolean | null {
 async function collectRows(
   root: string,
   run: LifecycleRunner,
+  env?: NodeJS.ProcessEnv,
   only?: RuntimeEntry,
-): Promise<RuntimeRow[]> {
+): Promise<{ rows: RuntimeRow[]; insideSandbox: boolean }> {
   const entries = only ? [only] : [...RUNTIME_CATALOG];
-  const target = targetFor(root, run);
+  const target = targetFor(root, run, env);
+  const hostMeasurable = target.kind !== "local";
 
   let reachable = false;
   try {
@@ -189,7 +203,7 @@ async function collectRows(
   for (const entry of entries) {
     const checks: CheckResult[] = [];
     for (const check of entry.preflight) {
-      checks.push(await runCheck(target, check, run, reachable));
+      checks.push(await runCheck(target, check, run, reachable, hostMeasurable));
     }
     rows.push({
       id: entry.id,
@@ -205,7 +219,7 @@ async function collectRows(
       ...(entry.tracking !== undefined ? { tracking: entry.tracking } : {}),
     });
   }
-  return rows;
+  return { rows, insideSandbox: !hostMeasurable };
 }
 
 function cell(value: boolean | null, absent: string): string {
@@ -213,7 +227,7 @@ function cell(value: boolean | null, absent: string): string {
   return value ? "yes" : "no";
 }
 
-function renderTable(rows: RuntimeRow[], io: RuntimeIO): void {
+function renderTable(rows: RuntimeRow[], io: RuntimeIO, insideSandbox: boolean): void {
   const header = ["RUNTIME", "TIER", "STATE", "SUPPORTED", "IN USE"];
   const body = rows.map((r) => [
     r.id,
@@ -231,13 +245,15 @@ function renderTable(rows: RuntimeRow[], io: RuntimeIO): void {
   for (const row of body) io.stdout(line(row));
   if (rows.some((r) => r.checks.length > 0 && r.supported === null)) {
     io.stdout(
-      "\nSUPPORTED is `?` — that requirement could not be measured. Start the sandbox with `oh sandbox`, then re-run.\n",
+      insideSandbox
+        ? "\nSUPPORTED is `?` — a host requirement cannot be measured from inside the sandbox. Re-run on the host.\n"
+        : "\nSUPPORTED is `?` — that requirement could not be measured. Start the sandbox with `oh sandbox`, then re-run.\n",
     );
   }
 }
 
-function renderDetail(rows: RuntimeRow[], io: RuntimeIO): void {
-  renderTable(rows, io);
+function renderDetail(rows: RuntimeRow[], io: RuntimeIO, insideSandbox: boolean): void {
+  renderTable(rows, io, insideSandbox);
   for (const r of rows) {
     if (r.checks.length === 0) continue;
     io.stdout(`\n${r.id} — requirements:\n`);
@@ -260,11 +276,11 @@ export async function runRuntimeList(
 ): Promise<number> {
   const run = opts.run ?? spawnRunner;
   const root = resolveProjectRoot(opts.cwd);
-  const rows = await collectRows(root, run);
+  const { rows, insideSandbox } = await collectRows(root, run, opts.env);
   if (opts.json) {
     io.stdout(`${JSON.stringify(rows, null, 2)}\n`);
   } else {
-    renderTable(rows, io);
+    renderTable(rows, io, insideSandbox);
   }
   return 0;
 }
@@ -289,11 +305,11 @@ export async function runRuntimeStatus(
     if (!only) return unknownRuntime(name, io);
   }
 
-  const rows = await collectRows(root, run, only);
+  const { rows, insideSandbox } = await collectRows(root, run, opts.env, only);
   if (opts.json) {
     io.stdout(`${JSON.stringify(only ? rows[0] : rows, null, 2)}\n`);
   } else {
-    renderDetail(rows, io);
+    renderDetail(rows, io, insideSandbox);
   }
   return 0;
 }
@@ -321,7 +337,14 @@ export async function runRuntimeInstall(
     return 1;
   }
 
-  const target = targetFor(root, run);
+  const target = targetFor(root, run, opts.env);
+  if (target.kind === "local") {
+    io.stderr(
+      "oh runtime install changes the sandbox\u2019s Docker configuration and must run on the host, at the project root.\n",
+    );
+    return 1;
+  }
+
   let status: string;
   try {
     status = await target.status();
@@ -353,7 +376,7 @@ export async function runRuntimeInstall(
 
   const checks: CheckResult[] = [];
   for (const check of entry.preflight) {
-    checks.push(await runCheck(target, check, run, true));
+    checks.push(await runCheck(target, check, run, true, true));
   }
   const supported = verdict(checks);
 

--- a/.oh/cli/src/commands/runtime.ts
+++ b/.oh/cli/src/commands/runtime.ts
@@ -1,6 +1,7 @@
 import {
   ExecutionSpawnError,
   resolveExecutionTarget,
+  runningInsideSandbox,
 } from "../lib/execution/index.js";
 import { spawnRunner, type LifecycleRunner } from "../lib/execution/runner.js";
 import type { ExecutionTarget } from "../lib/execution/target.js";
@@ -190,7 +191,7 @@ async function collectRows(
 ): Promise<{ rows: RuntimeRow[]; insideSandbox: boolean }> {
   const entries = only ? [only] : [...RUNTIME_CATALOG];
   const target = targetFor(root, run, env);
-  const hostMeasurable = target.kind !== "local";
+  const hostMeasurable = !runningInsideSandbox(env ?? process.env);
 
   let reachable = false;
   try {
@@ -337,14 +338,14 @@ export async function runRuntimeInstall(
     return 1;
   }
 
-  const target = targetFor(root, run, opts.env);
-  if (target.kind === "local") {
+  if (runningInsideSandbox(opts.env ?? process.env)) {
     io.stderr(
       "oh runtime install changes the sandbox\u2019s Docker configuration and must run on the host, at the project root.\n",
     );
     return 1;
   }
 
+  const target = targetFor(root, run, opts.env);
   let status: string;
   try {
     status = await target.status();

--- a/.oh/cli/src/commands/tool.ts
+++ b/.oh/cli/src/commands/tool.ts
@@ -35,6 +35,7 @@ export interface ToolOptions {
   cwd?: string;
   run?: LifecycleRunner;
   json?: boolean;
+  env?: NodeJS.ProcessEnv;
 }
 
 export interface ToolInstallOptions extends ToolOptions {
@@ -58,9 +59,18 @@ function isReachable(status: string): boolean {
   return status === "ready" || status === "starting";
 }
 
-function targetFor(root: string, run: LifecycleRunner): ExecutionTarget {
+function targetFor(
+  root: string,
+  run: LifecycleRunner,
+  env?: NodeJS.ProcessEnv,
+): ExecutionTarget {
   const name = configuredContainerName(root) ?? DEFAULT_CONTAINER_NAME;
-  return resolveExecutionTarget({ projectRoot: root, container: name, run });
+  return resolveExecutionTarget({
+    projectRoot: root,
+    container: name,
+    run,
+    ...(env ? { env } : {}),
+  });
 }
 
 async function tryExec(
@@ -81,7 +91,7 @@ async function probeInstalled(
   target: ExecutionTarget,
   entry: ToolEntry,
 ): Promise<boolean | null> {
-  const r = await tryExec(target, entry.verifyArgv, entry.installUser ?? "sandbox");
+  const r = await tryExec(target, entry.verifyArgv, "sandbox");
   return r === null ? null : r.exitCode === 0;
 }
 
@@ -90,7 +100,7 @@ async function probeVersion(
   entry: ToolEntry,
 ): Promise<string | null> {
   if (entry.versionArgv === undefined) return null;
-  const r = await tryExec(target, entry.versionArgv, entry.installUser ?? "sandbox");
+  const r = await tryExec(target, entry.versionArgv, "sandbox");
   if (r === null || r.exitCode !== 0) return null;
   const first = r.stdout.trim().split("\n")[0] ?? "";
   return first === "" ? null : first;
@@ -99,10 +109,11 @@ async function probeVersion(
 async function collectRows(
   root: string,
   run: LifecycleRunner,
+  env?: NodeJS.ProcessEnv,
   only?: ToolEntry,
 ): Promise<ToolRow[]> {
   const entries = only ? [only] : [...TOOL_CATALOG];
-  const target = targetFor(root, run);
+  const target = targetFor(root, run, env);
 
   let reachable = false;
   try {
@@ -170,7 +181,7 @@ function renderDetail(rows: ToolRow[], io: ToolIO): void {
 export async function runToolList(opts: ToolOptions, io: ToolIO): Promise<number> {
   const run = opts.run ?? spawnRunner;
   const root = resolveProjectRoot(opts.cwd);
-  const rows = await collectRows(root, run);
+  const rows = await collectRows(root, run, opts.env);
   if (opts.json) {
     io.stdout(`${JSON.stringify(rows, null, 2)}\n`);
   } else {
@@ -199,7 +210,7 @@ export async function runToolStatus(
     if (!only) return unknownTool(name, io);
   }
 
-  const rows = await collectRows(root, run, only);
+  const rows = await collectRows(root, run, opts.env, only);
   if (opts.json) {
     io.stdout(`${JSON.stringify(only ? rows[0] : rows, null, 2)}\n`);
   } else {
@@ -261,7 +272,7 @@ export async function runToolInstall(
 
   if (opts.persistOnly) return 0;
 
-  const target = targetFor(root, run);
+  const target = targetFor(root, run, opts.env);
   let status: string;
   try {
     status = await target.status();

--- a/.oh/cli/src/lib/execution/detect.ts
+++ b/.oh/cli/src/lib/execution/detect.ts
@@ -1,0 +1,16 @@
+import { existsSync } from "node:fs";
+
+
+export const SANDBOX_MARKER_FILE = "/.dockerenv";
+
+export const EXECUTION_TARGET_ENV = "OH_EXECUTION_TARGET";
+
+export function runningInsideSandbox(
+  env: NodeJS.ProcessEnv = process.env,
+  fileExists: (path: string) => boolean = existsSync,
+): boolean {
+  const override = env[EXECUTION_TARGET_ENV];
+  if (override === "local") return true;
+  if (override === "docker-compose") return false;
+  return fileExists(SANDBOX_MARKER_FILE) && (env.SANDBOX_NAME ?? "") !== "";
+}

--- a/.oh/cli/src/lib/execution/index.ts
+++ b/.oh/cli/src/lib/execution/index.ts
@@ -1,7 +1,9 @@
+import { runningInsideSandbox } from "./detect.js";
 import {
   DockerComposeExecutionTarget,
   type DockerComposeTargetOptions,
 } from "./docker-compose-target.js";
+import { LocalExecutionTarget } from "./local-target.js";
 import type { ExecutionTarget } from "./target.js";
 
 
@@ -13,10 +15,27 @@ export type ResolvedExecutionTarget = ExecutionTarget &
 export function resolveExecutionTarget(
   opts: ResolveExecutionTargetOptions,
 ): ResolvedExecutionTarget {
+  if (runningInsideSandbox(opts.env ?? process.env)) {
+    return new LocalExecutionTarget({
+      projectRoot: opts.projectRoot,
+      ...(opts.run ? { run: opts.run } : {}),
+      ...(opts.env ? { env: opts.env } : {}),
+    });
+  }
   return new DockerComposeExecutionTarget(opts);
 }
 
 export { DockerComposeExecutionTarget, type DockerComposeTargetOptions };
+export {
+  EXECUTION_TARGET_ENV,
+  runningInsideSandbox,
+  SANDBOX_MARKER_FILE,
+} from "./detect.js";
+export {
+  HostOnlyError,
+  LocalExecutionTarget,
+  type LocalTargetOptions,
+} from "./local-target.js";
 export {
   ExecutionExitError,
   ExecutionSpawnError,

--- a/.oh/cli/src/lib/execution/local-target.ts
+++ b/.oh/cli/src/lib/execution/local-target.ts
@@ -1,0 +1,132 @@
+import { userInfo } from "node:os";
+import {
+  assertSpawned,
+  spawnRunner,
+  type LifecycleRunner,
+} from "./runner.js";
+import type {
+  ExecRequest,
+  ExecResult,
+  ExecutionCapability,
+  ExecutionStatus,
+  ExecutionTarget,
+} from "./target.js";
+
+
+export class HostOnlyError extends Error {
+  constructor(what: string) {
+    super(
+      `${what} manages the sandbox container from the host — you are already inside the sandbox. Run it on the host, at the project root.`,
+    );
+    this.name = "HostOnlyError";
+  }
+}
+
+export interface LocalIdentity {
+  name: string;
+  uid: number;
+}
+
+export interface LocalTargetOptions {
+  projectRoot: string;
+  run?: LifecycleRunner;
+  env?: NodeJS.ProcessEnv;
+  identity?: () => LocalIdentity;
+}
+
+export class LocalExecutionTarget implements ExecutionTarget {
+  readonly kind = "local";
+  readonly contractVersion = 1;
+  readonly workspace: { hostRoot: string; targetRoot: string };
+
+  private readonly projectRoot: string;
+  private readonly run: LifecycleRunner;
+  private readonly env?: NodeJS.ProcessEnv;
+  private readonly identity: () => LocalIdentity;
+
+  constructor(opts: LocalTargetOptions) {
+    this.projectRoot = opts.projectRoot;
+    this.run = opts.run ?? spawnRunner;
+    this.env = opts.env;
+    this.identity = opts.identity ?? defaultIdentity;
+    this.workspace = { hostRoot: opts.projectRoot, targetRoot: opts.projectRoot };
+  }
+
+  async provision(): Promise<void> {
+    throw new HostOnlyError("`oh sandbox`");
+  }
+
+  async destroy(): Promise<void> {
+    throw new HostOnlyError("`oh destroy`");
+  }
+
+  async status(): Promise<ExecutionStatus> {
+    return "ready";
+  }
+
+  async capabilities(): Promise<ReadonlySet<ExecutionCapability>> {
+    return new Set<ExecutionCapability>(["exec", "pty", "files"]);
+  }
+
+  async exec(request: ExecRequest): Promise<ExecResult> {
+    const inherit = request.stdio === "inherit";
+    const [cmd, ...args] = this.argvFor(request, inherit);
+    const r = this.run(cmd, args, {
+      stdio: inherit ? "inherit" : "capture",
+      env: this.childEnv(request),
+      ...(request.cwd !== undefined ? { cwd: request.cwd } : {}),
+      ...(request.timeoutMs !== undefined ? { timeoutMs: request.timeoutMs } : {}),
+    });
+    if (r.error?.code === "ENOENT") {
+      return { exitCode: 127, stdout: "", stderr: `${cmd}: command not found\n` };
+    }
+    assertSpawned(r, cmd);
+    return {
+      exitCode: r.status ?? 1,
+      stdout: r.stdout ?? "",
+      stderr: r.stderr ?? "",
+    };
+  }
+
+  attach(request: ExecRequest): number {
+    const [cmd, ...args] = this.argvFor(request, true);
+    const r = this.run(cmd, args, {
+      stdio: "inherit",
+      env: this.childEnv(request),
+      ...(request.cwd !== undefined ? { cwd: request.cwd } : {}),
+    });
+    assertSpawned(r, cmd);
+    return r.status ?? 1;
+  }
+
+  describe(): string {
+    return `local target inside the sandbox at ${this.projectRoot}`;
+  }
+
+  private argvFor(request: ExecRequest, interactive: boolean): string[] {
+    const argv = [...request.argv];
+    const user = request.user;
+    if (user === undefined) return argv;
+
+    const me = this.identity();
+    if (user === me.name) return argv;
+    if (user === "root" && me.uid === 0) return argv;
+    if (user === "root") {
+      return interactive ? ["sudo", "--", ...argv] : ["sudo", "-n", "--", ...argv];
+    }
+    if (me.uid === 0) return ["gosu", user, ...argv];
+
+    throw new Error(
+      `cannot run as user "${user}" from user "${me.name}" inside the sandbox`,
+    );
+  }
+
+  private childEnv(request: ExecRequest): NodeJS.ProcessEnv {
+    return { ...(this.env ?? process.env), ...(request.env ?? {}) };
+  }
+}
+
+function defaultIdentity(): LocalIdentity {
+  const info = userInfo();
+  return { name: info.username, uid: info.uid };
+}

--- a/.oh/cli/src/lib/execution/runner.ts
+++ b/.oh/cli/src/lib/execution/runner.ts
@@ -16,12 +16,17 @@ export type LifecycleRunner = (
   opts: {
     stdio: "inherit" | "capture";
     env?: NodeJS.ProcessEnv;
+    cwd?: string;
     timeoutMs?: number;
   },
 ) => RunResult;
 
 export const spawnRunner: LifecycleRunner = (cmd, args, opts) => {
-  const common = { env: opts.env, ...(opts.timeoutMs !== undefined ? { timeout: opts.timeoutMs } : {}) };
+  const common = {
+    env: opts.env,
+    ...(opts.cwd !== undefined ? { cwd: opts.cwd } : {}),
+    ...(opts.timeoutMs !== undefined ? { timeout: opts.timeoutMs } : {}),
+  };
   const r =
     opts.stdio === "capture"
       ? spawnSync(cmd, args, { ...common, stdio: ["ignore", "pipe", "pipe"], encoding: "utf8" })

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,14 @@ Update policy and release automation live in [`/git`](.claude/skills/git/SKILL.m
 - Strip explanatory comments from all tracked code — `.ts`/`.mjs`/`.sh`/`.py` plus `oh-path`, the Dockerfile, the Makefile and `.zshrc` — leaving only machine-read directives ([#837](https://github.com/mifunedev/openharness/pull/837)).
 
 ### Fixed
+- `oh harness install` and `oh tool install` now install live when run inside the sandbox instead of skipping with "sandbox not running"; `list`/`status` report real values instead of `?` ([#861](https://github.com/mifunedev/openharness/issues/861)).
 - The `development` issue closer never fired: `pull_request_target` resolves the workflow from the **default** branch (`main`), where the file does not exist. Swapped to `pull_request` ([#841](https://github.com/mifunedev/openharness/issues/841)).
 - **`uv python install` now works as the `sandbox` user without `sudo`.** `install -d -o sandbox -g sandbox .../uv/tools` chowns the final component only, so the intermediate `.../share/uv` stayed `root:root`.
 - Root cause detail: `uv python install` writes `.../uv/python`, a sibling of `tools` inside that root-owned directory, so it failed with `Permission denied`. Every level is now named explicitly, parents first.
 - The boot-time ownership repair now covers the uv tree. The UID-sync sweep only rewrites paths owned by the *old* sandbox UID, so a root-owned uv directory was never repaired. Existing containers self-heal on restart.
 
 ### Added
+- `oh` detects in-sandbox execution (`OH_EXECUTION_TARGET=local|docker-compose` overrides); `oh sandbox` and `oh runtime install` refuse in-box as host-only ([#861](https://github.com/mifunedev/openharness/issues/861)).
 - `.oh/scripts/verify-sandbox-image.sh` — reusable image verifier for the base, apt suites, sandbox UID/GID, Node/pnpm pins, the Herdr checksum, and required tool versions ([#807](https://github.com/mifunedev/openharness/issues/807)).
 - `.github/workflows/sandbox-compatibility.yml` — Dockerfile-scoped CI that builds and verifies arm64 and one amd64 image with every optional installer ([#807](https://github.com/mifunedev/openharness/issues/807)).
 - `.oh/scripts/provision-python.sh` — idempotent, user-scoped uv/Python provisioning. Drops from root to the target user with `HOME` pinned, installs a managed interpreter and an `ipykernel` venv, and verifies the kernel.

--- a/docs/harnesses/overview.md
+++ b/docs/harnesses/overview.md
@@ -25,6 +25,11 @@ If the sandbox is not running, the command persists the flag, prints a hint, and
 exits 0 — start the sandbox with `oh sandbox` and re-run it, or let the next
 build pick the harness up.
 
+`oh harness` works from inside the sandbox too. There it installs into the
+environment you are already in, and `list`/`status` report the CLIs actually
+present rather than `?`. See
+[Lifecycle commands → Where you are standing when you type `oh`](../lifecycle-commands.md#where-you-are-standing-when-you-type-oh).
+
 Two escape hatches:
 
 | Flag | Effect |

--- a/docs/lifecycle-commands.md
+++ b/docs/lifecycle-commands.md
@@ -65,6 +65,29 @@ This is why neither surface delegates to the other: making the Makefile call
 `oh <verb> -- <args>` forwards extra arguments to `docker compose`, e.g.
 `oh logs -- --tail 50`.
 
+## Where you are standing when you type `oh`
+
+`oh` runs on the host **and** inside the sandbox, and it resolves a different
+execution target for each. On the host it drives the container through Docker
+Compose. Inside the sandbox it runs commands directly, because the sandbox *is*
+the environment those commands target.
+
+Detection is automatic: `oh` treats itself as in-sandbox when `/.dockerenv`
+exists **and** `SANDBOX_NAME` is set. Override it with
+`OH_EXECUTION_TARGET=local` or `OH_EXECUTION_TARGET=docker-compose`.
+
+| Verb | On the host | Inside the sandbox |
+|---|---|---|
+| `oh harness install` · `oh tool install` | installs into the running container over Docker Compose | installs live, in place |
+| `oh harness list/status` · `oh tool list/status` | reports `?` when the container is not reachable | reports the real state of this environment |
+| `oh runtime list/status` | measures host and container requirements | host-scope requirements report `?` — re-run on the host |
+| `oh runtime install` | installs the runtime | refuses with a host-only error |
+| `oh sandbox` | provisions the sandbox | refuses with a host-only error |
+| `oh shell` | `docker exec` into the container | opens a local `zsh` |
+
+`oh runtime install` and `oh sandbox` change the sandbox's own Docker
+configuration, so they stay host-only rather than failing halfway.
+
 ## The three deliberate exceptions
 
 A probe (`.oh/evals/probes/make-oh-lifecycle-parity.sh`) asserts that every

--- a/docs/runtimes/overview.md
+++ b/docs/runtimes/overview.md
@@ -38,6 +38,11 @@ command's.
 
 A stopped sandbox is not an error: the command says so and exits 0.
 
+`oh runtime` is host-scoped. Run from inside the sandbox, `install` refuses with
+a host-only error, and host requirements report `SUPPORTED` as `?` because they
+cannot be measured from the container. Re-run on the host for a verdict. See
+[Lifecycle commands → Where you are standing when you type `oh`](../lifecycle-commands.md#where-you-are-standing-when-you-type-oh).
+
 ## What is in the catalog
 
 | Runtime | Tier | State | Installable |

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,5 +8,8 @@ export default defineConfig({
       ".oh/cli/**/__tests__/**/*.test.ts",
     ],
     globals: true,
+    env: {
+      OH_EXECUTION_TARGET: "docker-compose",
+    },
   },
 });


### PR DESCRIPTION
Closes #861

## What changed

`oh` now knows where it is standing. Run from **inside** the sandbox,
`oh harness install` and `oh tool install` install live into the current
environment instead of printing "sandbox not running — skipping the live
install" and exiting 0. `list` / `status` report the real state of that
environment rather than a column of `?`.

The verbs that genuinely manage the container from outside now say so instead
of failing with a compose error:

| Verb | Inside the sandbox, after this PR |
|---|---|
| `oh harness install` · `oh tool install` | installs live, in place |
| `oh harness list/status` · `oh tool list/status` | real `INSTALLED` values |
| `oh runtime list/status` | host-scope checks report `?` + "re-run on the host" |
| `oh runtime install` | refuses: host-only |
| `oh sandbox` | refuses: host-only |
| `oh shell` | opens a local `zsh` |

Host behavior is unchanged.

## Design

- **`.oh/cli/src/lib/execution/detect.ts`** — `runningInsideSandbox()`. In-box
  when `/.dockerenv` exists **and** `SANDBOX_NAME` is non-empty. Both signals
  are required so a bare Docker build container is not mistaken for a sandbox.
  `OH_EXECUTION_TARGET=local|docker-compose` overrides, which is also what the
  test suite pins.
- **`.oh/cli/src/lib/execution/local-target.ts`** — `LocalExecutionTarget`,
  a second implementation of the existing `ExecutionTarget` contract
  (`kind: "local"`). `exec`/`attach` spawn directly; `status()` is `ready`;
  `provision()`/`destroy()` throw `HostOnlyError`. User switching is honest:
  same user → direct, root-from-nonroot → `sudo`, non-root-from-root → `gosu`,
  anything else → an explicit error rather than a silent wrong-user run.
- **`resolveExecutionTarget()`** picks the target; no call site learned a new
  concept beyond threading an optional `env`. `DockerComposeExecutionTarget` is
  untouched.
- **Host-only guards** — `runSandbox()` returns 1 with the `HostOnlyError`
  message before touching compose; `runRuntimeInstall()` refuses when the target
  is `local`; `runCheck()` returns unmeasured for `scope: "host"` checks in-box,
  and the `?` footer gains an in-box remediation.
- Verify/version probes now run as `sandbox` rather than `entry.installUser`.
  Probing installed-ness through `sudo` was already wrong on the compose target
  and is meaningless locally.
- `LifecycleRunner` gained an optional `cwd` so the local target can honor
  `ExecRequest.cwd`.

No behavior is expressed in comments — the repo's no-explanatory-comments rule
holds; the contract lives in the tests below.

## Tests

`.oh/cli` suite: **422 passing**, 27 of them new.

- `local-target.test.ts` (new) — detection precedence and both signals, exec /
  attach argv, user-switch matrix, `HostOnlyError` on provision/destroy, ENOENT
  → exit 127, env merge, `cwd` passthrough.
- `harness.test.ts` / `tool.test.ts` — in-box installs run the installer and
  persist the flag, never print "skipping the live install", never `docker
  inspect`, never `sudo` to verify; already-installed short-circuits.
- `runtime.test.ts` — in-box `install` exits 1 with "must run on the host" and
  spawns nothing; host-scope checks stay `?` without probing.
- `lifecycle.test.ts` — in-box `oh sandbox` exits 1 with "already inside the
  sandbox" and spawns nothing; `oh shell` spawns `zsh`.
- `vitest.config.ts` pins `OH_EXECUTION_TARGET=docker-compose` so the existing
  suite keeps asserting host behavior while running inside the sandbox.

`npm run typecheck` and `npm run build` are clean.
`.oh/evals/probes/execution-target-contract.sh` PASS,
`.oh/evals/probes/changelog-entry-length.sh` PASS.

**Pre-existing, unrelated local failure:** running the whole repo suite inside
the sandbox, `.oh/scripts/__tests__/compose-args.test.ts` (hermes-dashboard
overlay) fails. It fails on clean `development` too, this PR touches neither
that test nor `.oh/scripts/docker-compose.sh`, and it is green on CI.

### Two fixes CI caught that the in-sandbox run could not

1. `runtime-preflight-gate` forbids branching on `target.kind` inside
   `commands/runtime.ts`. Host measurability is a property of *where `oh` runs*,
   not of the target, so both sites now call `runningInsideSandbox()` directly.
2. The new in-box command tests read the real OS user through
   `LocalExecutionTarget`'s default identity — `sandbox` locally, `runner` on
   CI, where the user-switch guard correctly threw. `userInfo()` is now pinned
   in those three suites.

All four checks are green.

## Smoke test (inside the sandbox)

Before (forcing the old docker-compose target with the new override):

```
$ OH_EXECUTION_TARGET=docker-compose oh tool install agent-browser --no-persist
sandbox not running (absent) — skipping the live install.
Start it with `oh sandbox`, then re-run this command; or the next container start picks it up.

$ OH_EXECUTION_TARGET=docker-compose oh harness list
HARNESS      KIND       ENABLED  INSTALLED
claude-code  default    n/a      ?
...
INSTALLED is `?` — the sandbox is not running. Start it with `oh sandbox`.
```

After (auto-detected local target):

```
$ oh tool install agent-browser --no-persist
agent-browser: already installed (agent-browser)

$ oh harness list
HARNESS      KIND       ENABLED  INSTALLED
claude-code  default    n/a      yes
codex        default    n/a      yes
pi           default    n/a      yes
opencode     optional   no       no
...

$ oh runtime status docker
RUNTIME  TIER       STATE   SUPPORTED  IN USE
docker   container  active  ?          yes

SUPPORTED is `?` — a host requirement cannot be measured from inside the sandbox. Re-run on the host.

$ oh runtime install microsandbox
oh runtime install changes the sandbox’s Docker configuration and must run on the host, at the project root.

$ oh sandbox
`oh sandbox` manages the sandbox container from the host — you are already inside the sandbox. Run it on the host, at the project root.
```

## Docs

- `docs/lifecycle-commands.md` — new "Where you are standing when you type `oh`"
  section: detection, the `OH_EXECUTION_TARGET` override, and the per-verb table.
  This is the canonical statement; the other two pages link to it.
- `docs/harnesses/overview.md` — the "sandbox is not running" paragraph now says
  `oh harness` works in-box.
- `docs/runtimes/overview.md` — `oh runtime` is host-scoped; what `?` means in-box.
- `.oh/cli/README.md` — the same note for npm readers.

**Public documentation surface:** this repo's `docs/` is the source these pages
are published from, so the change lands here. If `mifunedev/openharness-web`
carries an independent copy of the lifecycle/harness/runtime pages, it needs the
same three edits — that repo is outside this PR.
