### PR TITLE
FROM feat/879-oh-lifecycle-parity TO feat/878-node-trixie-base

### DIFF
--- a/.oh/cli/README.md
+++ b/.oh/cli/README.md
@@ -91,6 +91,8 @@ with `OH_EXECUTION_TARGET=local` or `OH_EXECUTION_TARGET=docker-compose`.
 | `oh restart` | Restart the sandbox service. |
 | `oh logs` | Tail the sandbox compose logs. |
 | `oh ps` | Show sandbox service status. |
+| `oh destroy [--yes]` | Remove the sandbox and wipe its named volumes (`docker compose down -v`). Names the volumes, then requires you to type the sandbox name; refuses without a TTY unless `--yes` is passed. |
+| `oh compose config` | Print the compose configuration resolved from `.devcontainer/.env` and `.oh/config.json`. |
 | `oh harness <list\|install\|status>` | Install and inspect agent CLI harnesses. `install` sets the `.devcontainer/.env` `INSTALL_*` flag **and** installs into the running sandbox — no rebuild. |
 | `oh tool <list\|install\|status>` | Install and inspect sandbox tooling that is neither an agent CLI nor a runtime (agent-browser, `gh`, `herdr`, `cloudflared`, Docker CLI). A large download is confirmed first. |
 | `oh runtime <list\|install\|status>` | Report the isolation runtime in use (Docker today) and install MicroSandbox. Measures first and refuses an install that cannot succeed (`--force` overrides). Selects no runtime and writes no config. |
@@ -102,7 +104,7 @@ with `OH_EXECUTION_TARGET=local` or `OH_EXECUTION_TARGET=docker-compose`.
 These mirror the root `Makefile`'s targets one-for-one and run the same
 `.oh/scripts/docker-compose.sh`. Which one is canonical depends on where you
 are — see [lifecycle commands](https://github.com/mifunedev/openharness/blob/main/docs/lifecycle-commands.md), which also
-explains why `oh destroy` deliberately does not exist.
+states the confirmation policy `oh destroy` carries.
 
 `oh init` and `oh update` fetch their payload on demand — with no local source they shallow-clone
 the public OpenHarness repo into a temp dir and remove it after the run (`--from-remote`, `--ref <ref>`).

--- a/.oh/cli/src/__tests__/cli.property.test.ts
+++ b/.oh/cli/src/__tests__/cli.property.test.ts
@@ -10,7 +10,8 @@ vi.mock("../cli.js", async (importOriginal) => {
   return mod;
 });
 
-const { isHelpFlag, isVersionFlag } = await import("../cli.js");
+const { isHelpFlag, isVersionFlag, parseComposeArgs, parseDestroyArgs } =
+  await import("../cli.js");
 
 const stringOrUndefined = fc.oneof(fc.string(), fc.constant(undefined));
 
@@ -40,6 +41,65 @@ describe("CLI flag functions — no-throw property", () => {
       fc.property(stringOrUndefined, (s) => {
         expect(() => isHelpFlag(s)).not.toThrow();
         expect(() => isVersionFlag(s)).not.toThrow();
+      }),
+    );
+  });
+});
+
+describe("parseDestroyArgs — property tests", () => {
+  const tokens = fc.array(fc.string(), { maxLength: 5 });
+
+  it("never throws, and never confirms on tokens it did not recognise", () => {
+    fc.assert(
+      fc.property(tokens, (rest) => {
+        const parsed = parseDestroyArgs(rest);
+        if (!parsed.ok) return;
+        if (parsed.args.yes) {
+          expect(rest.some((t) => t === "--yes")).toBe(true);
+        }
+      }),
+    );
+  });
+
+  it("only ever accepts --yes and a leading help flag", () => {
+    fc.assert(
+      fc.property(tokens, (rest) => {
+        const parsed = parseDestroyArgs(rest);
+        if (!parsed.ok) return;
+        if (parsed.args.help) {
+          expect(isHelpFlag(rest[0])).toBe(true);
+          return;
+        }
+        expect(rest.every((t) => t === "--yes")).toBe(true);
+      }),
+    );
+  });
+});
+
+describe("parseComposeArgs — property tests", () => {
+  it("accepts nothing but the config subcommand and a help flag", () => {
+    fc.assert(
+      fc.property(fc.array(fc.string(), { maxLength: 5 }), (rest) => {
+        const parsed = parseComposeArgs(rest);
+        if (!parsed.ok) return;
+        if (parsed.args.subcommand !== undefined) {
+          expect(parsed.args.subcommand).toBe("config");
+          expect(rest[0]).toBe("config");
+          return;
+        }
+        expect(rest.length === 0 || isHelpFlag(rest[0])).toBe(true);
+      }),
+    );
+  });
+
+  it("only forwards tokens that appeared after a `--` separator", () => {
+    fc.assert(
+      fc.property(fc.array(fc.string(), { maxLength: 5 }), (rest) => {
+        const parsed = parseComposeArgs(rest);
+        if (!parsed.ok) return;
+        for (const token of parsed.args.passthrough) {
+          expect(rest.indexOf(token)).toBeGreaterThan(rest.indexOf("--"));
+        }
       }),
     );
   });

--- a/.oh/cli/src/__tests__/compose-verbs.test.ts
+++ b/.oh/cli/src/__tests__/compose-verbs.test.ts
@@ -56,12 +56,12 @@ function makeRunner(result: RunResult = { status: 0 }): {
 }
 
 describe("compose verbs — the surface gap they close", () => {
-  it("exposes exactly the four non-destructive verbs", () => {
-    expect(composeVerbs()).toEqual(["stop", "restart", "logs", "ps"]);
+  it("exposes every lifecycle verb the Makefile has", () => {
+    expect(composeVerbs()).toEqual(["stop", "restart", "logs", "ps", "destroy"]);
   });
 
-  it("does not expose destroy", () => {
-    expect(composeVerbs()).not.toContain("destroy" as ComposeVerb);
+  it("routes destroy through the same table, not a second implementation", () => {
+    expect(composeVerbs()).toContain("destroy" as ComposeVerb);
   });
 });
 
@@ -71,6 +71,7 @@ describe("runComposeVerb", () => {
     ["restart", ["restart"]],
     ["ps", ["ps"]],
     ["logs", ["logs", "-f"]],
+    ["destroy", ["down", "-v"]],
   ] as [ComposeVerb, string[]][])(
     "runs the vendored script with the %s argv the Makefile uses",
     (verb, expected) => {

--- a/.oh/cli/src/__tests__/destroy.test.ts
+++ b/.oh/cli/src/__tests__/destroy.test.ts
@@ -1,0 +1,330 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  destroyConfirmationPhrase,
+  namedVolumes,
+  runComposeConfig,
+  runDestroy,
+  type LifecycleIO,
+} from "../commands/lifecycle.js";
+import type { LifecycleRunner, RunResult } from "../lib/execution/runner.js";
+
+vi.mock("../cli.js", async (importOriginal) => {
+  const original = process.exit;
+  process.exit = (() => {}) as never;
+  const mod = await importOriginal<typeof import("../cli.js")>();
+  await new Promise((r) => setTimeout(r, 0));
+  process.exit = original;
+  return mod;
+});
+
+const { parseComposeArgs, parseDestroyArgs, printComposeHelp, printDestroyHelp } =
+  await import("../cli.js");
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+const cleanups: string[] = [];
+
+afterEach(() => {
+  while (cleanups.length > 0) rmSync(cleanups.pop()!, { recursive: true, force: true });
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+});
+
+const COMPOSE_YML = `name: \${SANDBOX_NAME:-openharness}
+
+services:
+  sandbox:
+    volumes:
+      - claude-auth:/home/sandbox/.claude
+      - not-a-top-level-volume:/tmp
+
+volumes:
+  claude-auth:
+  codex-auth:
+  ssh-config:
+`;
+
+function makeRepo(sandboxName?: string): string {
+  const d = mkdtempSync(join(tmpdir(), "oh-destroy-"));
+  cleanups.push(d);
+  mkdirSync(join(d, ".oh", "scripts"), { recursive: true });
+  writeFileSync(join(d, ".oh", "scripts", "docker-compose.sh"), "#!/usr/bin/env bash\n");
+  mkdirSync(join(d, ".devcontainer"), { recursive: true });
+  writeFileSync(join(d, ".devcontainer", "docker-compose.yml"), COMPOSE_YML);
+  if (sandboxName !== undefined) {
+    writeFileSync(join(d, ".devcontainer", ".env"), `SANDBOX_NAME=${sandboxName}\n`);
+  }
+  return d;
+}
+
+interface RecordedCall {
+  cmd: string;
+  args: string[];
+}
+
+function makeRunner(result: RunResult = { status: 0 }): {
+  calls: RecordedCall[];
+  run: LifecycleRunner;
+} {
+  const calls: RecordedCall[] = [];
+  const run: LifecycleRunner = (cmd, args) => {
+    calls.push({ cmd, args: [...args] });
+    return result;
+  };
+  return { calls, run };
+}
+
+function makeIo(answers?: string[]): {
+  out: string[];
+  err: string[];
+  asked: string[];
+  io: LifecycleIO;
+} {
+  const out: string[] = [];
+  const err: string[] = [];
+  const asked: string[] = [];
+  const io: LifecycleIO = {
+    stdout: (s) => out.push(s),
+    stderr: (s) => err.push(s),
+  };
+  if (answers !== undefined) {
+    const queue = [...answers];
+    io.ask = async (q: string): Promise<string> => {
+      asked.push(q);
+      return queue.shift() ?? "";
+    };
+  }
+  return { out, err, asked, io };
+}
+
+describe("named volumes — what destroy is about to delete", () => {
+  it("enumerates the top-level volumes from the compose file, not the service mounts", () => {
+    const root = makeRepo();
+    expect(namedVolumes(root)).toEqual(["claude-auth", "codex-auth", "ssh-config"]);
+  });
+
+  it("returns nothing rather than throwing when the compose file is absent", () => {
+    const d = mkdtempSync(join(tmpdir(), "oh-destroy-bare-"));
+    cleanups.push(d);
+    expect(namedVolumes(d)).toEqual([]);
+  });
+
+  it("reads the real repository's volumes so the prompt cannot drift from compose", () => {
+    const root = join(HERE, "..", "..", "..", "..");
+    expect(namedVolumes(root)).toContain("claude-auth");
+  });
+});
+
+describe("destroy confirmation phrase", () => {
+  it("prefers the ambient SANDBOX_NAME, matching what compose interpolates", () => {
+    vi.stubEnv("SANDBOX_NAME", "from-env");
+    expect(destroyConfirmationPhrase(makeRepo("from-file"))).toBe("from-env");
+  });
+
+  it("falls back to .devcontainer/.env, then to the default", () => {
+    vi.stubEnv("SANDBOX_NAME", "");
+    expect(destroyConfirmationPhrase(makeRepo("from-file"))).toBe("from-file");
+    expect(destroyConfirmationPhrase(makeRepo())).toBe("openharness");
+  });
+});
+
+describe("oh destroy — the confirmation policy", () => {
+  it("refuses outright when stdin is not a TTY and --yes is absent", async () => {
+    vi.stubEnv("SANDBOX_NAME", "");
+    const root = makeRepo("acme");
+    const { calls, run } = makeRunner();
+    const { err, io } = makeIo();
+
+    expect(await runDestroy({ cwd: root, run }, io)).toBe(1);
+    expect(calls).toHaveLength(0);
+    expect(err.join("")).toContain("refusing to destroy `acme` without a terminal");
+    expect(err.join("")).toContain("--yes");
+  });
+
+  it("names the volumes and the auth they hold before it asks", async () => {
+    vi.stubEnv("SANDBOX_NAME", "");
+    const root = makeRepo("acme");
+    const { run } = makeRunner();
+    const { out, asked, io } = makeIo(["acme"]);
+
+    expect(await runDestroy({ cwd: root, run }, io)).toBe(0);
+    const text = out.join("");
+    for (const volume of ["claude-auth", "codex-auth", "ssh-config"]) {
+      expect(text, volume).toContain(volume);
+    }
+    expect(text).toContain("provider authentication");
+    expect(asked.join("")).toContain("acme");
+  });
+
+  it("aborts and touches nothing on a bare Enter", async () => {
+    vi.stubEnv("SANDBOX_NAME", "");
+    const root = makeRepo("acme");
+    const { calls, run } = makeRunner();
+    const { err, io } = makeIo([""]);
+
+    expect(await runDestroy({ cwd: root, run }, io)).toBe(1);
+    expect(calls).toHaveLength(0);
+    expect(err.join("")).toContain("aborted — nothing was removed");
+  });
+
+  it.each(["ACME", "yes", "y", "openharness", "acme acme"])(
+    "aborts and touches nothing on the wrong answer %j",
+    async (answer) => {
+      vi.stubEnv("SANDBOX_NAME", "");
+      const root = makeRepo("acme");
+      const { calls, run } = makeRunner();
+      const { err, io } = makeIo([answer]);
+
+      expect(await runDestroy({ cwd: root, run }, io)).toBe(1);
+      expect(calls).toHaveLength(0);
+      expect(err.join("")).toContain("aborted");
+    },
+  );
+
+  it("runs `down -v` through the vendored script once the name matches", async () => {
+    vi.stubEnv("SANDBOX_NAME", "");
+    const root = makeRepo("acme");
+    const { calls, run } = makeRunner();
+    const { io } = makeIo(["acme"]);
+
+    expect(await runDestroy({ cwd: root, run }, io)).toBe(0);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].cmd).toBe("bash");
+    expect(calls[0].args).toEqual([
+      join(root, ".oh", "scripts", "docker-compose.sh"),
+      "down",
+      "-v",
+    ]);
+  });
+
+  it("skips the prompt entirely under --yes", async () => {
+    vi.stubEnv("SANDBOX_NAME", "");
+    const root = makeRepo("acme");
+    const { calls, run } = makeRunner();
+    const { out, asked, io } = makeIo();
+
+    expect(await runDestroy({ cwd: root, run, yes: true }, io)).toBe(0);
+    expect(asked).toHaveLength(0);
+    expect(out.join("")).toBe("");
+    expect(calls[0].args.slice(1)).toEqual(["down", "-v"]);
+  });
+
+  it("propagates the child's exit code", async () => {
+    vi.stubEnv("SANDBOX_NAME", "");
+    const root = makeRepo("acme");
+    const { run } = makeRunner({ status: 7 });
+    const { io } = makeIo();
+    expect(await runDestroy({ cwd: root, run, yes: true }, io)).toBe(7);
+  });
+});
+
+describe("parseDestroyArgs", () => {
+  it("defaults to prompting", () => {
+    const parsed = parseDestroyArgs([]);
+    expect(parsed).toEqual({ ok: true, args: { help: false, yes: false } });
+  });
+
+  it("accepts --yes", () => {
+    expect(parseDestroyArgs(["--yes"])).toEqual({
+      ok: true,
+      args: { help: false, yes: true },
+    });
+  });
+
+  it.each([["-y"], ["--force"], ["acme"]])("rejects %j — only --yes confirms", (token) => {
+    const parsed = parseDestroyArgs([token]);
+    expect(parsed.ok).toBe(false);
+    if (!parsed.ok) expect(parsed.error).toContain("--yes");
+  });
+
+  it.each([["--help"], ["-h"], ["help"]])("treats %j as help", (token) => {
+    expect(parseDestroyArgs([token])).toEqual({ ok: true, args: { help: true, yes: false } });
+  });
+});
+
+describe("oh compose config — the make config gap", () => {
+  it("parses the config subcommand", () => {
+    expect(parseComposeArgs(["config"])).toEqual({
+      ok: true,
+      args: { help: false, subcommand: "config", passthrough: [] },
+    });
+  });
+
+  it("forwards extra docker compose args after --", () => {
+    const parsed = parseComposeArgs(["config", "--", "--services"]);
+    expect(parsed.ok).toBe(true);
+    if (parsed.ok) expect(parsed.args.passthrough).toEqual(["--services"]);
+  });
+
+  it("rejects a bare argument rather than guessing", () => {
+    const parsed = parseComposeArgs(["config", "--services"]);
+    expect(parsed.ok).toBe(false);
+    if (!parsed.ok) expect(parsed.error).toContain("after `--`");
+  });
+
+  it("rejects an unknown subcommand and offers help", () => {
+    const parsed = parseComposeArgs(["down"]);
+    expect(parsed.ok).toBe(false);
+    if (!parsed.ok) {
+      expect(parsed.error).toContain('unknown subcommand "down"');
+      expect(parsed.showHelp).toBe(true);
+    }
+  });
+
+  it("shows help with no subcommand", () => {
+    const parsed = parseComposeArgs([]);
+    expect(parsed.ok).toBe(true);
+    if (parsed.ok) expect(parsed.args.help).toBe(true);
+  });
+
+  it("runs `config` through the vendored script", () => {
+    const root = makeRepo();
+    const { calls, run } = makeRunner();
+    expect(runComposeConfig({ cwd: root, run })).toBe(0);
+    expect(calls[0].cmd).toBe("bash");
+    expect(calls[0].args).toEqual([
+      join(root, ".oh", "scripts", "docker-compose.sh"),
+      "config",
+    ]);
+  });
+
+  it("forwards extra args to the script", () => {
+    const root = makeRepo();
+    const { calls, run } = makeRunner();
+    runComposeConfig({ cwd: root, run }, ["--services"]);
+    expect(calls[0].args.slice(1)).toEqual(["config", "--services"]);
+  });
+});
+
+describe("`oh config <integration>` is not overloaded", () => {
+  it("keeps compose config out of the integration namespace", () => {
+    const spy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    printComposeHelp();
+    const text = spy.mock.calls.map((c) => String(c[0])).join("");
+    expect(text).toContain("oh compose config");
+    expect(text).toContain("oh config <integration>");
+  });
+
+  it("dispatches compose and config down separate branches in cli.ts", async () => {
+    const { readFileSync } = await import("node:fs");
+    const cli = readFileSync(join(HERE, "..", "cli.ts"), "utf8");
+    expect(cli).toContain('if (first === "compose") {');
+    expect(cli).toContain('if (first === "config") {');
+    expect(cli).toContain("const INTEGRATIONS: Record<string, Integration> = {};");
+  });
+});
+
+describe("destroy help", () => {
+  it("states the confirmation policy and the --yes gate", () => {
+    const spy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    printDestroyHelp();
+    const text = spy.mock.calls.map((c) => String(c[0])).join("");
+    expect(text).toContain("type the sandbox name");
+    expect(text).toContain("--yes");
+    expect(text).toContain("make destroy");
+  });
+});

--- a/.oh/cli/src/cli.ts
+++ b/.oh/cli/src/cli.ts
@@ -6,7 +6,9 @@ import { runInit, type InitIO, type InitOptions } from "./commands/init.js";
 import { runUpdate } from "./commands/update.js";
 import { runCloud } from "./commands/cloud.js";
 import {
+  runComposeConfig,
   runComposeVerb,
+  runDestroy,
   runGateway,
   runSandbox,
   runShell,
@@ -93,6 +95,8 @@ Usage:
   oh restart                Restart the sandbox service
   oh logs                   Tail sandbox logs (follows)
   oh ps                     Show sandbox service status
+  oh destroy                Remove the sandbox and wipe its named volumes
+  oh compose config         Print the resolved docker compose configuration
   oh harness <args...>      Install and inspect agent CLI harnesses
   oh runtime <args...>      Inspect the sandbox's isolation runtime
   oh tool <args...>         Install and inspect sandbox tooling
@@ -354,6 +358,7 @@ export function printComposeVerbHelp(verb: ComposeVerb): void {
     restart: "Restart the sandbox service",
     logs: "Tail the sandbox compose logs (follows until interrupted)",
     ps: "Show sandbox service status",
+    destroy: "Remove the sandbox and wipe its named volumes",
   };
   process.stdout.write(`oh ${verb} — ${what[verb]}
 
@@ -367,6 +372,99 @@ that has no Makefile.
 
 See ${sourceDocsUrl("docs/lifecycle-commands.md")} for the full mapping.
 `);
+}
+
+export function printDestroyHelp(): void {
+  process.stdout.write(`oh destroy — Remove the sandbox and wipe its named volumes
+
+Usage:
+  oh destroy [--yes]
+
+Equivalent to \`make destroy\` — both run .oh/scripts/docker-compose.sh with
+\`down -v\`. This is the one destructive lifecycle verb: \`-v\` deletes the named
+volumes, and those volumes hold every agent CLI login, the gh CLI token, and
+the SSH keys. Use \`oh stop\` when you only want the containers gone.
+
+Before removing anything it names the volumes it will delete and asks you to
+type the sandbox name. A blank line, or any other answer, aborts and changes
+nothing.
+
+Flags:
+  --yes   Skip the prompt. Required when stdin is not a terminal — without a
+          terminal and without --yes, \`oh destroy\` refuses rather than guess.
+
+See ${sourceDocsUrl("docs/lifecycle-commands.md")} for the full mapping.
+`);
+}
+
+export function printComposeHelp(): void {
+  process.stdout.write(`oh compose — Inspect the resolved docker compose setup
+
+Usage:
+  oh compose config [-- <extra docker compose args>]
+
+Subcommands:
+  config   Print the compose configuration .oh/scripts/docker-compose.sh
+           resolves from .devcontainer/.env and .oh/config.json
+
+Equivalent to \`make config\`. This is namespaced under \`oh compose\` because
+\`oh config <integration>\` already means "run an integration wizard".
+
+See ${sourceDocsUrl("docs/lifecycle-commands.md")} for the full mapping.
+`);
+}
+
+export interface DestroyArgs {
+  help: boolean;
+  yes: boolean;
+}
+
+export function parseDestroyArgs(rest: string[]): ParseResult<DestroyArgs> {
+  const args: DestroyArgs = { help: false, yes: false };
+  if (isHelpFlag(rest[0])) return { ok: true, args: { ...args, help: true } };
+  for (const token of rest) {
+    if (token === "--yes") {
+      args.yes = true;
+    } else {
+      return {
+        ok: false,
+        error: `oh destroy: unexpected argument "${token}" — accepts only --yes`,
+      };
+    }
+  }
+  return { ok: true, args };
+}
+
+export interface ComposeArgs {
+  help: boolean;
+  subcommand?: "config";
+  passthrough: string[];
+}
+
+export function parseComposeArgs(rest: string[]): ParseResult<ComposeArgs> {
+  const args: ComposeArgs = { help: false, passthrough: [] };
+  if (rest.length === 0 || isHelpFlag(rest[0])) {
+    return { ok: true, args: { ...args, help: true } };
+  }
+  if (rest[0] !== "config") {
+    return {
+      ok: false,
+      error: `oh compose: unknown subcommand "${rest[0]}"`,
+      showHelp: true,
+    };
+  }
+  args.subcommand = "config";
+  const tail = rest.slice(1);
+  if (isHelpFlag(tail[0])) return { ok: true, args: { ...args, help: true } };
+  const sep = tail.indexOf("--");
+  if (sep === -1 && tail.length > 0) {
+    return {
+      ok: false,
+      error: `oh compose config: unexpected argument "${tail[0]}" — pass extra docker compose args after \`--\``,
+    };
+  }
+  if (sep !== -1) args.passthrough = tail.slice(sep + 1);
+  return { ok: true, args };
 }
 
 export function parseInitArgs(rest: string[]): ParseResult<InitArgs> {
@@ -993,6 +1091,33 @@ async function main(argv: string[]): Promise<number> {
       return 0;
     }
     return runShell({ container: parsed.args.container }, lifecycleIo());
+  }
+
+  if (first === "destroy") {
+    const parsed = parseDestroyArgs(argv.slice(1));
+    if (!parsed.ok) {
+      process.stderr.write(`${parsed.error}\n`);
+      return 1;
+    }
+    if (parsed.args.help) {
+      printDestroyHelp();
+      return 0;
+    }
+    return await runDestroy({ yes: parsed.args.yes }, lifecycleIo());
+  }
+
+  if (first === "compose") {
+    const parsed = parseComposeArgs(argv.slice(1));
+    if (!parsed.ok) {
+      process.stderr.write(`${parsed.error}\n`);
+      if (parsed.showHelp) printComposeHelp();
+      return 1;
+    }
+    if (parsed.args.help) {
+      printComposeHelp();
+      return 0;
+    }
+    return runComposeConfig({}, parsed.args.passthrough);
   }
 
   if ((composeVerbs() as string[]).includes(first)) {

--- a/.oh/cli/src/commands/lifecycle.ts
+++ b/.oh/cli/src/commands/lifecycle.ts
@@ -170,6 +170,7 @@ const COMPOSE_VERBS = Object.freeze({
   restart: Object.freeze(["restart"]),
   logs: Object.freeze(["logs", "-f"]),
   ps: Object.freeze(["ps"]),
+  destroy: Object.freeze(["down", "-v"]),
 });
 
 export type ComposeVerb = keyof typeof COMPOSE_VERBS;
@@ -191,6 +192,82 @@ export function runComposeVerb(
   });
   assertSpawned(r, `bash ${script} ${verb}`);
   return r.status ?? 1;
+}
+
+export function runComposeConfig(opts: LifecycleOptions, extra: string[] = []): number {
+  const run = opts.run ?? spawnRunner;
+  const root = resolveProjectRoot(opts.cwd);
+  const script = requireLifecycleScript(root, "docker-compose.sh");
+  const r = run("bash", [script, "config", ...extra], { stdio: "inherit" });
+  assertSpawned(r, `bash ${script} config`);
+  return r.status ?? 1;
+}
+
+export function namedVolumes(root: string): string[] {
+  let text: string;
+  try {
+    text = readFileSync(join(root, ".devcontainer", "docker-compose.yml"), "utf8");
+  } catch {
+    return [];
+  }
+  const lines = text.split("\n");
+  const start = lines.findIndex((line) => /^volumes:\s*$/.test(line));
+  if (start === -1) return [];
+  const names: string[] = [];
+  for (const line of lines.slice(start + 1)) {
+    if (/^\S/.test(line)) break;
+    const match = /^ {2}([A-Za-z0-9][A-Za-z0-9_.-]*):\s*$/.exec(line);
+    if (match) names.push(match[1]);
+  }
+  return names;
+}
+
+export interface DestroyOptions extends LifecycleOptions {
+  yes?: boolean;
+}
+
+export function destroyConfirmationPhrase(root: string): string {
+  const fromEnv = process.env.SANDBOX_NAME;
+  if (fromEnv !== undefined && fromEnv !== "") return fromEnv;
+  return configuredContainerName(root) ?? DEFAULT_CONTAINER_NAME;
+}
+
+export async function runDestroy(opts: DestroyOptions, io: LifecycleIO): Promise<number> {
+  const root = resolveProjectRoot(opts.cwd);
+  const name = destroyConfirmationPhrase(root);
+
+  if (opts.yes !== true) {
+    const interactive = process.stdin.isTTY === true || io.ask !== undefined;
+    if (!interactive) {
+      io.stderr(
+        `oh destroy: refusing to destroy \`${name}\` without a terminal — ` +
+          "re-run with --yes to confirm non-interactively\n",
+      );
+      return 1;
+    }
+
+    const volumes = namedVolumes(root);
+    io.stdout(`\n${prompt.bold(`oh destroy — ${name}`)}\n\n`);
+    io.stdout("`docker compose down -v` removes the containers and deletes\n");
+    io.stdout(
+      volumes.length > 0
+        ? `these named volumes with everything in them:\n\n  ${volumes.join("\n  ")}\n\n`
+        : "every named volume this project owns, with everything in them.\n\n",
+    );
+    io.stdout(
+      "That is the provider authentication those volumes hold — every agent CLI\n" +
+        "login, the gh CLI token, and the SSH keys. Sign-in starts over.\n\n",
+    );
+
+    const askFn = io.ask ?? prompt.ask;
+    const answer = (await askFn(`Type the sandbox name \`${name}\` to destroy it:`)).trim();
+    if (answer !== name) {
+      io.stderr("oh destroy: aborted — nothing was removed\n");
+      return 1;
+    }
+  }
+
+  return runComposeVerb("destroy", opts);
 }
 
 export function runGateway(args: string[], opts: LifecycleOptions): number {

--- a/.oh/evals/probes/make-oh-lifecycle-parity.sh
+++ b/.oh/evals/probes/make-oh-lifecycle-parity.sh
@@ -20,7 +20,7 @@ fi
 
 missing=()
 
-EXCEPTIONS=(help harness-config shell destroy config)
+EXCEPTIONS=(help harness-config shell)
 is_exception() {
   local t=$1 e
   for e in "${EXCEPTIONS[@]}"; do [[ $t == "$e" ]] && return 0; done
@@ -33,6 +33,11 @@ if [[ -z $phony ]]; then
 fi
 for target in $phony; do
   is_exception "$target" && continue
+  if [[ $target == config ]]; then
+    if grep -qF 'first === "compose"' "$CLI" && grep -qF 'runComposeConfig' "$CLI"; then continue; fi
+    missing+=("A1: make target \`config\` has no \`oh compose config\` verb")
+    continue
+  fi
   if grep -qF "first === \"$target\"" "$CLI"; then continue; fi
   if grep -qE "^  $target: " "$LIFECYCLE"; then continue; fi
   missing+=("A1: make target \`$target\` has no \`oh $target\` verb and is not a documented exception")

--- a/.oh/evals/probes/oh-destroy-guard.sh
+++ b/.oh/evals/probes/oh-destroy-guard.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# tier: A
+# source: issue #879 — `oh` becomes the only front door, so `make destroy` must
+#         survive as `oh destroy` without becoming one typo away from wiping
+#         the provider-auth volumes
+# desc: `oh destroy` never reaches docker-compose.sh without confirmation — it refuses
+#       outright when stdin is not a TTY and --yes is absent, and it aborts on any
+#       answer that is not the sandbox name when it does prompt.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+OH="$ROOT/.oh/cli/dist/oh.js"
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "SKIPPED: node is not on PATH — the oh CLI cannot be exercised" >&2
+  exit 2
+fi
+
+if [[ ! -f "$OH" ]]; then
+  echo "SKIPPED: .oh/cli/dist/oh.js is not built — run \`cd .oh/cli && npm install && npm run build\`" >&2
+  exit 2
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+SANDBOX_NAME=oh-destroy-guard
+MARKER="COMPOSE-SCRIPT-RAN"
+
+mkdir -p "$WORK/.oh/scripts" "$WORK/.devcontainer"
+cat >"$WORK/.oh/scripts/docker-compose.sh" <<EOF
+#!/usr/bin/env bash
+echo "$MARKER \$*"
+EOF
+chmod +x "$WORK/.oh/scripts/docker-compose.sh"
+cat >"$WORK/.devcontainer/docker-compose.yml" <<'EOF'
+name: ${SANDBOX_NAME:-openharness}
+
+services:
+  sandbox:
+    volumes:
+      - claude-auth:/home/sandbox/.claude
+
+volumes:
+  claude-auth:
+  ssh-config:
+EOF
+
+fails=()
+
+code=0
+out="$(cd "$WORK" && SANDBOX_NAME="$SANDBOX_NAME" node "$OH" destroy </dev/null 2>&1)" || code=$?
+[[ $code -eq 1 ]] || fails+=("non-interactive \`oh destroy\` exited $code, not 1 — it must refuse without --yes")
+grep -qF -- '--yes' <<<"$out" \
+  || fails+=("the non-interactive refusal does not name --yes, so there is no way forward: $out")
+grep -qF "$MARKER" <<<"$out" \
+  && fails+=("non-interactive \`oh destroy\` reached docker-compose.sh — the --yes gate is gone")
+
+if command -v script >/dev/null 2>&1; then
+  pty_out="$(printf 'not-the-name\n' \
+    | (cd "$WORK" && SANDBOX_NAME="$SANDBOX_NAME" script -qec "node '$OH' destroy" /dev/null 2>&1) || true)"
+
+  grep -qF "$MARKER" <<<"$pty_out" \
+    && fails+=("a wrong answer still reached docker-compose.sh — the confirmation is not enforced")
+  grep -qF "$SANDBOX_NAME" <<<"$pty_out" \
+    || fails+=("the prompt does not name the sandbox, so there is nothing specific to type")
+  grep -qF 'claude-auth' <<<"$pty_out" \
+    || fails+=("the prompt does not name the volumes it will delete")
+
+  blank_out="$(printf '\n' \
+    | (cd "$WORK" && SANDBOX_NAME="$SANDBOX_NAME" script -qec "node '$OH' destroy" /dev/null 2>&1) || true)"
+  grep -qF "$MARKER" <<<"$blank_out" \
+    && fails+=("a bare Enter still reached docker-compose.sh — the confirmation defaults to yes")
+
+  if ((${#fails[@]})); then
+    printf 'REGRESSION: %s\n' "${fails[@]}" >&2
+    exit 1
+  fi
+  echo "PASS: \`oh destroy\` refuses without a TTY and without --yes, and aborts on a wrong or blank answer" >&2
+  exit 0
+fi
+
+if ((${#fails[@]})); then
+  printf 'REGRESSION: %s\n' "${fails[@]}" >&2
+  exit 1
+fi
+
+echo "SKIPPED: \`script\` is unavailable — the --yes gate passed, the interactive prompt was not exercised" >&2
+exit 2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Update policy and release automation live in [`/git`](.claude/skills/git/SKILL.m
 ## [Unreleased]
 
 ### Added
+- `oh destroy` (a name-typing confirmation, `--yes` for non-TTY) and `oh compose config` close the last two `make`-only verbs, so `oh` is the single lifecycle door ([#879](https://github.com/mifunedev/openharness/issues/879)).
 - Restore `.oh/agents/` as an empty pack with its `.claude/agents` and `.codex/agents` provider symlinks; no agent is defined in it ([#866](https://github.com/mifunedev/openharness/pull/866)).
 
 ### Removed

--- a/docs/lifecycle-commands.md
+++ b/docs/lifecycle-commands.md
@@ -4,9 +4,10 @@ title: "Lifecycle commands: make vs oh"
 
 # Lifecycle commands: `make` vs `oh`
 
-There are two front doors to the sandbox lifecycle. This page is the single
-source of truth for which is which. Every other document links here rather than
-restating the table.
+`oh` is the front door to the sandbox lifecycle; `make` mirrors it in a source
+checkout that still has a Makefile. This page is the single source of truth for
+which is which. Every other document links here rather than restating the
+table.
 
 **They are not two implementations.** Every compose target — from both doors —
 runs `.oh/scripts/docker-compose.sh`. `make sandbox` calls it directly;
@@ -57,8 +58,8 @@ This is why neither surface delegates to the other: making the Makefile call
 | `make logs` | `oh logs` | `docker-compose.sh logs -f` |
 | `make ps` | `oh ps` | `docker-compose.sh ps` |
 | `make gateway <pi\|hermes>` | `oh gateway <args…>` | `.oh/scripts/gateway.sh` |
-| `make destroy` | — | see below |
-| `make config` | — | see below |
+| `make destroy` | `oh destroy [--yes]` | `docker-compose.sh down -v` — see below |
+| `make config` | `oh compose config` | `docker-compose.sh config` |
 | *(implicit in `make sandbox`)* | *(implicit in `oh sandbox`)* | seeds `.devcontainer/.env` from `.example.env` |
 | — | `oh init` · `oh update` · `oh harness` · `oh runtime` · `oh tool` · `oh cloud` · `oh config <integration>` | no `make` equivalent, by design |
 
@@ -88,23 +89,30 @@ exists **and** `SANDBOX_NAME` is set. Override it with
 `oh runtime install` and `oh sandbox` change the sandbox's own Docker
 configuration, so they stay host-only rather than failing halfway.
 
-## The three deliberate exceptions
+## `oh destroy` and its confirmation policy
+
+`down -v` wipes the named volumes, and those volumes hold provider
+authentication. `oh destroy` is therefore the only lifecycle verb that asks
+before it runs. It names the volumes it is about to delete — read from
+`.devcontainer/docker-compose.yml`, not hardcoded — then requires you to type
+the sandbox name. A blank line, a wrong name, or anything else aborts with a
+non-zero exit and removes nothing.
+
+Non-interactive use is gated on an explicit flag. When stdin is not a terminal
+and `--yes` is absent, `oh destroy` refuses outright rather than assume consent.
+
+## `oh compose config`, not `oh config`
+
+`oh config` already means *"configure an integration"* (`oh config <name>`), so
+the resolved-compose printer lives under its own namespace: `oh compose config`.
+That leaves room for further `oh compose <passthrough>` verbs without ever
+colliding with the integration wizards.
+
+## The one deliberate exception
 
 A probe (`.oh/evals/probes/make-oh-lifecycle-parity.sh`) asserts that every
 `make` target either has an `oh` verb or is named here. The list cannot grow
-silently.
-
-### `make destroy` — no `oh destroy`
-
-`down -v` wipes the named volumes, which hold provider authentication. A
-passthrough with no confirmation policy would put that one typo away. The verb
-is deferred until that policy is designed, not forgotten.
-
-### `make config` — no `oh` equivalent
-
-`oh config` already means *"configure an integration"* (`oh config <name>`).
-Overloading it to also print resolved compose config would be worse than the
-gap. A different verb name may resolve this later.
+silently, and it is now down to one entry.
 
 ### `make shell` — the one raw `docker exec`
 


### PR DESCRIPTION
Closes #879. Part 2 of #877. **Stacked on #878** — review that first; this targets its branch.

`docs/lifecycle-commands.md` documented two verb gaps as deliberate. The epic deletes the Makefile in part 4, so both must close first or `oh`-door users lose capability.

### `oh destroy`

Deferred until now because `down -v` wipes the named volumes holding provider auth, and a passthrough with no confirmation policy "would put that one typo away". `destroy: ["down", "-v"]` joins `COMPOSE_VERBS`, matching the Makefile's recipe, behind this policy — every check runs before anything is spawned:

1. `--yes` → straight through, no prompt.
2. Not interactive and no `--yes` → refuses at exit 1, naming `--yes`, runner never called.
3. Interactive → prints the **11 named volumes read from the compose file**, states plainly that this is every agent CLI login, the gh token and the SSH keys, then requires the sandbox name typed exactly.
4. Anything else — bare Enter, `y`, wrong case, a different name — aborts at exit 1 without spawning.

No `-y` alias, deliberately: a one-keystroke alias for the destructive verb undercuts the policy.

### `oh compose config`

`make config` collided with `oh config <integration>`, so rather than overload it this adds a `compose`-namespaced verb, leaving room for `oh compose <passthrough>` later. `oh config`'s branch is byte-identical and `INTEGRATIONS` stays empty for part 3.

**Baseline captured before the Makefile goes:** `make -s config` and `oh compose config` emit a byte-identical 144-line document (sha256 prefix `d5542909acd4f68c`), both exit 0.

### Two things found along the way

**A latent sandbox-name mismatch.** `configuredContainerName()` reads the env-file only, but compose interpolates `name: ${SANDBOX_NAME:-…}` from the *process* environment, which wins over `--env-file`. In one worktree the env-file answer was `openharness` while compose's actual project was `oh-sbx-remote` — a destroy prompt would have named a different sandbox than the one it was about to wipe. `runDestroy` resolves process env → env-file → default. `runShell` still has the old precedence; left alone as out of scope, worth a follow-up.

**The parity probe would have passed `config` for the wrong reason.** With `config` dropped from `EXCEPTIONS`, its `grep 'first === "config"'` matched the *integration* branch — green while guarding nothing. Now an explicit case requiring a `first === "compose"` branch plus `runComposeConfig`.

### Verification

465 CLI tests pass (22 files), including 28 new destroy tests and fast-check properties over both new parsers. 22 probes run individually: all PASS, none green→red against the `RESULTS.md` baseline.

`oh-destroy-guard.sh` builds a throwaway repo whose `docker-compose.sh` only echoes a marker, so a regression that lets destroy through is *detected* rather than destroying a real sandbox. It drives the interactive paths through a pty via `script(1)`, and degrades to SKIPPED without it — but only after the `--yes` half has already hard-failed on regression.
