### PR TITLE
FROM bug/1021-sandbox-install-idempotent TO development

### DIFF
--- a/.agro/cli/src/__tests__/sandbox.test.ts
+++ b/.agro/cli/src/__tests__/sandbox.test.ts
@@ -266,6 +266,245 @@ describe("oh sandbox install — the entry it writes", () => {
   });
 });
 
+describe("oh sandbox install — re-installing an existing name", () => {
+  it("preserves the saved timezone, docker socket and git identity", async () => {
+    const registryPath = registry();
+    const { run } = makeRunner();
+    const { io } = makeIo(["box", "Europe/Berlin", "Ada", "ada@example.com", "n", "y"]);
+
+    expect(await runSandboxInstall({ runtime: "docker", run }, io)).toBe(0);
+    const entry = join(registryPath, "box", "agro.json");
+    expect(readJson(entry)).toMatchObject({
+      timezone: "Europe/Berlin",
+      git: { userName: "Ada", userEmail: "ada@example.com" },
+      access: { dockerSocket: true },
+    });
+
+    expect(
+      await runSandboxInstall({ runtime: "docker", name: "box", yes: true, run }, makeIo().io),
+    ).toBe(0);
+    expect(readJson(entry)).toMatchObject({
+      name: "box",
+      timezone: "Europe/Berlin",
+      git: { userName: "Ada", userEmail: "ada@example.com" },
+      access: { dockerSocket: true },
+    });
+  });
+
+  it("keeps DOCKER_SOCKET and TZ in the compose env the recreated container gets", async () => {
+    registry();
+    const rendered: string[] = [];
+    const run: LifecycleRunner = (cmd, args) => {
+      if (cmd === "git") return { status: 0, stdout: "" };
+      const i = args.indexOf("--extra-env-file");
+      if (i !== -1) rendered.push(readFileSync(args[i + 1], "utf8"));
+      return { status: 0 };
+    };
+    const { io } = makeIo(["box", "Europe/Berlin", "", "", "n", "y"]);
+
+    expect(await runSandboxInstall({ runtime: "docker", run }, io)).toBe(0);
+    rendered.length = 0;
+
+    expect(
+      await runSandboxInstall({ runtime: "docker", name: "box", yes: true, run }, makeIo().io),
+    ).toBe(0);
+    expect(rendered.join("")).toContain("DOCKER_SOCKET=true");
+    expect(rendered.join("")).toContain("TZ=Europe/Berlin");
+  });
+
+  it("preserves the ssh port, home path, repo and every other config-set field", async () => {
+    const registryPath = registry();
+    const checkout = mkdtempSync(join(tmpdir(), "oh-sandbox-repo-"));
+    cleanups.push(checkout);
+    const { run } = makeRunner();
+
+    expect(
+      await runSandboxInstall(
+        { runtime: "docker", name: "box", repo: checkout, yes: true, run },
+        makeIo().io,
+      ),
+    ).toBe(0);
+
+    const entry = join(registryPath, "box", "agro.json");
+    const saved = readJson(entry);
+    writeFileSync(
+      entry,
+      `${JSON.stringify({
+        ...saved,
+        access: { ssh: true, sshPort: 2345, sshPasswordAuth: true, dockerSocket: true },
+        storage: { homePath: "/srv/oh-home" },
+        hermesDashboard: { enabled: true, port: 9200 },
+        cron: { agentBin: "codex" },
+        build: { skipPnpmInstall: true },
+        cloud: { apiUrl: "https://cloud.example.test" },
+        langfuse: { baseUrl: "https://lf.example.test", privacyPreset: "prompts-only" },
+        composeOverrides: ["docker-compose.extra.yml"],
+      })}\n`,
+    );
+
+    expect(
+      await runSandboxInstall({ runtime: "docker", name: "box", yes: true, run }, makeIo().io),
+    ).toBe(0);
+    expect(readJson(entry)).toMatchObject({
+      repo: checkout,
+      access: { ssh: true, sshPort: 2345, sshPasswordAuth: true, dockerSocket: true },
+      storage: { homePath: "/srv/oh-home" },
+      hermesDashboard: { enabled: true, port: 9200 },
+      cron: { agentBin: "codex" },
+      build: { skipPnpmInstall: true },
+      cloud: { apiUrl: "https://cloud.example.test" },
+      langfuse: { baseUrl: "https://lf.example.test", privacyPreset: "prompts-only" },
+      composeOverrides: ["docker-compose.extra.yml"],
+      image: { mode: "build" },
+    });
+  });
+
+  it("preserves image.ref and image.pullPolicy across a recycle", async () => {
+    const registryPath = registry();
+    const { run } = makeRunner();
+
+    expect(
+      await runSandboxInstall(
+        { runtime: "docker", name: "box", yes: true, imageRef: "example.test/img:1", run },
+        makeIo().io,
+      ),
+    ).toBe(0);
+    expect(
+      await runSandboxInstall({ runtime: "docker", name: "box", yes: true, run }, makeIo().io),
+    ).toBe(0);
+    expect(readJson(join(registryPath, "box", "agro.json"))).toMatchObject({
+      image: { ref: "example.test/img:1", mode: "image", pullPolicy: "missing" },
+    });
+  });
+
+  it("still lets an explicit --image=<ref> override the preserved image ref", async () => {
+    const registryPath = registry();
+    const { run } = makeRunner();
+
+    expect(
+      await runSandboxInstall(
+        { runtime: "docker", name: "box", yes: true, imageRef: "example.test/img:1", run },
+        makeIo().io,
+      ),
+    ).toBe(0);
+    expect(
+      await runSandboxInstall(
+        { runtime: "docker", name: "box", yes: true, imageRef: "example.test/img:2", run },
+        makeIo().io,
+      ),
+    ).toBe(0);
+    expect(readJson(join(registryPath, "box", "agro.json"))).toMatchObject({
+      image: { ref: "example.test/img:2" },
+    });
+  });
+
+  it("offers the preserved value as the wizard default and still lets an answer override it", async () => {
+    const registryPath = registry();
+    const { run } = makeRunner();
+    const entry = join(registryPath, "box", "agro.json");
+
+    expect(
+      await runSandboxInstall(
+        { runtime: "docker", run },
+        makeIo(["box", "Europe/Berlin", "Ada", "ada@example.com", "n", "y"]).io,
+      ),
+    ).toBe(0);
+
+    const { asked, io } = makeIo(["", "Asia/Tokyo", "", "", "", ""]);
+    expect(await runSandboxInstall({ runtime: "docker", name: "box", run }, io)).toBe(0);
+
+    expect(asked[1]).toContain("[Europe/Berlin]");
+    expect(asked[2]).toContain("[Ada]");
+    expect(asked[5]).toContain("[Y/n]");
+    expect(readJson(entry)).toMatchObject({
+      name: "box",
+      timezone: "Asia/Tokyo",
+      git: { userName: "Ada", userEmail: "ada@example.com" },
+      access: { dockerSocket: true },
+    });
+  });
+
+  it("lets a --repo seed override the existing entry", async () => {
+    const registryPath = registry();
+    const checkout = mkdtempSync(join(tmpdir(), "oh-sandbox-repo-"));
+    cleanups.push(checkout);
+    const { run } = makeRunner();
+    const { io } = makeIo(["box", "Europe/Berlin", "", "", "n", "y"]);
+
+    expect(await runSandboxInstall({ runtime: "docker", run }, io)).toBe(0);
+    writeFileSync(
+      join(checkout, "agro.json"),
+      `${JSON.stringify({ version: 1, timezone: "Asia/Tokyo" })}\n`,
+    );
+
+    expect(
+      await runSandboxInstall(
+        { runtime: "docker", name: "box", repo: checkout, yes: true, run },
+        makeIo().io,
+      ),
+    ).toBe(0);
+    expect(readJson(join(registryPath, "box", "agro.json"))).toMatchObject({
+      timezone: "Asia/Tokyo",
+      access: { dockerSocket: true },
+    });
+  });
+
+  it("a first install with no entry of its own is unaffected by another sandbox", async () => {
+    const registryPath = registry();
+    const { run } = makeRunner();
+    const { io } = makeIo(["saved", "Europe/Berlin", "", "", "n", "y"]);
+
+    expect(await runSandboxInstall({ runtime: "docker", run }, io)).toBe(0);
+    expect(
+      await runSandboxInstall({ runtime: "docker", name: "fresh", yes: true, run }, makeIo().io),
+    ).toBe(0);
+
+    expect(readJson(join(registryPath, "fresh", "agro.json"))).toMatchObject({
+      name: "fresh",
+      timezone: "UTC",
+      git: { userName: "Ada Lovelace", userEmail: "Ada Lovelace" },
+      access: { ssh: false, sshPort: 2222, dockerSocket: false },
+      image: { mode: "image" },
+    });
+  });
+
+  it("drops retired and secret keys carried by a stale entry", async () => {
+    const registryPath = registry();
+    const { run } = makeRunner();
+    const root = join(registryPath, "box");
+    mkdirSync(root, { recursive: true });
+    writeFileSync(
+      join(root, "agro.json"),
+      `${JSON.stringify({
+        version: 1,
+        name: "box",
+        runtime: "docker",
+        timezone: "Europe/Berlin",
+        WORKTREES_DIR: "/srv/worktrees",
+        INSTALL_TAILSCALE: true,
+        SANDBOX_SSH_AUTHORIZED_KEYS: "ssh-ed25519 AAAA",
+        LANGFUSE_PRIVACY_PRESET: "full-debug",
+        GH_TOKEN: "ghp_stale",
+      })}\n`,
+    );
+
+    expect(
+      await runSandboxInstall({ runtime: "docker", name: "box", yes: true, run }, makeIo().io),
+    ).toBe(0);
+    const config = readJson(join(root, "agro.json"));
+    expect(config).toMatchObject({ timezone: "Europe/Berlin" });
+    for (const key of [
+      "WORKTREES_DIR",
+      "INSTALL_TAILSCALE",
+      "SANDBOX_SSH_AUTHORIZED_KEYS",
+      "LANGFUSE_PRIVACY_PRESET",
+      "GH_TOKEN",
+    ]) {
+      expect(config[key], key).toBeUndefined();
+    }
+  });
+});
+
 describe("oh sandbox install — the wizard", () => {
   it("asks exactly six questions in order and writes the answers", async () => {
     const registryPath = registry();

--- a/.agro/cli/src/commands/sandbox.ts
+++ b/.agro/cli/src/commands/sandbox.ts
@@ -5,6 +5,8 @@ import { resolveExecutionTarget } from "../lib/execution/index.js";
 import { spawnRunner, type LifecycleRunner } from "../lib/execution/runner.js";
 import {
   defaultOhConfig,
+  getOhConfigValue,
+  OH_CONFIG_FIELDS,
   ohConfigPath,
   readOhConfig,
   writeOhConfig,
@@ -66,26 +68,61 @@ function readSeedConfig(repo: string | undefined): OhConfig | undefined {
   return existsSync(file) ? readOhConfig(file) : undefined;
 }
 
+function readEntryConfig(name: string): OhConfig | undefined {
+  const file = ohConfigPath(entryRoot(name));
+  return existsSync(file) ? readOhConfig(file) : undefined;
+}
+
+function assignSetting(target: OhConfig, path: string, value: unknown): void {
+  const segments = path.split(".");
+  let cursor = target as unknown as Record<string, unknown>;
+  for (const segment of segments.slice(0, -1)) {
+    const section = cursor[segment];
+    if (!section || typeof section !== "object" || Array.isArray(section)) cursor[segment] = {};
+    cursor = cursor[segment] as Record<string, unknown>;
+  }
+  cursor[segments[segments.length - 1]] = value;
+}
+
+function overlaySettings(target: OhConfig, source: OhConfig | undefined): OhConfig {
+  if (source === undefined) return target;
+  for (const field of OH_CONFIG_FIELDS) {
+    const value = getOhConfigValue(source, field.path);
+    if (value !== undefined) assignSetting(target, field.path, value);
+  }
+  return target;
+}
+
+function mergeSettings(...sources: (OhConfig | undefined)[]): OhConfig | undefined {
+  const present = sources.filter((source): source is OhConfig => source !== undefined);
+  if (present.length === 0) return undefined;
+  const merged: OhConfig = { version: 1 };
+  for (const source of present) overlaySettings(merged, source);
+  return merged;
+}
+
+function nonEmpty(value: string | undefined): string | undefined {
+  return value === undefined || value === "" ? undefined : value;
+}
+
 function seedConfig(
   name: string,
   repo: string | undefined,
   seed: OhConfig | undefined,
   run: LifecycleRunner,
 ): OhConfig {
-  const config = defaultOhConfig(name);
+  const config = overlaySettings(defaultOhConfig(name), seed);
+  config.name = name;
   config.runtime = "docker";
   if (repo !== undefined) config.repo = repo;
-  config.timezone = seed?.timezone ?? hostTimezone();
+  config.timezone = nonEmpty(seed?.timezone) ?? hostTimezone();
   config.git = {
-    userName: seed?.git?.userName ?? gitIdentity(run, "user.name"),
-    userEmail: seed?.git?.userEmail ?? gitIdentity(run, "user.email"),
+    userName: nonEmpty(seed?.git?.userName) ?? gitIdentity(run, "user.name"),
+    userEmail: nonEmpty(seed?.git?.userEmail) ?? gitIdentity(run, "user.email"),
   };
-  if (seed?.storage?.homePath !== undefined) config.storage = { homePath: seed.storage.homePath };
-  config.access = { ...config.access, ...(seed?.access ?? {}) };
   config.image = {
     ...config.image,
-    ...(seed?.image ?? {}),
-    mode: seed?.image?.mode ?? (repo === undefined ? "image" : "build"),
+    mode: seed?.image?.mode ?? (config.repo === undefined ? "image" : "build"),
   };
   return config;
 }
@@ -163,8 +200,8 @@ export async function runSandboxInstall(
     return 1;
   }
 
-  const seed = readSeedConfig(repo);
-  const name = opts.name ?? seed?.name ?? nextDefaultName(run);
+  const repoSeed = readSeedConfig(repo);
+  const name = opts.name ?? repoSeed?.name ?? nextDefaultName(run);
   try {
     assertSandboxName(name);
   } catch (error) {
@@ -172,7 +209,7 @@ export async function runSandboxInstall(
     return 1;
   }
 
-  const config = seedConfig(name, repo, seed, run);
+  const config = seedConfig(name, repo, mergeSettings(readEntryConfig(name), repoSeed), run);
   const interactive =
     opts.yes !== true && (process.stdin.isTTY === true || io.ask !== undefined);
   if (interactive) {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Update policy and release automation live in [`/git`](.claude/skills/git/SKILL.m
 - Require verified dependency acceptance and safe resume eligibility before dispatching delegated work. ([#1004](https://github.com/mifunedev/openharness/pull/1004))
 - Point the pi banner at the Mifune GitHub organization. ([#1001](https://github.com/mifunedev/openharness/issues/1001))
 - Release publishing waits for npm registry propagation with an uncached `npm view` before publishing the `@mifune/openharness` shim and fails when its deprecation notice is not applied. ([#994](https://github.com/mifunedev/openharness/issues/994))
+- Preserve an existing sandbox's configuration when `agro sandbox install` runs again, so a reinstall no longer discards settings such as a pinned `storage.homePath`. ([#1021](https://github.com/mifunedev/agro/issues/1021))
 
 ### Added
 


### PR DESCRIPTION
Closes mifunedev/agro#1021. `Refs mifunedev/openharness-cloud#146` — **no closing trailer for mifunedev/openharness-cloud#146 or mifunedev/agro#939**; Phase 4 is partial (10 of 12 stories) and both stay open.

## The defect

`agro sandbox install docker` was not idempotent. Re-running it against an existing sandbox seeded a fresh config from `defaultOhConfig(name)` and overlaid only a handful of fields from the repo-side seed file. The entry's **own** existing config was never read, so every setting outside that handful reverted to defaults.

The sharp case is a node: the bootstrap sets `storage.homePath` to pin the durable `/home/sandbox` mount, and a later `agro sandbox install` silently unpinned it. That is how this was found — while migrating the Cloud consumer (#944), whose node bootstrap depends on that pin surviving.

A second defect in the same path: empty strings were treated as present. A seed carrying `timezone: ""` or an empty git identity overrode the host-derived value with nothing instead of falling back.

## The fix

- `readEntryConfig(name)` reads the sandbox's own config, and `mergeSettings` merges it **ahead of** the repo seed, so the entry wins and the seed only fills gaps.
- The merge walks `OH_CONFIG_FIELDS` field by field rather than shallow-spreading, so nested sections (`storage`, `access`, `image`) survive instead of being replaced wholesale.
- `nonEmpty()` makes an empty string absent, restoring the host-derived fallback.
- `CHANGELOG.md` gains the required `### Fixed` entry for this user-visible change, linked to mifunedev/agro#1021.
- The image `mode` default derives from the **merged** repo rather than the raw argument, so it stays consistent with the config actually being written.

## Test evidence — exact head `b17d4d35d72ca4153ca00665928d439d09c64db1`

| Check | Result |
|---|---|
| `pnpm typecheck` (`tsc --noEmit`) | exit 0, no output |
| `.agro/cli/src/__tests__/sandbox.test.ts` | **26 passed**, 0 failed (9 added by this change) |
| `pnpm test` (full vitest suite) | 1255 passed, **2 failed**, 74 files |

### About those 2 failures — pre-existing and environmental, not caused by this change

Both are in `.agro/cli/src/commands/__tests__/migrate-rehearsal.test.ts`, a file this branch does not touch.

**Reproduced on a clean checkout of the base commit `b10ecac3` with none of this branch's changes applied: the identical 2 failures occur.** So this branch introduces no regression.

Root cause: the test gates on `dockerComposeAvailable()`, which runs `docker compose version`. That probes the **Compose plugin binary**, which is present, rather than **daemon reachability**, which is not — this environment has the `docker` CLI but no `/var/run/docker.sock`. The gate therefore takes the "Docker is available" branch and asserts `ps.status === 0`, while the command underneath legitimately fails without a daemon.

That is a defect in the test's availability probe, not in the product, and it is out of scope here. Worth a separate issue if it recurs in CI.

## CI at this exact head

| Check | Result |
|---|---|
| Lint, Typecheck, Build & Test | success |
| Eval Probe Regression Gate | success |
| Boot Path Lint (shellcheck + hadolint) | success |
| Validate sandbox compose and image build | success |
| Boot a legacy volume against the fresh image | success |

### Correction to an earlier version of this description

An earlier version of this body claimed that no CI would run here, citing mifunedev/agro#1020 — an issue I filed asserting that every workflow path filter still named `.oh/**` and therefore matched nothing after the Phase 3 rename.

**That was wrong, and mifunedev/agro#1020 is closed as invalid.** I had grepped a local checkout whose working tree silently reverts tracked files to their pre-AGRO generation, and read it as repository state. `origin/development` names `.agro/**`, `.agro/skills/**`, `.agro/hooks/**`, `.agro/evals/**`, `.agro/knowledge/**`, `agro.json` and `.example.env` throughout, and always did. The five green checks above are the disproof.

## Combined integration with mifunedev/agro#1023 and mifunedev/agro#1024

Merging all three onto `development` in either order produces the **identical tree `314c10a776fdb27e32a7c00b88c57b2fd6a1575b`** with zero conflicts. `CHANGELOG.md` is the one file this PR and mifunedev/agro#1023 share; the entries sit in different hunks of `### Fixed`, so both survive. Combined suite: 1255 passed, 2 failed — the same two pre-existing `migrate-rehearsal` Docker failures described above.

## Not in this PR

No merge, release, or publication. `agro sandbox install` was **not** exercised against a live Docker daemon — the socket is absent from this environment — so the idempotency fix is verified at unit level against the config-seeding logic, not by a real re-install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Gh4FRUfcQYD6CcNNH1xRU
