### PR TITLE
FROM skill/912-audit-slop-gate TO development

### DIFF
--- a/.oh/evals/RESULTS.md
+++ b/.oh/evals/RESULTS.md
@@ -6,110 +6,111 @@ probe id; git history is the time series.** Schema and exit-code semantics are i
 
 | probe | tier | last-run (UTC) | status | source |
 |-------|------|----------------|--------|--------|
-| advisor-monitored-loop | A | 2026-08-31 21:00 | PASS | conversation 2026-06-19 (single-owner implementation workflow, issue #257) |
-| agent-browser-cli | A | 2026-08-31 21:00 | PASS | retro lesson 2026-06-07 (agent-browser 0.8.5 CLI) |
-| agents-identity-contract | A | 2026-08-31 21:00 | PASS | issue #854 — T3-style root identity, glossary, and skill-owned procedures |
-| artifact-contract-audit | A | 2026-08-31 21:00 | PASS | issue #583/#645 — production /audit implementation Gate 1 behavior |
-| audit-dispatcher-contract | A | 2026-08-31 21:00 | PASS | issue #645 — audit consolidation public taxonomy |
-| audit-implementation-behavior | A | 2026-08-31 21:00 | PASS | issue #645 — implementation root/repo/browser behavior |
-| audit-pr-acquire | A | 2026-08-31 21:00 | PASS | issue #645 — production PR acquisition behavior |
-| audit-pr-classifier | A | 2026-08-31 21:00 | PASS | issue #645 — deterministic focused and queue PR classifier |
-| audit-run-root-contract | A | 2026-08-31 21:00 | PASS | issue #645 — executable immutable audit root/run correlation |
-| audit-shellcheck-coverage | A | 2026-08-31 21:00 | PASS | issue #645 — private audit scripts require release and CI lint coverage |
-| audit-stale-references | A | 2026-08-31 21:00 | PASS | issue #645 — clean-breaking audit migration |
-| boot-lint-glob | A | 2026-08-31 21:00 | PASS | issue #90, issue #120 |
-| builder-skill-consolidation | A | 2026-08-31 21:00 | PASS | issue #643 — consolidate artifact builders behind one /builder dispatcher |
-| capability-benchmark-schema | A | 2026-08-31 21:00 | PASS | issue #167 — capability benchmark instrument |
-| cc-safety-net-wiring | A | 2026-08-31 21:00 | SKIPPED | .oh/tasks/cc-safety-net/prd.json US-007 2026-07-19 |
-| changelog-entry-length | A | 2026-08-31 21:00 | PASS | conversation 2026-08-24 — CHANGELOG.md grew to 259KB of bullet prose because "one line" was unquantified |
-| cleanup-tasks-scoped-guard | A | 2026-08-31 21:00 | PASS | issue #85 |
-| cleanup-tasks-worktree-grooming | A | 2026-08-31 21:00 | PASS | issue #168; issue #327 |
-| cli-publish-typecheck-scope | A | 2026-08-31 21:00 | PASS | release run 33271077312 — v0.5.0 pushed its GHCR image, then failed to publish |
-| close-issues-on-development | A | 2026-08-31 21:00 | PASS | issue #841 (closing keywords never fire because the default branch is main) 2026-08-26 |
-| codex-stale-response-retry | A | 2026-08-31 21:00 | PASS | issue #506 — Codex previous_response_not_found RCA |
-| compose-config-path-parity | A | 2026-08-31 21:00 | PASS | PR #833 (remove harness.yaml — the wrapper and VS Code "Reopen in Container" paths must resolve the same service) 2026-08-26 |
-| config-schema-parity | A | 2026-08-31 21:00 | PASS | PR #833 (one schema file — DOCKER_SOCKET, SANDBOX_SSH, OH_SANDBOX_IMAGE, OH_PULL_POLICY, SKIP_PNPM_INSTALL were consumed but undocumented); rewritten for the oh.json/secrets split by PR #887 |
-| context-tier-size-budget | A | 2026-08-31 21:00 | PASS | .oh/tasks/spec-simplification/ (issue #816, US-007) — the always-on tier was 85,256 B |
-| cron-claude-codex-fallback | A | 2026-08-31 21:00 | PASS | conversation 2026-06-12 (default Codex fallback for crons) |
-| cron-watchdog | A | 2026-08-31 21:00 | PASS | issues #130/#453 (cron runtime watchdog + legacy system-cron reaping) 2026-06-19 |
-| crons-directory-guide | A | 2026-08-31 21:00 | PASS | issue #874 |
-| curl-bash-safe-alternatives | A | 2026-08-31 21:00 | PASS | vet-run/vet integration — public curl|bash examples need review-first alternatives |
-| datasets-schema | A | 2026-08-31 21:00 | PASS | issue #196 — .oh/evals/datasets verifiable trajectory corpus (Repo2RLEnv-inspired) |
-| debugmcp-availability | A | 2026-08-31 21:00 | SKIPPED | issue #297 — DebugMCP MCP debug-server availability |
-| default-provisioning | A | 2026-08-31 21:00 | PASS | #902 — `oh harness install` must work from inside the sandbox, where |
-| delegate-model-effort-policy | A | 2026-08-31 21:00 | PASS | conversation 2026-07-11 (delegate model inheritance and thinking policy) |
-| devtcp-hook | A | 2026-08-31 21:00 | PASS | retro lesson 2026-06-10 (zsh /dev/tcp) |
-| docker-inspect-env-guard | A | 2026-08-31 21:00 | PASS | operator directive 2026-08-08 (agents keep the docker socket, but must |
-| docs-build-fast-path | A | 2026-08-31 21:00 | PASS | #455 — docs builds must stay out of fast harness/eval/release gates; #536 — docs site externalized to openharness-web; docs markdown relocated to docs/ |
-| drift-check-cron-staleness-glob | A | 2026-08-31 21:00 | PASS | issue #98; issue #225 (restart-required cron frontmatter/config drift) |
-| entrypoint-pnpm-manifest-fingerprint | A | 2026-08-31 21:00 | PASS | issue #521 (manifest-aware sandbox installs) 2026-07-01 |
-| eval-ci-gate | A | 2026-08-31 21:00 | PASS | #103 — eval probe suite gated in CI |
-| eval-gate | A | 2026-08-31 21:00 | PASS | retro lesson 2026-06-11 (eval-gate) |
-| eval-results-atomic | A | 2026-08-31 21:00 | PASS | issue #83 (eval-results-atomic-write) |
-| eval-runner-exit | A | 2026-08-31 21:00 | PASS | retro lesson 2026-06-11 (eval-runner-exit) #29 |
-| eval-runs-once-per-cycle | A | 2026-08-31 21:00 | PASS | .oh/tasks/spec-simplification/ (issue #816, US-006) — /eval ran 3x per cycle on the |
-| execution-target-contract | A | 2026-08-31 21:00 | PASS | issue #733 (ExecutionTarget contract + Docker Compose adapter) 2026-08-10 |
-| get-oh-bootstrap | A | 2026-08-31 21:00 | PASS | get-oh.sh bootstrap — the Node-bootstrapping host-side path to the standalone `oh` CLI (also on npm as @mifune/openharness; see oh-npm-package.sh) |
-| git-skill | A | 2026-08-31 21:00 | PASS | conversation 2026-06-15 — rules are not always supported; git workflow must be the /git skill |
-| harness-audit-empty-output-gate | A | 2026-08-31 21:00 | PASS | issue #246 — /audit harness must fail closed on empty auditor outputs |
-| harness-ci-core-paths | A | 2026-08-31 21:00 | PASS | #165 — core sandbox config files must trigger harness CI |
-| harness-ci-hooks-paths | A | 2026-08-31 21:00 | PASS | issue #202 — credential/security hook changes must trigger harness CI |
-| harness-yaml-migration | A | 2026-08-31 21:00 | PASS | PR #833 (migrate-harness-yaml.sh — append / uncomment-in-place / preserve / overwrite, plus a silent no-op second run) 2026-08-26 |
-| health-check-docker-stats | A | 2026-08-31 21:00 | PASS | retro lesson 2026-06-10 (docker stats vs ps Size) |
-| health-check-socket-degrade | A | 2026-08-31 21:00 | PASS | issue #762 (refs #756) — /health-check degrades to one statement, not nine failures |
-| heartbeat-logging-contract | A | 2026-08-31 21:00 | PASS | issue #447 (heartbeat log append hardening) 2026-06-18 |
-| image-seed-hygiene | A | 2026-08-31 21:00 | PASS | issue #900 (slim the sandbox image) 2026-08-30 |
-| markitdown-wiki-ingest | A | 2026-08-31 21:00 | PASS | issue #649 — pinned local-document normalization contract for /wiki ingest |
-| next-dev-prod | A | 2026-08-31 21:00 | SKIPPED | retro lesson 2026-06-04 |
-| oh-compose-env-wiring | A | 2026-08-31 21:00 | PASS | issue #880 (oh as the only front door — oh.json is the non-secret config surface) |
-| oh-config-surfaces | A | 2026-08-31 21:00 | PASS | PR #887 (config split across two authored surfaces — a tracked oh.json and a secrets-only root dotenv — with nothing left under $HOME) |
-| oh-destroy-guard | A | 2026-08-31 21:00 | PASS | issue #879 — `oh` becomes the only front door, so `make destroy` must |
-| oh-devcontainer-restructure | A | 2026-08-31 21:00 | PASS | consolidate devcontainer — .oh/devcontainer/ folded back into .devcontainer/ |
-| oh-home-mount | A | 2026-08-31 21:00 | PASS | issue #898 (single $HOME mount) 2026-08-30 |
-| oh-image-only-deploy | A | 2026-08-31 21:00 | PASS | .oh/tasks/image-only-deploy/prd.json US-004 (issue #609, Flavor B image-only deploy) |
-| oh-init-headless-config | A | 2026-08-31 21:00 | PASS | PR #827 (installer answers landed in the losing config file); retargeted to the .example.env template by PR #833, then to oh.json by PR #887 |
-| oh-init-scaffold | A | 2026-08-31 21:00 | PASS | issue #531 Phase 2 |
-| oh-lifecycle-surface | A | 2026-08-31 21:00 | PASS | issue #881 — the Makefile is retired and `oh` is the only front door |
-| oh-npm-package | A | 2026-08-31 21:00 | PASS | npm publish path for the standalone `oh` CLI (@mifune/openharness) — alternative to get-oh.sh |
-| oh-payload-manifest | A | 2026-08-31 21:00 | PASS | issue #531 follow-on (.oh payload manifest — oh update ships a declared allowlist) |
-| oh-sandbox-image-mode | A | 2026-08-31 21:00 | PASS | conversation 2026-07-05 (basic Docker deployment — prebuilt-image mode) |
-| oh-shipped-repo-overridable | A | 2026-08-31 21:00 | PASS | issue #531 follow-on (de-hardcode residual — shipped .oh shell scripts keep the upstream repo overridable) |
-| oh-standalone-lifecycle | A | 2026-08-31 21:00 | PASS | issue #564 |
-| oh-update | A | 2026-08-31 21:00 | PASS | issue #531 Phase 3 (oh update — upgrade only the .oh control plane) |
-| operator-config-guard | A | 2026-08-31 21:00 | PASS | operator directives 2026-08-06 (.config/ and settings.local.json are operator-only) |
-| pnpm-audit-ci-gate | A | 2026-08-31 21:00 | PASS | issue #171 — pnpm security audits must run in CI |
-| post-bridge-publish-confirmation | A | 2026-08-31 21:00 | PASS | #523 — post-bridge live publishing requires an explicit final confirmation gate |
-| prd-output-path-contract | A | 2026-08-31 21:00 | PASS | retro lesson 2026-06-19 |
-| prompt-miner-schema-compat | A | 2026-08-31 21:00 | PASS | issue #253 — prompt-miner JSONL schema-drift guard |
-| prompt-miner-symlink-entrypoint | A | 2026-08-31 21:00 | PASS | issue #663 — prompt-miner engine no-ops via the documented .claude/skills symlink |
-| prompt-miner-weakness-record | A | 2026-08-31 21:00 | PASS | issue #580 — prompt-miner weakness-record (WH-xxx) cluster output |
-| protected-path-deletion | A | 2026-08-31 21:00 | PASS | .oh/tasks/spec-simplification/ (issue #816, US-001) — the critique gate was deleted, |
-| protected-paths-resolve | A | 2026-08-31 21:00 | PASS | issue #753 — .claude/protected-paths.txt named 7 paths that did not exist. |
-| registry-portability-gate | A | 2026-08-31 21:00 | PASS | issue #758 |
-| registry-portability | A | 2026-08-31 21:00 | SKIPPED | issue #758 |
-| retro-deterministic-contract | A | 2026-08-31 21:00 | PASS | issue #443 — /retro deterministic output and self-contained helper contract |
-| rl-delegation-write-worker | A | 2026-08-31 21:00 | PASS | retro lesson 2026-06-10 (rl-delegation) #57 |
-| rlm-context-budget | A | 2026-08-31 21:00 | PASS | .oh/tasks/rlm-weighted-trajectories/prd.json US-006 |
-| runtime-preflight-gate | A | 2026-08-31 21:00 | PASS | issue #806 § B1 (open sandbox.substrate vs sandbox.runtime selector); |
-| sandbox-boot-guard-ci | A | 2026-08-31 21:00 | PASS | issue #449 (sandbox image build CI guard) 2026-06-19; |
-| sandbox-node-base | A | 2026-08-31 21:00 | PASS | openharness#878 — oh as the only front door, T0 sandbox base image |
-| skill-paths | A | 2026-08-31 21:00 | PASS | issue #43 — stale path references; extended by issue #69 — apps/->packages/ rename guard; extended by issue #870 — deleted .oh/agents/advisor.md |
-| skills-dir-clean | A | 2026-08-31 21:00 | PASS | conversation 2026-06-29 — Pi parses every top-level `.md` in the skills |
-| skills-task-tool-coupling | A | 2026-08-31 21:00 | PASS | council review 2026-08-29 (issue #886) — /delegate instructed Claude-Code-only |
-| skills-vendored | A | 2026-08-31 21:00 | PASS | absorb .mifune submodule into .oh — the skills/agents/hooks pack is vendored |
-| slack-admin-command-surface | A | 2026-08-31 21:00 | PASS | issue #354 — Slack bridge docs must distinguish Pi /msg-bridge commands from Slack DM admin text handlers |
-| spec-family-contract | A | 2026-08-31 21:00 | PASS | issue #265; spec-simplification issue #816; workflow authority issue #854 |
-| spec-ready-finalization | A | 2026-08-31 21:00 | PASS | issue #134; spec-simplification issue #816; workflow authority issue #854 |
-| ste-checker-contract | A | 2026-08-31 21:00 | PASS | issue #750 PR audit — the /ste checker had four fail-open paths (unclosed |
-| submitted-by-trailers | A | 2026-08-31 21:00 | PASS | conversation 2026-06-12 (commit attribution trailers); the single-owner |
-| sync-skill-contract | A | 2026-08-31 21:00 | PASS | issue #331 — /sync dispatcher skill (bidirectional origin↔upstream sync) |
-| t3-headless-launch | A | 2026-08-31 21:00 | PASS | issue #858 — /t3 launched a bare `npx --yes t3`, which is the local GUI and |
-| tailscale-tool-boundary | A | 2026-08-31 21:00 | PASS | issue #858 — Tailscale mobile access for T3 Code. There is no tailnet, no |
-| tool-catalog-boundary | A | 2026-08-31 21:00 | PASS | agent-browser's exclusion from the harness catalog (#821) and the |
-| version-parity | A | 2026-08-31 21:00 | PASS | conversation 2026-08-29 — the oh CLI became the only lifecycle door, so its |
-| weigh-scorer-contract | A | 2026-08-31 21:00 | PASS | .oh/tasks/rlm-weighted-trajectories/prd.json US-003 (2026-06-27) |
-| wiki-readme-index | A | 2026-08-31 21:00 | PASS | issue #132 — wiki README index drift guard |
-| workflow-boundaries | A | 2026-08-31 21:00 | PASS | conversation 2026-06-19 (workflow consolidation, issue #259); authority moved to /spec in issue #854 |
-| worktrees-layout | A | 2026-08-31 21:00 | PASS | issue #872 |
+| advisor-monitored-loop | A | 2026-08-31 21:20 | PASS | conversation 2026-06-19 (single-owner implementation workflow, issue #257) |
+| agent-browser-cli | A | 2026-08-31 21:20 | PASS | retro lesson 2026-06-07 (agent-browser 0.8.5 CLI) |
+| agents-identity-contract | A | 2026-08-31 21:20 | PASS | issue #854 — T3-style root identity, glossary, and skill-owned procedures |
+| artifact-contract-audit | A | 2026-08-31 21:20 | PASS | issue #583/#645 — production /audit implementation Gate 1 behavior |
+| audit-dispatcher-contract | A | 2026-08-31 21:20 | PASS | issue #645 — audit consolidation public taxonomy |
+| audit-implementation-behavior | A | 2026-08-31 21:20 | PASS | issue #645 — implementation root/repo/browser behavior |
+| audit-pr-acquire | A | 2026-08-31 21:20 | PASS | issue #645 — production PR acquisition behavior |
+| audit-pr-classifier | A | 2026-08-31 21:20 | PASS | issue #645 — deterministic focused and queue PR classifier |
+| audit-run-root-contract | A | 2026-08-31 21:20 | PASS | issue #645 — executable immutable audit root/run correlation |
+| audit-shellcheck-coverage | A | 2026-08-31 21:20 | PASS | issue #645 — private audit scripts require release and CI lint coverage |
+| audit-slop-gate | A | 2026-08-31 21:20 | PASS | .claude/specs/images/reduce-slop.png — the four correctness gates all pass a change |
+| audit-stale-references | A | 2026-08-31 21:20 | PASS | issue #645 — clean-breaking audit migration |
+| boot-lint-glob | A | 2026-08-31 21:20 | PASS | issue #90, issue #120 |
+| builder-skill-consolidation | A | 2026-08-31 21:20 | PASS | issue #643 — consolidate artifact builders behind one /builder dispatcher |
+| capability-benchmark-schema | A | 2026-08-31 21:20 | PASS | issue #167 — capability benchmark instrument |
+| cc-safety-net-wiring | A | 2026-08-31 21:20 | SKIPPED | .oh/tasks/cc-safety-net/prd.json US-007 2026-07-19 |
+| changelog-entry-length | A | 2026-08-31 21:20 | PASS | conversation 2026-08-24 — CHANGELOG.md grew to 259KB of bullet prose because "one line" was unquantified |
+| cleanup-tasks-scoped-guard | A | 2026-08-31 21:20 | PASS | issue #85 |
+| cleanup-tasks-worktree-grooming | A | 2026-08-31 21:20 | PASS | issue #168; issue #327 |
+| cli-publish-typecheck-scope | A | 2026-08-31 21:20 | PASS | release run 33271077312 — v0.5.0 pushed its GHCR image, then failed to publish |
+| close-issues-on-development | A | 2026-08-31 21:20 | PASS | issue #841 (closing keywords never fire because the default branch is main) 2026-08-26 |
+| codex-stale-response-retry | A | 2026-08-31 21:20 | PASS | issue #506 — Codex previous_response_not_found RCA |
+| compose-config-path-parity | A | 2026-08-31 21:20 | PASS | PR #833 (remove harness.yaml — the wrapper and VS Code "Reopen in Container" paths must resolve the same service) 2026-08-26 |
+| config-schema-parity | A | 2026-08-31 21:20 | PASS | PR #833 (one schema file — DOCKER_SOCKET, SANDBOX_SSH, OH_SANDBOX_IMAGE, OH_PULL_POLICY, SKIP_PNPM_INSTALL were consumed but undocumented); rewritten for the oh.json/secrets split by PR #887 |
+| context-tier-size-budget | A | 2026-08-31 21:20 | PASS | .oh/tasks/spec-simplification/ (issue #816, US-007) — the always-on tier was 85,256 B |
+| cron-claude-codex-fallback | A | 2026-08-31 21:20 | PASS | conversation 2026-06-12 (default Codex fallback for crons) |
+| cron-watchdog | A | 2026-08-31 21:20 | PASS | issues #130/#453 (cron runtime watchdog + legacy system-cron reaping) 2026-06-19 |
+| crons-directory-guide | A | 2026-08-31 21:20 | PASS | issue #874 |
+| curl-bash-safe-alternatives | A | 2026-08-31 21:20 | PASS | vet-run/vet integration — public curl|bash examples need review-first alternatives |
+| datasets-schema | A | 2026-08-31 21:20 | PASS | issue #196 — .oh/evals/datasets verifiable trajectory corpus (Repo2RLEnv-inspired) |
+| debugmcp-availability | A | 2026-08-31 21:20 | SKIPPED | issue #297 — DebugMCP MCP debug-server availability |
+| default-provisioning | A | 2026-08-31 21:20 | PASS | #902 — `oh harness install` must work from inside the sandbox, where |
+| delegate-model-effort-policy | A | 2026-08-31 21:20 | PASS | conversation 2026-07-11 (delegate model inheritance and thinking policy) |
+| devtcp-hook | A | 2026-08-31 21:20 | PASS | retro lesson 2026-06-10 (zsh /dev/tcp) |
+| docker-inspect-env-guard | A | 2026-08-31 21:20 | PASS | operator directive 2026-08-08 (agents keep the docker socket, but must |
+| docs-build-fast-path | A | 2026-08-31 21:20 | PASS | #455 — docs builds must stay out of fast harness/eval/release gates; #536 — docs site externalized to openharness-web; docs markdown relocated to docs/ |
+| drift-check-cron-staleness-glob | A | 2026-08-31 21:20 | PASS | issue #98; issue #225 (restart-required cron frontmatter/config drift) |
+| entrypoint-pnpm-manifest-fingerprint | A | 2026-08-31 21:20 | PASS | issue #521 (manifest-aware sandbox installs) 2026-07-01 |
+| eval-ci-gate | A | 2026-08-31 21:20 | PASS | #103 — eval probe suite gated in CI |
+| eval-gate | A | 2026-08-31 21:20 | PASS | retro lesson 2026-06-11 (eval-gate) |
+| eval-results-atomic | A | 2026-08-31 21:20 | PASS | issue #83 (eval-results-atomic-write) |
+| eval-runner-exit | A | 2026-08-31 21:20 | PASS | retro lesson 2026-06-11 (eval-runner-exit) #29 |
+| eval-runs-once-per-cycle | A | 2026-08-31 21:20 | PASS | .oh/tasks/spec-simplification/ (issue #816, US-006) — /eval ran 3x per cycle on the |
+| execution-target-contract | A | 2026-08-31 21:20 | PASS | issue #733 (ExecutionTarget contract + Docker Compose adapter) 2026-08-10 |
+| get-oh-bootstrap | A | 2026-08-31 21:20 | PASS | get-oh.sh bootstrap — the Node-bootstrapping host-side path to the standalone `oh` CLI (also on npm as @mifune/openharness; see oh-npm-package.sh) |
+| git-skill | A | 2026-08-31 21:20 | PASS | conversation 2026-06-15 — rules are not always supported; git workflow must be the /git skill |
+| harness-audit-empty-output-gate | A | 2026-08-31 21:20 | PASS | issue #246 — /audit harness must fail closed on empty auditor outputs |
+| harness-ci-core-paths | A | 2026-08-31 21:20 | PASS | #165 — core sandbox config files must trigger harness CI |
+| harness-ci-hooks-paths | A | 2026-08-31 21:20 | PASS | issue #202 — credential/security hook changes must trigger harness CI |
+| harness-yaml-migration | A | 2026-08-31 21:20 | PASS | PR #833 (migrate-harness-yaml.sh — append / uncomment-in-place / preserve / overwrite, plus a silent no-op second run) 2026-08-26 |
+| health-check-docker-stats | A | 2026-08-31 21:20 | PASS | retro lesson 2026-06-10 (docker stats vs ps Size) |
+| health-check-socket-degrade | A | 2026-08-31 21:20 | PASS | issue #762 (refs #756) — /health-check degrades to one statement, not nine failures |
+| heartbeat-logging-contract | A | 2026-08-31 21:20 | PASS | issue #447 (heartbeat log append hardening) 2026-06-18 |
+| image-seed-hygiene | A | 2026-08-31 21:20 | PASS | issue #900 (slim the sandbox image) 2026-08-30 |
+| markitdown-wiki-ingest | A | 2026-08-31 21:20 | PASS | issue #649 — pinned local-document normalization contract for /wiki ingest |
+| next-dev-prod | A | 2026-08-31 21:20 | SKIPPED | retro lesson 2026-06-04 |
+| oh-compose-env-wiring | A | 2026-08-31 21:20 | SKIPPED | issue #880 (oh as the only front door — oh.json is the non-secret config surface) |
+| oh-config-surfaces | A | 2026-08-31 21:20 | PASS | PR #887 (config split across two authored surfaces — a tracked oh.json and a secrets-only root dotenv — with nothing left under $HOME) |
+| oh-destroy-guard | A | 2026-08-31 21:20 | SKIPPED | issue #879 — `oh` becomes the only front door, so `make destroy` must |
+| oh-devcontainer-restructure | A | 2026-08-31 21:20 | PASS | consolidate devcontainer — .oh/devcontainer/ folded back into .devcontainer/ |
+| oh-home-mount | A | 2026-08-31 21:20 | PASS | issue #898 (single $HOME mount) 2026-08-30 |
+| oh-image-only-deploy | A | 2026-08-31 21:20 | PASS | .oh/tasks/image-only-deploy/prd.json US-004 (issue #609, Flavor B image-only deploy) |
+| oh-init-headless-config | A | 2026-08-31 21:20 | SKIPPED | PR #827 (installer answers landed in the losing config file); retargeted to the .example.env template by PR #833, then to oh.json by PR #887 |
+| oh-init-scaffold | A | 2026-08-31 21:20 | PASS | issue #531 Phase 2 |
+| oh-lifecycle-surface | A | 2026-08-31 21:20 | PASS | issue #881 — the Makefile is retired and `oh` is the only front door |
+| oh-npm-package | A | 2026-08-31 21:20 | PASS | npm publish path for the standalone `oh` CLI (@mifune/openharness) — alternative to get-oh.sh |
+| oh-payload-manifest | A | 2026-08-31 21:20 | PASS | issue #531 follow-on (.oh payload manifest — oh update ships a declared allowlist) |
+| oh-sandbox-image-mode | A | 2026-08-31 21:20 | PASS | conversation 2026-07-05 (basic Docker deployment — prebuilt-image mode) |
+| oh-shipped-repo-overridable | A | 2026-08-31 21:20 | PASS | issue #531 follow-on (de-hardcode residual — shipped .oh shell scripts keep the upstream repo overridable) |
+| oh-standalone-lifecycle | A | 2026-08-31 21:20 | PASS | issue #564 |
+| oh-update | A | 2026-08-31 21:20 | PASS | issue #531 Phase 3 (oh update — upgrade only the .oh control plane) |
+| operator-config-guard | A | 2026-08-31 21:20 | PASS | operator directives 2026-08-06 (.config/ and settings.local.json are operator-only) |
+| pnpm-audit-ci-gate | A | 2026-08-31 21:20 | PASS | issue #171 — pnpm security audits must run in CI |
+| post-bridge-publish-confirmation | A | 2026-08-31 21:20 | PASS | #523 — post-bridge live publishing requires an explicit final confirmation gate |
+| prd-output-path-contract | A | 2026-08-31 21:20 | PASS | retro lesson 2026-06-19 |
+| prompt-miner-schema-compat | A | 2026-08-31 21:20 | PASS | issue #253 — prompt-miner JSONL schema-drift guard |
+| prompt-miner-symlink-entrypoint | A | 2026-08-31 21:20 | PASS | issue #663 — prompt-miner engine no-ops via the documented .claude/skills symlink |
+| prompt-miner-weakness-record | A | 2026-08-31 21:20 | PASS | issue #580 — prompt-miner weakness-record (WH-xxx) cluster output |
+| protected-path-deletion | A | 2026-08-31 21:20 | PASS | .oh/tasks/spec-simplification/ (issue #816, US-001) — the critique gate was deleted, |
+| protected-paths-resolve | A | 2026-08-31 21:20 | PASS | issue #753 — .claude/protected-paths.txt named 7 paths that did not exist. |
+| registry-portability-gate | A | 2026-08-31 21:20 | PASS | issue #758 |
+| registry-portability | A | 2026-08-31 21:20 | SKIPPED | issue #758 |
+| retro-deterministic-contract | A | 2026-08-31 21:20 | PASS | issue #443 — /retro deterministic output and self-contained helper contract |
+| rl-delegation-write-worker | A | 2026-08-31 21:20 | PASS | retro lesson 2026-06-10 (rl-delegation) #57 |
+| rlm-context-budget | A | 2026-08-31 21:20 | PASS | .oh/tasks/rlm-weighted-trajectories/prd.json US-006 |
+| runtime-preflight-gate | A | 2026-08-31 21:20 | PASS | issue #806 § B1 (open sandbox.substrate vs sandbox.runtime selector); |
+| sandbox-boot-guard-ci | A | 2026-08-31 21:20 | PASS | issue #449 (sandbox image build CI guard) 2026-06-19; |
+| sandbox-node-base | A | 2026-08-31 21:20 | PASS | openharness#878 — oh as the only front door, T0 sandbox base image |
+| skill-paths | A | 2026-08-31 21:20 | PASS | issue #43 — stale path references; extended by issue #69 — apps/->packages/ rename guard; extended by issue #870 — deleted .oh/agents/advisor.md |
+| skills-dir-clean | A | 2026-08-31 21:20 | PASS | conversation 2026-06-29 — Pi parses every top-level `.md` in the skills |
+| skills-task-tool-coupling | A | 2026-08-31 21:20 | PASS | council review 2026-08-29 (issue #886) — /delegate instructed Claude-Code-only |
+| skills-vendored | A | 2026-08-31 21:20 | PASS | absorb .mifune submodule into .oh — the skills/agents/hooks pack is vendored |
+| slack-admin-command-surface | A | 2026-08-31 21:20 | PASS | issue #354 — Slack bridge docs must distinguish Pi /msg-bridge commands from Slack DM admin text handlers |
+| spec-family-contract | A | 2026-08-31 21:20 | PASS | issue #265; spec-simplification issue #816; workflow authority issue #854 |
+| spec-ready-finalization | A | 2026-08-31 21:20 | PASS | issue #134; spec-simplification issue #816; workflow authority issue #854 |
+| ste-checker-contract | A | 2026-08-31 21:20 | PASS | issue #750 PR audit — the /ste checker had four fail-open paths (unclosed |
+| submitted-by-trailers | A | 2026-08-31 21:20 | PASS | conversation 2026-06-12 (commit attribution trailers); the single-owner |
+| sync-skill-contract | A | 2026-08-31 21:20 | PASS | issue #331 — /sync dispatcher skill (bidirectional origin↔upstream sync) |
+| t3-headless-launch | A | 2026-08-31 21:20 | PASS | issue #858 — /t3 launched a bare `npx --yes t3`, which is the local GUI and |
+| tailscale-tool-boundary | A | 2026-08-31 21:20 | PASS | issue #858 — Tailscale mobile access for T3 Code. There is no tailnet, no |
+| tool-catalog-boundary | A | 2026-08-31 21:20 | PASS | agent-browser's exclusion from the harness catalog (#821) and the |
+| version-parity | A | 2026-08-31 21:20 | PASS | conversation 2026-08-29 — the oh CLI became the only lifecycle door, so its |
+| weigh-scorer-contract | A | 2026-08-31 21:20 | PASS | .oh/tasks/rlm-weighted-trajectories/prd.json US-003 (2026-06-27) |
+| wiki-readme-index | A | 2026-08-31 21:20 | PASS | issue #132 — wiki README index drift guard |
+| workflow-boundaries | A | 2026-08-31 21:20 | PASS | conversation 2026-06-19 (workflow consolidation, issue #259); authority moved to /spec in issue #854 |
+| worktrees-layout | A | 2026-08-31 21:20 | PASS | issue #872 |
 
 <!-- benchmark: pass-rate = PASS / (PASS + REGRESSION + TIMEOUT); SKIPPED excluded -->

--- a/.oh/evals/probes/audit-slop-gate.sh
+++ b/.oh/evals/probes/audit-slop-gate.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# tier: A
+# source: .claude/specs/images/reduce-slop.png — the four correctness gates all pass a change
+#         that works and is twice the size it needed to be. Nothing forced the diff smaller.
+# desc: /audit implementation gate 5 measures slop, blocks on a concrete smaller alternative,
+#       and terminates by construction (round cap or a non-reducing round) rather than by taste.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+REF="$ROOT/.oh/skills/audit/references/implementation.md"
+EXEC="$ROOT/.oh/skills/spec/references/execute.md"
+GATE="$ROOT/.oh/skills/audit/scripts/implementation-gates.sh"
+
+fail() { echo "REGRESSION: $*" >&2; exit 1; }
+
+for f in "$REF" "$EXEC" "$GATE"; do [[ -f $f ]] || fail "missing: $f"; done
+
+grep -Fq '## The five gates (fail-fast, in order)' "$REF" || fail 'gate 5 not in the fail-fast chain'
+grep -Fq '### Gate 5 — Slop (less code, low complexity)' "$REF" || fail 'gate 5 section missing'
+grep -Fq 'concrete simpler alternative is not a finding' "$REF" \
+  || fail 'the termination rule that keeps gate 5 from becoming taste is missing'
+grep -Fq 'SIMPLICITY-RESIDUAL' "$REF" || fail 'residual disclosure missing from the verdict'
+grep -Fq 'never report it as CCN' "$REF" || fail 'the bash branch-point proxy is not labelled as a proxy'
+grep -Fq 'never infer green from' "$REF" || fail 'unavailable complexity tool may be read as green'
+grep -Fq '.oh/tasks/<slug>/simplify-rounds.json' "$REF" || fail 'gate 5 does not name the round record'
+grep -Fq 'simplify-rounds.json' "$EXEC" || fail 'the caller that owns the round record does not write it'
+grep -Fq 'non-reducing round' "$EXEC" || fail 'the monotone termination rule is not documented for the caller'
+
+root=$(mktemp -d); trap 'rm -rf "$root"' EXIT
+mkdir -p "$root/.oh/tasks/demo"
+git -C "$root" init -q
+git -C "$root" config user.email test@example.invalid
+git -C "$root" config user.name test
+printf 'a\nb\nc\n' >"$root/keep.sh"
+git -C "$root" add .; git -C "$root" commit -qm base
+base=$(git -C "$root" rev-parse HEAD)
+printf 'a\nb\nc\nif x; then y; fi\nwhile z; do w; done\n' >"$root/keep.sh"
+git -C "$root" add .; git -C "$root" commit -qm change
+
+metrics=$(AUDIT_ROOT="$root" bash "$GATE" slop-metrics "$base")
+[[ $(jq -r .netAdded <<<"$metrics") == 2 ]] || fail "netAdded wrong: $metrics"
+[[ $(jq -r .netRemoved <<<"$metrics") == 0 ]] || fail "netRemoved wrong: $metrics"
+[[ $(jq -r .shBranchPoints <<<"$metrics") == 2 ]] || fail "shBranchPoints wrong: $metrics"
+
+if AUDIT_ROOT="$root" bash "$GATE" slop-metrics no-such-ref >/dev/null 2>&1; then
+  fail 'unknown base ref was accepted'
+fi
+
+stub=$(mktemp -d); printf '#!/bin/sh\nexit 127\n' >"$stub/uvx"; chmod +x "$stub/uvx"
+printf 'export function f(){return 1}\n' >"$root/x.ts"
+git -C "$root" add .; git -C "$root" commit -qm ts
+offline=$(PATH="$stub:$PATH" AUDIT_ROOT="$root" bash "$GATE" slop-metrics "$base")
+rm -rf "$stub"
+[[ $(jq -r .tool <<<"$offline") == unavailable ]] \
+  || fail "an unresolvable lizard must report unavailable, got: $(jq -r .tool <<<"$offline")"
+
+round() { AUDIT_ROOT="$root" bash "$GATE" simplicity-round demo; }
+[[ $(round) == 'rounds=0 cap=3 escalate=false prevNetAdded=none' ]] || fail "missing counter: $(round)"
+printf '{"rounds":2,"netAdded":410}' >"$root/.oh/tasks/demo/simplify-rounds.json"
+[[ $(round) == 'rounds=2 cap=3 escalate=false prevNetAdded=410' ]] || fail "below cap: $(round)"
+printf '{"rounds":3,"netAdded":380}' >"$root/.oh/tasks/demo/simplify-rounds.json"
+[[ $(round) == 'rounds=3 cap=3 escalate=true prevNetAdded=380' ]] || fail "at cap must escalate: $(round)"
+printf '{"rounds":"two"}' >"$root/.oh/tasks/demo/simplify-rounds.json"
+if round >/dev/null 2>&1; then fail 'malformed counter was accepted'; fi
+if AUDIT_ROOT="$root" bash "$GATE" simplicity-round '../etc' >/dev/null 2>&1; then
+  fail 'traversal slug was accepted'
+fi
+ln -s /tmp "$root/.oh/tasks/linked"
+if AUDIT_ROOT="$root" bash "$GATE" simplicity-round linked >/dev/null 2>&1; then
+  fail 'symlinked task directory was accepted'
+fi
+
+grep -Fq 'slop-metrics|simplicity-round' "$GATE" || fail 'new modes absent from the usage line'
+
+echo 'PASS: gate 5 measures slop and terminates on the cap or a non-reducing round' >&2

--- a/.oh/skills/audit/SKILL.md
+++ b/.oh/skills/audit/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Explicit nine-target audit dispatcher for implementation promotability, one PR,
   the open PR queue, harness health, context budget, skill integrity, eval quality,
   drift, and correlated full campaigns. TRIGGER when: audit this task; verify this
-  implementation; audit PR N; classify this pull request; audit open PRs; triage
+  implementation; is this the simplest approach; audit PR N; classify this pull request; audit open PRs; triage
   the PR queue; audit the harness; find harness improvements; audit context budget;
   audit skills; find stale or broken skills; lint evals;
   find Goodharted probes; check framework drift; cron staleness; run a full audit

--- a/.oh/skills/audit/references/implementation.md
+++ b/.oh/skills/audit/references/implementation.md
@@ -31,7 +31,7 @@ is a downstream concern and remediation belongs to the build step on
 
 ---
 
-## The four gates (fail-fast, in order)
+## The five gates (fail-fast, in order)
 
 Run in order; the **first** gate that fails decides the verdict (`AUDIT-FAIL`,
 naming the gate). Only when **all** applicable gates pass is the verdict
@@ -158,6 +158,64 @@ repository. No clean screenshot/snapshot for an applicable story is `AUDIT-FAIL`
 When no story declares browser verification, this gate is **not applicable** and
 must not invoke `agent-browser` at all.
 
+### Gate 5 — Slop (less code, low complexity)
+
+The correctness gates above prove the change *works*. None of them can fail a change
+that works and is twice the size it needed to be. This gate asks the one question that
+closes that hole:
+
+> **Can this diff be smaller and still satisfy every acceptance criterion in `prd.json`?**
+
+While the answer is yes, the verdict is `AUDIT-FAIL` and the build simplifies. The goal
+stays one sentence on purpose — the ingenuity belongs in the execution, not in the
+objective. Less code is less code to maintain and fewer places for a bug to live.
+
+**Signals.** Run
+`"$AUDIT_ROOT/.oh/skills/audit/scripts/implementation-gates.sh" slop-metrics "$BASE"`,
+which emits one JSON object. Report every number in the verdict:
+
+| Field | Meaning |
+|---|---|
+| `netAdded` / `netRemoved` | Lines the unit's diff adds and removes vs. `--base`, excluding lockfiles, `.oh/evals/RESULTS.md`, and symlinked provider mirrors. `netAdded` is the headline number the loop drives down. |
+| `tsOverCcn` | Functions in the changed `.ts`/`.js`/`.mjs` files over `ccnMax` (default 10), from `uvx lizard`. **Real per-function cyclomatic complexity.** |
+| `shBranchPoints` | The *net* change in branch tokens across changed `.sh` files. No complexity tool parses bash, so this is an explicit **proxy** — never report it as CCN. |
+| `tool` | `lizard <version>`, `lizard n/a (no analysable files changed)`, or `unavailable`. |
+
+`tool: unavailable` means `uvx lizard` could not resolve (an offline runner). The
+complexity signal is then **SKIPPED and disclosed** — an empty `tsOverCcn` from an
+unavailable tool is never reported as a clean complexity result. Never infer green from
+silence.
+
+**Findings — the termination rule.** Every finding MUST cite `file:line`, name the
+concrete simpler alternative, and state the lines it removes. **A finding with no
+concrete simpler alternative is not a finding.** That rule is what keeps this gate an
+engineering check rather than an unbounded argument about taste. Typical shapes: a
+primitive the repo already has, an abstraction with exactly one call site and no
+criterion requiring it, a new file where editing an existing one would do, a path no
+story exercises.
+
+A finding is **blocking** only when its alternative satisfies every acceptance criterion
+with no new work. Anything else is disclosed, non-gating. A function the diff
+*introduces* above `ccnMax` is blocking; one already over the threshold on the base is
+disclosed only — the same pre-existing/new distinction gate 2 makes.
+
+**The bounded, monotone loop.** Read the caller's round record with
+`implementation-gates.sh simplicity-round "$SLUG"`, which prints
+`rounds=<n> cap=3 escalate=<bool> prevNetAdded=<n|none>` from
+`.oh/tasks/<slug>/simplify-rounds.json`:
+
+- `escalate=false` and a blocking finding exists → `AUDIT-FAIL` (gate 5). The build
+  simplifies and re-audits.
+- `escalate=true` (round cap reached), **or** `netAdded` did not strictly fall below
+  `prevNetAdded` on this round → stop blocking. `prevNetAdded=none` is the first round:
+  there is nothing to compare, so the monotone rule does not apply to it. The loop ends when the diff can no
+  longer be made smaller, not when taste is satisfied, so it terminates by construction.
+  Emit `AUDIT-PASS` with `SIMPLICITY-RESIDUAL: <n>` and list the residual findings for
+  the operator; they belong in `evidence.md`.
+
+This route **reads** the round record. It never writes or increments it — the
+orchestrating caller owns that file, exactly as it owns `evidence.md`.
+
 ---
 
 ## Verdict
@@ -168,7 +226,9 @@ must not invoke `agent-browser` at all.
 
 State the verdict, then — on the **final line** — emit the routing token. Always
 name the deciding gate on `AUDIT-FAIL` and disclose any non-gating pre-existing
-red from gate 2.
+red from gate 2. An `AUDIT-PASS` reached at the gate-5 round cap or on a
+non-reducing round carries `SIMPLICITY-RESIDUAL: <n>` with the residual findings;
+a `PASS` that hides residual slop is the one thing this gate exists to prevent.
 
 ---
 
@@ -180,6 +240,10 @@ red from gate 2.
 - **Fork PR classification.** It consumes the same private classifier JSON as
   `/audit pr` and `/audit prs`.
 - **Re-run a passing gate.** Fail-fast: stop at the first failing gate.
+- **Write or increment the gate-5 round counter.** It reads
+  `.oh/tasks/<slug>/simplify-rounds.json`; the orchestrating caller writes it.
+- **Apply the simplification.** Gate 5 names the smaller alternative; removing the
+  code is the `implement` node's job, like every other `AUDIT-FAIL`.
 - **Write the reviewer evidence doc.** The per-gate observations above are what
   `.oh/tasks/<slug>/evidence.md` is built from, but the orchestrating caller writes and
   commits it — see [`reviewer-evidence-doc.md`](reviewer-evidence-doc.md).
@@ -195,6 +259,6 @@ Return this structured observation to the outer dispatcher; do not report a run 
 - **Result**: OP
 - **Unit**: <slug> (PR #<N> / branch <branch>)
 - **Verdict**: AUDIT-PASS | AUDIT-FAIL (gate <n>: <reason>)
-- **Gates**: graph <p/t> · eval <rc> · promotable <class> · ui <pass|n/a>
+- **Gates**: graph <p/t> · eval <rc> · promotable <class> · ui <pass|n/a> · slop +<netAdded>/-<netRemoved> (<clean|blocking n|residual n>)
 - **Observation**: <one sentence>
 ```

--- a/.oh/skills/audit/references/reviewer-evidence-doc.md
+++ b/.oh/skills/audit/references/reviewer-evidence-doc.md
@@ -71,8 +71,9 @@ Every doc answers these, in this order, before the per-gate proof:
    plan: a criterion satisfied differently, a deliberate deviation, a mid-build scope
    call. Explicitly `None` when there was none.
 4. **What remains unverified** — skipped gates, criteria argued rather than observed,
-   pre-existing reds carried forward, anything a reviewer must check by hand.
-   Explicitly `Nothing` when there is none.
+   pre-existing reds carried forward, a `SIMPLICITY-RESIDUAL` list the simplify loop
+   ended on, anything a reviewer must check by hand. Explicitly `Nothing` when there is
+   none.
 
 **Why question 0 is first and separate.** Questions 1–4 prove the change is *correct*.
 None of them establishes it was *worth making*. A doc can pass every gate, diverge nowhere,
@@ -121,6 +122,7 @@ forward, anything needing a hand check — or "Nothing".>
 | Regression floor | `/eval` runner exit + delta | `rc=0`, no new green→red | PASS |
 | Promotable / CI | focused classifier JSON | `promotable=true`, `evidenceComplete=true` | PASS |
 | UI | browser criteria | n/a — no story declares browser verification | N/A |
+| Slop | net lines + changed-function CCN | `+<netAdded>/-<netRemoved>`, `<n>` over CCN <max> | PASS |
 
 ## Observed output
 

--- a/.oh/skills/audit/scripts/implementation-gates.sh
+++ b/.oh/skills/audit/scripts/implementation-gates.sh
@@ -2,6 +2,8 @@
 set -euo pipefail
 : "${AUDIT_ROOT:?AUDIT_ROOT is required}"
 AUDIT_ROOT=$(cd "$AUDIT_ROOT" && pwd -P)
+CCN_MAX=${CCN_MAX:-10}
+ROUND_CAP=${ROUND_CAP:-3}
 mode=${1:-}; shift || true
 case $mode in
   gate1)
@@ -78,5 +80,58 @@ case $mode in
     cmp -s "$before" "$after" || { echo 'FAIL gate4: browser preflight mutated AUDIT_ROOT content or index' >&2; exit 1; }
     rm -f "$before" "$after"
     ;;
-  *) echo 'usage: implementation-gates.sh <gate1|classify-pr|browser-required|browser-preflight> ...' >&2; exit 64;;
+  slop-metrics)
+    base=${1:-development}
+    [[ $base =~ ^[A-Za-z0-9._/-]+$ ]] || { echo 'usage: implementation-gates.sh slop-metrics <base-ref>' >&2; exit 64; }
+    git -C "$AUDIT_ROOT" rev-parse --verify --quiet "$base^{commit}" >/dev/null \
+      || { echo "FAIL gate5: unknown base ref: $base" >&2; exit 64; }
+    counted(){ case $1 in *pnpm-lock.yaml|*package-lock.json|*.oh/evals/RESULTS.md) return 1;; esac; [[ ! -L $AUDIT_ROOT/$1 ]]; }
+    added=0; removed=0
+    while read -r a r path; do
+      [[ $a == '-' ]] && continue
+      counted "$path" || continue
+      added=$((added + a)); removed=$((removed + r))
+    done < <(git -C "$AUDIT_ROOT" diff --numstat "$base...HEAD")
+    sh_delta=$(git -C "$AUDIT_ROOT" diff -U0 "$base...HEAD" -- '*.sh' | awk '
+      /^\+\+\+/ || /^---/ { next }
+      /^[+-]/ {
+        sign = (substr($0,1,1)=="+") ? 1 : -1; line = " " substr($0,2) " "
+        n = gsub(/&&|\|\|/, "", line)
+        n += gsub(/[^[:alnum:]_](if|elif|while|until|for|case)[^[:alnum:]_]/, " ", line)
+        total += sign * n
+      }
+      END { print total+0 }')
+    mapfile -t ts < <(git -C "$AUDIT_ROOT" diff --name-only --diff-filter=d "$base...HEAD" -- '*.ts' '*.mjs' '*.js')
+    tool=unavailable; over='[]'
+    if ((${#ts[@]})); then
+      if ver=$(uvx lizard --version 2>/dev/null); then
+        tool="lizard $ver"
+        warnings=$(cd "$AUDIT_ROOT" && uvx lizard -w --CCN "$CCN_MAX" "${ts[@]}" 2>/dev/null || true)
+        over=$(sed -nE 's/^(.+): warning: (\S+) has [0-9]+ NLOC, ([0-9]+) CCN.*/\1 \2 CCN \3/p' <<<"$warnings" | jq -R . | jq -s .)
+      fi
+    else
+      tool='lizard n/a (no analysable files changed)'
+    fi
+    jq -n --argjson netAdded "$added" --argjson netRemoved "$removed" \
+      --argjson shBranchPoints "$sh_delta" \
+      --argjson tsOverCcn "$over" --arg tool "$tool" --argjson ccnMax "$CCN_MAX" \
+      '{netAdded:$netAdded,netRemoved:$netRemoved,shBranchPoints:$shBranchPoints,ccnMax:$ccnMax,tsOverCcn:$tsOverCcn,tool:$tool}'
+    ;;
+  simplicity-round)
+    slug=${1:-}; [[ $slug =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]] || { echo 'FAIL gate5: invalid slug' >&2; exit 64; }
+    task_dir="$AUDIT_ROOT/.oh/tasks/$slug"; counter="$task_dir/simplify-rounds.json"
+    resolved_task=$(realpath -e -- "$task_dir" 2>/dev/null) \
+      || { echo "FAIL gate5: missing task directory: $task_dir" >&2; exit 1; }
+    [[ $resolved_task == "$task_dir" && ! -L $task_dir ]] \
+      || { echo "FAIL gate5: task directory is symlinked: $task_dir" >&2; exit 1; }
+    rounds=0; prev=none
+    if [[ -f $counter && ! -L $counter ]]; then
+      jq -e '(.rounds|type)=="number"' "$counter" >/dev/null \
+        || { echo "FAIL gate5: malformed counter: $counter" >&2; exit 1; }
+      rounds=$(jq -r '.rounds' "$counter"); prev=$(jq -r '.netAdded // "none"' "$counter")
+    fi
+    escalate=false; (( rounds >= ROUND_CAP )) && escalate=true
+    printf 'rounds=%s cap=%s escalate=%s prevNetAdded=%s\n' "$rounds" "$ROUND_CAP" "$escalate" "$prev"
+    ;;
+  *) echo 'usage: implementation-gates.sh <gate1|classify-pr|browser-required|browser-preflight|slop-metrics|simplicity-round> ...' >&2; exit 64;;
 esac

--- a/.oh/skills/spec/references/execute.md
+++ b/.oh/skills/spec/references/execute.md
@@ -218,7 +218,7 @@ nested implementation session.
 **Advisor `/goal` prompt** (one line; fill the placeholders — when `$CRON_WORKTREE` is set,
 substitute its actual path for `<worktree>` and use the "reuse" branch of step 1):
 
-> `/goal` As the **single expert Advisor on `/worktrees`**, implement `.oh/tasks/<slug>/prd.json` for PR `#<PR>` on branch `<prefix>/<N>-<slug>`. (1) **If `<worktree>` is already provided** (autopilot's `$CRON_WORKTREE`, already on branch `<prefix>/<N>-<slug>`): `cd <worktree>` and do NOT create another worktree. **Otherwise** create an isolated worktree at `.worktrees/<prefix>/<N>-<slug>` via `/worktrees` and `cd` into it. (2) Read `.oh/tasks/<slug>/prompt.md`, implement the dependency-ready stories directly, and use `/delegate` only for bounded disjoint work. Reconcile worker results, validate every acceptance criterion, update `prd.json` and `progress.txt`, and append `STATUS: COMPLETE` only after every story passes. (3) Continue in this same Advisor session with the implementation-side audit loop, `/eval` once, required wiki revision, `/compact`, `evidence.md`, `/spec retro`, improve steps, and a fresh `/audit pr`; run `gh pr ready <PR> --repo "$SPEC_REPO"` only if that audit is promotable (CI green + mergeable + clean). Otherwise comment the blocking gate and leave the PR draft. Never `gh pr merge`. Leave this single session alive for attach.
+> `/goal` As the **single expert Advisor on `/worktrees`**, implement `.oh/tasks/<slug>/prd.json` for PR `#<PR>` on branch `<prefix>/<N>-<slug>`. (1) **If `<worktree>` is already provided** (autopilot's `$CRON_WORKTREE`, already on branch `<prefix>/<N>-<slug>`): `cd <worktree>` and do NOT create another worktree. **Otherwise** create an isolated worktree at `.worktrees/<prefix>/<N>-<slug>` via `/worktrees` and `cd` into it. (2) Read `.oh/tasks/<slug>/prompt.md`, implement the dependency-ready stories directly, and use `/delegate` only for bounded disjoint work. Reconcile worker results, validate every acceptance criterion, update `prd.json` and `progress.txt`, and append `STATUS: COMPLETE` only after every story passes. (3) Continue in this same Advisor session with the implementation-side audit loop — including the gate-5 simplify sub-loop, where you delete the code each finding names and drive `netAdded` down until the round cap or a non-reducing round ends it — `/eval` once, required wiki revision, `/compact`, `evidence.md`, `/spec retro`, improve steps, and a fresh `/audit pr`; run `gh pr ready <PR> --repo "$SPEC_REPO"` only if that audit is promotable (CI green + mergeable + clean). Otherwise comment the blocking gate and leave the PR draft. Never `gh pr merge`. Leave this single session alive for attach.
 
 The Advisor owns implementation and all post-build gates inside the same session. This node's
 turn ends after launching it and reporting the session name; the ready-for-review PR is
@@ -240,15 +240,38 @@ When implementation is complete, run the per-unit verdict gate:
 ```
 
 `/audit implementation` composes `prd.json` task-graph conformance + the `/eval` regression
-floor + `/audit pr` promotable classification (+ `/agent-browser` for UI stories) into one
-verdict:
+floor + `/audit pr` promotable classification (+ `/agent-browser` for UI stories, + the
+gate-5 slop check) into one verdict:
 
 - `AUDIT-FAIL` → loop back to implementation in the same Advisor session to finish the
   unmet stories, then re-audit. This is the implementation-side adversary — keep looping
   until the Advisor satisfies the task graph.
 - `AUDIT-PASS` → implementation is promotable; continue to the tail.
 
-Two gates run inside this loop and must both clear before the audit can PASS.
+**The simplify sub-loop — drive `netAdded` down.** Gate 5 asks whether the diff can be
+smaller and still satisfy every acceptance criterion. On an `AUDIT-FAIL (gate 5)` the
+Advisor removes the code the finding names — it does not argue with it — and re-audits.
+The Advisor owns the round record; the read-only audit route only reads it:
+
+```bash
+COUNTER=".oh/tasks/<slug>/simplify-rounds.json"
+ROUNDS=$(jq -r '.rounds // 0' "$COUNTER" 2>/dev/null || echo 0)
+NET=$(AUDIT_ROOT="$PWD" bash .oh/skills/audit/scripts/implementation-gates.sh \
+        slop-metrics "$BASE" | jq -r .netAdded)
+cat > "$COUNTER" <<JSON
+{ "rounds": $((ROUNDS + 1)), "netAdded": $NET, "lastCommit": "$(git rev-parse HEAD)" }
+JSON
+git add -f "$COUNTER"
+```
+
+Two things end this loop, and neither of them is agreement: the **cap** of 3 rounds, and
+a round whose `netAdded` did not strictly fall below the previous round's. Either way the
+audit stops blocking and passes with `SIMPLICITY-RESIDUAL`, and those residual findings go
+into `evidence.md` under *What remains unverified* for the operator to judge. A simplify
+loop that cannot make the diff smaller has finished its work; one that keeps looping on
+taste has stopped doing work.
+
+Two further gates run inside this loop and must both clear before the audit can PASS.
 
 **The `/eval` gate — run ONCE per cycle.** Run `/eval` while still on the work branch. If it
 updates `.oh/evals/RESULTS.md`, commit the benchmark refresh on the branch. Treat only a NEW

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ Update policy and release automation live in [`/git`](.claude/skills/git/SKILL.m
 - **BREAKING:** Retire the `projectRoot` / `OH_PROJECT_ROOT` config knob — the checkout is fixed at `/home/sandbox/harness`, nested inside the home mount ([#898](https://github.com/mifunedev/openharness/issues/898)).
 
 ### Added
+- Add gate 5 to `/audit implementation`: fail a promotable change while its diff can still be smaller. Measures net lines and per-function CCN on changed TypeScript via `uvx lizard`. ([#912](https://github.com/mifunedev/openharness/issues/912))
+- Add `audit-slop-gate.sh`, a tier-A probe holding gate 5's termination contract: a finding needs a concrete smaller alternative, and the loop ends on the cap or a non-reducing round. ([#912](https://github.com/mifunedev/openharness/issues/912))
 - Provision the default harnesses into `/home/sandbox/.local` at boot, gated by `OH_PROVISION_HARNESSES`, so `oh harness install` also works from inside the sandbox ([#902](https://github.com/mifunedev/openharness/issues/902)).
 - Add `oh-home-mount.sh`, a tier-A probe holding the single-`$HOME`-mount contract: one mount per compose file, the baked `/opt/home-seed`, and the checkout prune that replaces `-xdev` ([#898](https://github.com/mifunedev/openharness/issues/898)).
 - Assert boot-provisioned harnesses in the boot smoke and reject a baked default harness in `verify-sandbox-image.sh`, so CI exercises the install path ([#904](https://github.com/mifunedev/openharness/issues/904)).


### PR DESCRIPTION
Closes #912

## Why this is better

Before this PR, `/audit implementation` could not fail a change that works. Its four gates are all correctness floors — task graph, `/eval`, promotable/CI, UI — so an Advisor could loop `implementation ⇄ audit` to `AUDIT-PASS` with a diff twice the size it needed to be, and nothing in the loop ever pushed back.

After it, the same loop carries a fifth gate that asks one question — *can this diff be smaller and still satisfy every acceptance criterion?* — and fails the audit while the answer is yes. The cost is 232 net lines and one more gate in the fail-fast chain.

## What was built

**Gate 5 — Slop** (`.oh/skills/audit/references/implementation.md`). Runs last, so it only judges code that already works and is otherwise promotable.

Signals come from `implementation-gates.sh slop-metrics <base>`, which emits one JSON object:

| Field | Source |
|---|---|
| `netAdded` / `netRemoved` | `git diff --numstat`, excluding lockfiles, `RESULTS.md`, and symlinked provider mirrors |
| `tsOverCcn` | **Real per-function CCN** on changed `.ts`/`.js`/`.mjs` via `uvx lizard` |
| `shBranchPoints` | Net branch-token delta on changed `.sh`, disclosed as a **proxy** — no complexity tool parses bash |
| `tool` | `lizard <version>` / `n/a` / `unavailable` |

`uv` is already in the image, so `uvx lizard` needs **no Dockerfile change and no CI change**. An unresolvable lizard reports `unavailable`; an empty `tsOverCcn` from an unavailable tool is never reported as clean. Never infer green from silence.

## Termination — by construction, not by agreement

A subjective gate must not thrash an unattended Advisor session. Three rules bound it:

1. Every finding must cite `file:line`, name the concrete simpler alternative, and state the lines it removes. **A finding with no concrete simpler alternative is not a finding.**
2. A finding blocks only when its alternative satisfies every acceptance criterion with no new work.
3. The loop ends at a **cap of 3 rounds**, or on a round whose `netAdded` did not strictly fall below the previous round's. Either way the audit passes with `SIMPLICITY-RESIDUAL` and hands the residual findings to the operator via `evidence.md`.

The audit route stays read-only. `/spec execute` step 5 owns `.oh/tasks/<slug>/simplify-rounds.json`, exactly as it owns `evidence.md`.

## Where it diverged from the plan

The plan specified parsing `lizard --csv`. That output shifts columns whenever a function signature contains a comma, producing malformed rows. Switched to `lizard -w`, which is line-oriented and stable. Likewise, `grep -E '^\+' | grep -v '^\+\+\+'` fails under the ugrep on `PATH` in this sandbox; the branch counter is a single `awk` pass instead — fewer processes and portable across both greps.

## Proof by gate

| Check | Observed | Result |
|---|---|---|
| `bash .oh/skills/eval/run.sh` | `ran 106 probe(s)`, no `REGRESSIONS` section, `audit-slop-gate PASS` | PASS |
| `shellcheck -S warning .oh/skills/audit/scripts/*.sh` (via `uvx shellcheck-py`) | rc=0, no output | PASS |
| `audit-dispatcher-contract.sh` | PASS — the nine-target table is untouched | PASS |
| `audit-implementation-behavior.sh`, `audit-stale-references.sh`, `advisor-monitored-loop.sh` | PASS | PASS |
| `uvx lizard --version` | `1.24.0` | PASS |
| Offline path (`uvx` stubbed to exit 127) | `"tool": "unavailable"` | PASS |

### Observed output

```text
$ AUDIT_ROOT="$PWD" bash .oh/skills/audit/scripts/implementation-gates.sh slop-metrics development
{
  "netAdded": 232,
  "netRemoved": 11,
  "shBranchPoints": 48,
  "ccnMax": 10,
  "tsOverCcn": [],
  "tool": "lizard n/a (no analysable files changed)"
}

$ AUDIT_ROOT=/tmp/fixture bash .oh/skills/audit/scripts/implementation-gates.sh simplicity-round demo
rounds=3 cap=3 escalate=true prevNetAdded=380
```

## What remains unverified

- Gate 5's **judgment** half — finding a smaller alternative and naming it — is model work and is not probe-covered. The probe holds the contract around it: the signals, the termination rule, and the loop bound. The mechanism is deterministic; the finding is not.
- Not exercised end-to-end through `scripts/audit-run.sh` with a live agent driver; the gate helper was verified directly and via fixtures.
- `link-providers.sh --check` fails in any fresh worktree because `.hermes/skills` is untracked scaffolding that exists only in the main checkout. **Pre-existing, unrelated to this PR** — verified green in the main checkout.