### PR TITLE
FROM bug/994-publish-registry-lag TO development

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -51,7 +51,7 @@ jobs:
         run: |
           V=$(node -p "require('./.oh/cli/package.json').version")
           echo "version=$V" >> "$GITHUB_OUTPUT"
-          if npm view "@mifune/agro@$V" version >/dev/null 2>&1; then
+          if npm view "@mifune/agro@$V" version --prefer-online >/dev/null 2>&1; then
             echo "@mifune/agro@$V already published — skipping"
             echo "skip=true" >> "$GITHUB_OUTPUT"
           else
@@ -90,7 +90,7 @@ jobs:
             echo "@mifune/openharness@$LEGACY_V pins @mifune/agro@$PIN — both must equal @mifune/agro@$V" >&2
             exit 1
           fi
-          if npm view "@mifune/openharness@$V" version >/dev/null 2>&1; then
+          if npm view "@mifune/openharness@$V" version --prefer-online >/dev/null 2>&1; then
             echo "@mifune/openharness@$V already published — skipping"
             echo "skip=true" >> "$GITHUB_OUTPUT"
           else
@@ -102,17 +102,7 @@ jobs:
         if: steps.legacy_guard.outputs.skip == 'false'
         env:
           V: ${{ steps.guard.outputs.version }}
-        run: |
-          for attempt in $(seq 1 10); do
-            if npm view "@mifune/agro@$V" version >/dev/null 2>&1; then
-              echo "@mifune/agro@$V resolves on the registry (attempt $attempt)"
-              exit 0
-            fi
-            echo "@mifune/agro@$V not yet resolvable (attempt $attempt/10); retrying in 15s"
-            sleep 15
-          done
-          echo "@mifune/agro@$V never resolved on the registry — cannot publish the dependent @mifune/openharness shim" >&2
-          exit 1
+        run: .oh/scripts/npm-wait-version.sh "@mifune/agro" "$V"
 
       - name: Publish @mifune/openharness to npm
         if: steps.legacy_guard.outputs.skip == 'false'
@@ -127,4 +117,12 @@ jobs:
         env:
           V: ${{ steps.guard.outputs.version }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm deprecate "@mifune/openharness@$V" "@mifune/openharness is the compatibility entry point for AGRO; install @mifune/agro (agro) — oh keeps working through the compatibility window"
+        run: |
+          .oh/scripts/npm-wait-version.sh "@mifune/openharness" "$V"
+          npm deprecate "@mifune/openharness@$V" "@mifune/openharness is the compatibility entry point for AGRO; install @mifune/agro (agro) — oh keeps working through the compatibility window"
+          DEPRECATED=$(npm view "@mifune/openharness@$V" deprecated --prefer-online --cache "$(mktemp -d)")
+          if [ -z "$DEPRECATED" ]; then
+            echo "@mifune/openharness@$V carries no deprecation notice after npm deprecate" >&2
+            exit 1
+          fi
+          echo "@mifune/openharness@$V is deprecated: $DEPRECATED"

--- a/.oh/scripts/__tests__/npm-wait-version.test.ts
+++ b/.oh/scripts/__tests__/npm-wait-version.test.ts
@@ -1,0 +1,114 @@
+import { spawnSync } from "node:child_process";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const ROOT = join(import.meta.dirname, "../../..");
+const SCRIPT = join(ROOT, ".oh", "scripts", "npm-wait-version.sh");
+const PACKAGE = "@mifune/agro";
+const VERSION = "0.9.0";
+
+let fixture = "";
+let bin = "";
+let callLog = "";
+
+function fakeNpm(failures: number) {
+  const npm = join(bin, "npm");
+  writeFileSync(
+    npm,
+    [
+      "#!/usr/bin/env bash",
+      "set -euo pipefail",
+      `printf '%s\\n' "$*" >> "${callLog}"`,
+      `calls=$(wc -l < "${callLog}")`,
+      `if [ "$calls" -le ${failures} ]; then exit 1; fi`,
+      `echo "${VERSION}"`,
+    ].join("\n") + "\n",
+    "utf8",
+  );
+  chmodSync(npm, 0o755);
+}
+
+function run(args: string[]) {
+  return spawnSync(SCRIPT, args, {
+    encoding: "utf8",
+    env: { ...process.env, PATH: `${bin}:${process.env.PATH ?? ""}` },
+  });
+}
+
+function calls(): string[][] {
+  return readFileSync(callLog, "utf8")
+    .trimEnd()
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => line.split(" "));
+}
+
+function cacheDirs(recorded: string[][]): string[] {
+  return recorded.map((argv) => argv[argv.indexOf("--cache") + 1]);
+}
+
+beforeEach(() => {
+  fixture = mkdtempSync(join(tmpdir(), "npm-wait-version-"));
+  bin = join(fixture, "bin");
+  callLog = join(fixture, "npm-calls.log");
+  mkdirSync(bin);
+  writeFileSync(callLog, "", "utf8");
+});
+
+afterEach(() => {
+  rmSync(fixture, { recursive: true, force: true });
+});
+
+describe("npm-wait-version.sh", () => {
+  it("retries past cached-404 territory with a fresh cache per attempt and reports the attempt", () => {
+    fakeNpm(3);
+    const result = run([PACKAGE, VERSION, "6", "0"]);
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain(`${PACKAGE}@${VERSION} resolves on the registry (attempt 4)`);
+    expect(result.stdout).toContain(`${PACKAGE}@${VERSION} not yet resolvable (attempt 3/6); retrying in 0s`);
+
+    const recorded = calls();
+    expect(recorded).toHaveLength(4);
+    for (const argv of recorded) {
+      expect(argv.slice(0, 3)).toEqual(["view", `${PACKAGE}@${VERSION}`, "version"]);
+      expect(argv).toContain("--prefer-online");
+      expect(argv).toContain("--cache");
+    }
+    const dirs = cacheDirs(recorded);
+    expect(new Set(dirs).size).toBe(4);
+    for (const dir of dirs) {
+      expect(dir).not.toBe("");
+      expect(dir).not.toBe(process.env.HOME);
+    }
+  });
+
+  it("fails after the attempt cap without a hidden extra call", () => {
+    fakeNpm(100);
+    const result = run([PACKAGE, VERSION, "3", "0"]);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(`${PACKAGE}@${VERSION} did not resolve after 3 attempts`);
+    expect(result.stdout).not.toContain("resolves on the registry");
+    expect(calls()).toHaveLength(3);
+  });
+
+  it("defaults to 20 attempts and 15 second intervals", () => {
+    const source = readFileSync(SCRIPT, "utf8");
+    expect(source).toContain("ATTEMPTS=${3:-20}");
+    expect(source).toContain("INTERVAL=${4:-15}");
+    expect(source).toContain('npm view "$SPEC" version --prefer-online --cache "$cache"');
+  });
+
+  it("rejects a malformed invocation before calling npm", () => {
+    fakeNpm(0);
+    for (const args of [[], [PACKAGE], [PACKAGE, VERSION, "0", "0"], [PACKAGE, VERSION, "1", "x"], ["", VERSION]]) {
+      const result = run(args);
+      expect(result.status, args.join(" ")).toBe(64);
+      expect(result.stderr).toContain("usage: npm-wait-version.sh");
+    }
+    expect(calls()).toHaveLength(0);
+  });
+});

--- a/.oh/scripts/__tests__/release-reservation.test.ts
+++ b/.oh/scripts/__tests__/release-reservation.test.ts
@@ -458,6 +458,20 @@ describe("CLI publication workflow contract", () => {
       'npm deprecate "@mifune/openharness@$V" "@mifune/openharness is the compatibility entry point for AGRO; install @mifune/agro (agro) — oh keeps working through the compatibility window"',
     );
     expect(source).toMatch(/Deprecate @mifune\/openharness[\s\S]*?if: steps\.legacy_guard\.outputs\.skip == 'false'/);
+    expect(source).toMatch(
+      /Wait for @mifune\/agro to resolve on the registry\n\s+if: steps\.legacy_guard\.outputs\.skip == 'false'\n\s+env:\n\s+V: \$\{\{ steps\.guard\.outputs\.version \}\}\n\s+run: \.oh\/scripts\/npm-wait-version\.sh "@mifune\/agro" "\$V"\n/,
+    );
+    expect(source).toMatch(
+      /run: \|\n\s+\.oh\/scripts\/npm-wait-version\.sh "@mifune\/openharness" "\$V"\n\s+npm deprecate "@mifune\/openharness@\$V" "@mifune\/openharness is the compatibility entry point for AGRO; install @mifune\/agro \(agro\) — oh keeps working through the compatibility window"\n\s+DEPRECATED=\$\(npm view "@mifune\/openharness@\$V" deprecated --prefer-online --cache "\$\(mktemp -d\)"\)\n\s+if \[ -z "\$DEPRECATED" \]; then\n[\s\S]*?exit 1\n\s+fi\n/,
+    );
+    expect(source.match(/\.oh\/scripts\/npm-wait-version\.sh/g)?.length).toBe(2);
+    expect(source.indexOf('.oh/scripts/npm-wait-version.sh "@mifune/openharness" "$V"')).toBeGreaterThan(legacyPublish);
+    expect(source.indexOf('.oh/scripts/npm-wait-version.sh "@mifune/openharness" "$V"')).toBeLessThan(deprecate);
+    expect(source).toContain('npm view "@mifune/agro@$V" version --prefer-online >/dev/null');
+    expect(source).toContain('npm view "@mifune/openharness@$V" version --prefer-online >/dev/null');
+    expect(source).not.toContain("seq 1 10");
+    expect(source).not.toContain("sleep 15");
+    expect(source).not.toMatch(/Deprecate @mifune\/openharness[\s\S]*?working-directory:/);
     expect(source).toContain("id-token: write");
     expect(source.match(/NODE_AUTH_TOKEN: \$\{\{ secrets\.NPM_TOKEN \}\}/g)?.length).toBe(3);
     expect(source.match(/npm ci/g)?.length).toBe(1);

--- a/.oh/scripts/npm-wait-version.sh
+++ b/.oh/scripts/npm-wait-version.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  echo "usage: npm-wait-version.sh <package> <version> [attempts] [interval-seconds]" >&2
+  exit 64
+}
+
+[[ $# -ge 2 && $# -le 4 ]] || usage
+PACKAGE=$1
+VERSION=$2
+ATTEMPTS=${3:-20}
+INTERVAL=${4:-15}
+[[ -n "$PACKAGE" && -n "$VERSION" ]] || usage
+[[ "$ATTEMPTS" =~ ^[1-9][0-9]*$ && "$INTERVAL" =~ ^[0-9]+$ ]] || usage
+SPEC="$PACKAGE@$VERSION"
+
+for ((attempt = 1; attempt <= ATTEMPTS; attempt++)); do
+  cache=$(mktemp -d)
+  if npm view "$SPEC" version --prefer-online --cache "$cache" >/dev/null 2>&1; then
+    rm -rf "$cache"
+    echo "$SPEC resolves on the registry (attempt $attempt)"
+    exit 0
+  fi
+  rm -rf "$cache"
+  if ((attempt < ATTEMPTS)); then
+    echo "$SPEC not yet resolvable (attempt $attempt/$ATTEMPTS); retrying in ${INTERVAL}s"
+    sleep "$INTERVAL"
+  fi
+done
+
+echo "$SPEC did not resolve after $ATTEMPTS attempts" >&2
+exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Update policy and release automation live in [`/git`](.claude/skills/git/SKILL.m
 
 ## [Unreleased]
 
+### Fixed
+
+- Release publishing waits for npm registry propagation with an uncached `npm view` before publishing the `@mifune/openharness` shim and fails when its deprecation notice is not applied. ([#994](https://github.com/mifunedev/openharness/issues/994))
+
 ## [0.9.0] - 2026-09-06
 
 ### Added


### PR DESCRIPTION
Closes #994.

On the first AGRO release (run 34056149241) the shim wait loop timed out on an already-published `@mifune/agro@0.9.0` because `npm view` reused a cached 404, and `npm deprecate` ran before the shim version resolved and warned with exit 0, so the deprecation was never applied until done by hand.

- New `.oh/scripts/npm-wait-version.sh <package> <version> [attempts=20] [interval=15]`: `npm view --prefer-online --cache "$(mktemp -d)"` per attempt (no cached 404 reused), exit 1 after the cap, exit 64 on misuse; 4 tests with a fake `npm`.
- `publish-cli.yml`: the agro wait and the deprecate step use the script; the deprecate step verifies `npm view … deprecated` is non-empty and fails otherwise; both skip guards use `--prefer-online`.
- `release-reservation.test.ts` pins the new literals and forbids the old loop.

Residual risk, deliberately left loud: if deprecation metadata itself lags, the verification fails the step rather than looping; re-run the job.

Verification: 25 tests green, shellcheck clean, YAML parses, probes `oh-npm-package`, `audit-shellcheck-coverage`, `agro-compat-inventory`, `changelog-entry-length` PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Gh4FRUfcQYD6CcNNH1xRU