### PR TITLE
FROM task/1001-pi-org-banner TO development

### DIFF
--- a/.pi/extensions/__tests__/mifune-banner.test.ts
+++ b/.pi/extensions/__tests__/mifune-banner.test.ts
@@ -49,13 +49,13 @@ describe("mifune-banner extension", () => {
   });
 
   describe("buildHeader", () => {
-    it("includes the ASCII wordmark, social URL, and repo URL", () => {
+    it("includes the ASCII wordmark, social URL, and organization URL", () => {
       const lines = buildHeader(fakeTheme);
       const joined = lines.join("\n");
       expect(lines[0]).toContain("███╗");
       expect(joined).toContain("agent harness");
       expect(joined).toContain("https://x.com/mifunedev");
-      expect(joined).toContain("github.com/ryaneggz/mifune");
+      expect(joined).toContain("https://github.com/mifunedev");
     });
 
     it("uses an ASCII wordmark without emoji or a text divider", () => {
@@ -63,7 +63,7 @@ describe("mifune-banner extension", () => {
       expect(lines).toHaveLength(8);
       expect(lines[0]).toBe("███╗   ███╗██╗███████╗██╗   ██╗███╗   ██╗███████╗");
       expect(lines[6]).toBe("  agent harness · https://x.com/mifunedev");
-      expect(lines[7]).toBe("  https://github.com/ryaneggz/mifune");
+      expect(lines[7]).toBe("  https://github.com/mifunedev");
       expect(lines.join("\n")).not.toContain("-------------------------------");
       expect(lines.join("\n")).not.toContain("⚔");
       expect(lines.join("\n")).not.toContain("🎬");
@@ -81,7 +81,7 @@ describe("mifune-banner extension", () => {
       const wordmarkCalls = calls.slice(0, 6);
       expect(wordmarkCalls).toHaveLength(6);
       expect(wordmarkCalls.every(([role]) => role === "accent")).toBe(true);
-      const linkCalls = calls.filter(([, t]) => t.includes("mifunedev") || t.includes("ryaneggz/mifune"));
+      const linkCalls = calls.filter(([, t]) => t.includes("mifunedev"));
       expect(linkCalls).toHaveLength(2);
       expect(linkCalls.every(([role]) => role === "muted")).toBe(true);
     });

--- a/.pi/extensions/mifune-banner.ts
+++ b/.pi/extensions/mifune-banner.ts
@@ -36,7 +36,7 @@ const WORDMARK_LINES: string[] = [
   "╚═╝     ╚═╝╚═╝╚═╝      ╚═════╝ ╚═╝  ╚═══╝╚══════╝",
 ];
 const TAGLINE = "  agent harness · https://x.com/mifunedev";
-const SOURCE  = "  https://github.com/ryaneggz/mifune";
+const SOURCE  = "  https://github.com/mifunedev";
 
 export function buildHeader(theme: Theme): string[] {
   return [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Update policy and release automation live in [`/git`](.claude/skills/git/SKILL.m
 
 ### Fixed
 
+- Point the pi banner at the Mifune GitHub organization. ([#1001](https://github.com/mifunedev/openharness/issues/1001))
 - Release publishing waits for npm registry propagation with an uncached `npm view` before publishing the `@mifune/openharness` shim and fails when its deprecation notice is not applied. ([#994](https://github.com/mifunedev/openharness/issues/994))
 
 ### Added


### PR DESCRIPTION
Closes #1001

## Summary
- Point the pi banner at the `mifunedev` GitHub organization.
- Update banner tests and changelog.

## Verification
- `/home/sandbox/harness/node_modules/.bin/vitest run .pi/extensions/__tests__/mifune-banner.test.ts`