### PR TITLE
FROM bug/967-skill-description-limit TO development

### DIFF
--- a/.oh/skills/spec/SKILL.md
+++ b/.oh/skills/spec/SKILL.md
@@ -1,15 +1,11 @@
 ---
 name: spec
 description: >-
-  Canonical decomposed build workflow and dispatcher, and the harness's closed
-  repo-knowledge learning loop. Routes the first token of $ARGUMENTS to plan or
-  execute; an unrecognized first token is an approved plan path and runs plan
-  then execute. `plan` recalls tracked knowledge from .oh/knowledge/, re-grounds
-  it against current sources, and writes the .oh/tasks/<slug>/ folder;
-  `execute` re-grounds, implements under one owner — the agent running it — and
-  derives knowledge invalidation from the actual diff. This skill owns the ONLY build
-  path; there is no all-in-one composer beside it. Full per-subcommand
-  procedures live in references/{plan,execute,retro}.md.
+  Canonical build dispatcher and repo-knowledge learning loop. Routes to plan,
+  execute, or retro; an approved plan path runs plan then execute. Recalls and
+  re-grounds .oh/knowledge/, scaffolds .oh/tasks/<slug>/, implements under one
+  owner, and derives knowledge invalidation from the diff. Owns the only build
+  path. Procedures: references/{plan,execute,retro}.md.
   TRIGGER when: an approved plan file should become a ready PR without further
   hand-holding, "/spec <plan-path>", "build this plan end to end" -> the default
   plan-then-execute path; a topic/plan/issue needs to become a buildable task

--- a/.oh/skills/wiki/SKILL.md
+++ b/.oh/skills/wiki/SKILL.md
@@ -1,14 +1,11 @@
 ---
 name: wiki
 description: |
-  Dispatcher for the harness knowledge base — routes the first token of
-  $ARGUMENTS to one of four subcommands: ingest, query, lint, or compile. The
-  knowledge lives at .oh/knowledge/ (source/ entity pages with kind: repo or
-  external, patterns/ pages with kind: pattern, raw/ immutable external
-  snapshots — all tracked; local/ is gitignored per-machine scratch that no
-  query reads). This skill owns the procedure; .oh/knowledge/ owns the data.
-  Canonical schema: .oh/skills/wiki/references/schema.md. Full per-subcommand
-  procedures live in references/{ingest,query,lint,compile}.md.
+  Dispatch harness knowledge-base operations: ingest, query, lint, or compile.
+  This skill owns procedures; .oh/knowledge/ owns tracked source pages, patterns,
+  and raw snapshots. Queries exclude local scratch. Canonical schema:
+  .oh/skills/wiki/references/schema.md. Procedures:
+  references/{ingest,query,lint,compile}.md.
   TRIGGER when: "add to wiki", "capture this page", "snapshot this source",
   "ingest <url|path>", or promoting a sub-agent draft -> ingest; "what does the
   wiki say about X", "find knowledge entries for X", "look up X in the wiki",

--- a/.oh/skills/wiki/SKILL.md
+++ b/.oh/skills/wiki/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: wiki
 description: |
-  Dispatch harness knowledge-base operations: ingest, query, lint, or compile.
+  Dispatch four subcommands: ingest, query, lint, or compile.
   This skill owns procedures; .oh/knowledge/ owns tracked source pages, patterns,
   and raw snapshots. Queries exclude local scratch. Canonical schema:
   .oh/skills/wiki/references/schema.md. Procedures:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Update policy and release automation live in [`/git`](.claude/skills/git/SKILL.m
 
 ## [Unreleased]
 
+### Fixed
+
+- Shorten spec and wiki skill descriptions to remove Pi skill-conflict warnings. ([#967](https://github.com/mifunedev/openharness/issues/967))
+
 ### Added
 
 - Boot the sandbox with `systemd` as PID 1 via `cap_add: SYS_ADMIN`, `apparmor=unconfined`, `tmpfs: /run,/run/lock,/sys/fs` and `cgroup: private` — no host cgroup bind. ([#956](https://github.com/mifunedev/openharness/issues/956))


### PR DESCRIPTION
## Summary
- Shorten canonical spec and wiki descriptions to 887 and 780 characters.
- Preserve all triggers and leave skill procedures unchanged.
- Add a changelog entry.

## Verification
- Both descriptions are below Pi’s 1024-character limit.
- Provider-link check passes.
- `git diff --check` passes.
- `wiki-compile-contract.sh` passes after preserving its required dispatcher wording.

Closes #967