### PR TITLE
FROM feat/878-node-trixie-base TO development

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:trixie-slim
+FROM node:22-trixie-slim
 
 ARG OH_PROJECT_ROOT=/home/sandbox/harness
 ENV OH_PROJECT_ROOT=${OH_PROJECT_ROOT}
@@ -12,10 +12,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
  && command -v lsof >/dev/null \
  && command -v htop >/dev/null \
  && command -v telnet >/dev/null \
- && rm -rf /var/lib/apt/lists/*
-
-RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
- && apt-get install -y --no-install-recommends nodejs \
  && rm -rf /var/lib/apt/lists/*
 
 RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
@@ -121,7 +117,8 @@ RUN cd /opt/oh && npm install --no-audit --no-fund && npm run build \
  && chmod +x /opt/oh/dist/oh.js \
  && ln -sf /opt/oh/dist/oh.js /usr/local/bin/oh
 
-RUN useradd -m -s /bin/zsh sandbox \
+RUN userdel -r node 2>/dev/null || true \
+ && useradd -m -u 1000 -s /bin/zsh sandbox \
  && echo "sandbox ALL=(ALL) ALL" > /etc/sudoers.d/sandbox \
  && chmod 0440 /etc/sudoers.d/sandbox \
  && groupadd -f docker && usermod -aG docker sandbox

--- a/.github/workflows/sandbox-compatibility.yml
+++ b/.github/workflows/sandbox-compatibility.yml
@@ -47,8 +47,8 @@ jobs:
       - name: Compare fixed Bookworm and Trixie bases
         run: |
           bash .oh/scripts/node-pnpm-parity.sh \
-            debian:bookworm-slim \
-            debian:trixie-slim
+            node:22-bookworm-slim \
+            node:22-trixie-slim
 
   optional-installers-image:
     name: Build one amd64 image with every optional installer

--- a/.oh/cli/src/lib/runtimes/catalog.ts
+++ b/.oh/cli/src/lib/runtimes/catalog.ts
@@ -100,7 +100,7 @@ export const RUNTIME_CATALOG: readonly RuntimeEntry[] = Object.freeze([
         minVersion: "2.39",
         probeArgv: Object.freeze(["bash", "-lc", "ldd --version | head -1"]),
         remediation:
-          "Rebuild the sandbox image: .devcontainer/Dockerfile pins debian:trixie-slim, whose glibc clears this floor. Tracked in #805.",
+          "Rebuild the sandbox image: .devcontainer/Dockerfile pins node:22-trixie-slim, whose glibc clears this floor. Tracked in #805.",
       }),
       Object.freeze({
         id: "device",

--- a/.oh/evals/probes/sandbox-boot-guard-ci.sh
+++ b/.oh/evals/probes/sandbox-boot-guard-ci.sh
@@ -80,8 +80,8 @@ else
     phas_regex() { grep -Eq -- "$1" <<<"$parity" || missing+=("compatibility parity job: $2"); }
     phas_regex '^    runs-on: ubuntu-latest$' "does not use the fixed Docker-capable amd64 runner"
     phas 'bash .oh/scripts/node-pnpm-parity.sh \' "does not invoke the Node/pnpm parity script"
-    phas 'debian:bookworm-slim \' "does not fix the baseline to debian:bookworm-slim"
-    phas 'debian:trixie-slim' "does not fix the candidate to debian:trixie-slim"
+    phas 'node:22-bookworm-slim \' "does not fix the baseline to node:22-bookworm-slim"
+    phas 'node:22-trixie-slim' "does not fix the candidate to node:22-trixie-slim"
     if grep -Eq '\$\{\{[[:space:]]*(inputs|github\.event\.inputs)\.' <<<"$parity"; then
       missing+=("compatibility parity job: images come from dispatch inputs instead of fixed values")
     fi

--- a/.oh/evals/probes/sandbox-node-base.sh
+++ b/.oh/evals/probes/sandbox-node-base.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# tier: A
+# source: openharness#878 — oh as the only front door, T0 sandbox base image
+# desc: the sandbox image builds on an official node trixie base (node:*-trixie*), the NodeSource vendor-script install is gone from every .devcontainer/ asset, and the sandbox user is pinned to an explicit uid 1000 so bind-mounted files keep their host ownership even though the node image already claims uid 1000.
+set -euo pipefail
+
+PROBE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$PROBE_DIR" && git rev-parse --show-toplevel 2>/dev/null)" \
+  || ROOT="$(cd "$PROBE_DIR/../../.." && pwd)"
+
+DC="$ROOT/.devcontainer"
+DOCKERFILE="$DC/Dockerfile"
+
+if [[ ! -f "$DOCKERFILE" ]]; then
+  echo "SKIPPED: not a source checkout — $DOCKERFILE absent" >&2
+  exit 2
+fi
+
+fail=()
+
+from_line="$(grep -m1 -E '^[[:space:]]*FROM[[:space:]]' "$DOCKERFILE" || true)"
+if [[ -z "$from_line" ]]; then
+  fail+=("(a) .devcontainer/Dockerfile has no FROM instruction")
+elif ! grep -Eq '^[[:space:]]*FROM[[:space:]]+node:[^[:space:]]*trixie' <<<"$from_line"; then
+  fail+=("(a) base image is not an official node trixie tag: ${from_line}")
+fi
+
+nodesource_hits="$(grep -rln 'deb\.nodesource\.com' "$DC" 2>/dev/null || true)"
+if [[ -n "$nodesource_hits" ]]; then
+  while IFS= read -r hit; do
+    fail+=("(b) NodeSource install survives in ${hit#"$ROOT"/} — node comes from the base image now")
+  done <<<"$nodesource_hits"
+fi
+
+if ! grep -Eq 'useradd[^|&]*-u[[:space:]]+1000[^|&]*[[:space:]]sandbox\b' "$DOCKERFILE"; then
+  fail+=("(c) the sandbox user is not created with an explicit '-u 1000'; the node image already holds uid 1000, so sandbox would silently land on 1001 and bind-mounted files would change apparent ownership on the host")
+fi
+
+if (( ${#fail[@]} )); then
+  printf 'REGRESSION: sandbox node base image contract broken:\n' >&2
+  printf '  - %s\n' "${fail[@]}" >&2
+  exit 1
+fi
+
+echo "PASS: sandbox builds on ${from_line#FROM }, no NodeSource vendor script under .devcontainer/, sandbox user pinned to uid 1000" >&2
+exit 0

--- a/.oh/scripts/__tests__/node-pnpm-parity.test.ts
+++ b/.oh/scripts/__tests__/node-pnpm-parity.test.ts
@@ -41,24 +41,24 @@ function run(fx: { bin: string }, args: string[] = []) {
 }
 
 describe("node-pnpm-parity", () => {
-  it("reads the NodeSource release and pnpm pin straight from the Dockerfile", () => {
+  it("reads the node base image tag and pnpm pin straight from the Dockerfile", () => {
     const fx = fixture({
-      "debian:bookworm-slim": "v22.14.0 10.33.0",
-      "debian:trixie-slim": "v22.14.0 10.33.0",
+      "node:22-bookworm-slim": "v22.14.0 10.33.0",
+      "node:22-trixie-slim": "v22.14.0 10.33.0",
     });
 
     const result = run(fx);
 
     expect(result.status).toBe(0);
-    expect(result.stdout).toContain("NodeSource: https://deb.nodesource.com/setup_22.x");
+    expect(result.stdout).toContain("node base:  node:22-trixie-slim");
     expect(result.stdout).toContain("pnpm pin:   10.33.0");
-    expect(result.stdout).toContain("PARITY: debian:bookworm-slim and debian:trixie-slim");
+    expect(result.stdout).toContain("PARITY: node:22-bookworm-slim and node:22-trixie-slim");
   });
 
   it("reports a divergence between the two bases", () => {
     const fx = fixture({
-      "debian:bookworm-slim": "v22.14.0 10.33.0",
-      "debian:trixie-slim": "v22.15.1 10.33.0",
+      "node:22-bookworm-slim": "v22.14.0 10.33.0",
+      "node:22-trixie-slim": "v22.15.1 10.33.0",
     });
 
     const result = run(fx);
@@ -79,6 +79,6 @@ describe("node-pnpm-parity", () => {
     });
 
     expect(result.status).toBe(1);
-    expect(result.stderr).toContain("could not read the NodeSource URL or the pnpm pin");
+    expect(result.stderr).toContain("could not read the node base image tag or the pnpm pin");
   });
 });

--- a/.oh/scripts/__tests__/sandbox-base-image.test.ts
+++ b/.oh/scripts/__tests__/sandbox-base-image.test.ts
@@ -7,9 +7,10 @@ const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../
 const dockerfile = readFileSync(path.join(repoRoot, ".devcontainer/Dockerfile"), "utf8");
 
 describe("sandbox base image", () => {
-  it("builds from Debian Trixie", () => {
-    expect(dockerfile).toMatch(/^FROM debian:trixie-slim$/m);
+  it("builds from the official Node image on Debian Trixie", () => {
+    expect(dockerfile).toMatch(/^FROM node:22-trixie-slim$/m);
     expect(dockerfile).not.toContain("debian:bookworm-slim");
+    expect(dockerfile).not.toContain("deb.nodesource.com");
   });
 
   it("tracks Trixie for Docker's apt repository", () => {

--- a/.oh/scripts/node-pnpm-parity.sh
+++ b/.oh/scripts/node-pnpm-parity.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Base-parity check: install Node and pnpm in two Debian bases using the exact
-# commands the sandbox Dockerfile uses, and require identical reported versions.
+# Base-parity check: activate pnpm in two Debian-suite variants of the Node base
+# image the sandbox Dockerfile pins, and require identical reported versions.
 # Usage: node-pnpm-parity.sh [base-a] [base-b]
 
 set -euo pipefail
@@ -9,26 +9,24 @@ SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 REPO_ROOT=$(cd "$SCRIPT_DIR/../.." && pwd)
 DOCKERFILE=${PARITY_DOCKERFILE:-$REPO_ROOT/.devcontainer/Dockerfile}
 
-BASE_A=${1:-debian:bookworm-slim}
-BASE_B=${2:-debian:trixie-slim}
-
-nodesource_url=$(grep -oE 'https://deb\.nodesource\.com/setup_[0-9]+\.x' "$DOCKERFILE" | head -1 || true)
+node_tag=$(grep -oE '^FROM node:[0-9]+-[a-z]+-slim' "$DOCKERFILE" | head -1 | cut -d: -f2 || true)
 pnpm_pin=$(grep -oE 'corepack prepare pnpm@[0-9]+\.[0-9]+\.[0-9]+' "$DOCKERFILE" | head -1 | cut -d@ -f2 || true)
 
-if [ -z "$nodesource_url" ] || [ -z "$pnpm_pin" ]; then
-  echo "FAIL: could not read the NodeSource URL or the pnpm pin from ${DOCKERFILE#"$REPO_ROOT"/}" >&2
+if [ -z "$node_tag" ] || [ -z "$pnpm_pin" ]; then
+  echo "FAIL: could not read the node base image tag or the pnpm pin from ${DOCKERFILE#"$REPO_ROOT"/}" >&2
   exit 1
 fi
 
-echo "NodeSource: $nodesource_url"
+node_major=${node_tag%%-*}
+
+BASE_A=${1:-node:$node_major-bookworm-slim}
+BASE_B=${2:-node:$node_tag}
+
+echo "node base:  node:$node_tag"
 echo "pnpm pin:   $pnpm_pin"
 
 install_snippet=$(cat <<EOF
 set -e
-apt-get update >/dev/null
-apt-get install -y --no-install-recommends ca-certificates curl gnupg >/dev/null
-curl -fsSL $nodesource_url | bash - >/dev/null 2>&1
-apt-get install -y --no-install-recommends nodejs >/dev/null
 export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
 corepack enable >/dev/null
 corepack prepare pnpm@$pnpm_pin --activate >/dev/null 2>&1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Update policy and release automation live in [`/git`](.claude/skills/git/SKILL.m
 - Delete the canonical agent definitions (`.oh/agents/`), `.oh/plans/`, `.oh/handoffs/`, and the accumulated `.oh/tasks/` folders and archive ([#865](https://github.com/mifunedev/openharness/pull/865)).
 
 ### Changed
+- Base the sandbox image on `node:22-trixie-slim` and drop the NodeSource vendor script; the `sandbox` user is now pinned to `-u 1000`, the uid the Node image already claims ([#878](https://github.com/mifunedev/openharness/issues/878)).
 - `crons/` carries its operating contract as `AGENTS.md` instead of `README.md`, documenting which cron edits apply at the next fire and which need a SIGHUP reschedule ([#874](https://github.com/mifunedev/openharness/issues/874)).
 - Move cron definitions from `.oh/crons/` to `crons/` at the repo root; `oh init`/`oh update` deliver them through the manifest's new `rootInclude` payload ([#874](https://github.com/mifunedev/openharness/issues/874)).
 - Add `CLAUDE.md` provider-compatibility symlinks beside every nested `AGENTS.md` — `.worktrees/`, `projects/`, and `crons/` — created by `oh init` for equipped repos ([#872](https://github.com/mifunedev/openharness/issues/872)).


### PR DESCRIPTION
Closes #878. Part 1 of #877.

Node is the host prerequisite now and `oh` is becoming the only front door, so Node is load-bearing inside the sandbox and deserves a first-class base rather than a vendor script piped to bash at build time.

- `FROM debian:trixie-slim` → `FROM node:22-trixie-slim`, and the NodeSource `curl … | bash -` block deleted. The official Node image *is* Debian 13 trixie, so every apt suite, keyring, and package name below it is byte-identical.
- **`useradd` now pins `-u 1000`.** The old line had no explicit UID, so `sandbox` took the first free one — 1000 on the Debian base. On the Node base UID 1000 belongs to the image's `node` user, so `sandbox` would have silently become 1001 and every bind-mounted file would have changed apparent ownership on the host. `userdel -r node` also frees gid 1000, without which the group would have drifted the same way.

### Verified in a real build

The image builds (57/57 steps) and inside it:

| check | result |
| --- | --- |
| `id sandbox` | `uid=1000(sandbox) gid=1000(sandbox) groups=1000(sandbox),1001(docker)` — byte-identical to the current `sandbox-openharness:latest` |
| `node -v` | v22.23.2 |
| `pnpm -v` | 10.33.0 (corepack 0.34.6 activates the pin cleanly) |
| `cc-safety-net --version` | 1.0.6, and `link-providers.sh`'s strict gate passes |
| `oh` / `claude` / `herdr` | all resolve |

New probe `sandbox-node-base.sh` (tier A): the `FROM` is a `node:*-trixie*` tag, no `deb.nodesource.com` survives under `.devcontainer/`, and `sandbox` is created with an explicit `-u 1000`. Its three assertions were verified to reject the pre-change forms. Full probe suite: zero non-{0,2} exits.

### One scope note

`runtime-preflight-gate.sh` pins the Dockerfile's `FROM` string to a remediation message in `catalog.ts`, so the base swap took it green→red. Fixed with a one-token prose sync (`pins debian:trixie-slim` → `pins node:22-trixie-slim`). This touches a microsandbox entry despite the Docker-only scope, but it is documentation prose the probe pins to the Dockerfile — no runtime semantics and no base-image abstraction.

### Follow-ups, not fixed here

- `PNPM_HOME=/usr/local/share/pnpm` is on PATH but the directory does not exist, and did not on the old base either — `pnpm setup --force` fails with `ERR_PNPM_UNKNOWN_SHELL`, swallowed by `|| true`. Dead config on both bases, unchanged behaviour.
- `corepack enable` overwrites the Node image's `yarn`/`yarnpkg` symlinks. Harmless (the harness uses pnpm) but a real behaviour difference.
- `docs/runtimes/microsandbox.md`, `docs/integrations/debugmcp.md`, and `docs/rfcs/rfc-runtime-support.md` still say the sandbox pins `debian:trixie-slim`. No probe guards that prose.
- `.oh/scripts/node-pnpm-parity.sh` and `.github/workflows/sandbox-compatibility.yml` keep `debian:trixie-slim` deliberately — that is an independent bookworm-vs-trixie parity harness, and `sandbox-boot-guard-ci.sh` actively asserts the workflow keeps the value.
