### PR TITLE
FROM bug/977-operator-config-guard-write-rules TO development

### DIFF
--- a/.oh/evals/probes/operator-config-guard.sh
+++ b/.oh/evals/probes/operator-config-guard.sh
@@ -116,8 +116,8 @@ for tool in Read Write Edit Grep Glob; do
   fi
 done
 
-for rule in "Read(file_path=**/$SEG/**)" "Write(file_path=**/$SEG/**)" "Edit(file_path=**/$SEG/**)" \
-  "Read(file_path=**/settings.local.json)" "Write(file_path=**/settings.local.json)" "Edit(file_path=**/settings.local.json)"; do
+for rule in "Read(file_path=**/$SEG/**)" "Edit(file_path=**/$SEG/**)" \
+  "Read(file_path=**/settings.local.json)" "Edit(file_path=**/settings.local.json)"; do
   if ! jq -e --arg r "$rule" '.permissions.deny | index($r)' "$SETTINGS" >/dev/null; then
     echo "REGRESSION: permissions.deny is missing '$rule'" >&2
     exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ Update policy and release automation live in [`/git`](.claude/skills/git/SKILL.m
 
 ### Fixed
 
-- Drop five unenforceable `Write(...)`/`NotebookEdit(...)` deny rules from `.claude/settings.json`. File permission checks match only `Edit(path)` rules, which already cover every file-editing tool, so each removed rule produced a startup warning on every Claude Code session while adding no protection. The equivalent `Edit(file_path=...)` denies and `deny-secret-paths.sh` keep `.config/` and `settings.local.json` off-limits. ([#974](https://github.com/mifunedev/openharness/pull/974))
+- Stop `operator-config-guard` requiring two deny rules that Claude Code never consults, which left the eval gate red for every pull request. ([#977](https://github.com/mifunedev/openharness/issues/977))
+- Drop five unenforceable `Write(...)`/`NotebookEdit(...)` deny rules that warned on every session start without adding protection. ([#974](https://github.com/mifunedev/openharness/pull/974))
 - Keep Hermes runtime state in the workspace, reject ambiguous homes, and reconcile shared skills without replacing user paths. ([#969](https://github.com/mifunedev/openharness/issues/969))
 - Shorten spec and wiki skill descriptions to remove Pi skill-conflict warnings. ([#967](https://github.com/mifunedev/openharness/issues/967))
 


### PR DESCRIPTION
Closes #977

## Summary

`operator-config-guard` was red on `development`, so the `eval-probes` job failed on every PR touching `.oh/**` or `.devcontainer/**` — including #976, whose diff does not contain `.claude/settings.json`.

The probe asserted six `permissions.deny` entries, two of which Claude Code accepts but never evaluates. Per the [permissions documentation](https://code.claude.com/docs/en/permissions.md):

> Claude Code checks file permissions against `Edit(path)` and `Read(path)` rules only. If you write a path rule for `Write`, `NotebookEdit`, `Glob`, or the legacy `MultiEdit` tool instead, Claude Code accepts the rule but never consults it, and warns at startup.

> Use `Edit(docs/**)` in place of `Write(docs/**)`… `Edit` rules apply to all built-in tools that edit files.

#974 removed those rules for exactly that reason and was correct to. The probe was still pinning them, so it demanded two declarations that do nothing but emit a startup warning on every session.

**Protection is unchanged.** Writes to the operator-only paths remain denied by two independent mechanisms, neither of which this PR touches:

1. the surviving `Edit(file_path=...)` rules, which per the docs above apply to Write, Edit, and NotebookEdit alike;
2. the `deny-secret-paths.sh` `PreToolUse` hook, whose matcher must still include `Write` — asserted separately at `operator-config-guard.sh:112-117` and left intact.

Only the unconsulted declaration goes away.

## Why this landed unnoticed

#974 touched only `.claude/settings.json`, which is not among the `ci-harness.yml` path filters, so `eval-probes` never ran on that PR. The regression sat on `development` until the next PR that happened to touch a filtered path.

That is a second, independent gap — a file whose contents a probe asserts on is not itself a CI trigger — and it will recur. It is deliberately **not** fixed here; it deserves its own change rather than being bundled into a probe correction.

## Also included

`CHANGELOG.md` — the `[Unreleased]` entry from #974 is 488 characters against the 250-character cap that `changelog-entry-length.sh` enforces, and was independently red on `development`. Trimmed to 191 characters with no loss of meaning; the detail it carried belongs in the PR body, per the `/git` skill's changelog rules. Both mechanical CI breakages are fixed together here so that the eval gate is genuinely restored by one merge.

## Verification

- `bash .oh/evals/probes/operator-config-guard.sh` → PASS (was REGRESSION).
- `bash .oh/evals/probes/changelog-entry-length.sh` → PASS (was REGRESSION).
- Fault injection, to confirm the guard is still load-bearing rather than merely quiet: removing the surviving `Edit(file_path=...)` rule from `.claude/settings.json` drives the probe red with `REGRESSION: permissions.deny is missing 'Edit(file_path=**/.config/**)'`; restored immediately afterward, with a clean `git status` confirming it.
- `.oh/evals/RESULTS.md` is intentionally unchanged. It already records `operator-config-guard` as `PASS`, which is the state CI will now observe. A local suite run reports unrelated failures caused by this container's environment (no `python3`, no `cc-safety-net` on `PATH`) rather than by repository state, so regenerating the scoreboard here would corrupt the baseline.

## Checklist

- [x] Base branch is `development`
- [x] Title is `FROM <source-branch> TO <target-branch>`
- [x] Closing keyword links every issue this PR completes
- [x] `CHANGELOG.md` has an `## [Unreleased]` entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018hyGq8qEWaHV4u1dpSagHp
