### PR TITLE
fix: three provisioning bugs — PNPM_HOME, a killed provision reporting healthy, and audit gate 4

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -34,12 +34,11 @@ RUN curl -LsSf https://astral.sh/uv/install.sh | env INSTALLER_NO_MODIFY_PATH=1 
  && cp /root/.local/bin/uv /usr/local/bin/uv \
  && cp /root/.local/bin/uvx /usr/local/bin/uvx
 
-ENV PNPM_HOME="/usr/local/share/pnpm"
+ENV PNPM_HOME="/home/sandbox/.local/share/pnpm"
 ENV NPM_USER_PREFIX="/home/sandbox/.local"
 ENV PATH="$NPM_USER_PREFIX/bin:$PNPM_HOME:$PATH"
 ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0
-RUN corepack enable && corepack prepare pnpm@10.33.0 --activate \
- && pnpm setup --force 2>/dev/null || true
+RUN corepack enable && corepack prepare pnpm@10.33.0 --activate
 
 SHELL ["/bin/bash", "-c"]
 
@@ -72,7 +71,7 @@ RUN install -d -o sandbox -g sandbox -m 0700 /home/sandbox/.ssh \
       /home/sandbox/.herdr \
       "$UV_TOOL_DIR" "$UV_TOOL_BIN_DIR" "$UV_PYTHON_INSTALL_DIR" "$UV_CACHE_DIR"
 
-RUN install -d -o sandbox -g sandbox "$NPM_USER_PREFIX" \
+RUN install -d -o sandbox -g sandbox "$NPM_USER_PREFIX" "$PNPM_HOME" \
  && rm -rf /home/sandbox/.npm
 
 RUN su - sandbox -c "RUNZSH=no CHSH=no KEEP_ZSHRC=yes sh -c \"\$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)\" --unattended" \
@@ -85,8 +84,8 @@ COPY --chown=sandbox:sandbox .oh/install/.tmux.conf /home/sandbox/.tmux.conf
 COPY --chown=sandbox:sandbox .oh/install/.zshrc /home/sandbox/.zshrc
 
 RUN printf '%s\n' \
-      'export NPM_USER_PREFIX="/home/sandbox/.local"' \
-      'export PNPM_HOME="/usr/local/share/pnpm"' \
+      'export NPM_USER_PREFIX="${NPM_USER_PREFIX:-/home/sandbox/.local}"' \
+      'export PNPM_HOME="${PNPM_HOME:-/home/sandbox/.local/share/pnpm}"' \
       'export PATH="$NPM_USER_PREFIX/bin:$PNPM_HOME:$PATH"' \
       '[ -r "$HOME/.local/share/oh/python-env.sh" ] && . "$HOME/.local/share/oh/python-env.sh"' \
       | tee -a /home/sandbox/.profile /home/sandbox/.zprofile \

--- a/.devcontainer/entrypoint.sh
+++ b/.devcontainer/entrypoint.sh
@@ -14,6 +14,23 @@ sandbox_ownership() {
   printf '%s:%s' "$(id -u sandbox)" "$(id -g sandbox)"
 }
 
+reconcile_shell_env_exports() {
+  local f repaired=0
+  for f in /home/sandbox/.profile /home/sandbox/.zprofile; do
+    [ -f "$f" ] || continue
+    grep -qE '^export (NPM_USER_PREFIX|PNPM_HOME)="/' "$f" 2>/dev/null || continue
+    sed -i \
+      -e 's|^export NPM_USER_PREFIX=.*|export NPM_USER_PREFIX="${NPM_USER_PREFIX:-/home/sandbox/.local}"|' \
+      -e 's|^export PNPM_HOME=.*|export PNPM_HOME="${PNPM_HOME:-/home/sandbox/.local/share/pnpm}"|' \
+      "$f" 2>/dev/null || continue
+    chown "$(sandbox_ownership)" "$f" 2>/dev/null || true
+    repaired=1
+  done
+  if [ "$repaired" = "1" ]; then
+    echo "[entrypoint] replaced hardcoded NPM_USER_PREFIX/PNPM_HOME exports in the home mount's shell profile; the image environment now wins"
+  fi
+}
+
 repair_home_mount_ownership() {
   local owner
   owner="$(sandbox_ownership)"
@@ -159,6 +176,7 @@ echo "sandbox:${PW}" | chpasswd || echo "[entrypoint] WARNING: failed to set san
 unset PW
 
 repair_home_mount_ownership
+reconcile_shell_env_exports
 
 HARNESS="${HARNESS:-$OH_PROJECT_ROOT}"
 

--- a/.oh/evals/probes/audit-implementation-behavior.sh
+++ b/.oh/evals/probes/audit-implementation-behavior.sh
@@ -1,10 +1,15 @@
 #!/usr/bin/env bash
 # tier: A
 # source: issue #645 — implementation root/repo/browser behavior
-# desc: browser preflight is conditional, isolated, non-installing, and repository-nonmutating
+# desc: browser preflight is conditional, isolated, non-installing, and repository-nonmutating;
+#   and it stays RUNNABLE — the isolated HOME must not hide Playwright's browser cache
+#   (PLAYWRIGHT_BROWSERS_PATH is passed through) and the daemon socket under XDG_RUNTIME_DIR
+#   must fit the 107-byte unix limit, both of which the mock cannot exercise on its own
 set -euo pipefail
 REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"; GATE="$REPO/.oh/skills/audit/scripts/implementation-gates.sh"
-root=$(mktemp -d); bin=$(mktemp -d); runtime=$(mktemp -d); calls=$(mktemp); trap 'rm -rf "$root" "$bin" "$runtime" "$calls"' EXIT
+root=$(mktemp -d); bin=$(mktemp -d); runtime=$(mktemp -d); calls=$(mktemp); envlog=$(mktemp)
+cache=$(mktemp -d)
+trap 'rm -rf "$root" "$bin" "$runtime" "$calls" "$envlog" "$cache"' EXIT
 mkdir -p "$root/.oh/tasks/no-ui" "$root/.oh/tasks/ui"
 printf '{"userStories":[{"passes":true,"acceptanceCriteria":["shell only"]}]}' >"$root/.oh/tasks/no-ui/prd.json"
 printf '{"userStories":[{"passes":true,"acceptanceCriteria":["Verify in browser"]}]}' >"$root/.oh/tasks/ui/prd.json"
@@ -12,11 +17,12 @@ git -C "$root" init -q; git -C "$root" config user.email test@example.invalid; g
 cat >"$bin/agent-browser" <<'MOCK'
 #!/usr/bin/env bash
 printf '%s\n' "$*" >>"$CALLS"
+printf '%s\t%s\n' "${PLAYWRIGHT_BROWSERS_PATH:-<unset>}" "${XDG_RUNTIME_DIR:-<unset>}" >>"$ENVLOG"
 mkdir -p "$HOME/mock-profile"
 [[ -z ${MUTATE_FILE:-} || $1 != open ]] || printf browser-change >>"$MUTATE_FILE"
 exit 0
 MOCK
-chmod +x "$bin/agent-browser"; export CALLS="$calls"
+chmod +x "$bin/agent-browser"; export CALLS="$calls" ENVLOG="$envlog" PLAYWRIGHT_BROWSERS_PATH="$cache"
 fail(){ echo "REGRESSION: $*" >&2; exit 1; }
 if AUDIT_ROOT="$root" PATH="$bin:$PATH" bash "$GATE" browser-required no-ui; then fail 'non-UI story selected browser'; fi
 [[ ! -s $calls ]] || fail 'non-UI applicability invoked browser'
@@ -28,6 +34,25 @@ after=$(git -C "$root" status --porcelain=v1 --untracked-files=all)
 [[ $(grep -c '^--version$' "$calls") -eq 1 && $(grep -c '^open about:blank --session audit-audit-20260717T120000Z-fixture$' "$calls") -eq 1 ]] || fail 'preflight command sequence'
 ! grep -Eqi 'install|npm|pnpm|https?://' "$calls" || fail 'preflight installed or navigated externally'
 [[ -z $(find "$runtime" -mindepth 1 -print -quit) ]] || fail 'browser profile not cleaned'
+
+# The isolated HOME hides ~/.cache/ms-playwright, so the browser executable is
+# unreachable unless the cache is passed through; and the daemon socket lives at
+# $XDG_RUNTIME_DIR/agent-browser/<session>.sock, which AUDIT_TMP_ROOT-length paths
+# overflow. A mocked agent-browser exits 0 through both, so assert the env instead.
+[[ -s $envlog ]] || fail 'preflight recorded no environment'
+while IFS=$'\t' read -r pbp xrd; do
+  [[ $pbp == "$cache" ]] || fail "preflight did not pass PLAYWRIGHT_BROWSERS_PATH through the isolated HOME (got '$pbp')"
+  [[ $xrd != '<unset>' && -n $xrd ]] || fail 'preflight did not set XDG_RUNTIME_DIR, so the daemon socket falls back under the isolated HOME'
+  sock="$xrd/agent-browser/audit-audit-20260717T120000Z-fixture.sock"
+  ((${#sock} < 108)) || fail "daemon socket path would be ${#sock} bytes, over the 107-byte unix limit: $sock"
+done <"$envlog"
+
+: >"$envlog"
+if AUDIT_ROOT="$root" AUDIT_RUN_ID='audit-20260717T120003Z-fixture' AUDIT_TMP_ROOT="$runtime" \
+  PLAYWRIGHT_BROWSERS_PATH="$cache/absent" PATH="$bin:$PATH" bash "$GATE" browser-preflight >/dev/null 2>&1; then
+  fail 'preflight passed with no Playwright browser cache present'
+fi
+[[ ! -s $envlog ]] || fail 'preflight launched the browser despite an absent cache'
 printf preexisting-change >>"$root/.oh/tasks/ui/prd.json"
 if AUDIT_ROOT="$root" AUDIT_RUN_ID='audit-20260717T120001Z-fixture' AUDIT_TMP_ROOT="$runtime" \
   MUTATE_FILE="$root/.oh/tasks/ui/prd.json" PATH="$bin:$PATH" bash "$GATE" browser-preflight >/dev/null 2>&1; then

--- a/.oh/evals/probes/provision-marker-fail-closed.sh
+++ b/.oh/evals/probes/provision-marker-fail-closed.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# tier: A
+# source: issue #937 — a --local guard run watched a killed provision report healthy
+# desc: boot provisioning runs under `timeout` in .devcontainer/entrypoint.sh, so the
+#   likeliest failure is SIGTERM part-way through an install, not a clean non-zero exit.
+#   The provision-failed marker the healthcheck reads must therefore be fail-closed:
+#   written before the first install and removed only after a clean completion, so a
+#   killed run leaves the sandbox unhealthy instead of healthy-with-nothing-installed.
+#   Exercised against the real script with a stub `oh` — one run that hangs and is
+#   killed, one that completes.
+set -euo pipefail
+
+ROOT="${PROVISION_MARKER_PROBE_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)}"
+SCRIPT="$ROOT/.oh/scripts/provision-defaults.sh"
+
+[[ -f "$SCRIPT" ]] || {
+  echo "REGRESSION provision marker: missing .oh/scripts/provision-defaults.sh" >&2
+  exit 1
+}
+command -v jq >/dev/null 2>&1 || {
+  echo "SKIPPED provision marker: jq is not on PATH" >&2
+  exit 2
+}
+
+WORK=$(mktemp -d "${TMPDIR:-/tmp}/oh-provision-marker.XXXXXX")
+trap 'rm -rf "${WORK:?}"' EXIT
+
+CATALOG='[{"id":"stub","kind":"default","installed":false,"enabled":true,"binary":"stub"}]'
+
+make_stub() {
+  local behavior="$1" bin="$WORK/bin"
+  mkdir -p "$bin"
+  cat >"$bin/oh" <<STUB
+#!/usr/bin/env bash
+[ "\$2" = "list" ] && { printf '%s\n' '$CATALOG'; exit 0; }
+$behavior
+STUB
+  chmod +x "$bin/oh"
+}
+
+run_provision() {
+  local timeout_secs="$1"
+  rm -rf "${WORK:?}/home"; mkdir -p "$WORK/home/.local/bin" "$WORK/home/.local/lib" "$WORK/home/.npm"
+  timeout "$timeout_secs" env -i \
+    PATH="$WORK/bin:/usr/bin:/bin" \
+    HOME="$WORK/home" \
+    OH_EXECUTION_TARGET=local \
+    OH_BIN="$WORK/bin/oh" \
+    NPM_USER_PREFIX="$WORK/home/.local" \
+    OH_PROVISION_MARKER="$WORK/home/marker" \
+    bash "$SCRIPT" >"$WORK/out" 2>&1
+}
+
+failures=()
+
+make_stub 'sleep 60'
+run_provision 3 && failures+=("a provision whose install hangs past the timeout still exited 0")
+if [[ ! -f "$WORK/home/marker" ]]; then
+  failures+=("a provision killed part-way through an install left no provision-failed marker, so sandbox-healthcheck.sh would report the sandbox healthy with defaults missing")
+fi
+
+make_stub 'exit 0'
+if run_provision 30; then
+  if [[ -f "$WORK/home/marker" ]]; then
+    failures+=("a clean provision left the provision-failed marker behind, which would hold the sandbox unhealthy forever")
+  fi
+else
+  failures+=("a provision whose installs all succeed did not exit 0: $(tail -3 "$WORK/out" | tr '\n' ' ')")
+fi
+
+if ((${#failures[@]})); then
+  printf 'REGRESSION provision marker fail-closed: %s\n' "${failures[*]}" >&2
+  exit 1
+fi
+
+echo "PASS provision marker fail-closed: a killed provision leaves the marker sandbox-healthcheck.sh reads, and only a clean completion clears it" >&2
+exit 0

--- a/.oh/scripts/provision-defaults.sh
+++ b/.oh/scripts/provision-defaults.sh
@@ -14,6 +14,11 @@ esac
 
 log() { echo "[provision-defaults] $*"; }
 
+mark_failed() {
+  mkdir -p "$(dirname "$PROVISION_MARKER")" 2>/dev/null || return 0
+  printf '%s\n' "$*" >"$PROVISION_MARKER" 2>/dev/null || true
+}
+
 die() {
   echo "[provision-defaults] ERROR: $1" >&2
   shift
@@ -61,9 +66,15 @@ fi
 HOME="${HOME:-$(getent passwd "$(id -u)" | cut -d: -f6)}"
 export HOME
 
+PROVISION_MARKER="${OH_PROVISION_MARKER:-$HOME/.local/share/oh/provision-failed}"
+
 NPM_USER_PREFIX="${NPM_USER_PREFIX:-$HOME/.local}"
 export NPM_USER_PREFIX
 export PATH="$NPM_USER_PREFIX/bin:$PATH"
+
+if [ "$MODE" = "provision" ]; then
+  mark_failed "provisioning started at $(date -u +%Y-%m-%dT%H:%M:%SZ) and has not reported completion"
+fi
 
 check_writable() {
   local dir="$1"
@@ -166,17 +177,21 @@ if ((provisioned == 0)); then
 fi
 
 if [ "$MODE" = "verify" ] && ((${#missing[@]})); then
+  mark_failed "not installed: ${missing[*]}"
   die "defaults are not installed: ${missing[*]}" \
       "run inside the sandbox (\`oh shell\` from the host):" \
       "  bash .oh/scripts/provision-defaults.sh"
 fi
 
 if ((${#failed[@]})); then
+  mark_failed "failed to install: ${failed[*]}"
   die "failed to install: ${failed[*]}" \
       "each install runs as '$SANDBOX_USER' into $NPM_USER_PREFIX; a network outage is the usual cause." \
       "re-run inside the sandbox once it has network:" \
       "  bash .oh/scripts/provision-defaults.sh"
 fi
+
+rm -f "$PROVISION_MARKER" 2>/dev/null || true
 
 if [ "$MODE" = "verify" ]; then
   log "OK  all $provisioned default harnesses and tools present under $NPM_USER_PREFIX"

--- a/.oh/scripts/sandbox-healthcheck.sh
+++ b/.oh/scripts/sandbox-healthcheck.sh
@@ -85,6 +85,12 @@ else
   fi
 fi
 
+PROVISION_MARKER="${OH_PROVISION_MARKER:-/home/sandbox/.local/share/oh/provision-failed}"
+if [ -f "$PROVISION_MARKER" ]; then
+  reason=$(tr -d '\n' <"$PROVISION_MARKER" 2>/dev/null)
+  record_failure "boot provisioning did not complete (${reason:-see the boot log}) — recover with: bash $HARNESS/.oh/scripts/provision-defaults.sh"
+fi
+
 if [ "${#failures[@]}" -gt 0 ]; then
   printf 'sandbox healthcheck failed:\n' >&2
   printf -- '- %s\n' "${failures[@]}" >&2

--- a/.oh/skills/agent-browser/SKILL.md
+++ b/.oh/skills/agent-browser/SKILL.md
@@ -44,22 +44,16 @@ Run each check sequentially. If any check fails, **stop immediately** and report
 command -v agent-browser && agent-browser --version 2>&1 || echo "FAIL: agent-browser not found in PATH"
 ```
 
-If not found, install it — **use npm (not pnpm)** and **pin to 0.8.5**:
+If not found, install it through the CLI — the catalog entry pins the
+version, fixes the binary's mode, and runs `agent-browser install --with-deps`
+for you:
 
 ```bash
-sudo npm install -g agent-browser@0.8.5
+oh tool install agent-browser --yes
 ```
 
-Then install Chromium + system deps. `agent-browser install --with-deps`
-shells out to a `playwright` binary that isn't bundled with this package,
-so on a fresh image you'll also need the playwright CLI available:
-
-```bash
-agent-browser install --with-deps    # installs system libs (apt)
-# If it ends with "sh: 1: playwright: not found":
-sudo npm install -g playwright@latest
-npx playwright install chromium
-```
+`--yes` is required whenever stdin is not a TTY: the entry declares a
+`~1 GB` download, and the confirmation gate refuses rather than prompting.
 
 Verify:
 
@@ -68,14 +62,16 @@ agent-browser --version     # → agent-browser 0.8.5
 agent-browser open about:blank && agent-browser close
 ```
 
-Rationale for the pins:
-- **npm, not pnpm** — `PNPM_HOME` is `/usr/local/share/pnpm`, owned by
-  root; `pnpm add -g` as the sandbox user fails with `EACCES`.
+Notes:
 - **0.8.5** — later majors have breaking CLI changes; the rest of this
-  skill targets 0.8.5's flags.
-
-Or rebuild the image with `INSTALL_AGENT_BROWSER=true` in
-`.devcontainer/.env` to bake this in.
+  skill targets 0.8.5's flags. The catalog owns the pin.
+- **Do not reach for `sudo npm install -g`.** It lands under
+  `/usr/lib/node_modules`, which no running sandbox can upgrade in place —
+  `provision-defaults.sh` rejects that path by name. The catalog installs
+  into `$PNPM_HOME` under the sandbox user's own home.
+- If `agent-browser install --with-deps` ever ends with
+  `sh: 1: playwright: not found`, the playwright CLI is missing:
+  `npx playwright install chromium` after `pnpm add -g playwright@latest`.
 
 After installing, resume the health check from step 2b — **do not stop**.
 

--- a/.oh/skills/audit/scripts/implementation-gates.sh
+++ b/.oh/skills/audit/scripts/implementation-gates.sh
@@ -48,6 +48,11 @@ case $mode in
     : "${AUDIT_RUN_ID:?AUDIT_RUN_ID is required}"
     : "${AUDIT_TMP_ROOT:?AUDIT_TMP_ROOT is required}"
     command -v agent-browser >/dev/null || { echo 'FAIL gate4: agent-browser not found' >&2; exit 1; }
+    browsers=${PLAYWRIGHT_BROWSERS_PATH:-$HOME/.cache/ms-playwright}
+    [[ -d $browsers ]] || {
+      echo "FAIL gate4: no Playwright browser cache at $browsers; install one with: agent-browser install --with-deps" >&2
+      exit 1
+    }
     snapshot_repo(){
       local out=$1 path rel
       {
@@ -69,11 +74,18 @@ case $mode in
     snapshot_repo "$before"
     profile=$(mktemp -d "$AUDIT_TMP_ROOT/browser-profile.XXXXXX")
     session="audit-$AUDIT_RUN_ID"
-    close_browser(){ HOME="$profile" agent-browser close --session "$session" >/dev/null 2>&1 || true; rm -rf "$profile"; }
+    runtime=$(mktemp -d "${TMPDIR:-/tmp}/oh-audit-xdg.XXXXXX")
+    sock="$runtime/agent-browser/$session.sock"
+    ((${#sock} < 108)) || {
+      echo "FAIL gate4: daemon socket path is ${#sock} bytes, over the 107-byte unix limit: $sock" >&2
+      rm -rf "$runtime"; exit 1
+    }
+    browser_env=(HOME="$profile" XDG_RUNTIME_DIR="$runtime" PLAYWRIGHT_BROWSERS_PATH="$browsers")
+    close_browser(){ env "${browser_env[@]}" agent-browser close --session "$session" >/dev/null 2>&1 || true; rm -rf "$profile" "$runtime"; }
     trap close_browser EXIT INT TERM HUP
-    HOME="$profile" agent-browser --version >/dev/null 2>&1 \
+    env "${browser_env[@]}" agent-browser --version >/dev/null 2>&1 \
       || { echo 'FAIL gate4: agent-browser version check' >&2; exit 1; }
-    HOME="$profile" agent-browser open about:blank --session "$session" >/dev/null 2>&1 \
+    env "${browser_env[@]}" agent-browser open about:blank --session "$session" >/dev/null 2>&1 \
       || { echo 'FAIL gate4: Chromium launch' >&2; exit 1; }
     close_browser; trap - EXIT INT TERM HUP
     snapshot_repo "$after"


### PR DESCRIPTION
Three provisioning bugs, split out of #938 so they can ship without the deployment-guard scaffolding that PR is being reshaped around.

Each is independently verifiable and none touches the image-only flavor.

## 1. `PNPM_HOME` was unusable by the sandbox user

`PNPM_HOME` was `/usr/local/share/pnpm` — root-owned, and absent from the image — while the tool catalog declares `installUser: "sandbox"`. `agent-browser` is the only entry installed with `pnpm add -g`, and pnpm honours `PNPM_HOME`, not `NPM_USER_PREFIX`:

```
ERROR  EACCES: permission denied, mkdir '/usr/local/share/pnpm'
```

It could not succeed for any non-root user on any current image.

**Moving it into the home mount only fixes fresh volumes.** The Dockerfile also wrote `export PNPM_HOME="/usr/local/share/pnpm"` into `/home/sandbox/.profile` and `.zprofile` — files that live on the home volume, so they survive an image upgrade and override the corrected `ENV`. Every install runs through a *login* shell (the catalog's `installArgv` is literally `["bash","-lc",…]`), so the stale value was the one that counted.

The profile now defers to the environment, and the entrypoint rewrites an already-stale profile on boot — which works because `entrypoint.sh` ships in the image rather than the home mount.

Verified against the exact failing scenario — fixed image booted onto a volume carrying the old profile:

```
[entrypoint] replaced hardcoded NPM_USER_PREFIX/PNPM_HOME exports…
bash -lc   PNPM_HOME=/home/sandbox/.local/share/pnpm
oh tool install agent-browser --yes  →  installed
           /home/sandbox/.local/share/pnpm/agent-browser
           agent-browser 0.8.5   sandbox:sandbox
```

The `agent-browser` skill's "use `sudo npm`, not pnpm" workaround goes with the bug it worked around. It also pointed at `/usr/lib/node_modules`, which `provision-defaults.sh` rejects by name.

## 2. A killed provision reported healthy

Boot provisioning runs under `timeout` in `entrypoint.sh`, so its likeliest failure is SIGTERM part-way through an install — not a clean non-zero exit. The marker `sandbox-healthcheck.sh` reads was only written by `mark_failed()` at the *end* of the script, which a killed run never reaches.

Observed live: a child logged `sandbox healthcheck ok` while `herdr` and `cloudflared` were absent. Silent corruption, and it reaches `:latest`.

Now fail-closed: written before the first install, removed only after a clean completion.

## 3. The audit's gate 4 could not pass for any unit

Two independent defects: the isolated `HOME` hid Playwright's browser cache, and the `agent-browser` daemon socket under `AUDIT_TMP_ROOT` exceeded the 107-byte unix `sun_path` limit — so fixing only the cache still gave `Daemon failed to start`.

The existing probe passed throughout, because its mocked `agent-browser` exits 0 and never touches the daemon or the cache. It now asserts the environment the preflight hands the browser.

## Verification

| Check | Result |
|---|---|
| `provision-marker-fail-closed.sh` | PASS; 2/2 fault injections caught |
| `audit-implementation-behavior.sh` | PASS; 4/4 fault injections caught |
| Full probe suite | 139 probes, only the known authoring-checkout `compose-config-path-parity` red (untracked root `.env`; PASS in a clean worktree and in CI) |
| shellcheck `-S warning` | clean on all five changed scripts |
| Upgrade path | verified live — old image → keep volume → new image → install succeeds |

## Note on scope

`.profile` is not the only image-authored file stranded in the state volume — the Dockerfile also ships `.tmux.conf`, `.zshrc`, and `.bashrc` aliases there, and Docker seeds a named volume only when it is new, so **no image-shipped dotfile can be updated on an existing sandbox**. This PR does not address that; the fix is to stop putting image config in the state volume (`/etc/profile.d`, `/etc/zsh/zprofile`), which is tracked with the seed redesign.
