### PR TITLE
feat(sandbox): enable Claude Code todo tools by default

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,8 @@
 {
   "enabledMcpjsonServers": ["debugmcp"],
+  "env": {
+    "CLAUDE_CODE_ENABLE_TODO_TOOLS": "1"
+  },
   "permissions": {
     "deny": [
       "Read(file_path=**/.env*)",

--- a/.devcontainer/docker-compose.image-only.yml
+++ b/.devcontainer/docker-compose.image-only.yml
@@ -50,6 +50,7 @@ services:
       # CC_SAFETY_NET_OFF left unset (kill-switch, opt-in per session).
       - CC_SAFETY_NET_STRICT=1
       - CC_SAFETY_NET_WORKTREE=1
+      - CLAUDE_CODE_ENABLE_TODO_TOOLS=1
       - GIT_USER_NAME=${GIT_USER_NAME:-}
       - GIT_USER_EMAIL=${GIT_USER_EMAIL:-}
       - GH_TOKEN=${GH_TOKEN:-}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -75,6 +75,7 @@ services:
       # CC_SAFETY_NET_OFF left unset (kill-switch, opt-in per session).
       - CC_SAFETY_NET_STRICT=1
       - CC_SAFETY_NET_WORKTREE=1
+      - CLAUDE_CODE_ENABLE_TODO_TOOLS=1
       - GIT_USER_NAME=${GIT_USER_NAME:-}
       - GIT_USER_EMAIL=${GIT_USER_EMAIL:-}
       - GH_TOKEN=${GH_TOKEN:-}

--- a/.oh/evals/probes/todo-tools-default.sh
+++ b/.oh/evals/probes/todo-tools-default.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # tier: A
-# desc: Claude Code 2.1.233+ drops the todo/task tools on current models unless CLAUDE_CODE_ENABLE_TODO_TOOLS=1; the sandbox sets it so every agent session gets the todo list by default
+# desc: Claude Code 2.1.233+ drops the todo/task tools on current models unless CLAUDE_CODE_ENABLE_TODO_TOOLS=1; the sandbox compose env and both Claude settings files set it so every agent session gets the todo list by default
 set -euo pipefail
 
 PROBE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -22,8 +22,20 @@ for f in "${COMPOSE_FILES[@]}"; do
     || fail+=("${f#"$ROOT"/} does not set CLAUDE_CODE_ENABLE_TODO_TOOLS=1")
 done
 
+SETTINGS_FILES=(
+  "$ROOT/.claude/settings.json"
+  "$ROOT/.oh/templates/full/.claude/settings.json"
+)
+
+for f in "${SETTINGS_FILES[@]}"; do
+  [[ -f "$f" ]] || continue
+  present=$(( present + 1 ))
+  grep -Eq '"CLAUDE_CODE_ENABLE_TODO_TOOLS"[[:space:]]*:[[:space:]]*"1"' "$f" \
+    || fail+=("${f#"$ROOT"/} env block does not set CLAUDE_CODE_ENABLE_TODO_TOOLS=1")
+done
+
 if (( present == 0 )); then
-  echo "SKIPPED: no .devcontainer compose file on this branch" >&2
+  echo "SKIPPED: no sandbox compose or Claude settings file on this branch" >&2
   exit 2
 fi
 
@@ -33,5 +45,5 @@ if (( ${#fail[@]} )); then
   exit 1
 fi
 
-echo "PASS: every sandbox compose file sets CLAUDE_CODE_ENABLE_TODO_TOOLS=1 ($present checked)" >&2
+echo "PASS: every sandbox compose file and Claude settings file sets CLAUDE_CODE_ENABLE_TODO_TOOLS=1 ($present checked)" >&2
 exit 0

--- a/.oh/evals/probes/todo-tools-default.sh
+++ b/.oh/evals/probes/todo-tools-default.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# tier: A
+# desc: Claude Code 2.1.233+ drops the todo/task tools on current models unless CLAUDE_CODE_ENABLE_TODO_TOOLS=1; the sandbox sets it so every agent session gets the todo list by default
+set -euo pipefail
+
+PROBE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$PROBE_DIR" && git rev-parse --show-toplevel 2>/dev/null)" \
+  || ROOT="$(cd "$PROBE_DIR/../../.." && pwd)"
+
+COMPOSE_FILES=(
+  "$ROOT/.devcontainer/docker-compose.yml"
+  "$ROOT/.devcontainer/docker-compose.image-only.yml"
+)
+
+present=0
+fail=()
+
+for f in "${COMPOSE_FILES[@]}"; do
+  [[ -f "$f" ]] || continue
+  present=$(( present + 1 ))
+  grep -Eq 'CLAUDE_CODE_ENABLE_TODO_TOOLS[=:][[:space:]]*1' "$f" \
+    || fail+=("${f#"$ROOT"/} does not set CLAUDE_CODE_ENABLE_TODO_TOOLS=1")
+done
+
+if (( present == 0 )); then
+  echo "SKIPPED: no .devcontainer compose file on this branch" >&2
+  exit 2
+fi
+
+if (( ${#fail[@]} )); then
+  printf 'REGRESSION: the sandbox no longer enables the todo/task tools by default:\n' >&2
+  printf '  - %s\n' "${fail[@]}" >&2
+  exit 1
+fi
+
+echo "PASS: every sandbox compose file sets CLAUDE_CODE_ENABLE_TODO_TOOLS=1 ($present checked)" >&2
+exit 0

--- a/.oh/templates/full/.claude/settings.json
+++ b/.oh/templates/full/.claude/settings.json
@@ -1,5 +1,8 @@
 {
   "outputStyle": "Concise",
+  "env": {
+    "CLAUDE_CODE_ENABLE_TODO_TOOLS": "1"
+  },
   "autoMemoryEnabled": false,
   "autoDreamEnabled": false,
   "includeGitInstructions": false,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Update policy and release automation live in [`/git`](.claude/skills/git/SKILL.m
 ## [Unreleased]
 
 ### Added
+- Set `CLAUDE_CODE_ENABLE_TODO_TOOLS=1` in the sandbox compose environment so agent sessions keep the todo/task tools that Claude Code 2.1.233+ withholds by default on current models ([#884](https://github.com/mifunedev/openharness/issues/884)).
+- Add `todo-tools-default.sh`, a tier-A probe asserting both sandbox compose files still set `CLAUDE_CODE_ENABLE_TODO_TOOLS=1` ([#884](https://github.com/mifunedev/openharness/issues/884)).
 - Restore `.oh/agents/` as an empty pack with its `.claude/agents` and `.codex/agents` provider symlinks; no agent is defined in it ([#866](https://github.com/mifunedev/openharness/pull/866)).
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ Update policy and release automation live in [`/git`](.claude/skills/git/SKILL.m
 ## [Unreleased]
 
 ### Added
-- Set `CLAUDE_CODE_ENABLE_TODO_TOOLS=1` in the sandbox compose environment so agent sessions keep the todo/task tools that Claude Code 2.1.233+ withholds by default on current models ([#884](https://github.com/mifunedev/openharness/issues/884)).
-- Add `todo-tools-default.sh`, a tier-A probe asserting both sandbox compose files still set `CLAUDE_CODE_ENABLE_TODO_TOOLS=1` ([#884](https://github.com/mifunedev/openharness/issues/884)).
+- Set `CLAUDE_CODE_ENABLE_TODO_TOOLS=1` in the sandbox compose env and both Claude settings files, restoring the todo/task tools Claude Code 2.1.233+ withholds on current models ([#884](https://github.com/mifunedev/openharness/issues/884)).
+- Add `todo-tools-default.sh`, a tier-A probe asserting both sandbox compose files and both Claude settings files still set `CLAUDE_CODE_ENABLE_TODO_TOOLS=1` ([#884](https://github.com/mifunedev/openharness/issues/884)).
 - Restore `.oh/agents/` as an empty pack with its `.claude/agents` and `.codex/agents` provider symlinks; no agent is defined in it ([#866](https://github.com/mifunedev/openharness/pull/866)).
 
 ### Removed


### PR DESCRIPTION
## Problem

Claude Code 2.1.233+ no longer provides `TodoWrite`, `TaskCreate`, `TaskGet`, `TaskUpdate` or `TaskList` on Opus 4.8, Sonnet 5, Fable 5, Mythos 5 and later versions of those families. A session must opt in with `CLAUDE_CODE_ENABLE_TODO_TOOLS=1`. Agent sessions in the sandbox therefore run without a todo list, and multi-step work has no visible progress surface.

Source: [Track todos](https://code.claude.com/docs/en/agent-sdk/todo-tracking) — the environment variable is the opt-in for the CLI; `todoFeatureEnabled` in `settings.json` only toggles the panel and is unrelated.

## Change

- Set `CLAUDE_CODE_ENABLE_TODO_TOOLS=1` in the `environment:` block of `.devcontainer/docker-compose.yml` and `.devcontainer/docker-compose.image-only.yml`, beside the existing `CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS` and `CC_SAFETY_NET_*` entries.
- Add an `env` block setting the same variable in `.claude/settings.json` and `.oh/templates/full/.claude/settings.json`.
- Add `.oh/evals/probes/todo-tools-default.sh` (tier A), asserting all four surfaces still carry the variable.

The two surfaces cover different sessions. Compose env reaches every process in the container regardless of cwd — worktrees under `.worktrees/`, clones under `projects/`, cron and tmux services — and takes effect on the next sandbox recreate. The settings `env` block covers a host-run session in this repo, applies without a container restart, and ships to every project scaffolded by `oh init --full`; note that per the settings docs most `env` values apply only after the folder is trusted, which is why compose is not sufficient on its own. `oh init --full` also copies `.devcontainer/` from the source checkout, so initialized projects inherit both.

## Surfaces

- **Host and sandbox:** applied in the sandbox definition; no host change.
- **Lifecycle doors:** not applicable — `make` and `oh` both reach these compose files through `.oh/scripts/docker-compose.sh`.
- **Canonical and provider surfaces:** applied — `.devcontainer/` is outside `.oh/`; the scaffold copy is the canonical `.oh/templates/full/.claude/settings.json`, and no symlink is touched.
- **Root and scaffold:** both; `oh init --full` copies the source `.devcontainer/`.
- **Interactive and headless processes:** applied to both — container environment, inherited by Herdr panes and tmux services alike.
- **Local and remote operation:** applied; the variable is in the container, not an attached shell.
- **Parallel operation:** no shared mutable state.
- **Public documentation:** not applicable — no user-facing terminology change.
- **Verification:** `todo-tools-default.sh` covers all four surfaces; full suite run below.

## Verification

```
bash .oh/skills/eval/run.sh
ran 95 probe(s) — 0 REGRESSION
todo-tools-default               PASS        new-pass  (4 surfaces checked)
```

Not verified here: the running container predates the change, so the compose variable takes effect on the next `make sandbox` recreate.

Closes #884
