### PR TITLE
FROM task/924-logs-agents-guide TO development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,8 @@ projects/*
 .oh/tasks/*
 !.oh/tasks/README.md
 .oh/logs/*
-!.oh/logs/README.md
+!.oh/logs/AGENTS.md
+!.oh/logs/CLAUDE.md
 
 # Build artifacts
 **/.venv/

--- a/.oh/evals/RESULTS.md
+++ b/.oh/evals/RESULTS.md
@@ -6,121 +6,121 @@ probe id; git history is the time series.** Schema and exit-code semantics are i
 
 | probe | tier | last-run (UTC) | status | source |
 |-------|------|----------------|--------|--------|
-| advisor-monitored-loop | A | 2026-08-31 22:25 | PASS | conversation 2026-06-19 (single-owner implementation workflow, issue #257) |
-| agent-browser-cli | A | 2026-08-31 22:25 | PASS | retro lesson 2026-06-07 (agent-browser 0.8.5 CLI) |
-| agents-identity-contract | A | 2026-08-31 22:25 | PASS | issue #854 — T3-style root identity, glossary, and skill-owned procedures |
-| artifact-contract-audit | A | 2026-08-31 22:25 | PASS | issue #583/#645 — production /audit implementation Gate 1 behavior |
-| audit-dispatcher-contract | A | 2026-08-31 22:25 | PASS | issue #645 — audit consolidation public taxonomy |
-| audit-implementation-behavior | A | 2026-08-31 22:25 | PASS | issue #645 — implementation root/repo/browser behavior |
-| audit-pr-acquire | A | 2026-08-31 22:25 | PASS | issue #645 — production PR acquisition behavior |
-| audit-pr-classifier | A | 2026-08-31 22:25 | PASS | issue #645 — deterministic focused and queue PR classifier |
-| audit-run-root-contract | A | 2026-08-31 22:25 | PASS | issue #645 — executable immutable audit root/run correlation |
-| audit-shellcheck-coverage | A | 2026-08-31 22:25 | PASS | issue #645 — private audit scripts require release and CI lint coverage |
-| audit-slop-gate | A | 2026-08-31 22:25 | PASS | .claude/specs/images/reduce-slop.png — the four correctness gates all pass a change |
-| audit-stale-references | A | 2026-08-31 22:25 | PASS | issue #645 — clean-breaking audit migration |
-| boot-lint-glob | A | 2026-08-31 22:25 | PASS | issue #90, issue #120 |
-| builder-skill-consolidation | A | 2026-08-31 22:25 | PASS | issue #643 — consolidate artifact builders behind one /builder dispatcher |
-| builder-wiki-proposer | A | 2026-08-31 22:25 | PASS | wikiskill arXiv:2608.27454 — the skill proposer reads accumulated knowledge first |
-| capability-benchmark-schema | A | 2026-08-31 22:25 | PASS | issue #167 — capability benchmark instrument |
-| cc-safety-net-wiring | A | 2026-08-31 22:25 | SKIPPED | .oh/tasks/cc-safety-net/prd.json US-007 2026-07-19 |
-| changelog-entry-length | A | 2026-08-31 22:25 | PASS | conversation 2026-08-24 — CHANGELOG.md grew to 259KB of bullet prose because "one line" was unquantified |
-| cleanup-tasks-scoped-guard | A | 2026-08-31 22:25 | PASS | issue #85 |
-| cleanup-tasks-worktree-grooming | A | 2026-08-31 22:25 | PASS | issue #168; issue #327 |
-| cli-publish-typecheck-scope | A | 2026-08-31 22:25 | PASS | release run 33271077312 — v0.5.0 pushed its GHCR image, then failed to publish |
-| close-issues-on-development | A | 2026-08-31 22:25 | PASS | issue #841 (closing keywords never fire because the default branch is main) 2026-08-26 |
-| codex-stale-response-retry | A | 2026-08-31 22:25 | PASS | issue #506 — Codex previous_response_not_found RCA |
-| compose-config-path-parity | A | 2026-08-31 22:25 | PASS | PR #833 (remove harness.yaml — the wrapper and VS Code "Reopen in Container" paths must resolve the same service) 2026-08-26 |
-| config-schema-parity | A | 2026-08-31 22:25 | PASS | PR #833 (one schema file — DOCKER_SOCKET, SANDBOX_SSH, OH_SANDBOX_IMAGE, OH_PULL_POLICY, SKIP_PNPM_INSTALL were consumed but undocumented); rewritten for the oh.json/secrets split by PR #887 |
-| context-tier-size-budget | A | 2026-08-31 22:25 | PASS | .oh/tasks/spec-simplification/ (issue #816, US-007) — the always-on tier was 85,256 B |
-| continual-learning-20260831 | A | 2026-08-31 22:25 | PASS | retro lesson 2026-08-31 (unexercised oracle) — a probe green in a 112-probe run carried three parser defects |
-| cron-claude-codex-fallback | A | 2026-08-31 22:25 | PASS | conversation 2026-06-12 (default Codex fallback for crons) |
-| cron-watchdog | A | 2026-08-31 22:25 | PASS | issues #130/#453 (cron runtime watchdog + legacy system-cron reaping) 2026-06-19 |
-| crons-directory-guide | A | 2026-08-31 22:25 | PASS | issue #874 |
-| curl-bash-safe-alternatives | A | 2026-08-31 22:25 | PASS | vet-run/vet integration — public curl|bash examples need review-first alternatives |
-| datasets-schema | A | 2026-08-31 22:25 | PASS | issue #196 — .oh/evals/datasets verifiable trajectory corpus (Repo2RLEnv-inspired) |
-| debugmcp-availability | A | 2026-08-31 22:25 | SKIPPED | issue #297 — DebugMCP MCP debug-server availability |
-| default-provisioning | A | 2026-08-31 22:25 | PASS | #902 — `oh harness install` must work from inside the sandbox, where |
-| delegate-model-effort-policy | A | 2026-08-31 22:25 | PASS | conversation 2026-07-11 (delegate model inheritance and thinking policy) |
-| devtcp-hook | A | 2026-08-31 22:25 | PASS | retro lesson 2026-06-10 (zsh /dev/tcp) |
-| docker-inspect-env-guard | A | 2026-08-31 22:25 | PASS | operator directive 2026-08-08 (agents keep the docker socket, but must |
-| docs-build-fast-path | A | 2026-08-31 22:25 | PASS | #455 — docs builds must stay out of fast harness/eval/release gates; #536 — docs site externalized to openharness-web; docs markdown relocated to docs/ |
-| drift-check-cron-staleness-glob | A | 2026-08-31 22:25 | PASS | issue #98; issue #225 (restart-required cron frontmatter/config drift) |
-| entrypoint-pnpm-manifest-fingerprint | A | 2026-08-31 22:25 | PASS | issue #521 (manifest-aware sandbox installs) 2026-07-01 |
-| escalate-contract | A | 2026-08-31 22:25 | PASS | issue #799 — seven comments on a GitHub thread produced zero notifications and nobody |
-| eval-ci-gate | A | 2026-08-31 22:25 | PASS | #103 — eval probe suite gated in CI |
-| eval-contract-text-20260831 | A | 2026-08-31 22:25 | PASS | retro lesson 2026-08-31 (prose-literal pinning) — two assertions failed on first run purely from source line wrapping |
-| eval-gate | A | 2026-08-31 22:25 | PASS | retro lesson 2026-06-11 (eval-gate) |
-| eval-results-atomic | A | 2026-08-31 22:25 | PASS | issue #83 (eval-results-atomic-write) |
-| eval-runner-exit | A | 2026-08-31 22:25 | PASS | retro lesson 2026-06-11 (eval-runner-exit) #29 |
-| eval-runs-once-per-cycle | A | 2026-08-31 22:25 | PASS | .oh/tasks/spec-simplification/ (issue #816, US-006) — /eval ran 3x per cycle on the |
-| execution-target-contract | A | 2026-08-31 22:25 | PASS | issue #733 (ExecutionTarget contract + Docker Compose adapter) 2026-08-10 |
-| get-oh-bootstrap | A | 2026-08-31 22:25 | PASS | get-oh.sh bootstrap — the Node-bootstrapping host-side path to the standalone `oh` CLI (also on npm as @mifune/openharness; see oh-npm-package.sh) |
-| git-skill | A | 2026-08-31 22:25 | PASS | conversation 2026-06-15 — rules are not always supported; git workflow must be the /git skill |
-| harness-audit-empty-output-gate | A | 2026-08-31 22:25 | PASS | issue #246 — /audit harness must fail closed on empty auditor outputs |
-| harness-ci-core-paths | A | 2026-08-31 22:25 | PASS | #165 — core sandbox config files must trigger harness CI |
-| harness-ci-hooks-paths | A | 2026-08-31 22:25 | PASS | issue #202 — credential/security hook changes must trigger harness CI |
-| harness-yaml-migration | A | 2026-08-31 22:25 | PASS | PR #833 (migrate-harness-yaml.sh — append / uncomment-in-place / preserve / overwrite, plus a silent no-op second run) 2026-08-26 |
-| health-check-docker-stats | A | 2026-08-31 22:25 | PASS | retro lesson 2026-06-10 (docker stats vs ps Size) |
-| health-check-socket-degrade | A | 2026-08-31 22:25 | PASS | issue #762 (refs #756) — /health-check degrades to one statement, not nine failures |
-| heartbeat-logging-contract | A | 2026-08-31 22:25 | PASS | issue #447 (heartbeat log append hardening) 2026-06-18 |
-| image-seed-hygiene | A | 2026-08-31 22:25 | PASS | issue #900 (slim the sandbox image) 2026-08-30 |
-| markitdown-wiki-ingest | A | 2026-08-31 22:25 | PASS | issue #649 — pinned local-document normalization contract for /wiki ingest |
-| next-dev-prod | A | 2026-08-31 22:25 | SKIPPED | retro lesson 2026-06-04 |
-| oh-compose-env-wiring | A | 2026-08-31 22:25 | SKIPPED | issue #880 (oh as the only front door — oh.json is the non-secret config surface) |
-| oh-config-surfaces | A | 2026-08-31 22:25 | PASS | PR #887 (config split across two authored surfaces — a tracked oh.json and a secrets-only root dotenv — with nothing left under $HOME) |
-| oh-destroy-guard | A | 2026-08-31 22:25 | SKIPPED | issue #879 — `oh` becomes the only front door, so `make destroy` must |
-| oh-devcontainer-restructure | A | 2026-08-31 22:25 | PASS | consolidate devcontainer — .oh/devcontainer/ folded back into .devcontainer/ |
-| oh-home-mount | A | 2026-08-31 22:25 | PASS | issue #898 (single $HOME mount) 2026-08-30 |
-| oh-image-only-deploy | A | 2026-08-31 22:25 | PASS | .oh/tasks/image-only-deploy/prd.json US-004 (issue #609, Flavor B image-only deploy) |
-| oh-init-headless-config | A | 2026-08-31 22:25 | SKIPPED | PR #827 (installer answers landed in the losing config file); retargeted to the .example.env template by PR #833, then to oh.json by PR #887 |
-| oh-init-scaffold | A | 2026-08-31 22:25 | PASS | issue #531 Phase 2 |
-| oh-lifecycle-surface | A | 2026-08-31 22:25 | PASS | issue #881 — the Makefile is retired and `oh` is the only front door |
-| oh-npm-package | A | 2026-08-31 22:25 | PASS | npm publish path for the standalone `oh` CLI (@mifune/openharness) — alternative to get-oh.sh |
-| oh-payload-manifest | A | 2026-08-31 22:25 | PASS | issue #531 follow-on (.oh payload manifest — oh update ships a declared allowlist) |
-| oh-sandbox-image-mode | A | 2026-08-31 22:25 | PASS | conversation 2026-07-05 (basic Docker deployment — prebuilt-image mode) |
-| oh-shipped-repo-overridable | A | 2026-08-31 22:25 | PASS | issue #531 follow-on (de-hardcode residual — shipped .oh shell scripts keep the upstream repo overridable) |
-| oh-standalone-lifecycle | A | 2026-08-31 22:25 | PASS | issue #564 |
-| oh-update | A | 2026-08-31 22:25 | PASS | issue #531 Phase 3 (oh update — upgrade only the .oh control plane) |
-| operator-config-guard | A | 2026-08-31 22:25 | PASS | operator directives 2026-08-06 (.config/ and settings.local.json are operator-only) |
-| pnpm-audit-ci-gate | A | 2026-08-31 22:25 | PASS | issue #171 — pnpm security audits must run in CI |
-| post-bridge-publish-confirmation | A | 2026-08-31 22:25 | PASS | #523 — post-bridge live publishing requires an explicit final confirmation gate |
-| prd-output-path-contract | A | 2026-08-31 22:25 | PASS | retro lesson 2026-06-19 |
-| prompt-miner-schema-compat | A | 2026-08-31 22:25 | PASS | issue #253 — prompt-miner JSONL schema-drift guard |
-| prompt-miner-symlink-entrypoint | A | 2026-08-31 22:25 | PASS | issue #663 — prompt-miner engine no-ops via the documented .claude/skills symlink |
-| prompt-miner-weakness-record | A | 2026-08-31 22:25 | PASS | issue #580 — prompt-miner weakness-record (WH-xxx) cluster output |
-| protected-path-deletion | A | 2026-08-31 22:25 | PASS | .oh/tasks/spec-simplification/ (issue #816, US-001) — the critique gate was deleted, |
-| protected-paths-resolve | A | 2026-08-31 22:25 | PASS | issue #753 — .claude/protected-paths.txt named 7 paths that did not exist. |
-| registry-portability-gate | A | 2026-08-31 22:25 | PASS | issue #758 |
-| registry-portability | A | 2026-08-31 22:25 | SKIPPED | issue #758 |
-| retro-deterministic-contract | A | 2026-08-31 22:25 | PASS | issue #443 — /retro deterministic output and self-contained helper contract |
-| rl-delegation-write-worker | A | 2026-08-31 22:25 | PASS | retro lesson 2026-06-10 (rl-delegation) #57 |
-| rlm-context-budget | A | 2026-08-31 22:25 | PASS | .oh/tasks/rlm-weighted-trajectories/prd.json US-006 |
-| runtime-preflight-gate | A | 2026-08-31 22:25 | PASS | issue #806 § B1 (open sandbox.substrate vs sandbox.runtime selector); |
-| sandbox-boot-guard-ci | A | 2026-08-31 22:25 | PASS | issue #449 (sandbox image build CI guard) 2026-06-19; |
-| sandbox-node-base | A | 2026-08-31 22:25 | PASS | openharness#878 — oh as the only front door, T0 sandbox base image |
-| skill-paths | A | 2026-08-31 22:25 | PASS | issue #43 — stale path references; extended by issue #69 — apps/->packages/ rename guard; extended by issue #870 — deleted .oh/agents/advisor.md |
-| skills-dir-clean | A | 2026-08-31 22:25 | PASS | conversation 2026-06-29 — Pi parses every top-level `.md` in the skills |
-| skills-task-tool-coupling | A | 2026-08-31 22:25 | PASS | council review 2026-08-29 (issue #886) — /delegate instructed Claude-Code-only |
-| skills-vendored | A | 2026-08-31 22:25 | PASS | absorb .mifune submodule into .oh — the skills/agents/hooks pack is vendored |
-| slack-admin-command-surface | A | 2026-08-31 22:25 | PASS | issue #354 — Slack bridge docs must distinguish Pi /msg-bridge commands from Slack DM admin text handlers |
-| spec-family-contract | A | 2026-08-31 22:25 | PASS | issue #265; spec-simplification issue #816; workflow authority issue #854; |
-| spec-ready-finalization | A | 2026-08-31 22:25 | PASS | issue #134; spec-simplification issue #816; workflow authority issue #854 |
-| ste-checker-contract | A | 2026-08-31 22:25 | PASS | issue #750 PR audit — the /ste checker had four fail-open paths (unclosed |
-| submitted-by-trailers | A | 2026-08-31 22:25 | PASS | conversation 2026-06-12 (commit attribution trailers); the single-owner |
-| sync-skill-contract | A | 2026-08-31 22:25 | PASS | issue #331 — /sync dispatcher skill (bidirectional origin↔upstream sync) |
-| t3-headless-launch | A | 2026-08-31 22:25 | PASS | issue #858 — /t3 launched a bare `npx --yes t3`, which is the local GUI and |
-| tailscale-tool-boundary | A | 2026-08-31 22:25 | PASS | issue #858 — Tailscale mobile access for T3 Code. There is no tailnet, no |
-| tool-catalog-boundary | A | 2026-08-31 22:25 | PASS | agent-browser's exclusion from the harness catalog (#821) and the |
-| version-parity | A | 2026-08-31 22:25 | PASS | conversation 2026-08-29 — the oh CLI became the only lifecycle door, so its |
-| weigh-scorer-contract | A | 2026-08-31 22:25 | PASS | .oh/tasks/rlm-weighted-trajectories/prd.json US-003 (2026-06-27) |
-| wiki-compile-contract | A | 2026-08-31 22:25 | PASS | wikiskill arXiv:2608.27454 — Wiki Maintainer role added as /wiki compile |
-| wiki-kind-schema-contract | A | 2026-08-31 22:25 | PASS | wikiskill arXiv:2608.27454 — pattern layer added to the wiki corpus |
-| wiki-pattern-persistence | A | 2026-08-31 22:25 | SKIPPED | wikiskill arXiv:2608.27454 — pattern pages are never rolled back |
-| wiki-query-pattern-isolation | A | 2026-08-31 22:25 | PASS | wikiskill arXiv:2608.27454 — proposer-only pattern access |
-| wiki-readme-index | A | 2026-08-31 22:25 | PASS | issue #132 — wiki README index drift guard |
-| wiki-related-slugs | A | 2026-08-31 22:25 | PASS | wikiskill arXiv:2608.27454 — wiki lint related-slug check |
-| wiki-skill-impact-append-only | A | 2026-08-31 22:25 | PASS | wikiskill arXiv:2608.27454 — skill-change ledger, never rolled back |
-| workflow-boundaries | A | 2026-08-31 22:25 | PASS | conversation 2026-06-19 (workflow consolidation, issue #259); authority moved to /spec in issue #854 |
-| worktrees-layout | A | 2026-08-31 22:25 | PASS | issue #872 |
+| advisor-monitored-loop | A | 2026-08-31 22:35 | PASS | conversation 2026-06-19 (single-owner implementation workflow, issue #257) |
+| agent-browser-cli | A | 2026-08-31 22:35 | PASS | retro lesson 2026-06-07 (agent-browser 0.8.5 CLI) |
+| agents-identity-contract | A | 2026-08-31 22:35 | PASS | issue #854 — T3-style root identity, glossary, and skill-owned procedures |
+| artifact-contract-audit | A | 2026-08-31 22:35 | PASS | issue #583/#645 — production /audit implementation Gate 1 behavior |
+| audit-dispatcher-contract | A | 2026-08-31 22:35 | PASS | issue #645 — audit consolidation public taxonomy |
+| audit-implementation-behavior | A | 2026-08-31 22:35 | PASS | issue #645 — implementation root/repo/browser behavior |
+| audit-pr-acquire | A | 2026-08-31 22:35 | PASS | issue #645 — production PR acquisition behavior |
+| audit-pr-classifier | A | 2026-08-31 22:35 | PASS | issue #645 — deterministic focused and queue PR classifier |
+| audit-run-root-contract | A | 2026-08-31 22:35 | PASS | issue #645 — executable immutable audit root/run correlation |
+| audit-shellcheck-coverage | A | 2026-08-31 22:35 | PASS | issue #645 — private audit scripts require release and CI lint coverage |
+| audit-slop-gate | A | 2026-08-31 22:35 | PASS | .claude/specs/images/reduce-slop.png — the four correctness gates all pass a change |
+| audit-stale-references | A | 2026-08-31 22:35 | PASS | issue #645 — clean-breaking audit migration |
+| boot-lint-glob | A | 2026-08-31 22:35 | PASS | issue #90, issue #120 |
+| builder-skill-consolidation | A | 2026-08-31 22:35 | PASS | issue #643 — consolidate artifact builders behind one /builder dispatcher |
+| builder-wiki-proposer | A | 2026-08-31 22:35 | PASS | wikiskill arXiv:2608.27454 — the skill proposer reads accumulated knowledge first |
+| capability-benchmark-schema | A | 2026-08-31 22:35 | PASS | issue #167 — capability benchmark instrument |
+| cc-safety-net-wiring | A | 2026-08-31 22:35 | SKIPPED | .oh/tasks/cc-safety-net/prd.json US-007 2026-07-19 |
+| changelog-entry-length | A | 2026-08-31 22:35 | PASS | conversation 2026-08-24 — CHANGELOG.md grew to 259KB of bullet prose because "one line" was unquantified |
+| cleanup-tasks-scoped-guard | A | 2026-08-31 22:35 | PASS | issue #85 |
+| cleanup-tasks-worktree-grooming | A | 2026-08-31 22:35 | PASS | issue #168; issue #327 |
+| cli-publish-typecheck-scope | A | 2026-08-31 22:35 | PASS | release run 33271077312 — v0.5.0 pushed its GHCR image, then failed to publish |
+| close-issues-on-development | A | 2026-08-31 22:35 | PASS | issue #841 (closing keywords never fire because the default branch is main) 2026-08-26 |
+| codex-stale-response-retry | A | 2026-08-31 22:35 | PASS | issue #506 — Codex previous_response_not_found RCA |
+| compose-config-path-parity | A | 2026-08-31 22:35 | PASS | PR #833 (remove harness.yaml — the wrapper and VS Code "Reopen in Container" paths must resolve the same service) 2026-08-26 |
+| config-schema-parity | A | 2026-08-31 22:35 | PASS | PR #833 (one schema file — DOCKER_SOCKET, SANDBOX_SSH, OH_SANDBOX_IMAGE, OH_PULL_POLICY, SKIP_PNPM_INSTALL were consumed but undocumented); rewritten for the oh.json/secrets split by PR #887 |
+| context-tier-size-budget | A | 2026-08-31 22:35 | PASS | .oh/tasks/spec-simplification/ (issue #816, US-007) — the always-on tier was 85,256 B |
+| continual-learning-20260831 | A | 2026-08-31 22:35 | PASS | retro lesson 2026-08-31 (unexercised oracle) — a probe green in a 112-probe run carried three parser defects |
+| cron-claude-codex-fallback | A | 2026-08-31 22:35 | PASS | conversation 2026-06-12 (default Codex fallback for crons) |
+| cron-watchdog | A | 2026-08-31 22:35 | PASS | issues #130/#453 (cron runtime watchdog + legacy system-cron reaping) 2026-06-19 |
+| crons-directory-guide | A | 2026-08-31 22:35 | PASS | issue #874 |
+| curl-bash-safe-alternatives | A | 2026-08-31 22:35 | PASS | vet-run/vet integration — public curl|bash examples need review-first alternatives |
+| datasets-schema | A | 2026-08-31 22:35 | PASS | issue #196 — .oh/evals/datasets verifiable trajectory corpus (Repo2RLEnv-inspired) |
+| debugmcp-availability | A | 2026-08-31 22:35 | SKIPPED | issue #297 — DebugMCP MCP debug-server availability |
+| default-provisioning | A | 2026-08-31 22:35 | PASS | #902 — `oh harness install` must work from inside the sandbox, where |
+| delegate-model-effort-policy | A | 2026-08-31 22:35 | PASS | conversation 2026-07-11 (delegate model inheritance and thinking policy) |
+| devtcp-hook | A | 2026-08-31 22:35 | PASS | retro lesson 2026-06-10 (zsh /dev/tcp) |
+| docker-inspect-env-guard | A | 2026-08-31 22:35 | PASS | operator directive 2026-08-08 (agents keep the docker socket, but must |
+| docs-build-fast-path | A | 2026-08-31 22:35 | PASS | #455 — docs builds must stay out of fast harness/eval/release gates; #536 — docs site externalized to openharness-web; docs markdown relocated to docs/ |
+| drift-check-cron-staleness-glob | A | 2026-08-31 22:35 | PASS | issue #98; issue #225 (restart-required cron frontmatter/config drift) |
+| entrypoint-pnpm-manifest-fingerprint | A | 2026-08-31 22:35 | PASS | issue #521 (manifest-aware sandbox installs) 2026-07-01 |
+| escalate-contract | A | 2026-08-31 22:35 | PASS | issue #799 — seven comments on a GitHub thread produced zero notifications and nobody |
+| eval-ci-gate | A | 2026-08-31 22:35 | PASS | #103 — eval probe suite gated in CI |
+| eval-contract-text-20260831 | A | 2026-08-31 22:35 | PASS | retro lesson 2026-08-31 (prose-literal pinning) — two assertions failed on first run purely from source line wrapping |
+| eval-gate | A | 2026-08-31 22:35 | PASS | retro lesson 2026-06-11 (eval-gate) |
+| eval-results-atomic | A | 2026-08-31 22:35 | PASS | issue #83 (eval-results-atomic-write) |
+| eval-runner-exit | A | 2026-08-31 22:35 | PASS | retro lesson 2026-06-11 (eval-runner-exit) #29 |
+| eval-runs-once-per-cycle | A | 2026-08-31 22:35 | PASS | .oh/tasks/spec-simplification/ (issue #816, US-006) — /eval ran 3x per cycle on the |
+| execution-target-contract | A | 2026-08-31 22:35 | PASS | issue #733 (ExecutionTarget contract + Docker Compose adapter) 2026-08-10 |
+| get-oh-bootstrap | A | 2026-08-31 22:35 | PASS | get-oh.sh bootstrap — the Node-bootstrapping host-side path to the standalone `oh` CLI (also on npm as @mifune/openharness; see oh-npm-package.sh) |
+| git-skill | A | 2026-08-31 22:35 | PASS | conversation 2026-06-15 — rules are not always supported; git workflow must be the /git skill |
+| harness-audit-empty-output-gate | A | 2026-08-31 22:35 | PASS | issue #246 — /audit harness must fail closed on empty auditor outputs |
+| harness-ci-core-paths | A | 2026-08-31 22:35 | PASS | #165 — core sandbox config files must trigger harness CI |
+| harness-ci-hooks-paths | A | 2026-08-31 22:35 | PASS | issue #202 — credential/security hook changes must trigger harness CI |
+| harness-yaml-migration | A | 2026-08-31 22:35 | PASS | PR #833 (migrate-harness-yaml.sh — append / uncomment-in-place / preserve / overwrite, plus a silent no-op second run) 2026-08-26 |
+| health-check-docker-stats | A | 2026-08-31 22:35 | PASS | retro lesson 2026-06-10 (docker stats vs ps Size) |
+| health-check-socket-degrade | A | 2026-08-31 22:35 | PASS | issue #762 (refs #756) — /health-check degrades to one statement, not nine failures |
+| heartbeat-logging-contract | A | 2026-08-31 22:35 | PASS | issue #447 (heartbeat log append hardening) 2026-06-18 |
+| image-seed-hygiene | A | 2026-08-31 22:35 | PASS | issue #900 (slim the sandbox image) 2026-08-30 |
+| markitdown-wiki-ingest | A | 2026-08-31 22:35 | PASS | issue #649 — pinned local-document normalization contract for /wiki ingest |
+| next-dev-prod | A | 2026-08-31 22:35 | SKIPPED | retro lesson 2026-06-04 |
+| oh-compose-env-wiring | A | 2026-08-31 22:35 | SKIPPED | issue #880 (oh as the only front door — oh.json is the non-secret config surface) |
+| oh-config-surfaces | A | 2026-08-31 22:35 | PASS | PR #887 (config split across two authored surfaces — a tracked oh.json and a secrets-only root dotenv — with nothing left under $HOME) |
+| oh-destroy-guard | A | 2026-08-31 22:35 | SKIPPED | issue #879 — `oh` becomes the only front door, so `make destroy` must |
+| oh-devcontainer-restructure | A | 2026-08-31 22:35 | PASS | consolidate devcontainer — .oh/devcontainer/ folded back into .devcontainer/ |
+| oh-home-mount | A | 2026-08-31 22:35 | PASS | issue #898 (single $HOME mount) 2026-08-30 |
+| oh-image-only-deploy | A | 2026-08-31 22:35 | PASS | .oh/tasks/image-only-deploy/prd.json US-004 (issue #609, Flavor B image-only deploy) |
+| oh-init-headless-config | A | 2026-08-31 22:35 | SKIPPED | PR #827 (installer answers landed in the losing config file); retargeted to the .example.env template by PR #833, then to oh.json by PR #887 |
+| oh-init-scaffold | A | 2026-08-31 22:35 | PASS | issue #531 Phase 2 |
+| oh-lifecycle-surface | A | 2026-08-31 22:35 | PASS | issue #881 — the Makefile is retired and `oh` is the only front door |
+| oh-npm-package | A | 2026-08-31 22:35 | PASS | npm publish path for the standalone `oh` CLI (@mifune/openharness) — alternative to get-oh.sh |
+| oh-payload-manifest | A | 2026-08-31 22:35 | PASS | issue #531 follow-on (.oh payload manifest — oh update ships a declared allowlist) |
+| oh-sandbox-image-mode | A | 2026-08-31 22:35 | PASS | conversation 2026-07-05 (basic Docker deployment — prebuilt-image mode) |
+| oh-shipped-repo-overridable | A | 2026-08-31 22:35 | PASS | issue #531 follow-on (de-hardcode residual — shipped .oh shell scripts keep the upstream repo overridable) |
+| oh-standalone-lifecycle | A | 2026-08-31 22:35 | PASS | issue #564 |
+| oh-update | A | 2026-08-31 22:35 | PASS | issue #531 Phase 3 (oh update — upgrade only the .oh control plane) |
+| operator-config-guard | A | 2026-08-31 22:35 | PASS | operator directives 2026-08-06 (.config/ and settings.local.json are operator-only) |
+| pnpm-audit-ci-gate | A | 2026-08-31 22:35 | PASS | issue #171 — pnpm security audits must run in CI |
+| post-bridge-publish-confirmation | A | 2026-08-31 22:35 | PASS | #523 — post-bridge live publishing requires an explicit final confirmation gate |
+| prd-output-path-contract | A | 2026-08-31 22:35 | PASS | retro lesson 2026-06-19 |
+| prompt-miner-schema-compat | A | 2026-08-31 22:35 | PASS | issue #253 — prompt-miner JSONL schema-drift guard |
+| prompt-miner-symlink-entrypoint | A | 2026-08-31 22:35 | PASS | issue #663 — prompt-miner engine no-ops via the documented .claude/skills symlink |
+| prompt-miner-weakness-record | A | 2026-08-31 22:35 | PASS | issue #580 — prompt-miner weakness-record (WH-xxx) cluster output |
+| protected-path-deletion | A | 2026-08-31 22:35 | PASS | .oh/tasks/spec-simplification/ (issue #816, US-001) — the critique gate was deleted, |
+| protected-paths-resolve | A | 2026-08-31 22:35 | PASS | issue #753 — .claude/protected-paths.txt named 7 paths that did not exist. |
+| registry-portability-gate | A | 2026-08-31 22:35 | PASS | issue #758 |
+| registry-portability | A | 2026-08-31 22:35 | SKIPPED | issue #758 |
+| retro-deterministic-contract | A | 2026-08-31 22:35 | PASS | issue #443 — /retro deterministic output and self-contained helper contract |
+| rl-delegation-write-worker | A | 2026-08-31 22:35 | PASS | retro lesson 2026-06-10 (rl-delegation) #57 |
+| rlm-context-budget | A | 2026-08-31 22:35 | PASS | .oh/tasks/rlm-weighted-trajectories/prd.json US-006 |
+| runtime-preflight-gate | A | 2026-08-31 22:35 | PASS | issue #806 § B1 (open sandbox.substrate vs sandbox.runtime selector); |
+| sandbox-boot-guard-ci | A | 2026-08-31 22:35 | PASS | issue #449 (sandbox image build CI guard) 2026-06-19; |
+| sandbox-node-base | A | 2026-08-31 22:35 | PASS | openharness#878 — oh as the only front door, T0 sandbox base image |
+| skill-paths | A | 2026-08-31 22:35 | PASS | issue #43 — stale path references; extended by issue #69 — apps/->packages/ rename guard; extended by issue #870 — deleted .oh/agents/advisor.md |
+| skills-dir-clean | A | 2026-08-31 22:35 | PASS | conversation 2026-06-29 — Pi parses every top-level `.md` in the skills |
+| skills-task-tool-coupling | A | 2026-08-31 22:35 | PASS | council review 2026-08-29 (issue #886) — /delegate instructed Claude-Code-only |
+| skills-vendored | A | 2026-08-31 22:35 | PASS | absorb .mifune submodule into .oh — the skills/agents/hooks pack is vendored |
+| slack-admin-command-surface | A | 2026-08-31 22:35 | PASS | issue #354 — Slack bridge docs must distinguish Pi /msg-bridge commands from Slack DM admin text handlers |
+| spec-family-contract | A | 2026-08-31 22:35 | PASS | issue #265; spec-simplification issue #816; workflow authority issue #854; |
+| spec-ready-finalization | A | 2026-08-31 22:35 | PASS | issue #134; spec-simplification issue #816; workflow authority issue #854 |
+| ste-checker-contract | A | 2026-08-31 22:35 | PASS | issue #750 PR audit — the /ste checker had four fail-open paths (unclosed |
+| submitted-by-trailers | A | 2026-08-31 22:35 | PASS | conversation 2026-06-12 (commit attribution trailers); the single-owner |
+| sync-skill-contract | A | 2026-08-31 22:35 | PASS | issue #331 — /sync dispatcher skill (bidirectional origin↔upstream sync) |
+| t3-headless-launch | A | 2026-08-31 22:35 | PASS | issue #858 — /t3 launched a bare `npx --yes t3`, which is the local GUI and |
+| tailscale-tool-boundary | A | 2026-08-31 22:35 | PASS | issue #858 — Tailscale mobile access for T3 Code. There is no tailnet, no |
+| tool-catalog-boundary | A | 2026-08-31 22:35 | PASS | agent-browser's exclusion from the harness catalog (#821) and the |
+| version-parity | A | 2026-08-31 22:35 | PASS | conversation 2026-08-29 — the oh CLI became the only lifecycle door, so its |
+| weigh-scorer-contract | A | 2026-08-31 22:35 | PASS | .oh/tasks/rlm-weighted-trajectories/prd.json US-003 (2026-06-27) |
+| wiki-compile-contract | A | 2026-08-31 22:35 | PASS | wikiskill arXiv:2608.27454 — Wiki Maintainer role added as /wiki compile |
+| wiki-kind-schema-contract | A | 2026-08-31 22:35 | PASS | wikiskill arXiv:2608.27454 — pattern layer added to the wiki corpus |
+| wiki-pattern-persistence | A | 2026-08-31 22:35 | PASS | wikiskill arXiv:2608.27454 — pattern pages are never rolled back |
+| wiki-query-pattern-isolation | A | 2026-08-31 22:35 | PASS | wikiskill arXiv:2608.27454 — proposer-only pattern access |
+| wiki-readme-index | A | 2026-08-31 22:35 | PASS | issue #132 — wiki README index drift guard |
+| wiki-related-slugs | A | 2026-08-31 22:35 | PASS | wikiskill arXiv:2608.27454 — wiki lint related-slug check |
+| wiki-skill-impact-append-only | A | 2026-08-31 22:35 | PASS | wikiskill arXiv:2608.27454 — skill-change ledger, never rolled back |
+| workflow-boundaries | A | 2026-08-31 22:35 | PASS | conversation 2026-06-19 (workflow consolidation, issue #259); authority moved to /spec in issue #854 |
+| worktrees-layout | A | 2026-08-31 22:35 | PASS | issue #872 |
 
 <!-- benchmark: pass-rate = PASS / (PASS + REGRESSION + TIMEOUT); SKIPPED excluded -->

--- a/.oh/evals/probes/escalate-contract.sh
+++ b/.oh/evals/probes/escalate-contract.sh
@@ -14,9 +14,13 @@ fail() { echo "REGRESSION: $*" >&2; exit 1; }
 
 [[ -f $S && -x $S ]] || fail 'escalate script missing or not executable'
 [[ -f $SKILL ]] || fail 'escalate SKILL.md missing'
-[[ -f $ROOT/.oh/logs/README.md ]] || fail '.oh/logs/README.md missing — the log directory has no contract'
+[[ -f $ROOT/.oh/logs/AGENTS.md ]] || fail '.oh/logs/AGENTS.md missing — the log directory has no contract'
+[[ -L $ROOT/.oh/logs/CLAUDE.md && $(readlink "$ROOT/.oh/logs/CLAUDE.md") == AGENTS.md ]] \
+  || fail '.oh/logs/CLAUDE.md must be a symlink to the sibling AGENTS.md'
 grep -Fq '.oh/logs/*' "$ROOT/.gitignore" || fail '.oh/logs contents are not gitignored'
-grep -Fq '!.oh/logs/README.md' "$ROOT/.gitignore" || fail '.oh/logs/README.md is not exempted from the ignore'
+for keep in '!.oh/logs/AGENTS.md' '!.oh/logs/CLAUDE.md'; do
+  grep -Fq "$keep" "$ROOT/.gitignore" || fail "$keep is not exempted from the ignore"
+done
 
 grep -Fq 'Exit 0 is not proof' "$SKILL" || fail 'SKILL.md does not warn that exit 0 is not delivery'
 grep -Fq 'conversations.info' "$SKILL" || fail 'SKILL.md does not document the channel health check'

--- a/.oh/logs/AGENTS.md
+++ b/.oh/logs/AGENTS.md
@@ -1,5 +1,7 @@
 # `.oh/logs/`
 
+`CLAUDE.md` is a provider-compatibility symlink to this file. Edit `AGENTS.md`.
+
 Durable operational records written by unattended sessions. Everything here is
 gitignored except this file: a log is evidence for the next session and for the
 operator, never repository content.
@@ -23,6 +25,10 @@ without a parser:
 ```bash
 jq -c 'select(.ok == false)' .oh/logs/escalations.jsonl   # what never reached a human
 ```
+
+Write here only when the record must survive the session. A session that can
+still act on a finding acts on it; a session that cannot leaves the record and
+says so where a human looks.
 
 Rotation is manual. These files are small and are read by humans after something
 went wrong; truncate them when they stop being useful, and never rewrite a record

--- a/.oh/logs/CLAUDE.md
+++ b/.oh/logs/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/.oh/skills/escalate/SKILL.md
+++ b/.oh/skills/escalate/SKILL.md
@@ -115,7 +115,7 @@ remove, so the reason is always printed to stderr and returned in the JSON.
 
   This is what makes a no-op recoverable: the next session, or the operator after
   the fact, can see an escalation was attempted and died in a dead channel. See
-  [`.oh/logs/README.md`](../../logs/README.md).
+  [`.oh/logs/AGENTS.md`](../../logs/AGENTS.md).
 - **Timeout**: `ESCALATE_TIMEOUT` seconds per Slack call, default 10 — an
   unreachable gateway must not hang an unattended session.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,8 +141,8 @@ silently skip a surface.
 ## How to work in this repository
 
 This file is the only always-on context. A nested `AGENTS.md` exists only in
-`.worktrees/`, `projects/`, and `crons/`, whose contents run or are checked
-out apart from it. Every other directory uses a `README.md`.
+`.worktrees/`, `projects/`, `crons/`, and `.oh/logs/`, whose contents are
+produced apart from it. Every other directory uses a `README.md`.
 
 Use the lifecycle in this order:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ Update policy and release automation live in [`/git`](.claude/skills/git/SKILL.m
 - **BREAKING:** Retire the DeepAgents harness — `deepagents-cli` is deprecated upstream. `install.deepagents` is no longer a settable oh.json field ([#910](https://github.com/mifunedev/openharness/issues/910)).
 - **BREAKING:** Retire the `projectRoot` / `OH_PROJECT_ROOT` config knob — the checkout is fixed at `/home/sandbox/harness`, nested inside the home mount ([#898](https://github.com/mifunedev/openharness/issues/898)).
 
+### Changed
+- `.oh/logs/` carries an `AGENTS.md` with a `CLAUDE.md` symlink instead of a `README.md`, matching the directories whose contents are produced apart from the root context. ([#924](https://github.com/mifunedev/openharness/issues/924))
+
 ### Added
 - Add `/escalate`: an unattended session delivers a human-addressed escalation to the operator's Slack channel. An unavailable channel no-ops loudly rather than failing the session. ([#919](https://github.com/mifunedev/openharness/issues/919))
 - Add `.oh/logs/`, gitignored by default with a tracked README, for records that outlive the session that wrote them; `/escalate` appends every attempt to `escalations.jsonl`. ([#919](https://github.com/mifunedev/openharness/issues/919))


### PR DESCRIPTION
Closes #924

## Why this is better

`.oh/logs/` shipped in #921 with a `README.md`, which is the wrong artifact for it. Root `AGENTS.md` already draws the line: a nested `AGENTS.md` belongs to directories whose contents are produced apart from the root context — `.worktrees/`, `projects/`, `crons/` — and every other directory gets a `README.md`.

`.oh/logs/` is that same shape. Unattended sessions write to it without the root context loaded, and the guide's reader is the next agent deciding whether a record belongs there — not a human browsing the repo.

## What was built

- `.oh/logs/README.md` → `.oh/logs/AGENTS.md` (a `git mv`, so history follows), with `CLAUDE.md` a symlink to it — byte-identical idiom to `.worktrees/` and `crons/`.
- `.gitignore` un-ignores both files.
- Root `AGENTS.md` names the fourth directory.
- `/escalate`'s link and the `escalate-contract` probe follow the rename; the probe now asserts the **symlink target**, not just that a guide exists.
- The guide gains the rule it was missing: write here only when the record must survive the session.

## Where it diverged from the plan

Adding `.oh/logs/` to the root sentence pushed `AGENTS.md` to **9507 B against a 9500 B budget**, and `context-tier-size-budget` went `PASS → REGRESSION`. That probe says its budget is *"a RATCHET, not a measurement… regrowth must be a decision someone makes"*, so I compressed the sentence instead of raising the number:

> whose contents run, are checked out, or are written apart from it → whose contents are **produced** apart from it

`AGENTS.md` is now 9483 B, and the probe is back to `REGRESSION → PASS`. The always-on tier is smaller than before this PR despite naming one more directory.

## Proof by gate

| Check | Observed | Result |
|---|---|---|
| `bash .oh/skills/eval/run.sh` | rc=0, no `REGRESSIONS`, `context-tier-size-budget REGRESSION->PASS` | PASS |
| `context-tier-size-budget.sh` | `AGENTS.md is 9483 B of 9500 B budget` | PASS |
| `escalate-contract.sh` | PASS with the new symlink assertion | PASS |
| `worktrees-layout.sh` | PASS — the existing guide layout is untouched | PASS |
| Tracked files under `.oh/logs/` | exactly `AGENTS.md` + `CLAUDE.md`; `readlink` → `AGENTS.md` | PASS |
| Stale `logs/README` references | none repo-wide | PASS |

## What remains unverified

- No probe generalizes the nested-`AGENTS.md` convention across all four directories; `worktrees-layout.sh` still covers only `.worktrees/` and `projects/`, and `.oh/logs/` is covered by `escalate-contract.sh` instead. A single probe owning the rule would be better than two partial ones.