### PR TITLE
FROM skill/914-spec-ship-by-default TO development

### DIFF
--- a/.oh/evals/RESULTS.md
+++ b/.oh/evals/RESULTS.md
@@ -6,111 +6,111 @@ probe id; git history is the time series.** Schema and exit-code semantics are i
 
 | probe | tier | last-run (UTC) | status | source |
 |-------|------|----------------|--------|--------|
-| advisor-monitored-loop | A | 2026-08-31 21:20 | PASS | conversation 2026-06-19 (single-owner implementation workflow, issue #257) |
-| agent-browser-cli | A | 2026-08-31 21:20 | PASS | retro lesson 2026-06-07 (agent-browser 0.8.5 CLI) |
-| agents-identity-contract | A | 2026-08-31 21:20 | PASS | issue #854 — T3-style root identity, glossary, and skill-owned procedures |
-| artifact-contract-audit | A | 2026-08-31 21:20 | PASS | issue #583/#645 — production /audit implementation Gate 1 behavior |
-| audit-dispatcher-contract | A | 2026-08-31 21:20 | PASS | issue #645 — audit consolidation public taxonomy |
-| audit-implementation-behavior | A | 2026-08-31 21:20 | PASS | issue #645 — implementation root/repo/browser behavior |
-| audit-pr-acquire | A | 2026-08-31 21:20 | PASS | issue #645 — production PR acquisition behavior |
-| audit-pr-classifier | A | 2026-08-31 21:20 | PASS | issue #645 — deterministic focused and queue PR classifier |
-| audit-run-root-contract | A | 2026-08-31 21:20 | PASS | issue #645 — executable immutable audit root/run correlation |
-| audit-shellcheck-coverage | A | 2026-08-31 21:20 | PASS | issue #645 — private audit scripts require release and CI lint coverage |
-| audit-slop-gate | A | 2026-08-31 21:20 | PASS | .claude/specs/images/reduce-slop.png — the four correctness gates all pass a change |
-| audit-stale-references | A | 2026-08-31 21:20 | PASS | issue #645 — clean-breaking audit migration |
-| boot-lint-glob | A | 2026-08-31 21:20 | PASS | issue #90, issue #120 |
-| builder-skill-consolidation | A | 2026-08-31 21:20 | PASS | issue #643 — consolidate artifact builders behind one /builder dispatcher |
-| capability-benchmark-schema | A | 2026-08-31 21:20 | PASS | issue #167 — capability benchmark instrument |
-| cc-safety-net-wiring | A | 2026-08-31 21:20 | SKIPPED | .oh/tasks/cc-safety-net/prd.json US-007 2026-07-19 |
-| changelog-entry-length | A | 2026-08-31 21:20 | PASS | conversation 2026-08-24 — CHANGELOG.md grew to 259KB of bullet prose because "one line" was unquantified |
-| cleanup-tasks-scoped-guard | A | 2026-08-31 21:20 | PASS | issue #85 |
-| cleanup-tasks-worktree-grooming | A | 2026-08-31 21:20 | PASS | issue #168; issue #327 |
-| cli-publish-typecheck-scope | A | 2026-08-31 21:20 | PASS | release run 33271077312 — v0.5.0 pushed its GHCR image, then failed to publish |
-| close-issues-on-development | A | 2026-08-31 21:20 | PASS | issue #841 (closing keywords never fire because the default branch is main) 2026-08-26 |
-| codex-stale-response-retry | A | 2026-08-31 21:20 | PASS | issue #506 — Codex previous_response_not_found RCA |
-| compose-config-path-parity | A | 2026-08-31 21:20 | PASS | PR #833 (remove harness.yaml — the wrapper and VS Code "Reopen in Container" paths must resolve the same service) 2026-08-26 |
-| config-schema-parity | A | 2026-08-31 21:20 | PASS | PR #833 (one schema file — DOCKER_SOCKET, SANDBOX_SSH, OH_SANDBOX_IMAGE, OH_PULL_POLICY, SKIP_PNPM_INSTALL were consumed but undocumented); rewritten for the oh.json/secrets split by PR #887 |
-| context-tier-size-budget | A | 2026-08-31 21:20 | PASS | .oh/tasks/spec-simplification/ (issue #816, US-007) — the always-on tier was 85,256 B |
-| cron-claude-codex-fallback | A | 2026-08-31 21:20 | PASS | conversation 2026-06-12 (default Codex fallback for crons) |
-| cron-watchdog | A | 2026-08-31 21:20 | PASS | issues #130/#453 (cron runtime watchdog + legacy system-cron reaping) 2026-06-19 |
-| crons-directory-guide | A | 2026-08-31 21:20 | PASS | issue #874 |
-| curl-bash-safe-alternatives | A | 2026-08-31 21:20 | PASS | vet-run/vet integration — public curl|bash examples need review-first alternatives |
-| datasets-schema | A | 2026-08-31 21:20 | PASS | issue #196 — .oh/evals/datasets verifiable trajectory corpus (Repo2RLEnv-inspired) |
-| debugmcp-availability | A | 2026-08-31 21:20 | SKIPPED | issue #297 — DebugMCP MCP debug-server availability |
-| default-provisioning | A | 2026-08-31 21:20 | PASS | #902 — `oh harness install` must work from inside the sandbox, where |
-| delegate-model-effort-policy | A | 2026-08-31 21:20 | PASS | conversation 2026-07-11 (delegate model inheritance and thinking policy) |
-| devtcp-hook | A | 2026-08-31 21:20 | PASS | retro lesson 2026-06-10 (zsh /dev/tcp) |
-| docker-inspect-env-guard | A | 2026-08-31 21:20 | PASS | operator directive 2026-08-08 (agents keep the docker socket, but must |
-| docs-build-fast-path | A | 2026-08-31 21:20 | PASS | #455 — docs builds must stay out of fast harness/eval/release gates; #536 — docs site externalized to openharness-web; docs markdown relocated to docs/ |
-| drift-check-cron-staleness-glob | A | 2026-08-31 21:20 | PASS | issue #98; issue #225 (restart-required cron frontmatter/config drift) |
-| entrypoint-pnpm-manifest-fingerprint | A | 2026-08-31 21:20 | PASS | issue #521 (manifest-aware sandbox installs) 2026-07-01 |
-| eval-ci-gate | A | 2026-08-31 21:20 | PASS | #103 — eval probe suite gated in CI |
-| eval-gate | A | 2026-08-31 21:20 | PASS | retro lesson 2026-06-11 (eval-gate) |
-| eval-results-atomic | A | 2026-08-31 21:20 | PASS | issue #83 (eval-results-atomic-write) |
-| eval-runner-exit | A | 2026-08-31 21:20 | PASS | retro lesson 2026-06-11 (eval-runner-exit) #29 |
-| eval-runs-once-per-cycle | A | 2026-08-31 21:20 | PASS | .oh/tasks/spec-simplification/ (issue #816, US-006) — /eval ran 3x per cycle on the |
-| execution-target-contract | A | 2026-08-31 21:20 | PASS | issue #733 (ExecutionTarget contract + Docker Compose adapter) 2026-08-10 |
-| get-oh-bootstrap | A | 2026-08-31 21:20 | PASS | get-oh.sh bootstrap — the Node-bootstrapping host-side path to the standalone `oh` CLI (also on npm as @mifune/openharness; see oh-npm-package.sh) |
-| git-skill | A | 2026-08-31 21:20 | PASS | conversation 2026-06-15 — rules are not always supported; git workflow must be the /git skill |
-| harness-audit-empty-output-gate | A | 2026-08-31 21:20 | PASS | issue #246 — /audit harness must fail closed on empty auditor outputs |
-| harness-ci-core-paths | A | 2026-08-31 21:20 | PASS | #165 — core sandbox config files must trigger harness CI |
-| harness-ci-hooks-paths | A | 2026-08-31 21:20 | PASS | issue #202 — credential/security hook changes must trigger harness CI |
-| harness-yaml-migration | A | 2026-08-31 21:20 | PASS | PR #833 (migrate-harness-yaml.sh — append / uncomment-in-place / preserve / overwrite, plus a silent no-op second run) 2026-08-26 |
-| health-check-docker-stats | A | 2026-08-31 21:20 | PASS | retro lesson 2026-06-10 (docker stats vs ps Size) |
-| health-check-socket-degrade | A | 2026-08-31 21:20 | PASS | issue #762 (refs #756) — /health-check degrades to one statement, not nine failures |
-| heartbeat-logging-contract | A | 2026-08-31 21:20 | PASS | issue #447 (heartbeat log append hardening) 2026-06-18 |
-| image-seed-hygiene | A | 2026-08-31 21:20 | PASS | issue #900 (slim the sandbox image) 2026-08-30 |
-| markitdown-wiki-ingest | A | 2026-08-31 21:20 | PASS | issue #649 — pinned local-document normalization contract for /wiki ingest |
-| next-dev-prod | A | 2026-08-31 21:20 | SKIPPED | retro lesson 2026-06-04 |
-| oh-compose-env-wiring | A | 2026-08-31 21:20 | SKIPPED | issue #880 (oh as the only front door — oh.json is the non-secret config surface) |
-| oh-config-surfaces | A | 2026-08-31 21:20 | PASS | PR #887 (config split across two authored surfaces — a tracked oh.json and a secrets-only root dotenv — with nothing left under $HOME) |
-| oh-destroy-guard | A | 2026-08-31 21:20 | SKIPPED | issue #879 — `oh` becomes the only front door, so `make destroy` must |
-| oh-devcontainer-restructure | A | 2026-08-31 21:20 | PASS | consolidate devcontainer — .oh/devcontainer/ folded back into .devcontainer/ |
-| oh-home-mount | A | 2026-08-31 21:20 | PASS | issue #898 (single $HOME mount) 2026-08-30 |
-| oh-image-only-deploy | A | 2026-08-31 21:20 | PASS | .oh/tasks/image-only-deploy/prd.json US-004 (issue #609, Flavor B image-only deploy) |
-| oh-init-headless-config | A | 2026-08-31 21:20 | SKIPPED | PR #827 (installer answers landed in the losing config file); retargeted to the .example.env template by PR #833, then to oh.json by PR #887 |
-| oh-init-scaffold | A | 2026-08-31 21:20 | PASS | issue #531 Phase 2 |
-| oh-lifecycle-surface | A | 2026-08-31 21:20 | PASS | issue #881 — the Makefile is retired and `oh` is the only front door |
-| oh-npm-package | A | 2026-08-31 21:20 | PASS | npm publish path for the standalone `oh` CLI (@mifune/openharness) — alternative to get-oh.sh |
-| oh-payload-manifest | A | 2026-08-31 21:20 | PASS | issue #531 follow-on (.oh payload manifest — oh update ships a declared allowlist) |
-| oh-sandbox-image-mode | A | 2026-08-31 21:20 | PASS | conversation 2026-07-05 (basic Docker deployment — prebuilt-image mode) |
-| oh-shipped-repo-overridable | A | 2026-08-31 21:20 | PASS | issue #531 follow-on (de-hardcode residual — shipped .oh shell scripts keep the upstream repo overridable) |
-| oh-standalone-lifecycle | A | 2026-08-31 21:20 | PASS | issue #564 |
-| oh-update | A | 2026-08-31 21:20 | PASS | issue #531 Phase 3 (oh update — upgrade only the .oh control plane) |
-| operator-config-guard | A | 2026-08-31 21:20 | PASS | operator directives 2026-08-06 (.config/ and settings.local.json are operator-only) |
-| pnpm-audit-ci-gate | A | 2026-08-31 21:20 | PASS | issue #171 — pnpm security audits must run in CI |
-| post-bridge-publish-confirmation | A | 2026-08-31 21:20 | PASS | #523 — post-bridge live publishing requires an explicit final confirmation gate |
-| prd-output-path-contract | A | 2026-08-31 21:20 | PASS | retro lesson 2026-06-19 |
-| prompt-miner-schema-compat | A | 2026-08-31 21:20 | PASS | issue #253 — prompt-miner JSONL schema-drift guard |
-| prompt-miner-symlink-entrypoint | A | 2026-08-31 21:20 | PASS | issue #663 — prompt-miner engine no-ops via the documented .claude/skills symlink |
-| prompt-miner-weakness-record | A | 2026-08-31 21:20 | PASS | issue #580 — prompt-miner weakness-record (WH-xxx) cluster output |
-| protected-path-deletion | A | 2026-08-31 21:20 | PASS | .oh/tasks/spec-simplification/ (issue #816, US-001) — the critique gate was deleted, |
-| protected-paths-resolve | A | 2026-08-31 21:20 | PASS | issue #753 — .claude/protected-paths.txt named 7 paths that did not exist. |
-| registry-portability-gate | A | 2026-08-31 21:20 | PASS | issue #758 |
-| registry-portability | A | 2026-08-31 21:20 | SKIPPED | issue #758 |
-| retro-deterministic-contract | A | 2026-08-31 21:20 | PASS | issue #443 — /retro deterministic output and self-contained helper contract |
-| rl-delegation-write-worker | A | 2026-08-31 21:20 | PASS | retro lesson 2026-06-10 (rl-delegation) #57 |
-| rlm-context-budget | A | 2026-08-31 21:20 | PASS | .oh/tasks/rlm-weighted-trajectories/prd.json US-006 |
-| runtime-preflight-gate | A | 2026-08-31 21:20 | PASS | issue #806 § B1 (open sandbox.substrate vs sandbox.runtime selector); |
-| sandbox-boot-guard-ci | A | 2026-08-31 21:20 | PASS | issue #449 (sandbox image build CI guard) 2026-06-19; |
-| sandbox-node-base | A | 2026-08-31 21:20 | PASS | openharness#878 — oh as the only front door, T0 sandbox base image |
-| skill-paths | A | 2026-08-31 21:20 | PASS | issue #43 — stale path references; extended by issue #69 — apps/->packages/ rename guard; extended by issue #870 — deleted .oh/agents/advisor.md |
-| skills-dir-clean | A | 2026-08-31 21:20 | PASS | conversation 2026-06-29 — Pi parses every top-level `.md` in the skills |
-| skills-task-tool-coupling | A | 2026-08-31 21:20 | PASS | council review 2026-08-29 (issue #886) — /delegate instructed Claude-Code-only |
-| skills-vendored | A | 2026-08-31 21:20 | PASS | absorb .mifune submodule into .oh — the skills/agents/hooks pack is vendored |
-| slack-admin-command-surface | A | 2026-08-31 21:20 | PASS | issue #354 — Slack bridge docs must distinguish Pi /msg-bridge commands from Slack DM admin text handlers |
-| spec-family-contract | A | 2026-08-31 21:20 | PASS | issue #265; spec-simplification issue #816; workflow authority issue #854 |
-| spec-ready-finalization | A | 2026-08-31 21:20 | PASS | issue #134; spec-simplification issue #816; workflow authority issue #854 |
-| ste-checker-contract | A | 2026-08-31 21:20 | PASS | issue #750 PR audit — the /ste checker had four fail-open paths (unclosed |
-| submitted-by-trailers | A | 2026-08-31 21:20 | PASS | conversation 2026-06-12 (commit attribution trailers); the single-owner |
-| sync-skill-contract | A | 2026-08-31 21:20 | PASS | issue #331 — /sync dispatcher skill (bidirectional origin↔upstream sync) |
-| t3-headless-launch | A | 2026-08-31 21:20 | PASS | issue #858 — /t3 launched a bare `npx --yes t3`, which is the local GUI and |
-| tailscale-tool-boundary | A | 2026-08-31 21:20 | PASS | issue #858 — Tailscale mobile access for T3 Code. There is no tailnet, no |
-| tool-catalog-boundary | A | 2026-08-31 21:20 | PASS | agent-browser's exclusion from the harness catalog (#821) and the |
-| version-parity | A | 2026-08-31 21:20 | PASS | conversation 2026-08-29 — the oh CLI became the only lifecycle door, so its |
-| weigh-scorer-contract | A | 2026-08-31 21:20 | PASS | .oh/tasks/rlm-weighted-trajectories/prd.json US-003 (2026-06-27) |
-| wiki-readme-index | A | 2026-08-31 21:20 | PASS | issue #132 — wiki README index drift guard |
-| workflow-boundaries | A | 2026-08-31 21:20 | PASS | conversation 2026-06-19 (workflow consolidation, issue #259); authority moved to /spec in issue #854 |
-| worktrees-layout | A | 2026-08-31 21:20 | PASS | issue #872 |
+| advisor-monitored-loop | A | 2026-08-31 22:13 | PASS | conversation 2026-06-19 (single-owner implementation workflow, issue #257) |
+| agent-browser-cli | A | 2026-08-31 22:13 | PASS | retro lesson 2026-06-07 (agent-browser 0.8.5 CLI) |
+| agents-identity-contract | A | 2026-08-31 22:13 | PASS | issue #854 — T3-style root identity, glossary, and skill-owned procedures |
+| artifact-contract-audit | A | 2026-08-31 22:13 | PASS | issue #583/#645 — production /audit implementation Gate 1 behavior |
+| audit-dispatcher-contract | A | 2026-08-31 22:13 | PASS | issue #645 — audit consolidation public taxonomy |
+| audit-implementation-behavior | A | 2026-08-31 22:13 | PASS | issue #645 — implementation root/repo/browser behavior |
+| audit-pr-acquire | A | 2026-08-31 22:13 | PASS | issue #645 — production PR acquisition behavior |
+| audit-pr-classifier | A | 2026-08-31 22:13 | PASS | issue #645 — deterministic focused and queue PR classifier |
+| audit-run-root-contract | A | 2026-08-31 22:13 | PASS | issue #645 — executable immutable audit root/run correlation |
+| audit-shellcheck-coverage | A | 2026-08-31 22:13 | PASS | issue #645 — private audit scripts require release and CI lint coverage |
+| audit-slop-gate | A | 2026-08-31 22:13 | PASS | .claude/specs/images/reduce-slop.png — the four correctness gates all pass a change |
+| audit-stale-references | A | 2026-08-31 22:13 | PASS | issue #645 — clean-breaking audit migration |
+| boot-lint-glob | A | 2026-08-31 22:13 | PASS | issue #90, issue #120 |
+| builder-skill-consolidation | A | 2026-08-31 22:13 | PASS | issue #643 — consolidate artifact builders behind one /builder dispatcher |
+| capability-benchmark-schema | A | 2026-08-31 22:13 | PASS | issue #167 — capability benchmark instrument |
+| cc-safety-net-wiring | A | 2026-08-31 22:13 | SKIPPED | .oh/tasks/cc-safety-net/prd.json US-007 2026-07-19 |
+| changelog-entry-length | A | 2026-08-31 22:13 | PASS | conversation 2026-08-24 — CHANGELOG.md grew to 259KB of bullet prose because "one line" was unquantified |
+| cleanup-tasks-scoped-guard | A | 2026-08-31 22:13 | PASS | issue #85 |
+| cleanup-tasks-worktree-grooming | A | 2026-08-31 22:13 | PASS | issue #168; issue #327 |
+| cli-publish-typecheck-scope | A | 2026-08-31 22:13 | PASS | release run 33271077312 — v0.5.0 pushed its GHCR image, then failed to publish |
+| close-issues-on-development | A | 2026-08-31 22:13 | PASS | issue #841 (closing keywords never fire because the default branch is main) 2026-08-26 |
+| codex-stale-response-retry | A | 2026-08-31 22:13 | PASS | issue #506 — Codex previous_response_not_found RCA |
+| compose-config-path-parity | A | 2026-08-31 22:13 | PASS | PR #833 (remove harness.yaml — the wrapper and VS Code "Reopen in Container" paths must resolve the same service) 2026-08-26 |
+| config-schema-parity | A | 2026-08-31 22:13 | PASS | PR #833 (one schema file — DOCKER_SOCKET, SANDBOX_SSH, OH_SANDBOX_IMAGE, OH_PULL_POLICY, SKIP_PNPM_INSTALL were consumed but undocumented); rewritten for the oh.json/secrets split by PR #887 |
+| context-tier-size-budget | A | 2026-08-31 22:13 | PASS | .oh/tasks/spec-simplification/ (issue #816, US-007) — the always-on tier was 85,256 B |
+| cron-claude-codex-fallback | A | 2026-08-31 22:13 | PASS | conversation 2026-06-12 (default Codex fallback for crons) |
+| cron-watchdog | A | 2026-08-31 22:13 | PASS | issues #130/#453 (cron runtime watchdog + legacy system-cron reaping) 2026-06-19 |
+| crons-directory-guide | A | 2026-08-31 22:13 | PASS | issue #874 |
+| curl-bash-safe-alternatives | A | 2026-08-31 22:13 | PASS | vet-run/vet integration — public curl|bash examples need review-first alternatives |
+| datasets-schema | A | 2026-08-31 22:13 | PASS | issue #196 — .oh/evals/datasets verifiable trajectory corpus (Repo2RLEnv-inspired) |
+| debugmcp-availability | A | 2026-08-31 22:13 | SKIPPED | issue #297 — DebugMCP MCP debug-server availability |
+| default-provisioning | A | 2026-08-31 22:13 | PASS | #902 — `oh harness install` must work from inside the sandbox, where |
+| delegate-model-effort-policy | A | 2026-08-31 22:13 | PASS | conversation 2026-07-11 (delegate model inheritance and thinking policy) |
+| devtcp-hook | A | 2026-08-31 22:13 | PASS | retro lesson 2026-06-10 (zsh /dev/tcp) |
+| docker-inspect-env-guard | A | 2026-08-31 22:13 | PASS | operator directive 2026-08-08 (agents keep the docker socket, but must |
+| docs-build-fast-path | A | 2026-08-31 22:13 | PASS | #455 — docs builds must stay out of fast harness/eval/release gates; #536 — docs site externalized to openharness-web; docs markdown relocated to docs/ |
+| drift-check-cron-staleness-glob | A | 2026-08-31 22:13 | PASS | issue #98; issue #225 (restart-required cron frontmatter/config drift) |
+| entrypoint-pnpm-manifest-fingerprint | A | 2026-08-31 22:13 | PASS | issue #521 (manifest-aware sandbox installs) 2026-07-01 |
+| eval-ci-gate | A | 2026-08-31 22:13 | PASS | #103 — eval probe suite gated in CI |
+| eval-gate | A | 2026-08-31 22:13 | PASS | retro lesson 2026-06-11 (eval-gate) |
+| eval-results-atomic | A | 2026-08-31 22:13 | PASS | issue #83 (eval-results-atomic-write) |
+| eval-runner-exit | A | 2026-08-31 22:13 | PASS | retro lesson 2026-06-11 (eval-runner-exit) #29 |
+| eval-runs-once-per-cycle | A | 2026-08-31 22:13 | PASS | .oh/tasks/spec-simplification/ (issue #816, US-006) — /eval ran 3x per cycle on the |
+| execution-target-contract | A | 2026-08-31 22:13 | PASS | issue #733 (ExecutionTarget contract + Docker Compose adapter) 2026-08-10 |
+| get-oh-bootstrap | A | 2026-08-31 22:13 | PASS | get-oh.sh bootstrap — the Node-bootstrapping host-side path to the standalone `oh` CLI (also on npm as @mifune/openharness; see oh-npm-package.sh) |
+| git-skill | A | 2026-08-31 22:13 | PASS | conversation 2026-06-15 — rules are not always supported; git workflow must be the /git skill |
+| harness-audit-empty-output-gate | A | 2026-08-31 22:13 | PASS | issue #246 — /audit harness must fail closed on empty auditor outputs |
+| harness-ci-core-paths | A | 2026-08-31 22:13 | PASS | #165 — core sandbox config files must trigger harness CI |
+| harness-ci-hooks-paths | A | 2026-08-31 22:13 | PASS | issue #202 — credential/security hook changes must trigger harness CI |
+| harness-yaml-migration | A | 2026-08-31 22:13 | PASS | PR #833 (migrate-harness-yaml.sh — append / uncomment-in-place / preserve / overwrite, plus a silent no-op second run) 2026-08-26 |
+| health-check-docker-stats | A | 2026-08-31 22:13 | PASS | retro lesson 2026-06-10 (docker stats vs ps Size) |
+| health-check-socket-degrade | A | 2026-08-31 22:13 | PASS | issue #762 (refs #756) — /health-check degrades to one statement, not nine failures |
+| heartbeat-logging-contract | A | 2026-08-31 22:13 | PASS | issue #447 (heartbeat log append hardening) 2026-06-18 |
+| image-seed-hygiene | A | 2026-08-31 22:13 | PASS | issue #900 (slim the sandbox image) 2026-08-30 |
+| markitdown-wiki-ingest | A | 2026-08-31 22:13 | PASS | issue #649 — pinned local-document normalization contract for /wiki ingest |
+| next-dev-prod | A | 2026-08-31 22:13 | SKIPPED | retro lesson 2026-06-04 |
+| oh-compose-env-wiring | A | 2026-08-31 22:13 | SKIPPED | issue #880 (oh as the only front door — oh.json is the non-secret config surface) |
+| oh-config-surfaces | A | 2026-08-31 22:13 | PASS | PR #887 (config split across two authored surfaces — a tracked oh.json and a secrets-only root dotenv — with nothing left under $HOME) |
+| oh-destroy-guard | A | 2026-08-31 22:13 | SKIPPED | issue #879 — `oh` becomes the only front door, so `make destroy` must |
+| oh-devcontainer-restructure | A | 2026-08-31 22:13 | PASS | consolidate devcontainer — .oh/devcontainer/ folded back into .devcontainer/ |
+| oh-home-mount | A | 2026-08-31 22:13 | PASS | issue #898 (single $HOME mount) 2026-08-30 |
+| oh-image-only-deploy | A | 2026-08-31 22:13 | PASS | .oh/tasks/image-only-deploy/prd.json US-004 (issue #609, Flavor B image-only deploy) |
+| oh-init-headless-config | A | 2026-08-31 22:13 | SKIPPED | PR #827 (installer answers landed in the losing config file); retargeted to the .example.env template by PR #833, then to oh.json by PR #887 |
+| oh-init-scaffold | A | 2026-08-31 22:13 | PASS | issue #531 Phase 2 |
+| oh-lifecycle-surface | A | 2026-08-31 22:13 | PASS | issue #881 — the Makefile is retired and `oh` is the only front door |
+| oh-npm-package | A | 2026-08-31 22:13 | PASS | npm publish path for the standalone `oh` CLI (@mifune/openharness) — alternative to get-oh.sh |
+| oh-payload-manifest | A | 2026-08-31 22:13 | PASS | issue #531 follow-on (.oh payload manifest — oh update ships a declared allowlist) |
+| oh-sandbox-image-mode | A | 2026-08-31 22:13 | PASS | conversation 2026-07-05 (basic Docker deployment — prebuilt-image mode) |
+| oh-shipped-repo-overridable | A | 2026-08-31 22:13 | PASS | issue #531 follow-on (de-hardcode residual — shipped .oh shell scripts keep the upstream repo overridable) |
+| oh-standalone-lifecycle | A | 2026-08-31 22:13 | PASS | issue #564 |
+| oh-update | A | 2026-08-31 22:13 | PASS | issue #531 Phase 3 (oh update — upgrade only the .oh control plane) |
+| operator-config-guard | A | 2026-08-31 22:13 | PASS | operator directives 2026-08-06 (.config/ and settings.local.json are operator-only) |
+| pnpm-audit-ci-gate | A | 2026-08-31 22:13 | PASS | issue #171 — pnpm security audits must run in CI |
+| post-bridge-publish-confirmation | A | 2026-08-31 22:13 | PASS | #523 — post-bridge live publishing requires an explicit final confirmation gate |
+| prd-output-path-contract | A | 2026-08-31 22:13 | PASS | retro lesson 2026-06-19 |
+| prompt-miner-schema-compat | A | 2026-08-31 22:13 | PASS | issue #253 — prompt-miner JSONL schema-drift guard |
+| prompt-miner-symlink-entrypoint | A | 2026-08-31 22:13 | PASS | issue #663 — prompt-miner engine no-ops via the documented .claude/skills symlink |
+| prompt-miner-weakness-record | A | 2026-08-31 22:13 | PASS | issue #580 — prompt-miner weakness-record (WH-xxx) cluster output |
+| protected-path-deletion | A | 2026-08-31 22:13 | PASS | .oh/tasks/spec-simplification/ (issue #816, US-001) — the critique gate was deleted, |
+| protected-paths-resolve | A | 2026-08-31 22:13 | PASS | issue #753 — .claude/protected-paths.txt named 7 paths that did not exist. |
+| registry-portability-gate | A | 2026-08-31 22:13 | PASS | issue #758 |
+| registry-portability | A | 2026-08-31 22:13 | SKIPPED | issue #758 |
+| retro-deterministic-contract | A | 2026-08-31 22:13 | PASS | issue #443 — /retro deterministic output and self-contained helper contract |
+| rl-delegation-write-worker | A | 2026-08-31 22:13 | PASS | retro lesson 2026-06-10 (rl-delegation) #57 |
+| rlm-context-budget | A | 2026-08-31 22:13 | PASS | .oh/tasks/rlm-weighted-trajectories/prd.json US-006 |
+| runtime-preflight-gate | A | 2026-08-31 22:13 | PASS | issue #806 § B1 (open sandbox.substrate vs sandbox.runtime selector); |
+| sandbox-boot-guard-ci | A | 2026-08-31 22:13 | PASS | issue #449 (sandbox image build CI guard) 2026-06-19; |
+| sandbox-node-base | A | 2026-08-31 22:13 | PASS | openharness#878 — oh as the only front door, T0 sandbox base image |
+| skill-paths | A | 2026-08-31 22:13 | PASS | issue #43 — stale path references; extended by issue #69 — apps/->packages/ rename guard; extended by issue #870 — deleted .oh/agents/advisor.md |
+| skills-dir-clean | A | 2026-08-31 22:13 | PASS | conversation 2026-06-29 — Pi parses every top-level `.md` in the skills |
+| skills-task-tool-coupling | A | 2026-08-31 22:13 | PASS | council review 2026-08-29 (issue #886) — /delegate instructed Claude-Code-only |
+| skills-vendored | A | 2026-08-31 22:13 | PASS | absorb .mifune submodule into .oh — the skills/agents/hooks pack is vendored |
+| slack-admin-command-surface | A | 2026-08-31 22:13 | PASS | issue #354 — Slack bridge docs must distinguish Pi /msg-bridge commands from Slack DM admin text handlers |
+| spec-family-contract | A | 2026-08-31 22:13 | PASS | issue #265; spec-simplification issue #816; workflow authority issue #854; |
+| spec-ready-finalization | A | 2026-08-31 22:13 | PASS | issue #134; spec-simplification issue #816; workflow authority issue #854 |
+| ste-checker-contract | A | 2026-08-31 22:13 | PASS | issue #750 PR audit — the /ste checker had four fail-open paths (unclosed |
+| submitted-by-trailers | A | 2026-08-31 22:13 | PASS | conversation 2026-06-12 (commit attribution trailers); the single-owner |
+| sync-skill-contract | A | 2026-08-31 22:13 | PASS | issue #331 — /sync dispatcher skill (bidirectional origin↔upstream sync) |
+| t3-headless-launch | A | 2026-08-31 22:13 | PASS | issue #858 — /t3 launched a bare `npx --yes t3`, which is the local GUI and |
+| tailscale-tool-boundary | A | 2026-08-31 22:13 | PASS | issue #858 — Tailscale mobile access for T3 Code. There is no tailnet, no |
+| tool-catalog-boundary | A | 2026-08-31 22:13 | PASS | agent-browser's exclusion from the harness catalog (#821) and the |
+| version-parity | A | 2026-08-31 22:13 | PASS | conversation 2026-08-29 — the oh CLI became the only lifecycle door, so its |
+| weigh-scorer-contract | A | 2026-08-31 22:13 | PASS | .oh/tasks/rlm-weighted-trajectories/prd.json US-003 (2026-06-27) |
+| wiki-readme-index | A | 2026-08-31 22:13 | PASS | issue #132 — wiki README index drift guard |
+| workflow-boundaries | A | 2026-08-31 22:13 | PASS | conversation 2026-06-19 (workflow consolidation, issue #259); authority moved to /spec in issue #854 |
+| worktrees-layout | A | 2026-08-31 22:13 | PASS | issue #872 |
 
 <!-- benchmark: pass-rate = PASS / (PASS + REGRESSION + TIMEOUT); SKIPPED excluded -->

--- a/.oh/evals/probes/spec-family-contract.sh
+++ b/.oh/evals/probes/spec-family-contract.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 # tier: A
-# source: issue #265; spec-simplification issue #816; workflow authority issue #854
-# desc: /spec owns the three-node folder workflow and execute.md carries the complete build.
+# source: issue #265; spec-simplification issue #816; workflow authority issue #854;
+#         ship-by-default issue #914
+# desc: /spec owns the four-node workflow — ship (the default, composing plan then
+#       execute), plan, execute, retro — and execute.md carries the complete build.
 set -u
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
@@ -9,7 +11,7 @@ SKILLS="$ROOT/.claude/skills"
 SPEC="$SKILLS/spec"
 AGENTS="$ROOT/AGENTS.md"
 
-subs=(plan execute retro)
+subs=(ship plan execute retro)
 retired_subs=(critique)
 
 if [ ! -f "$SPEC/SKILL.md" ]; then
@@ -34,7 +36,7 @@ for s in "${retired_subs[@]}"; do
 done
 [ -e "$SKILLS/approve" ] && missing+=("approve: retired skill directory still present (.claude/skills/approve)")
 
-for f in "$SPEC/SKILL.md" "$SPEC/references"/plan.md \
+for f in "$SPEC/SKILL.md" "$SPEC/references"/ship.md "$SPEC/references"/plan.md \
          "$SPEC/references"/execute.md "$SPEC/references"/retro.md; do
   [ -f "$f" ] || continue
   rel="${f#"$ROOT"/}"
@@ -46,6 +48,19 @@ for f in "$SPEC/SKILL.md" "$SPEC/references"/plan.md \
 done
 
 [ -e "$SKILLS/ship-spec" ] && missing+=("ship-spec: the all-in-one composer must be absorbed and deleted, not left beside /spec")
+SHIP="$SPEC/references/ship.md"
+if [ -f "$SHIP" ]; then
+  # ship composes plan and execute; owning a build literal would fork execute.md.
+  for literal in 'gh pr create' 'gh pr ready' 'gh issue create' 'git push'; do
+    grep -qF "$literal" "$SHIP" && missing+=("references/ship.md carries the build literal '$literal' — ship composes plan and execute and must not fork execute.md")
+  done
+  grep -qF 'commitment gate' "$SHIP" || missing+=("references/ship.md does not state how it treats the commitment gate")
+fi
+# The dispatcher must route an unrecognized first token to ship, not to usage.
+grep -qF 'ship|plan|execute|retro)' "$SPEC/SKILL.md" \
+  || missing+=("SKILL.md dispatch case does not name all four nodes")
+grep -qE 'DEFAULT: not a node name' "$SPEC/SKILL.md" \
+  || missing+=("SKILL.md no longer routes an unrecognized first token to ship (a plan path would print usage)")
 EXEC="$SPEC/references/execute.md"
 if [ -f "$EXEC" ]; then
   grep -qF 'reuses those by reference' "$EXEC" && missing+=("execute.md still defers its build mechanics by reference instead of holding them")
@@ -74,5 +89,5 @@ if [ "${#missing[@]}" -gt 0 ]; then
   exit 1
 fi
 
-echo "PASS: /spec owns the workflow, dispatches three folder-pointed procedures, carries no loop ## Handoff, keeps retired surfaces absent, and holds the build literals" >&2
+echo "PASS: /spec owns the workflow, dispatches four procedures with ship as the default composing plan and execute, carries no loop ## Handoff, keeps retired surfaces absent, and holds the build literals" >&2
 exit 0

--- a/.oh/skills/spec/SKILL.md
+++ b/.oh/skills/spec/SKILL.md
@@ -2,17 +2,21 @@
 name: spec
 description: >-
   Canonical decomposed build workflow and dispatcher. Routes the first token of
-  $ARGUMENTS to one of three subcommands: plan, execute, or retro. Each is pointed
-  at a .oh/tasks/<slug>/ folder (the universal interface) and is independently
-  runnable and fan-out-able. This skill owns the ONLY build path; there is no
-  all-in-one composer beside it. Full per-subcommand procedures live in
-  references/{plan,execute,retro}.md.
-  TRIGGER when: a topic/plan/issue needs to become a buildable task folder, "plan
-  <topic>", "scaffold the task for <issue>" -> plan; an approved .oh/tasks/<slug>/
-  folder needs building to a promotable PR, "execute <slug>", "build <slug>" ->
-  execute; a build PASSed audit and its lessons should be captured, "retro the
-  <slug> build", "capture lessons for <slug>" -> retro.
-argument-hint: "plan <topic> [--plan <path>] [--issue <N>] [--slug <slug>] [--prefix <type>] [--repo <o/n>] [--base <branch>] | execute <slug> [--pr <N>] [--repo <o/n>] [--remote <name>] [--base <branch>] | retro <slug> [--dry-run]"
+  $ARGUMENTS to one of four subcommands: ship, plan, execute, or retro. Each of
+  plan/execute/retro is pointed at a .oh/tasks/<slug>/ folder (the universal
+  interface) and is independently runnable and fan-out-able; ship composes plan
+  then execute. This skill owns the ONLY build path; there is no all-in-one
+  composer beside it. Full per-subcommand procedures live in
+  references/{ship,plan,execute,retro}.md.
+  TRIGGER when: an approved plan file should become a ready PR without further
+  hand-holding, "/spec <plan-path>", "ship this plan", "build this plan end to end"
+  -> ship (also the DEFAULT for an unrecognized first token); a topic/plan/issue
+  needs to become a buildable task folder without building it, "plan <topic>",
+  "scaffold the task for <issue>" -> plan; an approved .oh/tasks/<slug>/ folder
+  needs building to a promotable PR, "execute <slug>", "build <slug>" -> execute; a
+  build PASSed audit and its lessons should be captured, "retro the <slug> build",
+  "capture lessons for <slug>" -> retro.
+argument-hint: "<plan-path> | ship <plan-path|topic> [--issue <N>] [--slug <slug>] | plan <topic> [--plan <path>] [--issue <N>] [--slug <slug>] [--prefix <type>] [--repo <o/n>] [--base <branch>] | execute <slug> [--pr <N>] [--repo <o/n>] [--remote <name>] [--base <branch>] | retro <slug> [--dry-run]"
 ---
 
 # /spec — canonical workflow dispatcher
@@ -22,6 +26,11 @@ argument-hint: "plan <topic> [--plan <path>] [--issue <N>] [--slug <slug>] [--pr
 selects the subcommand; everything after it is that subcommand's own argument
 string. Each subcommand's full procedure lives in a reference doc under
 `references/` — read that doc and follow it as the authoritative instructions.
+
+**An unrecognized first token is not an error — it is `ship`.** `/spec <plan-path>`
+is the ordinary way in: it scaffolds the task folder and then builds it through to a
+ready-for-review pull request. Naming a node explicitly (`plan`, `execute`, `retro`)
+runs only that node, which is what fan-out and recovery need.
 
 This is the **only** spec pipeline; there is no all-in-one composer beside it.
 `references/execute.md` holds the build mechanics in full — the issue, the branch,
@@ -36,7 +45,11 @@ The canonical operative path is
 `spec-plan → spec-execute → merge → reset|clean`.
 
 There is no automated selection node. A human selects the work and approves
-`prd.md`; that approval is the commitment gate. `/spec execute` runs
+`prd.md`; that approval is the commitment gate. **Handing `/spec` an approved plan
+file satisfies that gate** — writing the plan and passing it in *is* the operator's
+approval, so `ship` carries it through to `execute` without a second prompt. A bare
+topic with no plan file has no such approval behind it: `ship` stops after `plan` and
+hands the operator the folder to approve. `/spec execute` runs
 `build ⇄ audit → evidence → spec-retro → improve` and stops at a ready-for-review
 pull request. The human alone merges. The runner performs `reset` or `clean`.
 
@@ -49,6 +62,7 @@ evidence is absent or uncommitted.
 
 | Subcommand | Arg shape | Purpose | Procedure |
 |---|---|---|---|
+| `ship` | `<plan-path\|topic> [--issue <N>] [--slug <slug>] [--prefix <type>] [--repo <o/n>] [--base <branch>]` | **The default.** `plan` → `execute` in one invocation: an approved plan file becomes a ready-for-review PR. Selected by an unrecognized first token, so `/spec <plan-path>` works bare | `references/ship.md` |
 | `plan` | `<topic> [--plan <path>] [--issue <N>] [--slug <slug>] [--prefix <type>] [--repo <o/n>] [--base <branch>]` | Turn a topic/plan/issue into a fully-scaffolded `.oh/tasks/<slug>/` four-file folder | `references/plan.md` |
 | `execute` | `<slug> [--pr <N>] [--repo <o/n>] [--remote <name>] [--base <branch>]` | `implementation ⇄ audit → evidence → spec-retro → improve` to a ready PR, stopping at the human merge gate | `references/execute.md` |
 | `retro` | `<slug> [--dry-run]` | Execution-side `/retro` scoped to a built `.oh/tasks/<slug>/` | `references/retro.md` |
@@ -56,20 +70,30 @@ evidence is absent or uncommitted.
 ## Dispatch
 
 1. Split `$ARGUMENTS`: `SUB` = the first token; `REST` = everything after it.
-2. Read `references/<SUB>.md` and follow it, treating `REST` as that doc's
-   `$ARGUMENTS` (e.g. for `/spec plan <topic> --issue 7`, the plan procedure
-   sees `<topic> --issue 7`).
-3. Any unrecognized or empty `SUB` → print the Subcommands table as usage and stop.
+2. When `SUB` names a node (`ship`, `plan`, `execute`, `retro`), read
+   `references/<SUB>.md` and follow it, treating `REST` as that doc's `$ARGUMENTS`
+   (e.g. for `/spec plan <topic> --issue 7`, the plan procedure sees
+   `<topic> --issue 7`).
+3. **Any other non-empty `$ARGUMENTS` is `ship`, with the whole string — `SUB`
+   included — as its argument.** `/spec .claude/plans/x.md` and
+   `/spec ship .claude/plans/x.md` are the same invocation. Do not print usage for an
+   argument that merely fails to name a node; a plan path is the expected input.
+4. Empty `$ARGUMENTS` → print the Subcommands table as usage and stop. There is
+   nothing to ship.
 
 ```bash
-SUB="${ARGUMENTS%% *}"                          # first token (subcommand)
-REST="${ARGUMENTS#"$SUB"}"; REST="${REST# }"    # remainder = subcommand arguments
+SUB="${ARGUMENTS%% *}"                          # first token
+REST="${ARGUMENTS#"$SUB"}"; REST="${REST# }"    # remainder
 case "$SUB" in
-  plan|execute|retro)
+  ship|plan|execute|retro)
     # read references/$SUB.md and execute it with REST as its $ARGUMENTS
     ;;
+  "")
+    echo "usage: /spec [ship] <plan-path|topic> | plan <topic> | execute <slug> | retro <slug>"
+    ;;
   *)
-    echo "usage: /spec <plan|execute|retro> [args]  — see the Subcommands table"
+    # DEFAULT: not a node name -> ship, keeping the full argument string
+    # read references/ship.md and execute it with "$ARGUMENTS" as its $ARGUMENTS
     ;;
 esac
 ```
@@ -78,12 +102,13 @@ esac
 
 - **This skill owns the workflow** — keep the operative path, human selection,
   plan-approval gate, evidence gate, and human merge boundary in this skill and its
-  three direct references. Do not duplicate the workflow in root instructions.
+  four direct references. Do not duplicate the workflow in root instructions.
 - **The `.oh/tasks/<slug>/` folder is the universal interface** — `plan` produces it;
   `execute` and `retro` are each pointed at it. The `<slug>` is the
   universal key (task directory, branch second segment, tmux session name).
 - **Compose, don't fork** — each node reuses existing skills rather than
-  re-implementing them: `plan` composes `/prd` + `/ralph`; `execute` owns the
+  re-implementing them: `ship` composes `plan` then `execute` and owns no build
+  mechanics of its own; `plan` composes `/prd` + `/ralph`; `execute` owns the
   implementation in one Advisor session, uses `/delegate` only for bounded fan-out,
   and composes `/audit implementation` + `/eval` + `/audit pr`; `retro` composes
   `/retro`. The build **literals** — the `gh` invocations, the branch and PR shapes,
@@ -95,7 +120,8 @@ esac
   commitment gate**, and nothing GitHub-side exists until `execute` starts.
 - **Honest terminal reports** — each subcommand reports what it actually produced: `plan`
   the folder path and story count; `execute` `READY` or `DRAFT-BLOCKED (<gate>)` with the PR
-  URL; `retro` the promotion counts. There are no `STATUS: SPEC-*` tokens — all four had
+  URL; `ship` the same terminal report as whichever node it stopped at; `retro` the
+  promotion counts. There are no `STATUS: SPEC-*` tokens — all four had
   **zero executable consumers repo-wide**, so printing them was ceremony. The rule they
   encoded still holds and is what matters: never infer success from silence. A missing
   artifact, a crashed build, or an undecided gate is reported as blocked, never as done.
@@ -103,9 +129,10 @@ esac
 ## When NOT to use
 
 - **selection** — choosing which issue to build is the human's job; `/spec`
-  builds the one folder it is handed.
+  builds the one plan or folder it is handed. `ship` automates the hop from plan to
+  execute, never the choice of what to work on.
 
 ## See Also
 
-- `references/plan.md`, `references/execute.md`, and
+- `references/ship.md`, `references/plan.md`, `references/execute.md`, and
   `references/retro.md` — the authoritative per-subcommand procedures.

--- a/.oh/skills/spec/references/plan.md
+++ b/.oh/skills/spec/references/plan.md
@@ -128,6 +128,10 @@ done
 Within the workflow owned by `.oh/skills/spec/SKILL.md`, `plan` is the first node.
 The operator approves `prd.md`, then runs `/spec execute <slug>`.
 
+Running `plan` by name is the deliberate stop-after-scaffolding path. The default entry
+point, `ship`, runs this node and then continues into `execute` when the operator handed
+in an approved plan file (`references/ship.md`).
+
 The terminal artifact is the folder itself: `.oh/tasks/<slug>/` carrying the four-file
 contract, with `prd.md` awaiting the operator's approval. Report the folder path and the
 story count. There is no `STATUS: SPEC-PLANNED` token — it had no executable consumer, so

--- a/.oh/skills/spec/references/ship.md
+++ b/.oh/skills/spec/references/ship.md
@@ -1,0 +1,121 @@
+# `/spec ship` — an approved plan to a ready pull request
+
+> Detail doc for the **`ship`** subcommand of the `/spec` skill
+> (`.oh/skills/spec/SKILL.md`). Argument form:
+> `ship <plan-path|topic> [--issue <N>] [--slug <slug>] [--prefix feat|bug|task|audit|skill|agent] [--repo <owner/name>] [--base <branch>]`.
+> `ship` is the **default** node: the dispatcher routes any non-empty `$ARGUMENTS`
+> whose first token is not `ship`/`plan`/`execute`/`retro` here, passing the whole
+> string. Authority: `.oh/skills/spec/SKILL.md`.
+
+`ship` runs the canonical operative path — `plan → execute` — in one invocation, so
+handing `/spec` a plan file produces a ready-for-review pull request. It produces no
+artifact of its own: `plan` writes the `.oh/tasks/<slug>/` folder that is the universal
+interface, and `execute` builds from it.
+
+**Core principle: `ship` composes, it does not build.** Every artifact it produces is
+produced by `plan` or `execute` under their own procedures. `ship` adds no mechanics of
+its own — no `gh` invocation, no branch shape, no gate. It decides one thing: whether
+the commitment gate is already satisfied, and therefore whether to continue into
+`execute`.
+
+---
+
+## Inputs
+
+| Arg | Meaning |
+|-----|---------|
+| `<plan-path>` | A readable path to a plan file (`.claude/plans/*.md`, `/imagine` output, any markdown spec). **Its presence is the operator's approval** — see the gate below. |
+| `<topic>` | Free-text description, when no plan file exists. Carries no approval; `ship` stops after `plan`. |
+| `--issue <N>` | Issue this builds. Passed to `plan` (which embeds it in the branch name via `/ralph`). When absent, `execute`'s standalone-run path opens one. |
+| `--slug <slug>` | Override slug derivation. `[a-z0-9-]+`, ≤5 hyphen-words, not `archive`. |
+| `--prefix <type>` | Branch/issue prefix, default `feat`, per `.claude/skills/git/SKILL.md`. |
+| `--repo <owner/name>` | Default `mifunedev/openharness`. Recorded by `plan`, acted on by `execute`. |
+| `--base <branch>` | Default `development`. Same. |
+
+The first token is a plan path when it resolves to a readable file; otherwise it is
+treated as the start of a free-text topic.
+
+---
+
+## The commitment gate
+
+`.oh/skills/spec/SKILL.md` makes approving `prd.md` the commitment gate — nothing
+GitHub-side exists until it is crossed. `ship` does not remove that gate; it recognizes
+when the operator has already crossed it.
+
+| Input | Gate | Behavior |
+|---|---|---|
+| A plan file (`<plan-path>` or `--plan <path>`) | **Satisfied.** The operator wrote the plan and handed it in; requiring a second approval of a `prd.md` derived from it asks the same question twice | `plan`, then `execute` — through to a ready PR |
+| A bare topic, no plan file | **Not satisfied.** Nothing has been approved; the PRD is the first artifact anyone could approve | `plan` only. Report the folder path and stop with the `/spec execute <slug>` invocation to run after approval |
+
+An operator who wants the folder without the build asks for the node by name:
+`/spec plan <plan-path>`. That is the escape hatch, and it is why `plan` stays a public
+subcommand.
+
+---
+
+## The pipeline
+
+1. **Resolve the input.** Determine plan-path vs topic; derive or accept `<slug>`.
+   Report both before doing anything, so a wrong slug is caught before files exist.
+
+2. **Run `plan`.** Follow `references/plan.md` with
+   `<topic-or-plan> [--plan <path>] [--issue <N>] [--slug <slug>] [--prefix ...] [--repo ...] [--base ...]`.
+   A plan-path first token is passed to `plan` as `--plan <path>` with the topic derived
+   from the plan's own title. Verify the four-file contract
+   (`prd.md`, `prd.json`, `prompt.md`, `progress.txt`) before continuing — an incomplete
+   folder is a failure, not a clean plan, and `ship` must not build on one.
+
+3. **Decide at the gate** (table above). Not satisfied → report and stop. This is a
+   complete, honest outcome, not a blocked one.
+
+4. **Run `execute`.** Follow `references/execute.md` with
+   `<slug> [--repo ...] [--remote ...] [--base ...]`, which owns the issue, branch, draft
+   PR, Advisor build, `implementation ⇄ audit` loop, evidence, `/eval` and wiki gates,
+   and the undraft. `ship` neither reimplements nor relaxes any of it: a
+   `DRAFT-BLOCKED (<gate>)` from `execute` is `ship`'s outcome verbatim.
+
+5. **Stop at the human merge boundary.** `ship` never merges, and never marks a PR ready
+   that `execute`'s own gates left draft.
+
+---
+
+## Output
+
+Whatever the node it stopped at produced:
+
+| Stopped at | Report |
+|---|---|
+| `plan` (gate not satisfied) | The folder path, the story count, and `/spec execute <slug>` as the next command |
+| `execute` | `READY` or `DRAFT-BLOCKED (<gate>)` with the PR URL |
+
+Report which node it stopped at and why. A run that stopped after `plan` because the
+input was a bare topic is a success; a run that stopped after `plan` because the
+four-file contract was incomplete is a failure. Never report them the same way, and
+never infer success from silence.
+
+---
+
+## What this node does NOT do
+
+- **Add a build step.** Every mechanic belongs to `plan` or `execute`. If `ship` needs
+  new build behavior, the behavior belongs in `execute.md` — the protected single source
+  for build literals — not here.
+- **Merge.** The human alone merges (`.oh/skills/spec/SKILL.md`).
+- **Select the work.** It builds the one plan it is handed.
+- **Skip a gate.** It reads the commitment gate as already satisfied when an approved
+  plan was passed in. Every other gate — evidence, audit, `/eval`, wiki — is `execute`'s
+  and is untouched.
+
+## Pipeline position
+
+Within the workflow owned by `.oh/skills/spec/SKILL.md`, `ship` is the entry point —
+the node an operator reaches by typing nothing but a plan path. It occupies no position
+of its own in `spec-plan → spec-execute → merge → reset|clean`; it walks the first two
+and stops at the human merge boundary, exactly where `execute` stops.
+
+## See Also
+
+- `.oh/skills/spec/SKILL.md` — the dispatcher and workflow contract; the authority.
+- `references/plan.md` — the folder-scaffolding node.
+- `references/execute.md` — the build node and the single source for its literals.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Update policy and release automation live in [`/git`](.claude/skills/git/SKILL.m
 ## [Unreleased]
 
 ### Changed
+- Make `/spec` ship by default: an unrecognized first token routes to a new `ship` node that runs `plan` then `execute`, so `/spec <plan-path>` produces a ready-for-review PR ([#914](https://github.com/mifunedev/openharness/issues/914)).
 - **BREAKING:** Persist the sandbox home through one `/home/sandbox` mount, not eleven per-tool volumes; set `storage.homePath` for a host path, else `<name>_workspace` ([#898](https://github.com/mifunedev/openharness/issues/898)).
 - Shrink the sandbox image ~540 MB: drop build caches from the baked home seed, stage the seed once via a builder stage, and keep untracked build output out of the build context ([#900](https://github.com/mifunedev/openharness/issues/900)).
 - **BREAKING:** Stop baking Claude Code, Codex, and Pi into the image; boot installs them into the home mount, so a first boot needs network and runs 60-180s longer ([#904](https://github.com/mifunedev/openharness/issues/904)).


### PR DESCRIPTION
Closes #914

## What changed

`/spec <plan-path>` printed usage. The dispatcher's `case` only matched
`plan|execute|retro`, so the most common way an operator enters the workflow —
handing over an approved plan file — did nothing.

An unrecognized non-empty first token now routes to a new **`ship`** node with the
whole argument string, so `/spec .claude/plans/x.md` and `/spec ship .claude/plans/x.md`
are the same invocation. `ship` runs `plan`, then `execute`, and stops where `execute`
stops: the human merge boundary.

## The commitment gate survives

`SKILL.md` makes approving `prd.md` the commitment gate. `ship` does not remove it — it
recognizes when the operator already crossed it:

| Input | Gate | Behavior |
|---|---|---|
| A plan file | Satisfied — writing the plan and passing it in *is* the approval | `plan` → `execute` → ready PR |
| A bare topic, no plan file | Not satisfied — nothing has been approved yet | `plan` only, then report the folder and the `/spec execute <slug>` to run next |

`/spec plan <path>` remains the escape hatch for scaffolding without building, which is
why `plan` stays a public subcommand.

## ship owns no build mechanics

Every artifact comes from `plan` or `execute` under their own procedures. `ship` decides
one thing — whether to continue past the gate. `references/execute.md` stays the single
source for build literals, and the probe now enforces that: `ship.md` containing
`gh pr create`, `gh pr ready`, `gh issue create`, or `git push` is a regression.

## Probe

`spec-family-contract.sh` went from three nodes to four and gained assertions that the
dispatch case names all four, that the default-routing branch exists (a plan path must
not print usage), that `ship.md` states its treatment of the commitment gate, and that
it forks no build literal.

**Mutation-verified** — each new assertion broken deliberately, each exits 1:

| Mutation | Result |
|---|---|
| drop the DEFAULT routing branch | exit 1 |
| drop `ship` from the dispatch case | exit 1 |
| unname `ship` in the Subcommands table | exit 1 |
| add `gh pr create` to `ship.md` | exit 1 |
| drop the commitment-gate statement from `ship.md` | exit 1 |
| `ship.md` absent | exit 1 |

## Verification

- `bash .claude/skills/eval/run.sh` — 106 probes, exit 0, no green→red row. `RESULTS.md` regenerated.
- `spec-family-contract` and `workflow-boundaries` both PASS.
- `shellcheck` is not installed in this sandbox; CI runs it.
