### PR TITLE
FROM task/933-retire-cron-worktree-isolation TO development

### DIFF
--- a/.oh/README.md
+++ b/.oh/README.md
@@ -74,8 +74,7 @@ a symlink and nothing reads the bare `tasks/` path anymore.
 
 The ignored worktree root briefly lived at `.oh/worktrees/` and moved back **out**
 to the repo root as `.worktrees/`, with no back-compat symlink in either
-direction. The location is a fixed convention rather than a setting, and cron
-worktree isolation uses `.worktrees/cron/`.
+direction. The location is a fixed convention rather than a setting.
 Clones of non-harness repositories, formerly `.oh/worktrees/project/<owner>/<repo>/`,
 now live at `projects/<owner>/<repo>/`, and
 each keeps its own worktrees at `projects/<owner>/<repo>/.worktrees/`. Both roots

--- a/.oh/evals/probes/audit-run-root-contract.sh
+++ b/.oh/evals/probes/audit-run-root-contract.sh
@@ -5,7 +5,7 @@
 set -euo pipefail
 unset AUDIT_RUN_ID AUDIT_ROOT AUDIT_TMP_ROOT AUDIT_EVIDENCE_PATH \
       AUDIT_ROUTE AUDIT_TARGET AUDIT_TARGET_ARGS_JSON AUDIT_AGENT_COMMAND_JSON
-REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"; RUN="$REPO/.oh/skills/audit/scripts/audit-run.sh"
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 tmp=$(mktemp -d); tmpdir=$(mktemp -d); trap 'rm -rf "$tmp" "$tmpdir"' EXIT
 mkdir -p "$tmp/.oh/skills/audit/references" "$tmp/.oh/scripts"
 for route in implementation pr prs harness context skills eval-quality drift full; do
@@ -16,11 +16,13 @@ printf '# private external route\n' >"$tmp/.oh/skills/audit/references/external-
 cp "$REPO/.oh/scripts/locked-append.sh" "$tmp/.oh/scripts/locked-append.sh"
 mkdir -p "$tmp/.oh/skills/audit/scripts"
 cp "$REPO/.oh/skills/audit/scripts/audit-evidence.sh" "$tmp/.oh/skills/audit/scripts/audit-evidence.sh"
+cp "$REPO/.oh/skills/audit/scripts/audit-run.sh" "$tmp/.oh/skills/audit/scripts/audit-run.sh"
+RUN="$tmp/.oh/skills/audit/scripts/audit-run.sh"
 cat >"$tmp/complete-driver" <<'DRIVER'
 #!/usr/bin/env bash
 "$AUDIT_ROOT/.oh/skills/audit/scripts/audit-evidence.sh" complete TEST-COMPLETE
 DRIVER
-chmod +x "$tmp/complete-driver" "$tmp/.oh/skills/audit/scripts/audit-evidence.sh"
+chmod +x "$tmp/complete-driver" "$tmp/.oh/skills/audit/scripts/audit-evidence.sh" "$RUN"
 git -C "$tmp" init -q; git -C "$tmp" config user.email test@example.invalid; git -C "$tmp" config user.name test
 git -C "$tmp" add .; git -C "$tmp" commit -qm init
 fail(){ echo "REGRESSION: $*" >&2; exit 1; }
@@ -30,17 +32,17 @@ still_running(){
   [[ -n $st && ${st#Z} == "$st" ]]
 }
 export TMPDIR="$tmpdir"
-set +e; usage_out=$(CRON_WORKTREE="$tmp" CRON_LOG_ROOT="$tmp" bash "$RUN" nope 2>&1); usage_rc=$?; set -e
+set +e; usage_out=$(bash "$RUN" nope 2>&1); usage_rc=$?; set -e
 [[ $usage_rc -eq 64 ]] || fail 'unknown target accepted/wrong usage rc'
 [[ ${usage_out%%$'\n'*} == 'usage: /audit <implementation|pr|prs|harness|context|skills|eval-quality|drift|full> [target options]' ]] || fail 'usage first line is not exact'
 for route in implementation pr prs harness context skills eval-quality drift full; do grep -q "^| $route |" <<<"$usage_out" || fail "usage table missing $route"; done
 [[ -z $(find "$tmpdir" -mindepth 1 -print -quit) && ! -e "$tmp/.oh/logs" ]] || fail 'invalid usage created lifecycle state'
-if CRON_WORKTREE="$tmp" CRON_LOG_ROOT="$tmp" bash "$RUN" harness --external source --focus x -- true >/dev/null 2>&1; then fail 'external/focus conflict accepted'; fi
-if CRON_WORKTREE="$tmp" CRON_LOG_ROOT="$tmp" bash "$RUN" harness --wiki-ingest -- true >/dev/null 2>&1; then fail 'external-only option reached survey mode'; fi
-if CRON_WORKTREE="$tmp" CRON_LOG_ROOT="$tmp" bash "$RUN" implementation -- true >/dev/null 2>&1; then fail 'missing implementation slug accepted'; fi
-if CRON_WORKTREE="$tmp" CRON_LOG_ROOT="$tmp" bash "$RUN" pr 7 --repo bad -- true >/dev/null 2>&1; then fail 'invalid focused repo accepted'; fi
-if CRON_WORKTREE="$tmp" CRON_LOG_ROOT="$tmp" bash "$RUN" drift >/dev/null 2>&1; then fail 'missing route driver accepted'; fi
-if CRON_WORKTREE="$tmp" CRON_LOG_ROOT="$tmp" bash "$RUN" drift -- true >/dev/null 2>&1; then fail 'true callback certified completion'; fi
+if bash "$RUN" harness --external source --focus x -- true >/dev/null 2>&1; then fail 'external/focus conflict accepted'; fi
+if bash "$RUN" harness --wiki-ingest -- true >/dev/null 2>&1; then fail 'external-only option reached survey mode'; fi
+if bash "$RUN" implementation -- true >/dev/null 2>&1; then fail 'missing implementation slug accepted'; fi
+if bash "$RUN" pr 7 --repo bad -- true >/dev/null 2>&1; then fail 'invalid focused repo accepted'; fi
+if bash "$RUN" drift >/dev/null 2>&1; then fail 'missing route driver accepted'; fi
+if bash "$RUN" drift -- true >/dev/null 2>&1; then fail 'true callback certified completion'; fi
 cat >"$tmp/fake-agent" <<'AGENT'
 #!/usr/bin/env bash
 prompt=${!#}
@@ -55,14 +57,14 @@ leaked=$(printenv | grep -c '^AUDIT_' || true)
 printf 'route report\nAUDIT-EVIDENCE: DRIFT-OK\n'
 AGENT
 chmod +x "$tmp/fake-agent"
-AUDIT_AGENT_COMMAND_JSON="[\"$tmp/fake-agent\"]" CRON_WORKTREE="$tmp" CRON_LOG_ROOT="$tmp" \
+AUDIT_AGENT_COMMAND_JSON="[\"$tmp/fake-agent\"]" \
   bash "$RUN" drift -- "$REPO/.oh/skills/audit/scripts/route-driver.sh" >/dev/null \
   || fail 'canonical production route driver did not publish correlated evidence (rc 8 = it leaked AUDIT_* into the agent)'
-CRON_WORKTREE="$tmp" CRON_LOG_ROOT="$tmp" bash "$RUN" pr 7 --base stack-parent -- "$tmp/complete-driver" >/dev/null
-CRON_WORKTREE="$tmp" CRON_LOG_ROOT="$tmp" bash "$RUN" prs --mine -- "$tmp/complete-driver" >/dev/null
-CRON_WORKTREE="$tmp" CRON_LOG_ROOT="$tmp" bash "$RUN" full --repo owner/name -- "$tmp/complete-driver" >/dev/null
+bash "$RUN" pr 7 --base stack-parent -- "$tmp/complete-driver" >/dev/null
+bash "$RUN" prs --mine -- "$tmp/complete-driver" >/dev/null
+bash "$RUN" full --repo owner/name -- "$tmp/complete-driver" >/dev/null
 [[ ! -e "$tmp/.oh/logs" ]] || fail 'a run wrote the deleted .oh/logs tier'
-CRON_WORKTREE="$tmp" CRON_LOG_ROOT="$tmp" bash "$RUN" drift -- bash -c '
+bash "$RUN" drift -- bash -c '
   [[ $AUDIT_ROUTE == "$AUDIT_ROOT/.oh/skills/audit/references/drift.md" ]]
   [[ ! -e "$AUDIT_ROOT/.oh/logs" ]]
   [[ $PWD == "$AUDIT_ROOT" ]]
@@ -72,11 +74,11 @@ CRON_WORKTREE="$tmp" CRON_LOG_ROOT="$tmp" bash "$RUN" drift -- bash -c '
 '
 [[ $(<"$tmp/driver-marker") == route-ran ]] || fail 'selected route driver did not run/chdir or receive bindings'
 rm "$tmp/driver-marker"
-rec=$(CRON_WORKTREE="$tmp" CRON_LOG_ROOT="$tmp" bash "$RUN" drift -- "$tmp/complete-driver" 2>&1 >/dev/null)
+rec=$(bash "$RUN" drift -- "$tmp/complete-driver" 2>&1 >/dev/null)
 [[ $(grep -c '^audit -- run-id=' <<<"$rec") -eq 1 ]] || fail 'terminal run record did not follow driver'
 [[ ! -e "$tmp/.oh/logs" ]] || fail 'run record was written to the deleted .oh/logs tier'
 for n in 1 2; do
-  CRON_WORKTREE="$tmp" CRON_LOG_ROOT="$tmp" bash "$RUN" drift -- \
+  bash "$RUN" drift -- \
     bash -c 'printf "%s|%s" "$AUDIT_RUN_ID" "$AUDIT_ROOT" >"$AUDIT_TMP_ROOT/seen"; "$AUDIT_ROOT/.oh/skills/audit/scripts/audit-evidence.sh" complete DRIFT-OK' 2>"$tmp/rec.$n" & pids[n]=$!
 done
 wait "${pids[1]}"; wait "${pids[2]}"
@@ -96,12 +98,12 @@ printf '%s\n' "$PWD" "$AUDIT_TARGET" "$AUDIT_TARGET_ARGS_JSON" "$@" >"$AUDIT_ROO
 "$AUDIT_ROOT/.oh/skills/audit/scripts/audit-evidence.sh" complete PRS-AUDIT-COMPLETE
 DRIVER
 chmod +x "$tmp/args-driver"
-CRON_WORKTREE="$tmp" CRON_LOG_ROOT="$tmp" bash "$RUN" prs --label 'needs review' --base development -- "$tmp/args-driver"
+bash "$RUN" prs --label 'needs review' --base development -- "$tmp/args-driver"
 mapfile -t seen <"$tmp/args-seen"
 [[ ${seen[0]} == "$tmp" && ${seen[1]} == prs && ${seen[2]} == '["--label","needs review","--base","development"]' ]] || fail 'named argument bindings differ'
 [[ ${seen[3]} == prs && ${seen[4]} == --label && ${seen[5]} == 'needs review' && ${seen[6]} == --base && ${seen[7]} == development ]] || fail 'driver argv not exact'
 set +e
-failed_rec=$(CRON_WORKTREE="$tmp" CRON_LOG_ROOT="$tmp" bash "$RUN" drift -- bash -c 'exit 23' 2>&1 >/dev/null)
+failed_rec=$(bash "$RUN" drift -- bash -c 'exit 23' 2>&1 >/dev/null)
 failed_rc=$?
 set -e
 [[ $failed_rc -eq 23 ]] || fail 'driver failure rc was not propagated'
@@ -122,7 +124,7 @@ DRIVER
 chmod +x "$tmp/signal-driver"
 for sig in INT TERM HUP; do
   rm -f "$tmp/pids-seen" "$tmp/${sig,,}-seen"
-  SIGNAL_NAME=$sig CRON_WORKTREE="$tmp" CRON_LOG_ROOT="$tmp" bash "$RUN" drift -- "$tmp/signal-driver" 2>"$tmp/sig-rec" & wrapper=$!
+  SIGNAL_NAME=$sig bash "$RUN" drift -- "$tmp/signal-driver" 2>"$tmp/sig-rec" & wrapper=$!
   for _ in {1..50}; do [[ -s "$tmp/pids-seen" ]] && break; sleep .05; done
   [[ -s "$tmp/pids-seen" ]] || fail "$sig signal fixture did not start"
   read -r driver_pid grandchild_pid <"$tmp/pids-seen"
@@ -142,7 +144,7 @@ while :; do sleep 1; done
 DRIVER
 chmod +x "$tmp/direct-driver"
 rm -f "$tmp/pids-seen" "$tmp/int-seen"
-AUDIT_FORCE_DIRECT=1 CRON_WORKTREE="$tmp" CRON_LOG_ROOT="$tmp" bash "$RUN" drift -- "$tmp/direct-driver" & wrapper=$!
+AUDIT_FORCE_DIRECT=1 bash "$RUN" drift -- "$tmp/direct-driver" & wrapper=$!
 for _ in {1..50}; do [[ -s "$tmp/pids-seen" ]] && break; sleep .05; done
 driver_pid=$(<"$tmp/pids-seen")
 kill -INT "$wrapper"

--- a/.oh/evals/probes/worktrees-layout.sh
+++ b/.oh/evals/probes/worktrees-layout.sh
@@ -55,8 +55,8 @@ for sample in ".worktrees/feat/1-probe" "projects/an-owner/a-repo"; do
   fi
 done
 
-if ! grep -Fq 'const WORKTREES_DIR = ".worktrees";' .oh/scripts/cron-runtime.ts; then
-  echo "REGRESSION: cron-runtime.ts does not pin WORKTREES_DIR to the .worktrees constant" >&2
+if grep -Fq 'WORKTREES_DIR' .oh/scripts/cron-runtime.ts; then
+  echo "REGRESSION: cron-runtime.ts references a worktree root it no longer owns" >&2
   exit 1
 fi
 if ! grep -Fq 'const CRONS_DIR = path.resolve("crons");' .oh/scripts/cron-runtime.ts; then

--- a/.oh/scripts/__tests__/cron-runtime.test.ts
+++ b/.oh/scripts/__tests__/cron-runtime.test.ts
@@ -22,7 +22,6 @@ import {
   buildTmuxWrapper,
   decideOverlap,
   fire,
-  inspectFallbackWorktree,
   isValidAgentBin,
   isValidCronId,
   isValidRemote,
@@ -31,7 +30,6 @@ import {
   loadCrons,
   onJobError,
   parseCronFile,
-  pruneAndCountFallbackWorktrees,
   readFailureTail,
   reloadEntryForFire,
   remoteForRepo,
@@ -43,7 +41,6 @@ import {
   scheduleAll,
   sighupHandler,
   tmuxSessionName,
-  worktreeInUse,
 } from "../cron-runtime";
 
 vi.mock("node:fs", async (importOriginal) => {
@@ -164,52 +161,27 @@ Heartbeat body.
     expect(parseCronFile(`---\nschedule: "* * * * *"\n---\nbody\n`, "c.md")?.repo).toBeUndefined();
   });
 
-  it("parses worktree: true and defaults to false otherwise", () => {
-    expect(
-      parseCronFile(`---\nschedule: "* * * * *"\nworktree: true\n---\nbody\n`, "a.md")
-        ?.worktree,
-    ).toBe(true);
-    expect(
-      parseCronFile(`---\nschedule: "* * * * *"\nworktree: false\n---\nbody\n`, "b.md")
-        ?.worktree,
-    ).toBe(false);
-    expect(
-      parseCronFile(`---\nschedule: "* * * * *"\n---\nbody\n`, "c.md")?.worktree,
-    ).toBe(false);
-  });
 });
 
 describe("decideOverlap", () => {
-  it("returns 'worktree' for a worktree cron regardless of lock state", () => {
-    for (const pidfileExists of [false, true]) {
-      for (const holderAlive of [false, true]) {
-        for (const overlap of [false, true]) {
-          expect(
-            decideOverlap({ overlap, worktree: true, pidfileExists, holderAlive }),
-          ).toBe("worktree");
-        }
-      }
-    }
-  });
-
   it("runs (never skips) when overlap is allowed", () => {
     expect(
-      decideOverlap({ overlap: true, worktree: false, pidfileExists: true, holderAlive: true }),
+      decideOverlap({ overlap: true, pidfileExists: true, holderAlive: true }),
     ).toBe("run");
   });
 
   it("reclaims (runs) when there is no live holder of the id lock", () => {
     expect(
-      decideOverlap({ overlap: false, worktree: false, pidfileExists: false, holderAlive: false }),
+      decideOverlap({ overlap: false, pidfileExists: false, holderAlive: false }),
     ).toBe("run");
     expect(
-      decideOverlap({ overlap: false, worktree: false, pidfileExists: true, holderAlive: false }),
+      decideOverlap({ overlap: false, pidfileExists: true, holderAlive: false }),
     ).toBe("run");
   });
 
-  it("skips a non-worktree cron only when a live holder owns the id lock", () => {
+  it("skips only when a live holder owns the id lock", () => {
     expect(
-      decideOverlap({ overlap: false, worktree: false, pidfileExists: true, holderAlive: true }),
+      decideOverlap({ overlap: false, pidfileExists: true, holderAlive: true }),
     ).toBe("skip");
   });
 });
@@ -461,24 +433,7 @@ describe("buildTmuxWrapper", () => {
     );
   });
 
-  it("uses a session-scoped pidfile and exports CRON_WORKTREE for an isolated worktree fire", () => {
-    const wt = buildTmuxWrapper({
-      session: "cron-autopilot-0610-1805",
-      id: "autopilot",
-      agentBin: "pi",
-      promptFile: "/tmp/cron-autopilot-0610-1805.prompt",
-      pidFile: "/tmp/cron-autopilot-0610-1805.pid",
-      worktree: "/home/sandbox/harness/.worktrees/cron/cron-autopilot-0610-1805",
-    });
-    expect(wt).toContain("echo $$ > '/tmp/cron-autopilot-0610-1805.pid';");
-    expect(wt).toContain("rm -f '/tmp/cron-autopilot-0610-1805.pid';");
-    expect(wt).not.toContain("/tmp/cron-autopilot.pid");
-    expect(wt).toContain(
-      "CRON_OVERLAP_PIDFILE='/tmp/cron-autopilot-0610-1805.pid' CRON_WORKTREE='/home/sandbox/harness/.worktrees/cron/cron-autopilot-0610-1805';",
-    );
-  });
-
-  it("omits CRON_WORKTREE and defaults to the id-scoped pidfile for a primary fire", () => {
+  it("defaults to the id-scoped pidfile and never exports CRON_WORKTREE", () => {
     expect(wrapper).toContain("echo $$ > '/tmp/cron-autopilot.pid';");
     expect(wrapper).not.toContain("CRON_WORKTREE=");
   });
@@ -1131,7 +1086,6 @@ describe("reloadBody", () => {
       overlap: false,
       catchup: false,
       tmux: false,
-      worktree: false,
       body: "cached body\n",
       filePath: missingPath,
     };
@@ -1144,219 +1098,6 @@ describe("reloadBody", () => {
 
     const loggedArgs = appendSpy.mock.calls.map((c) => String(c[1]));
     expect(loggedArgs.some((line) => line.includes("BODY_RELOAD_ERR"))).toBe(true);
-  });
-});
-
-describe("fallback worktree pruning", () => {
-  const git = (cwd: string, args: string[]): void => {
-    const result = spawnSync("git", args, { cwd, encoding: "utf-8" });
-    expect(result.status, `${args.join(" ")}\n${result.stderr}`).toBe(0);
-  };
-
-  const initRepoWithFallbackWorktrees = (): { repo: string; dirtyWt: string; cleanWt: string } => {
-    const repo = path.join(tmp, "repo");
-    mkdirSync(repo, { recursive: true });
-    git(repo, ["init", "-b", "development"]);
-    writeFileSync(path.join(repo, "README.md"), "fixture\n");
-    git(repo, ["add", "README.md"]);
-    git(repo, ["-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "-m", "init"]);
-
-    const dirtyWt = path.join(repo, ".worktrees", "cron", "cron-autopilot-dirty");
-    const cleanWt = path.join(repo, ".worktrees", "cron", "cron-autopilot-clean");
-    git(repo, ["worktree", "add", "--detach", dirtyWt, "HEAD"]);
-    git(repo, ["worktree", "add", "--detach", cleanWt, "HEAD"]);
-    writeFileSync(path.join(dirtyWt, "uncommitted.txt"), "salvage me\n");
-    return { repo, dirtyWt, cleanWt };
-  };
-
-  it("resolves the cron worktree root at the fixed .worktrees/ root", async () => {
-    const repo = path.join(tmp, "envrepo");
-    mkdirSync(path.join(repo, ".worktrees", "cron"), { recursive: true });
-
-    const priorCwd = process.cwd();
-    try {
-      process.chdir(repo);
-
-      vi.resetModules();
-      const runtime = await import("../cron-runtime.ts");
-      expect(runtime.pruneAndCountFallbackWorktrees("autopilot")).toBe(0);
-      expect(existsSync(path.join(repo, ".worktrees", "cron"))).toBe(true);
-    } finally {
-      process.chdir(priorCwd);
-      vi.resetModules();
-    }
-  });
-
-  it("reports dirty fallback worktree state including untracked files", () => {
-    const { dirtyWt } = initRepoWithFallbackWorktrees();
-
-    const state = inspectFallbackWorktree(dirtyWt);
-
-    expect(state.dirty).toBe(true);
-    expect(state.changes).toContain("?? uncommitted.txt");
-    expect(state.ref).not.toBe("unknown");
-  });
-
-  it("treats a matching live tmux session name as fallback worktree liveness", () => {
-    const wt = path.join(tmp, "repo", ".worktrees", "cron", "cron-autopilot-0618-1505");
-
-    expect(worktreeInUse(wt, [], ["cron-autopilot-0618-1505"])).toBe(true);
-    expect(worktreeInUse(wt, [path.join(wt, "nested")], [])).toBe(true);
-    expect(worktreeInUse(wt, [path.join(tmp, "elsewhere")], ["autopilot-feat-445-example"])).toBe(false);
-  });
-
-  it("does not prune a clean fallback worktree while a matching tmux session is live", () => {
-    const { repo, cleanWt } = initRepoWithFallbackWorktrees();
-    const priorCwd = process.cwd();
-    const priorPath = process.env.PATH;
-    const binDir = path.join(tmp, "bin");
-    const fakeTmux = path.join(binDir, "tmux");
-    mkdirSync(binDir, { recursive: true });
-    writeFileSync(
-      fakeTmux,
-      `#!/usr/bin/env bash
-set -euo pipefail
-case "$1" in
-  list-panes) printf '%s\\n' '${path.join(tmp, "elsewhere").replace(/'/g, "'\\''")}' ;;
-  ls) printf '%s\\n' 'cron-autopilot-clean' ;;
-  *) exit 1 ;;
-esac
-`,
-    );
-    chmodSync(fakeTmux, 0o755);
-
-    try {
-      process.chdir(repo);
-      process.env.PATH = `${binDir}:${priorPath ?? ""}`;
-
-      expect(pruneAndCountFallbackWorktrees("autopilot")).toBe(1);
-    } finally {
-      process.env.PATH = priorPath;
-      process.chdir(priorCwd);
-    }
-
-    expect(existsSync(cleanWt)).toBe(true);
-  });
-
-  it("preserves dirty dead fallback worktrees but removes clean dead ones", () => {
-    const { repo, dirtyWt, cleanWt } = initRepoWithFallbackWorktrees();
-    const priorCwd = process.cwd();
-    const appendSpy = vi.mocked(fsModule.appendFileSync);
-    appendSpy.mockClear();
-
-    try {
-      process.chdir(repo);
-      expect(pruneAndCountFallbackWorktrees("autopilot")).toBe(0);
-    } finally {
-      process.chdir(priorCwd);
-    }
-
-    expect(existsSync(dirtyWt)).toBe(true);
-    expect(readFileSync(path.join(dirtyWt, "uncommitted.txt"), "utf-8")).toBe("salvage me\n");
-    expect(existsSync(cleanWt)).toBe(false);
-    expect(
-      appendSpy.mock.calls.some((c) =>
-        String(c[1]).includes("\tautopilot\tWORKTREE_DIRTY\t") &&
-        String(c[1]).includes("?? uncommitted.txt"),
-      ),
-    ).toBe(true);
-  });
-
-
-  it("reports an orphaned fallback worktree as orphaned, not dirty", () => {
-    const { repo } = initRepoWithFallbackWorktrees();
-    const orphanWt = orphanWorktree(repo, "cron-autopilot-orphan");
-
-    const state = inspectFallbackWorktree(orphanWt);
-
-    expect(state.orphaned).toBe(true);
-    expect(state.dirty).toBe(false);
-    expect(state.changes).toEqual([]);
-    expect(state.reason ?? "").not.toBe("");
-  });
-
-  const orphanWorktree = (repo: string, name: string): string => {
-    const wt = path.join(repo, ".worktrees", "cron", name);
-    git(repo, ["worktree", "add", "--detach", wt, "HEAD"]);
-    rmSync(path.join(repo, ".git", "worktrees", name), { recursive: true, force: true });
-    return wt;
-  };
-
-  it("does NOT classify a worktree as orphaned when its .git file is unreadable", () => {
-    const { repo } = initRepoWithFallbackWorktrees();
-    const wt = path.join(repo, ".worktrees", "cron", "cron-autopilot-unreadable");
-    git(repo, ["worktree", "add", "--detach", wt, "HEAD"]);
-    const dotGit = path.join(wt, ".git");
-    chmodSync(dotGit, 0o000);
-    try {
-      const state = inspectFallbackWorktree(wt);
-      expect(state.orphaned ?? false).toBe(false);
-    } finally {
-      chmodSync(dotGit, 0o644);
-    }
-  });
-
-  it("does NOT classify a worktree as orphaned when its .git file is corrupt", () => {
-    const { repo } = initRepoWithFallbackWorktrees();
-    const wt = path.join(repo, ".worktrees", "cron", "cron-autopilot-corrupt");
-    git(repo, ["worktree", "add", "--detach", wt, "HEAD"]);
-    writeFileSync(path.join(wt, ".git"), "this is not a gitdir pointer\n");
-
-    const state = inspectFallbackWorktree(wt);
-
-    expect(state.orphaned ?? false).toBe(false);
-  });
-
-  it("does not count an orphaned worktree toward the live count", () => {
-    const { repo } = initRepoWithFallbackWorktrees();
-    orphanWorktree(repo, "cron-autopilot-orphan-count");
-    const priorCwd = process.cwd();
-    let live: number;
-    try {
-      process.chdir(repo);
-      live = pruneAndCountFallbackWorktrees("autopilot");
-    } finally {
-      process.chdir(priorCwd);
-    }
-    expect(live).toBe(0);
-  });
-
-  it("removes an orphaned fallback worktree while still preserving a dirty one", () => {
-    const { repo, dirtyWt } = initRepoWithFallbackWorktrees();
-    const orphanWt = orphanWorktree(repo, "cron-autopilot-orphan");
-    const priorCwd = process.cwd();
-    const appendSpy = vi.mocked(fsModule.appendFileSync);
-    appendSpy.mockClear();
-
-    try {
-      process.chdir(repo);
-      pruneAndCountFallbackWorktrees("autopilot");
-    } finally {
-      process.chdir(priorCwd);
-    }
-
-    expect(existsSync(orphanWt)).toBe(false);
-    expect(
-      appendSpy.mock.calls.some((c) =>
-        String(c[1]).includes("\tautopilot\tWORKTREE_ORPHANED\t"),
-      ),
-    ).toBe(true);
-
-    expect(
-      appendSpy.mock.calls.some((c) =>
-        String(c[1]).includes("\tautopilot\tWORKTREE_DIRTY\t") &&
-        String(c[1]).includes("cron-autopilot-orphan"),
-      ),
-    ).toBe(false);
-
-    expect(existsSync(dirtyWt)).toBe(true);
-    expect(readFileSync(path.join(dirtyWt, "uncommitted.txt"), "utf-8")).toBe("salvage me\n");
-    expect(
-      appendSpy.mock.calls.some((c) =>
-        String(c[1]).includes("\tautopilot\tWORKTREE_DIRTY\t") &&
-        String(c[1]).includes("?? uncommitted.txt"),
-      ),
-    ).toBe(true);
   });
 });
 
@@ -1520,7 +1261,6 @@ describe("runPreflight + the fire() preflight gate", () => {
     overlap: false,
     catchup: false,
     tmux: true,
-    worktree: true,
     preflight,
     repo: undefined as string | undefined,
     body: "body\n",
@@ -1578,7 +1318,7 @@ describe("runPreflight + the fire() preflight gate", () => {
     const script = preflightScript({ exit: 10, stdout: "SKIPPED-CAP-DAILY" });
     writeFileSync(
       cronFile,
-      `---\nid: autopilot\nschedule: "* * * * *"\nenabled: true\ntmux: true\nworktree: true\npreflight: ${script}\n---\nbody\n`,
+      `---\nid: autopilot\nschedule: "* * * * *"\nenabled: true\ntmux: true\npreflight: ${script}\n---\nbody\n`,
     );
     fire({ ...entry(script), filePath: cronFile });
     const lines = loggedLines();
@@ -1592,7 +1332,7 @@ describe("runPreflight + the fire() preflight gate", () => {
     const script = preflightScript({ exit: 10, stdout: "SKIPPED-CAP-DAILY" });
     writeFileSync(
       cronFile,
-      `---\nid: autopilot\nschedule: "* * * * *"\nenabled: true\ntmux: true\nworktree: true\npreflight: ${script}\nrepo: mifunedev/openharness\n---\nbody\n`,
+      `---\nid: autopilot\nschedule: "* * * * *"\nenabled: true\ntmux: true\npreflight: ${script}\nrepo: mifunedev/openharness\n---\nbody\n`,
     );
     fire({ ...entry(undefined), filePath: cronFile });
 
@@ -1625,7 +1365,7 @@ describe("runPreflight + the fire() preflight gate", () => {
     const cronFile = path.join(tmp, "autopilot.md");
     writeFileSync(
       cronFile,
-      `---\nid: autopilot\nschedule: "* * * * *"\nenabled: true\ntmux: true\nworktree: true\npreflight: scripts/definitely-missing-preflight.sh\n---\nbody\n`,
+      `---\nid: autopilot\nschedule: "* * * * *"\nenabled: true\ntmux: true\npreflight: scripts/definitely-missing-preflight.sh\n---\nbody\n`,
     );
     fire({ ...entry("scripts/definitely-missing-preflight.sh"), filePath: cronFile });
     const lines = loggedLines();

--- a/.oh/scripts/cron-runtime.ts
+++ b/.oh/scripts/cron-runtime.ts
@@ -11,7 +11,6 @@ export interface CronEntry {
   overlap: boolean;
   catchup: boolean;
   tmux: boolean;
-  worktree: boolean;
   agentBin?: string;
   preflight?: string;
   repo?: string;
@@ -20,7 +19,6 @@ export interface CronEntry {
 }
 
 const CRONS_DIR = path.resolve("crons");
-const WORKTREES_DIR = ".worktrees";
 const PID_FILE = path.join(CRONS_DIR, ".pid");
 const LOG_FILE = path.join(CRONS_DIR, ".cron.log");
 const AGENT_BIN_FALLBACK = "claude";
@@ -108,7 +106,6 @@ export function parseCronFile(content: string, file: string): CronEntry | null {
     overlap: fm.overlap === "true",
     catchup: fm.catchup === "true",
     tmux: fm.tmux === "true",
-    worktree: fm.worktree === "true",
     agentBin: fm.agent || undefined,
     preflight: fm.preflight || undefined,
     repo: fm.repo || undefined,
@@ -221,7 +218,6 @@ const FIRE_RELOAD_FIELDS: (keyof CronEntry)[] = [
   "overlap",
   "catchup",
   "tmux",
-  "worktree",
   "agentBin",
   "preflight",
   "repo",
@@ -357,7 +353,6 @@ export function buildTmuxWrapper(opts: {
   agentBin: string;
   promptFile: string;
   pidFile?: string;
-  worktree?: string;
   repo?: string;
   remote?: string;
 }): string {
@@ -369,12 +364,11 @@ export function buildTmuxWrapper(opts: {
   const pidFile = opts.pidFile ?? `/tmp/cron-${id}.pid`;
   const quotedAgent = shellQuote(agentBin);
   const quotedPidFile = shellQuote(pidFile);
-  const worktreeExport = opts.worktree ? ` CRON_WORKTREE=${shellQuote(opts.worktree)}` : "";
   const repoExport = opts.repo ? ` CRON_REPO=${shellQuote(opts.repo)}` : "";
   const remoteExport = opts.remote ? ` CRON_REMOTE=${shellQuote(opts.remote)}` : "";
   return (
     `echo $$ > ${quotedPidFile}; ` +
-    `export CRON_TMUX_SESSION=${shellQuote(session)} CRON_KEEP_MARKER=${shellQuote(`/tmp/${session}.keep`)} CRON_OVERLAP_PIDFILE=${quotedPidFile}${worktreeExport}${repoExport}${remoteExport}; ` +
+    `export CRON_TMUX_SESSION=${shellQuote(session)} CRON_KEEP_MARKER=${shellQuote(`/tmp/${session}.keep`)} CRON_OVERLAP_PIDFILE=${quotedPidFile}${repoExport}${remoteExport}; ` +
     buildCronAgentCommand({
       id,
       agentBin,
@@ -487,8 +481,6 @@ export function buildCronAgentCommand(opts: {
   );
 }
 
-const WORKTREE_MAX_CONCURRENT = 6;
-
 function isProcessAlive(pid: number): boolean {
   try {
     process.kill(pid, 0);
@@ -498,209 +490,23 @@ function isProcessAlive(pid: number): boolean {
   }
 }
 
-export type OverlapDecision = "run" | "skip" | "worktree";
+export type OverlapDecision = "run" | "skip";
 
 export function decideOverlap(opts: {
   overlap: boolean;
-  worktree: boolean;
   pidfileExists: boolean;
   holderAlive: boolean;
 }): OverlapDecision {
-  if (opts.worktree) return "worktree";
   if (opts.overlap) return "run";
   if (!opts.pidfileExists || !opts.holderAlive) return "run";
   return "skip";
 }
 
-const FALLBACK_WORKTREE_DIR = path.join(WORKTREES_DIR, "cron");
-
-function detectBaseRef(remote = "origin"): string | null {
-  if (!isValidRemote(remote)) return null;
-  for (const ref of ["development", "main", "master"]) {
-    if (
-      spawnSync("git", ["show-ref", "--verify", "--quiet", `refs/remotes/${remote}/${ref}`])
-        .status === 0
-    ) {
-      return `${remote}/${ref}`;
-    }
-  }
-  for (const ref of ["development", "main", "master"]) {
-    if (spawnSync("git", ["show-ref", "--verify", "--quiet", `refs/heads/${ref}`]).status === 0) {
-      return ref;
-    }
-  }
-  return null;
-}
-
-function livePaneCwds(): string[] {
-  const r = spawnSync("tmux", ["list-panes", "-a", "-F", "#{pane_current_path}"], {
-    encoding: "utf-8",
-  });
-  if (r.status !== 0 || !r.stdout) return [];
-  return r.stdout.split("\n").map((s) => s.trim()).filter(Boolean);
-}
-
-function liveTmuxSessionNames(): string[] {
-  const r = spawnSync("tmux", ["ls", "-F", "#{session_name}"], { encoding: "utf-8" });
-  if (r.status !== 0 || !r.stdout) return [];
-  return r.stdout.split("\n").map((s) => s.trim()).filter(Boolean);
-}
-
-export function worktreeInUse(
-  wtPath: string,
-  cwds: string[],
-  sessionNames: string[] = liveTmuxSessionNames(),
-): boolean {
-  const abs = path.resolve(wtPath);
-  return (
-    cwds.some((p) => p === abs || p.startsWith(abs + path.sep)) ||
-    sessionNames.includes(path.basename(abs))
-  );
-}
-
-export interface FallbackWorktreeState {
-  dirty: boolean;
-  ref: string;
-  changes: string[];
-  reason?: string;
-  orphaned?: boolean;
-}
-
-function isOrphanedWorktree(wtPath: string): boolean {
-  const dotGit = path.join(wtPath, ".git");
-  let raw: string;
-  try {
-    const st = fs.statSync(dotGit);
-    if (!st.isFile()) return false;
-    raw = fs.readFileSync(dotGit, "utf-8");
-  } catch {
-    return false;
-  }
-  const match = /^gitdir:\s*(.+?)\s*$/m.exec(raw);
-  if (!match) return false;
-  const admin = path.resolve(path.dirname(dotGit), match[1]);
-  return !fs.existsSync(admin);
-}
-
-function worktreeRef(wtPath: string): string {
-  const branch = spawnSync("git", ["-C", wtPath, "rev-parse", "--abbrev-ref", "HEAD"], {
-    encoding: "utf-8",
-  });
-  const name = (branch.stdout || "").trim();
-  if (branch.status === 0 && name && name !== "HEAD") return name;
-
-  const head = spawnSync("git", ["-C", wtPath, "rev-parse", "--short", "HEAD"], {
-    encoding: "utf-8",
-  });
-  return head.status === 0 && head.stdout.trim() ? head.stdout.trim() : "unknown";
-}
-
-export function inspectFallbackWorktree(wtPath: string): FallbackWorktreeState {
-  const status = spawnSync("git", ["-C", wtPath, "status", "--porcelain"], {
-    encoding: "utf-8",
-  });
-  const ref = worktreeRef(wtPath);
-  if (status.status !== 0) {
-    const reason = (status.stderr || status.error?.message || "git status failed").trim();
-    if (isOrphanedWorktree(wtPath)) {
-      return { dirty: false, orphaned: true, ref, changes: [], reason };
-    }
-    return { dirty: true, ref, changes: [], reason };
-  }
-
-  const changes = (status.stdout || "").split("\n").map((s) => s.trim()).filter(Boolean);
-  return { dirty: changes.length > 0, ref, changes };
-}
-
-function formatWorktreeChanges(state: FallbackWorktreeState): string {
-  if (state.reason) return `status-unavailable=${state.reason.slice(0, 160)}`;
-  const shown = state.changes.slice(0, 20).join("; ");
-  const suffix = state.changes.length > 20 ? `; +${state.changes.length - 20} more` : "";
-  return shown + suffix;
-}
-
-export function pruneAndCountFallbackWorktrees(id: string): number {
-  const dir = path.resolve(FALLBACK_WORKTREE_DIR);
-  let names: string[];
-  try {
-    names = fs.readdirSync(dir);
-  } catch {
-    return 0;
-  }
-  const cwds = livePaneCwds();
-  const sessionNames = liveTmuxSessionNames();
-  let live = 0;
-  for (const name of names) {
-    if (!name.startsWith(`cron-${id}-`)) continue;
-    const wt = path.join(dir, name);
-    if (worktreeInUse(wt, cwds, sessionNames)) {
-      live++;
-      continue;
-    }
-
-    const state = inspectFallbackWorktree(wt);
-    if (state.orphaned) {
-      log(id, "WORKTREE_ORPHANED", `${wt} ref=${state.ref} reason=${(state.reason ?? "").slice(0, 160)}`);
-      try {
-        fs.rmSync(wt, { recursive: true, force: true });
-      } catch (err) {
-        log(id, "WORKTREE_ORPHAN_RM_FAILED", `${wt} ${String(err).slice(0, 160)}`);
-      }
-      continue;
-    }
-    if (state.dirty) {
-      log(id, "WORKTREE_DIRTY", `${wt} ref=${state.ref} changes=${formatWorktreeChanges(state)}`);
-      continue;
-    }
-
-    spawnSync("git", ["worktree", "remove", "--force", wt], { stdio: "ignore" });
-  }
-  spawnSync("git", ["worktree", "prune"], { stdio: "ignore" });
-  return live;
-}
-
-function createFallbackWorktree(entry: CronEntry, session: string): string | null {
-  const live = pruneAndCountFallbackWorktrees(entry.id);
-  if (live >= WORKTREE_MAX_CONCURRENT) {
-    log(
-      entry.id,
-      "ERR_WORKTREE_CAP",
-      `${live} live worktree runs >= cap ${WORKTREE_MAX_CONCURRENT}`,
-    );
-    return null;
-  }
-  const remote = entry.repo ? remoteForRepo(entry.repo) : undefined;
-  if (entry.repo && !remote) {
-    log(entry.id, "REPO_REMOTE_MISSING", `no local remote for ${entry.repo}`);
-    return null;
-  }
-  const base = detectBaseRef(remote || "origin");
-  if (!base) {
-    log(entry.id, "ERR_WORKTREE", "no base ref (development/main/master) found");
-    return null;
-  }
-  const dir = path.resolve(FALLBACK_WORKTREE_DIR);
-  try {
-    fs.mkdirSync(dir, { recursive: true });
-  } catch {
-  }
-  const wtPath = path.join(dir, session);
-  const add = spawnSync("git", ["worktree", "add", "--detach", wtPath, base], {
-    encoding: "utf-8",
-  });
-  if (add.status !== 0) {
-    log(entry.id, "ERR_WORKTREE", `git worktree add failed: ${(add.stderr || "").trim().slice(0, 150)}`);
-    return null;
-  }
-  return wtPath;
-}
-
 function fireTmux(entry: CronEntry): void {
   const session = tmuxSessionName(entry.id, new Date());
   const idPidFile = `/tmp/cron-${entry.id}.pid`;
-  let cwd = process.cwd();
-  let pidFile = idPidFile;
-  let worktree: string | undefined;
+  const cwd = process.cwd();
+  const pidFile = idPidFile;
   const agentBin = entry.agentBin || resolveAgentBin();
   if (!isValidAgentBin(agentBin)) {
     log(entry.id, "AGENT_INVALID", `invalid agent: ${agentBin}`);
@@ -720,20 +526,12 @@ function fireTmux(entry: CronEntry): void {
   }
   const decision = decideOverlap({
     overlap: entry.overlap,
-    worktree: entry.worktree,
     pidfileExists,
     holderAlive,
   });
   if (decision === "skip") {
     log(entry.id, "SKIPPED_OVERLAP");
     return;
-  }
-  if (decision === "worktree") {
-    const wt = createFallbackWorktree(entry, session);
-    if (wt === null) return;
-    cwd = wt;
-    worktree = wt;
-    pidFile = `/tmp/${session}.pid`;
   }
 
   const promptFile = `/tmp/${session}.prompt`;
@@ -754,7 +552,6 @@ function fireTmux(entry: CronEntry): void {
         agentBin,
         promptFile,
         pidFile,
-        worktree,
         repo: entry.repo,
         remote: repoRemote,
       }),
@@ -762,11 +559,7 @@ function fireTmux(entry: CronEntry): void {
     { stdio: "ignore" },
   );
   child.on("error", (e: Error) => log(entry.id, "ERR", String(e)));
-  if (worktree) {
-    log(entry.id, "SPAWNED_WORKTREE", `${session} ${worktree}`);
-  } else {
-    log(entry.id, "SPAWNED", session);
-  }
+  log(entry.id, "SPAWNED", session);
 }
 
 const PREFLIGHT_TIMEOUT_MS = 60_000;

--- a/.oh/skills/audit/scripts/audit-run.sh
+++ b/.oh/skills/audit/scripts/audit-run.sh
@@ -120,11 +120,7 @@ if [[ -n ${AUDIT_RUN_ID:-} ]]; then
   [[ $resolved_root == "$AUDIT_ROOT" ]] || { echo 'audit: inherited root must be canonical' >&2; exit 64; }
   outer=false
 else
-  if [[ -n ${CRON_WORKTREE:-} ]] && git -C "$CRON_WORKTREE" rev-parse --show-toplevel >/dev/null 2>&1; then
-    resolved_root=$(git -C "$CRON_WORKTREE" rev-parse --show-toplevel)
-  else
-    resolved_root=$(git -C "$script_root" rev-parse --show-toplevel)
-  fi
+  resolved_root=$(git -C "$script_root" rev-parse --show-toplevel)
   resolved_root=$(cd "$resolved_root" && pwd -P)
   AUDIT_RUN_ID="audit-$(date -u +%Y%m%dT%H%M%SZ)-$BASHPID"
   AUDIT_ROOT=$resolved_root

--- a/.oh/skills/spec/references/execute.md
+++ b/.oh/skills/spec/references/execute.md
@@ -198,18 +198,14 @@ background-shell launch, and no runner selection. There is **no fallback runner 
 is no handoff step**. The agent that reached this line implements the task itself and carries
 it through every gate below.
 
-**Build worktree — reuse vs. create.** Isolation stays. When `$CRON_WORKTREE` is set (a
-`worktree: true` cron's default), this run is ALREADY inside an isolated worktree that step 2
-put on the feature branch, so **reuse it** — do NOT create a second worktree (a second
-`git worktree add` for the same branch would nest under the cron worktree via the relative
-path, or fail with `branch already checked out`). Standalone (no `$CRON_WORKTREE`), create
+**Build worktree — reuse vs. create.** Isolation stays. When this run is ALREADY inside an
+isolated worktree that step 2 put on the feature branch, **reuse it** — do NOT create a second
+worktree (a second `git worktree add` for the same branch would nest under the current worktree
+via the relative path, or fail with `branch already checked out`). Otherwise create
 `.worktrees/<prefix>/<N>-<slug>` via `/worktrees` and work there:
 
 ```bash
-WT="${CRON_WORKTREE:-}"                       # set by the cron runtime in worktree mode
-if [ -n "$WT" ]; then
-  cd "$WT"                                    # already on <prefix>/<N>-<slug>
-else
+if [ "$(git rev-parse --abbrev-ref HEAD)" != "<prefix>/<N>-<slug>" ]; then
   git worktree add ".worktrees/<prefix>/<N>-<slug>" "<prefix>/<N>-<slug>"
   cd ".worktrees/<prefix>/<N>-<slug>"
 fi

--- a/.worktrees/AGENTS.md
+++ b/.worktrees/AGENTS.md
@@ -10,7 +10,6 @@ its worktrees at its own root, so a project clone under `projects/` has a
 | --------- | --------------- |
 | `agent/` | Per-agent checkouts — either a `git worktree` of an `agent/<name>` branch in this repo, or a standalone clone of a repo that adopts the Open Harness shape (including a fork of an orchestrator). |
 | `feat/` `bug/` `task/` `audit/` `skill/` | Branch worktrees named after the branch prefix in `.oh/skills/git/SKILL.md`. |
-| `cron/` | `cron/<session>` — per-fire isolation worktrees created by `worktree: true` crons. The runtime prunes and reaps these; do not manage them by hand. |
 | `archive/` | `archive/<YYYY-MM-DD>` — weekly cleanup-tasks archive sweeps. |
 
 Lifecycle is `git worktree add` / `git worktree remove`. The root is always

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Update policy and release automation live in [`/git`](.claude/skills/git/SKILL.m
 - **BREAKING:** Stop baking OpenCode, Hermes, and Grok Build into the image; `oh harness install <id>` installs them into `~/.local` as the sandbox user ([#908](https://github.com/mifunedev/openharness/issues/908)).
 
 ### Removed
+- **BREAKING:** Retire cron worktree isolation — the `worktree:` frontmatter key, `.worktrees/cron/` per-fire worktrees, the `CRON_WORKTREE` export, and every `*_WORKTREE*` log state are gone; crons fire in the shared root under the id lock.
 - **BREAKING:** Retire the `OH_IMAGE_ONLY` flag; `entrypoint.sh` detects the sandbox flavor from whether `/home/sandbox/harness` is a bind mount holding `.oh/`, and logs the detected mode ([#920](https://github.com/mifunedev/openharness/issues/920)).
 - **BREAKING:** Retire `docker-compose.hermes-dashboard.yml` and its published `127.0.0.1:9119`; the dashboard now binds container loopback, reachable over cloudflared or Tailscale ([#920](https://github.com/mifunedev/openharness/issues/920)).
 - Remove the duplicate agent-browser and Tailscale installers from `entrypoint.sh`; the tool catalog is the sole owner of both pins and Tailscale's two checksums ([#920](https://github.com/mifunedev/openharness/issues/920)).

--- a/crons/AGENTS.md
+++ b/crons/AGENTS.md
@@ -29,7 +29,7 @@ See `.oh/scripts/cron-runtime.ts` for the runtime implementation
 | Change | Takes effect |
 | --- | --- |
 | Body (the agent prompt) | Next fire, automatically — the runtime re-reads the file. Logs `BODY_RELOADED`. |
-| Frontmatter (`schedule`, `enabled`, `timezone`, `overlap`, `agent`, `tmux`, `worktree`, `preflight`) | Only after a `SIGHUP` reschedule or a runtime restart. Until then the **old** schedule is live. |
+| Frontmatter (`schedule`, `enabled`, `timezone`, `overlap`, `agent`, `tmux`, `preflight`) | Only after a `SIGHUP` reschedule or a runtime restart. Until then the **old** schedule is live. |
 | Adding or removing a `<id>.md` file | Only after a `SIGHUP` reschedule or a runtime restart. |
 | `.oh/scripts/cron-runtime.ts` itself | Only after a full runtime restart. |
 
@@ -48,7 +48,6 @@ enabled: true
 overlap: false           # skip new fire if previous still running
 catchup: false           # don't replay missed fires after downtime
 tmux: false              # optional — run each fire in its own detached tmux session
-worktree: false          # optional — run each fire in a fresh .worktrees/cron/<session> (root stays clean; never SKIPPED_OVERLAP)
 agent: pi                # optional — override CRON_AGENT_BIN for this job only
 description: <one-line>
 ---
@@ -90,7 +89,6 @@ status column is one of:
 | `SCHED_INVALID` | A cron was skipped because its `schedule:` is not a valid cron expression (`msg` contains the offending schedule string). |
 | `AGENT_INVALID` | A cron was skipped because its `agent:` override or effective `CRON_AGENT_BIN` is not a safe executable token/path. |
 | `SPAWNED` | A `tmux: true` fire launched its detached session (`msg` is the session name). |
-| `SPAWNED_WORKTREE` | A `worktree: true` fire launched its detached session inside a fresh isolated `.worktrees/cron/<session>` worktree (`msg` is `<session> <worktree-path>`); the shared root checkout is untouched. |
 | `FIRE` | A scheduled job fired and began running its body. |
 | `AGENT_START` | The shell wrapper started an agent for the task (`msg` is `agent=<name>`). A Claude→Codex fallback emits a second `AGENT_START` for Codex. |
 | `AGENT_FALLBACK` | Default Claude execution hit a usage/session-limit pattern and retried through Codex (`msg` is `from=claude to=codex`). |
@@ -99,9 +97,7 @@ status column is one of:
 | `EXIT_n` | The fired child process exited non-zero with code `n`. When the job's log file is populated, a bounded tail of the job's trailing output is appended as the `msg` (4th column) — the optional field already used by `ERR_JOB`/`ERR`/`BODY_RELOADED` — so the failure is diagnosable from `.cron.log` alone (see example below). |
 | `ERR` | The child process failed to spawn (process-level error, not a job throw). |
 | `ERR_JOB` | A synchronous cron job-callback threw; recorded instead of being swallowed. Format: `<id>\tERR_JOB\t<error-string>`. |
-| `SKIPPED_OVERLAP` | A fire was skipped because the previous run was still in flight (`overlap: false`). Only possible for **non-`worktree`** crons — a `worktree: true` cron isolates instead of skipping (see `SPAWNED_WORKTREE`). |
-| `ERR_WORKTREE` | A `worktree: true` fire could not create its isolated worktree (no base ref, or `git worktree add` failed); the fire did not run. A surfaced failure, never a silent skip. |
-| `ERR_WORKTREE_CAP` | A `worktree: true` fire hit the live-worktree concurrency cap for its id; the fire did not run (retried next fire once a stuck session + its worktree are reaped). A surfaced failure, never a silent skip. |
+| `SKIPPED_OVERLAP` | A fire was skipped because the previous run was still in flight (`overlap: false`). |
 
 An enriched `EXIT_n` line (tab-separated, tail whitespace-collapsed and
 bounded to 200 chars):
@@ -143,7 +139,6 @@ A job with `tmux: true` in its frontmatter runs each fire in its own detached tm
 - **Env exported into the agent**: `CRON_TMUX_SESSION=<session>`, `CRON_KEEP_MARKER=/tmp/<session>.keep`, and `CRON_OVERLAP_PIDFILE=/tmp/cron-<id>.pid`.
 - **Keep-marker contract**: if the agent `touch`es `$CRON_KEEP_MARKER` before exiting, the session persists by resuming the run's own conversation as a live, attachable agent (`claude --continue` for a Claude run, `pi --continue` for an `agent: pi` run, or `codex` after a Claude→Codex fallback), falling back to a shell if that exits; otherwise it auto-closes when the agent finishes. Claude/Codex tmux runs are headless (`claude -p`, or `codex exec --sandbox danger-full-access` after a Claude usage/session-limit fallback). Pi tmux runs intentionally use the positional TUI shape (`pi "$(cat prompt)"`), matching `tmux new -s <name> pi "<prompt>"`, so attaching mid-run shows the live Pi pane instead of a blank piped/headless screen. By convention a job keeps its session only when the run produced something worth revisiting (e.g. a PR was opened).
 - **Overlap guard**: a per-id pidfile `/tmp/cron-<id>.pid` blocks a new fire while a previous one is still running when `overlap: false`; the skipped fire logs `SKIPPED_OVERLAP`. Kept interactive sessions that reach a terminal state can remove `$CRON_OVERLAP_PIDFILE` themselves before staying alive for manual review, so an intentionally retained pane does not suppress future fires.
-- **Worktree isolation (`worktree: true`)**: instead of serializing on the shared root checkout, a `worktree: true` `tmux` cron runs **every** fire in a fresh detached `.worktrees/cron/<session>` worktree cut from the base branch (`development`→`main`→`master`), exported to the run as `$CRON_WORKTREE`. The root checkout is never touched for source/branch work (no dirty-env stalls) and a fire is **never silently skipped** — it isolates (`SPAWNED_WORKTREE`) or surfaces a failure (`ERR_WORKTREE`, or `ERR_WORKTREE_CAP` at the live-worktree concurrency cap). Isolated fires use a session-scoped lock (`/tmp/<session>.pid`) so they never clobber the id-scoped overlap lock; the runtime prunes dead-session worktrees before counting the cap, and the heartbeat reaps stuck sessions + their worktrees. Dead-session pruning distinguishes three outcomes, because a `git status` **failure** is not evidence of uncommitted work: (1) **clean** — `git status --porcelain` succeeds and is empty → the worktree is removed; (2) **dirty** — `git status --porcelain` succeeds and reports modified or untracked files → the runtime preserves the worktree and logs `WORKTREE_DIRTY` with its path, ref, and changed files for manual salvage; (3) **orphaned** — the directory survives but its `.git/worktrees/<name>` admin entry is gone, so `git status` cannot report at all → the runtime logs `WORKTREE_ORPHANED` and removes the directory outright (`git worktree remove` would itself fail, and `git worktree prune` cannot reach it — prune clears entries whose *directory* is missing, which is the inverse case). Only a provable orphan is reaped this way: any other `git status` failure (permissions, a corrupt repo) still falls through to the preserve-and-log-`WORKTREE_DIRTY` branch, because it cannot be shown that there is nothing to salvage. `SKIPPED_OVERLAP` remains the behaviour for non-`worktree` crons (heartbeat/cleanup/eval). A `worktree: true` cron treats runtime observability as the narrow exception: its source work stays in `$CRON_WORKTREE`, but it resolves `$CRON_LOG_ROOT` to the shared root checkout and appends `crons/.cron.log` there so humans can still inspect liveness after the ephemeral worktree is reaped.
 
 Jobs with `tmux` absent or `false` keep the default in-process spawn.
 
@@ -169,7 +164,7 @@ The bare `kill -HUP "$(cat crons/.pid)"` form works only from *inside* the conta
 
 ## Layout
 
-The runtime always reads `crons/` at the repository root, and isolated cron
-worktrees and `/worktrees` scratch roots always live under `.worktrees/`. These
-locations are a convention, not a setting; `.oh/scripts/oh-path crons` and
-`.oh/scripts/oh-path worktrees` resolve them.
+The runtime always reads `crons/` at the repository root, and `/worktrees`
+scratch roots always live under `.worktrees/`. These locations are a convention,
+not a setting; `.oh/scripts/oh-path crons` and `.oh/scripts/oh-path worktrees`
+resolve them.

--- a/crons/prompt-miner.md
+++ b/crons/prompt-miner.md
@@ -6,7 +6,6 @@ enabled: false
 overlap: false
 catchup: false
 tmux: true
-worktree: true
 repo: mifunedev/openharness
 description: Daily prompt-miner — mine 24h of session traces for prompt-quality markers and ship a top finding to the origin fork via /spec (opt-in, cap-gated)
 ---
@@ -14,9 +13,8 @@ description: Daily prompt-miner — mine 24h of session traces for prompt-qualit
 # prompt-miner
 
 You are running on a daily prompt-miner cycle, inside your own detached tmux
-session **in an isolated git worktree** (`$CRON_WORKTREE`, set by the cron runtime
-because this cron declares `worktree: true`). The shared root checkout is never
-touched for source/branch work. Your job is to mine the last 24h of session
+session. Create an isolated `/worktrees` checkout for any source or branch work so
+the shared root checkout stays clean. Your job is to mine the last 24h of session
 traces for a high-confidence prompt-quality marker and, when one clears the bar,
 ship it to the **origin fork** through `/spec` — never upstream, never
 auto-merged.
@@ -110,13 +108,12 @@ gh pr edit <PR> --repo mifunedev/openharness --add-label prompt-miner
 
 ### 4. Append the liveness line
 
-Append a `crons/.cron.log` liveness line, resolving the **shared root** under
-worktree mode (the worktree is reaped after the run; humans + heartbeat read the
-root checkout). Mirror the autopilot convention: honor `$CRON_LOG_ROOT` if
-set, else map `$CRON_WORKTREE` back to its shared root, else the current toplevel.
+Append a `crons/.cron.log` liveness line against the **shared root** (humans +
+heartbeat read the root checkout, never a build worktree). Honor `$CRON_LOG_ROOT`
+if set, else map the current checkout back to its shared root.
 
 ```bash
-ROOT="${CRON_LOG_ROOT:-$(git -C "${CRON_WORKTREE:-.}" worktree list --porcelain 2>/dev/null | awk 'NR==1 && $1 == "worktree" { sub(/^worktree /,""); print; exit }' || true)}"
+ROOT="${CRON_LOG_ROOT:-$(git worktree list --porcelain 2>/dev/null | awk 'NR==1 && $1 == "worktree" { sub(/^worktree /,""); print; exit }' || true)}"
 ROOT="${ROOT:-$(git rev-parse --show-toplevel)}"
 printf '[%s]\tprompt-miner\t%s\t%s\n' "$(date -Iseconds)" "<STATUS>" "<msg>" \
   | "$ROOT/.oh/scripts/locked-append.sh" "$ROOT/crons/.cron.log"


### PR DESCRIPTION
Closes #933

## What this is

Two commits that existed **only as unpushed work on a local `development`** in the shared checkout, moved onto a branch so they can go through CI and review. Authorship is preserved (`ryaneggz`); `Submitted-by: Claude` records who moved them.

```
1a44b11d  task: retire cron worktree isolation
912199f1  task: drop the CRON_WORKTREE root seam from audit-run
```

Nothing was rewritten except the two things called out below. Every file touched *only* by these commits is byte-identical to the local version — verified per file with `git diff --quiet`.

## What the change does

Retires per-fire cron worktree isolation. Every cron now fires in the shared root checkout under the id-scoped overlap lock. Removed: the `worktree:` frontmatter key, `.worktrees/cron/` per-fire worktrees, the `CRON_WORKTREE` export and all consumers, the fallback-worktree prune/inspect/reap machinery, and the `SPAWNED_WORKTREE` / `ERR_WORKTREE` / `ERR_WORKTREE_CAP` / `WORKTREE_DIRTY` / `WORKTREE_ORPHANED` log states. `audit-run.sh` now resolves its root from the script path alone, and `audit-run-root-contract.sh` runs a fixture-local copy instead of overriding the root through the environment.

Net **−480 lines** across 11 files.

## The one conflict, and how it was resolved

These commits were written against the **pre-#928** `execute.md`. #930 landed first and rewrote step 4 to retire the automated `/spec` agent handoff.

`.oh/skills/spec/references/execute.md` was the single conflict. Its incoming side still carried the whole retired handoff — `tmux new-session`, `tmux pipe-pane`, `agent-spec-<slug>`, the `/goal` Advisor prompt, "Leave this single session alive for attach" — because it predates #928 and only stripped `$CRON_WORKTREE` *out of* that machinery.

**Resolution: keep #928's step 4 in full, delete only its two `$CRON_WORKTREE` references.** Taking the incoming side, or naively keeping both, would have resurrected the handoff #928 just retired. The reuse-vs-create behavior survives in a form that no longer depends on a cron env var:

```bash
if [ "$(git rev-parse --abbrev-ref HEAD)" != "<prefix>/<N>-<slug>" ]; then
  git worktree add ".worktrees/<prefix>/<N>-<slug>" "<prefix>/<N>-<slug>"
  cd ".worktrees/<prefix>/<N>-<slug>"
fi
```

`spec-no-agent-handoff` and `spec-single-owner` are green, which is the check that this resolution did not walk #928 backwards.

## Two deliberate modifications to the original commits

1. **`execute.md` conflict resolution** above — the only content change.
2. **Added `Tracks #933.` and `Submitted-by: Claude` trailers.** Both commits had empty trailers; the repo requires `Submitted-by:` naming the actual submitter.

## Validation

- `bash .oh/skills/eval/run.sh` — **121 probes, 0 REGRESSION, 0 TIMEOUT, 0 ERROR.**
- `pnpm typecheck` — clean.
- `bash .oh/scripts/link-providers.sh --check` — Providers OK.
- `git diff --check` — clean.
- `pnpm test` — 58/59 files, 963/969 tests pass. **Test count drops 982 → 969 because this change deletes 278 lines of `cron-runtime.test.ts` covering the removed machinery** — expected, not lost coverage. The 6 failures are all in `compose-args.test.ts`, are unrelated to cron worktrees, and are pre-existing on `development` (verified at `ecc49800`); CI's test job is green on that file.
- Residual `CRON_WORKTREE` mentions repo-wide: one negative assertion in `cron-runtime.test.ts` (`never exports CRON_WORKTREE`) and the historical `CHANGELOG.md` entry. Both correct.

## What remains unverified

- These commits were never run through CI before this PR — that is the reason the PR exists.
- The BREAKING removal of the `worktree:` frontmatter key is not exercised against a live cron fire here; it is covered by `cron-runtime.test.ts` and `worktrees-layout.sh` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)