### PR TITLE
fix(delegate): track the wave graph in the .oh/tasks ledger

### DIFF
--- a/.oh/evals/probes/skills-task-tool-coupling.sh
+++ b/.oh/evals/probes/skills-task-tool-coupling.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# tier: A
+# source: council review 2026-08-29 (issue #886) — /delegate instructed Claude-Code-only
+#         TaskCreate/TaskUpdate from .oh/skills/, the canonical pack symlinked into
+#         .claude, .codex and .pi. Codex and Pi never had those tools, and Claude Code
+#         2.1.233 stopped providing them by default, so the step became a silent no-op.
+# desc: the canonical skill pack and the sandbox agree about the Claude-Code-only task
+#       tools — a skill may instruct them only while the sandbox enables them, and the
+#       sandbox may enable them only while some skill needs them
+set -euo pipefail
+
+PROBE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$PROBE_DIR" && git rev-parse --show-toplevel 2>/dev/null)" \
+  || ROOT="$(cd "$PROBE_DIR/../../.." && pwd)"
+
+SKILLS="$ROOT/.oh/skills"
+TOOLS='TodoWrite|TaskCreate|TaskGet|TaskUpdate|TaskList'
+
+if [[ ! -d "$SKILLS" ]]; then
+  echo "SKIPPED: .oh/skills/ absent on this branch" >&2
+  exit 2
+fi
+
+mapfile -t consumers < <(
+  grep -rlE "\`($TOOLS)\`" "$SKILLS" 2>/dev/null | sed "s|^$ROOT/||" | sort
+)
+
+enabled_in=()
+for f in "$ROOT/.devcontainer/docker-compose.yml" \
+         "$ROOT/.devcontainer/docker-compose.image-only.yml" \
+         "$ROOT/.claude/settings.json" \
+         "$ROOT/.oh/templates/full/.claude/settings.json"; do
+  [[ -f "$f" ]] || continue
+  grep -qE 'CLAUDE_CODE_ENABLE_TODO_TOOLS' "$f" && enabled_in+=("${f#"$ROOT"/}")
+done
+
+if (( ${#consumers[@]} > 0 && ${#enabled_in[@]} == 0 )); then
+  echo "REGRESSION: a canonical skill instructs Claude-Code-only task tools that the sandbox does not enable:" >&2
+  printf '  - %s\n' "${consumers[@]}" >&2
+  echo "  Those tools are absent on Codex and Pi, and on Claude Code 2.1.233+ by default." >&2
+  echo "  Fix the skill to use the .oh/tasks/ ledger, or enable CLAUDE_CODE_ENABLE_TODO_TOOLS=1 in the sandbox." >&2
+  exit 1
+fi
+
+if (( ${#consumers[@]} == 0 && ${#enabled_in[@]} > 0 )); then
+  echo "REGRESSION: the sandbox enables CLAUDE_CODE_ENABLE_TODO_TOOLS but no canonical skill needs it:" >&2
+  printf '  - %s\n' "${enabled_in[@]}" >&2
+  echo "  Dead configuration — drop it, or point at the skill that depends on the tools." >&2
+  exit 1
+fi
+
+if (( ${#consumers[@]} == 0 )); then
+  echo "PASS: no canonical skill depends on the Claude-Code-only task tools, and the sandbox does not enable them" >&2
+else
+  echo "PASS: ${#consumers[@]} skill(s) instruct the task tools and the sandbox enables them (${enabled_in[*]})" >&2
+fi
+exit 0

--- a/.oh/skills/delegate/SKILL.md
+++ b/.oh/skills/delegate/SKILL.md
@@ -45,7 +45,7 @@ flowchart TD
 
     B -->|Yes| C["Step 2: Deep-think task decomposition"]
     C --> D["Step 3: Build dependency graph"]
-    D --> E["Step 4: Create tasks + compute waves"]
+    D --> E["Step 4: Write run ledger to .oh/tasks/"]
     E --> F{--dry-run?}
     F -->|Yes| DRY["Report: task graph + wave plan"]
     DRY --> MEM_DRY[Memory Protocol]
@@ -126,11 +126,39 @@ Output the wave plan:
 - No circular dependencies (if found, report error and stop)
 - Max 5 concurrent agents per wave (split larger waves into sub-waves)
 
-### 4. Create tasks and track dependencies
+### 4. Write the run ledger
 
-Use `TaskCreate` for each task. Then use `TaskUpdate` with `addBlockedBy` to wire dependencies.
+The task graph is durable state, not conversation state. A delegation outlives a
+context window: `/spec execute` compacts mid-build, sessions die, and another agent
+can pick up the worktree. Write the graph to disk before spawning any worker.
 
-If `--dry-run`, output the full task graph and wave plan, then skip to **Step 9**.
+**Resolve the run directory** as `.oh/tasks/<slug>/`:
+
+- Invoked inside a `/spec execute` task (a `--plan` path under `.oh/tasks/<slug>/`,
+  or that folder is the current task): reuse that `<slug>`.
+- Otherwise: `delegate-<kebab-topic>-<YYYY-MM-DD>`, created if absent.
+
+**Write two files, both owned by this skill:**
+
+| File | Contents |
+|------|----------|
+| `delegate-graph.json` | Every task's ID, title, description, `dependsOn`, files, complexity, model override plus its reason, thinking level, acceptance criteria, assigned wave, and `status` (`pending`/`running`/`completed`/`FAIL`/`BLOCKED`) |
+| `delegate-log.txt` | Append-only run log; one line per wave boundary and per status change |
+
+Never write `prd.json` or `progress.txt`. Those belong to the Advisor
+(`.oh/tasks/README.md`), and `progress.txt` in particular must not be edited by hand.
+This skill's two files sit beside them without collision.
+
+Both live under `.oh/tasks/`, which is gitignored — that is correct for run state.
+Stage them with `git add -f` only when a PR must carry the delegation as evidence.
+
+**Resume rather than restart.** If `delegate-graph.json` already exists in the resolved
+directory, read it first. Re-run only tasks whose status is `pending`, `FAIL`, or
+`BLOCKED`; treat `completed` tasks as done and pass their summaries forward as
+prior-wave context. A resumed run appends to `delegate-log.txt`; it never truncates it.
+
+If `--dry-run`, write neither file — output the full task graph and wave plan, then
+skip to **Step 7**.
 
 ### 5. Execute waves
 
@@ -169,7 +197,9 @@ If any field is missing, either add it or downgrade the task to flat execution (
 
 **b) Collect results**
 
-After all agents in the wave complete, update each task via `TaskUpdate`:
+After all agents in the wave complete, set each task's `status` and `summary` in
+`delegate-graph.json`, then append the wave's outcome to `delegate-log.txt`. Write both
+before spawning the next wave — a crash between waves must leave the graph readable.
 
 | Task | Status | Summary | Files Changed |
 |------|--------|---------|---------------|

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,12 @@ Update policy and release automation live in [`/git`](.claude/skills/git/SKILL.m
 
 ## [Unreleased]
 
+### Added
+- Add `skills-task-tool-coupling.sh`, a tier-A probe holding the canonical skill pack and the sandbox in agreement about the Claude-Code-only task tools ([#886](https://github.com/mifunedev/openharness/issues/886)).
+
 ### Fixed
 - Give the five probes that shipped without one a `# source:` header, so every probe records the lesson it closes and the `source` column in `RESULTS.md` is fully populated ([#889](https://github.com/mifunedev/openharness/issues/889)).
+- `/delegate` no longer instructs the Claude-Code-only `TaskCreate`/`TaskUpdate` from the provider-shared skill pack; its wave graph persists to a `.oh/tasks/<slug>/` run ledger ([#886](https://github.com/mifunedev/openharness/issues/886)).
 
 ## [0.5.1] - 2026-08-29
 


### PR DESCRIPTION
Implements the four-seat council ruling that closed #885. Closes #886.

## Problem

`.oh/skills/delegate/SKILL.md` instructed Claude-Code-only tools from the canonical pack that is symlinked into `.claude/skills`, `.codex/skills` and `.pi/skills`:

- `:131` (step 4) — "Use `TaskCreate` for each task. Then use `TaskUpdate` with `addBlockedBy` to wire dependencies."
- `:172` (step 5b) — "update each task via `TaskUpdate`"

Two independent breakages:

1. **Codex and Pi: broken since always.** Neither provides those tools. `docs/harnesses/pi.md:39` confirms Pi's `Task*` is a different plugin with different semantics, so the names were never a shared contract. This strains `AGENTS.md` non-negotiable #2.
2. **Claude Code: broken since v2.1.233 (2026-08-14).** `TodoWrite`, `TaskCreate`, `TaskGet`, `TaskUpdate` and `TaskList` are no longer provided by default on Opus 4.8, Sonnet 5, Fable 5, Mythos 5 and newer.

Verified in a live Opus 5 sandbox session: the tools are absent, so step 4 was a no-op the model could not report. The wave graph degraded to prose held in a context window that `/spec execute` later compacts (`execute.md:221`) — during a fan-out explicitly designed not to share mutable state. It fails silently: waves launch without dependency wiring and workers land out of order, which reads as model flakiness rather than a missing tool.

## Change

**`/delegate` steps 4 and 5b now write a run ledger** under `.oh/tasks/<slug>/`:

| File | Contents |
|------|----------|
| `delegate-graph.json` | Per-task ID, title, description, `dependsOn`, files, complexity, model override + reason, thinking level, acceptance criteria, wave, `status` |
| `delegate-log.txt` | Append-only; one line per wave boundary and per status change |

- The run directory reuses the enclosing `/spec execute` slug when there is one, else `delegate-<kebab-topic>-<YYYY-MM-DD>`.
- Both files are owned by this skill. It never writes `prd.json` or `progress.txt` — those belong to the Advisor, and `.oh/tasks/README.md` says `progress.txt` must not be edited by hand.
- Step 5b persists status *before* spawning the next wave, so a crash between waves leaves a readable graph.
- **Resume rather than restart**: an existing `delegate-graph.json` is read first, and only `pending`/`FAIL`/`BLOCKED` tasks re-run.

The fix is provider-neutral and needs no environment flag — which is the point. `CLAUDE_CODE_ENABLE_TODO_TOOLS=1` (the closed #885) would have restored the tools on Claude Code only, leaving Codex and Pi broken.

**New probe `skills-task-tool-coupling.sh`** (tier A), a two-sided invariant: a canonical skill may instruct the task tools only while the sandbox enables them, and the sandbox may enable them only while some skill needs them. It carries a `# source:` header naming the coupling, per `.oh/evals/README.md:36-40`.

This replaces the probe on the closed PR, which the council judged Goodharted against this repo's own standard (`.oh/skills/audit/references/eval-quality.md` check 6, too-narrow/special-cased; check 4, asserts an implementation detail rather than an outcome). The new probe goes green legitimately when `/delegate` stops needing the tools — which is exactly what this PR makes happen — rather than freezing a boolean forever.

## Surfaces

- **Canonical and provider surfaces:** applied — the edit is in canonical `.oh/skills/delegate/`, inherited by all three provider symlinks. No mirror patched.
- **Host and sandbox:** not applicable — no runtime or image change.
- **Lifecycle doors:** not applicable.
- **Root and scaffold:** applied to both; `.oh/skills/` ships via the manifest.
- **Interactive and headless processes:** applied to both — the ledger is on disk, so an unattended run is inspectable without an attached pane.
- **Local and remote operation:** improved; the graph now survives disconnect, session death, and worktree handoff.
- **Parallel operation:** improved; the wave graph is explicit shared state on disk rather than hidden per-session state.
- **Public documentation:** not applicable — no user-facing terminology change.
- **Verification:** below.

## Verification

```
bash .oh/skills/eval/run.sh
ran 95 probe(s) — 0 REGRESSION
skills-task-tool-coupling        PASS        new-pass
```

Both failure directions of the new probe were exercised before commit, then reverted:

- Appending a `TaskCreate` instruction to a skill with the sandbox not enabling → `REGRESSION`, exit 1, naming the file.
- Adding `CLAUDE_CODE_ENABLE_TODO_TOOLS=1` to compose with no skill consumer → `REGRESSION`, exit 1, naming it dead configuration.

Not verified here: no live `/delegate` fan-out was run against the new ledger. The council's suggested check is a `/delegate --dry-run` on ≥3 tasks with ≥1 dependency; `--dry-run` deliberately writes no files, so a real run is needed to exercise the write path.

## Council findings not acted on

- The researcher's "harness-owned ledger with Task/Todo as presentation adapters" was **rejected** as re-proposing `.oh/tasks/`, which already carries `prd.json`, `progress.txt` and `evidence.md` behind an evidence gate (`AGENTS.md:66,70,184` — YAGNI, smaller truthful model).
- `.gitignore:20-21` gitignores `.oh/tasks/*`, so ledger durability across git depends on `git add -f`. Durable by gate, not by default. Not addressed here — worth its own issue.
- 5 of 95 probes lack the required `# source:` header. Not addressed here.
