### PR TITLE
FROM development TO main

### DIFF
--- a/.oh/cli/package-lock.json
+++ b/.oh/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mifune/openharness",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mifune/openharness",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "bin": {
         "oh": "dist/oh.js"
       },

--- a/.oh/cli/package.json
+++ b/.oh/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mifune/openharness",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Open Harness CLI — scaffold sandboxes and manage OpenHarness Cloud nodes.",
   "license": "Apache-2.0",
   "homepage": "https://github.com/mifunedev/openharness#readme",

--- a/.oh/cli/tsconfig.build.json
+++ b/.oh/cli/tsconfig.build.json
@@ -1,5 +1,5 @@
 {
   "extends": "./tsconfig.json",
   "include": ["src/**/*.ts"],
-  "exclude": ["src/__tests__/**"]
+  "exclude": ["src/**/__tests__/**"]
 }

--- a/.oh/evals/probes/cli-publish-typecheck-scope.sh
+++ b/.oh/evals/probes/cli-publish-typecheck-scope.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# tier: A
+# source: release run 33271077312 — v0.5.0 pushed its GHCR image, then failed to publish
+#         the CLI to npm: prepublishOnly runs typecheck:build, which pulled in
+#         src/lib/__tests__/*.test.ts because tsconfig.build.json excluded only
+#         src/__tests__/**, and vitest is a workspace-root dependency that the publish
+#         environment does not install
+# desc: every CLI test file lives under a __tests__/ directory, and
+#       .oh/cli/tsconfig.build.json excludes all of them. Running the typecheck cannot
+#       catch this: at the workspace root vitest resolves and it passes, so the failure
+#       appears only when npm installs .oh/cli alone. The scope is asserted statically.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$ROOT"
+
+CFG=".oh/cli/tsconfig.build.json"
+SRC=".oh/cli/src"
+
+if [[ ! -f "$CFG" || ! -d "$SRC" ]]; then
+  echo "SKIPPED: not a source checkout ($CFG or $SRC missing)" >&2
+  exit 2
+fi
+
+stray="$(find "$SRC" -name "*.test.ts" -not -path "*/__tests__/*" | sort)"
+if [[ -n "$stray" ]]; then
+  echo "REGRESSION: test files outside a __tests__/ directory are invisible to the exclude:" >&2
+  printf '%s\n' "$stray" | sed 's|^|  |' >&2
+  exit 1
+fi
+
+if ! grep -q '"src/\*\*/__tests__/\*\*"' "$CFG"; then
+  echo "REGRESSION: $CFG does not exclude src/**/__tests__/**" >&2
+  echo "  Current exclude: $(grep '"exclude"' "$CFG" || echo '(none)')" >&2
+  echo "  prepublishOnly typechecks this config. A test file left in scope imports" >&2
+  echo "  vitest, which npm does not install for .oh/cli alone, so the npm publish" >&2
+  echo "  fails after the GHCR image has already been pushed." >&2
+  exit 1
+fi
+
+count="$(find "$SRC" -name "*.test.ts" | wc -l | tr -d ' ')"
+echo "PASS: $count test files, all under __tests__/ and excluded from the publish typecheck" >&2
+exit 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Update policy and release automation live in [`/git`](.claude/skills/git/SKILL.m
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-08-29
+
+### Fixed
+- `tsconfig.build.json` excluded only `src/__tests__/**`, so `prepublishOnly` typechecked `src/lib/__tests__/` and failed on the absent `vitest`, blocking the npm publish after the image had shipped.
+
 ## [0.5.0] - 2026-08-29
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openharness",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "description": "Open Harness \u2014 AI Agent Sandbox Orchestrator",
   "license": "Apache-2.0",


### PR DESCRIPTION
Promotes `development` to `main` as **v0.5.1**, completing the release that v0.5.0 started and could not finish.

### Why 0.5.1 and not 0.5.0

Run [33271077312](https://github.com/mifunedev/openharness/actions/runs/33271077312) reserved the tag and **pushed the GHCR image**, then failed at `Publish CLI to npm`:

```
src/lib/__tests__/secrets.test.ts(1,49): error TS2307:
  Cannot find module 'vitest' or its corresponding type declarations.
npm error command sh -c npm run typecheck:build
```

`prepublishOnly` runs `typecheck:build`, and `tsconfig.build.json` excluded only `src/__tests__/**`. The three files [#887](https://github.com/mifunedev/openharness/pull/887) added under `src/lib/__tests__/` stayed in scope; they import `vitest`, a workspace-root dependency that npm does not install when it builds `.oh/cli` alone. `Finalize GitHub Release` was gated on the publish and skipped, so the release is still a draft and npm is still on `0.2.0`.

`v0.5.0` is already tagged, so re-promoting under that version would have `reserve-github-release.mjs` classify it as `already-released` and skip the image, the npm publish, and the release alike. A patch bump is the path that actually ships.

**The v0.5.0 draft release, its tag, and its GHCR image are deliberately left alone.** The image is valid; it simply never got a matching CLI on npm. Deleting them was the alternative and carried more risk than the orphan does — the workflow pushes immutable SemVer tags, and `:0.5.0` already exists.

### The fix

- `tsconfig.build.json` excludes `src/**/__tests__/**` instead of `src/__tests__/**`.
- **`cli-publish-typecheck-scope.sh`** asserts every CLI test file lives under a `__tests__/` directory and that the build config excludes all of them.

The probe is static on purpose. **CI could not have caught this by running the command** — at the workspace root `vitest` resolves and `typecheck:build` passes, so the failure exists only in the publish environment. Running it harder would not have helped; asserting the scope does.

Both probe failure paths were negative-tested: narrowing the exclude back, and adding a stray `src/lib/stray.test.ts`, each exit 1 naming the cause.

### Verification

Against the real publish path, not the workspace: a clean `npm install` inside a copy of `.oh/cli`, then `npm run typecheck:build` → **exit 0**. Restoring the old exclude in that same copy reproduces all three `TS2307` errors from the failed run.

`version-parity.sh`, `changelog-entry-length.sh`, and `cli-publish-typecheck-scope.sh` all PASS at `0.5.1`.

### Expected on merge

```
reserve v0.5.1        OK
publish-image 0.5.1   OK
publish-cli   0.5.1   OK   <- npm finally moves off 0.2.0
finalize              OK
```

Then the site mirror refreshes and the check that has been failing since this began finally passes:

```bash
curl -fsS https://oh.mifune.dev/oh.js | grep -c "oh secret"   # expect > 0
```

Merge with a **merge commit**, not a squash.

Refs #877
