### PR TITLE
FROM task/972-remove-pi-plan-mode TO development

### DIFF
--- a/.pi/extensions/__tests__/settings.test.ts
+++ b/.pi/extensions/__tests__/settings.test.ts
@@ -17,7 +17,6 @@ describe("project Pi settings", () => {
       "npm:@tintinweb/pi-subagents@0.12.0",
       "npm:@tintinweb/pi-tasks@0.7.0",
       "npm:@narumitw/pi-goal@0.4.2",
-      "npm:@narumitw/pi-plan-mode@0.4.2",
       "npm:@narumitw/pi-codex-usage@0.6.2",
       "npm:@tifan/pi-recap@0.4.2",
       "npm:@trevonistrevon/pi-loop@0.5.5",

--- a/.pi/settings.json
+++ b/.pi/settings.json
@@ -25,7 +25,6 @@
     "npm:@tintinweb/pi-subagents@0.12.0",
     "npm:@tintinweb/pi-tasks@0.7.0",
     "npm:@narumitw/pi-goal@0.4.2",
-    "npm:@narumitw/pi-plan-mode@0.4.2",
     "npm:@narumitw/pi-codex-usage@0.6.2",
     "npm:@tifan/pi-recap@0.4.2",
     "npm:@trevonistrevon/pi-loop@0.5.5",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ Update policy and release automation live in [`/git`](.claude/skills/git/SKILL.m
 
 ### Removed
 
+- Remove `@narumitw/pi-plan-mode` from the default Pi packages and its bundled `/plan` mode. ([#972](https://github.com/mifunedev/openharness/issues/972))
+
 - **BREAKING:** Remove the `cron-watchdog` tmux supervisor, its generated `/tmp/cron-watchdog.sh`, and `CRON_WATCHDOG_INTERVAL`; systemd `Restart=` replaces the polling loop. ([#956](https://github.com/mifunedev/openharness/issues/956))
 - **BREAKING:** Remove the scheduler-level `cron-system` tmux session and the legacy `system-cron` reaping; per-fire `tmux: true` sessions are unchanged. ([#956](https://github.com/mifunedev/openharness/issues/956))
 - Remove `.oh/scripts/maintenance/restart-openharness-tmux.sh` and its date-expired heartbeat step, which recreated the retired scheduler sessions. ([#956](https://github.com/mifunedev/openharness/issues/956))

--- a/docs/harnesses/pi.md
+++ b/docs/harnesses/pi.md
@@ -38,7 +38,6 @@ Open Harness loads these project-local Pi packages from `.pi/settings.json`:
 - [`@tintinweb/pi-subagents`](https://pi.dev/packages/@tintinweb/pi-subagents) — Claude Code-style sub-agent commands for Pi, including FleetView (enabled by default). With an empty prompt, press `↓` (or `←`) to focus the agent list, then `↑`/`↓` to select and `Enter` to open an agent; toggle it via `/agents` → Settings → Fleet view.
 - [`@tintinweb/pi-tasks`](https://github.com/tintinweb/pi-tasks) — task tracking for Pi with `TaskCreate`, `TaskList`, `TaskGet`, `TaskUpdate`, `TaskOutput`, `TaskStop`, and `TaskExecute` tools; a `/tasks` menu; and a persistent task widget. `TaskExecute` integrates with `@tintinweb/pi-subagents` so tracked tasks can run through configured subagents.
 - [`@narumitw/pi-goal`](https://pi.dev/packages/@narumitw/pi-goal?name=goal) — `/goal <task>` mode that keeps Pi working until it verifies completion and calls the `goal_complete` tool. Use `/goal pause`, `/goal resume`, or `/goal clear` to manage the active goal.
-- [`@narumitw/pi-plan-mode`](https://pi.dev/packages/@narumitw/pi-plan-mode) — Codex-like `/plan` mode for read-only exploration, structured clarification through `plan_mode_question`, and approval-gated implementation. Open Harness uses this upstream package instead of maintaining a local `.pi/extensions/plan-mode/` implementation.
 - [`@narumitw/pi-codex-usage`](https://github.com/narumiruna/pi-extensions/tree/main/extensions/pi-codex-usage) — `/codex-status` plus a compact `openai-codex` statusline for 5-hour session usage and weekly usage. Open Harness pins `0.6.2`, which includes the upstream stale-`ExtensionContext` statusline timer fix that prevents crashes after Pi replaces an extension context.
 - [`@tifan/pi-recap`](https://github.com/tifandotme/pi-extensions/tree/master/packages/pi-recap) — one-line session recaps for re-entry. Use `/recap` for a fresh goal-first recap, `/recap status` to inspect freshness/model state, and `/recap config` to choose the recap model. The package also generates one idle recap after five minutes and refreshes stale/missing recaps on resume.
 - [`@trevonistrevon/pi-loop`](https://pi.dev/packages/@trevonistrevon/pi-loop?name=monitor) — Monitor and loop tools for background command monitoring and scheduled re-wakes. Use `MonitorCreate`, `MonitorList`, and `MonitorStop` for long-running commands; use `/loop` or `LoopCreate` for cron/event-triggered follow-up prompts.
@@ -58,13 +57,7 @@ and configure its external Langfuse deployment before installing it.
 
 The installed `@earendil-works/pi-ai` Codex Responses provider can reuse WebSocket cached continuation state by sending `previous_response_id`. If the upstream Codex backend forgets that response id, it returns `previous_response_not_found`; Pi clears the stale continuation but the failed user turn would otherwise be lost. Open Harness keeps a small auto-loaded `.pi/extensions/codex-stale-response-retry.ts` extension that re-injects non-Slack failed turns once via `sendUserMessage(..., { deliverAs: "followUp" })`, causing the next request to start from fresh/full context. Slack-prefixed turns remain owned by the dedicated `.pi/bridge-recovery/` extension that is co-loaded with `pi-messenger-bridge`.
 
-In Open Harness, start package-backed plan mode with:
-
-```bash
-pi --plan
-```
-
-Outside this project, try the packages manually with `pi -e npm:@narumitw/pi-goal`, `pi -e npm:@narumitw/pi-plan-mode --plan`, `pi -e npm:@narumitw/pi-codex-usage@0.6.2`, `pi -e npm:@tifan/pi-recap`, `pi -e npm:@trevonistrevon/pi-loop`, `pi -e npm:@guwidoe/pi-prompt-suggester@0.3.10`, or `pi -e git:github.com/Michaelliv/pi-dynamic-workflows@dbc6800d1f725f7439e51705e2664c59484afcd1`.
+Outside this project, try the packages manually with `pi -e npm:@narumitw/pi-goal`, `pi -e npm:@narumitw/pi-codex-usage@0.6.2`, `pi -e npm:@tifan/pi-recap`, `pi -e npm:@trevonistrevon/pi-loop`, `pi -e npm:@guwidoe/pi-prompt-suggester@0.3.10`, or `pi -e git:github.com/Michaelliv/pi-dynamic-workflows@dbc6800d1f725f7439e51705e2664c59484afcd1`.
 
 ## Prompt suggestions
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -275,7 +275,7 @@ Once installed, proceed to the [Quickstart](./quickstart.md) to authenticate ins
 
 The sandbox image ships a complete development environment. The required host dependencies are Docker with the Compose plugin, Git, and Node.js ≥ 20 (see [Prerequisites](#prerequisites)).
 
-Project-local Pi packages are loaded from `.pi/settings.json`; the defaults include `@tintinweb/pi-subagents`, `@tintinweb/pi-tasks`, `@narumitw/pi-goal`, `@narumitw/pi-plan-mode`, `@narumitw/pi-codex-usage@0.6.2` for `/codex-status` plus fixed statusline usage timers, `@tifan/pi-recap` for `/recap` plus automatic idle/resume session summaries, `@trevonistrevon/pi-loop` for Monitor/Loop tools, `@guwidoe/pi-prompt-suggester` for next-prompt suggestions, and `pi-dynamic-workflows` for workflow-script fan-out through isolated Pi subagents.
+Project-local Pi packages are loaded from `.pi/settings.json`; the defaults include `@tintinweb/pi-subagents`, `@tintinweb/pi-tasks`, `@narumitw/pi-goal`, `@narumitw/pi-codex-usage@0.6.2` for `/codex-status` plus fixed statusline usage timers, `@tifan/pi-recap` for `/recap` plus automatic idle/resume session summaries, `@trevonistrevon/pi-loop` for Monitor/Loop tools, `@guwidoe/pi-prompt-suggester` for next-prompt suggestions, and `pi-dynamic-workflows` for workflow-script fan-out through isolated Pi subagents.
 
 ### Base image
 


### PR DESCRIPTION
Remove `@narumitw/pi-plan-mode` from the default Pi package list. Pi sessions using these defaults no longer load its `/plan` mode or `--plan` startup option.

Update the existing package-list test, remove the installation and Pi guide references, and add an Unreleased changelog entry.

Validation: all 50 Pi tests pass; provider link check and `git diff --check` pass.

Closes #972.

Public docs: mifunedev/openharness-web#45 removes the matching site references.

CI: all checks pass, including the eval regression gate, boot lint, and lint/typecheck/build/test job.
