### PR TITLE
FROM bug/1019-boot-recovery TO development

### DIFF
--- a/.agro/evals/RESULTS.md
+++ b/.agro/evals/RESULTS.md
@@ -114,6 +114,7 @@ probe id; git history is the time series.** Schema and exit-code semantics are i
 | retro-deterministic-contract | A | 2026-09-09 03:51 | PASS | issue #443 — /retro deterministic output and self-contained helper contract |
 | rlm-context-budget | A | 2026-09-09 03:51 | PASS | .agro/tasks/rlm-weighted-trajectories/prd.json US-006 |
 | roles-are-skills | A | 2026-09-09 03:51 | PASS | ADR #929 — roles are behavior, skills encode behavior, agents execute behavior; |
+| sandbox-boot-advisory-recovery | A | 2026-09-09 05:39 | SKIPPED | issue #1019 — GHSA-82fw-gwwq-j7x9 turned the 0.9.0 manifest's `pnpm:devPreinstall` audit |
 | sandbox-boot-guard-ci | A | 2026-09-09 03:51 | PASS | issue #449 (sandbox image build CI guard) 2026-06-19; |
 | sandbox-node-base | A | 2026-09-09 03:51 | PASS | openharness#878 — oh as the only front door, T0 sandbox base image |
 | sandbox-registry | A | 2026-09-09 03:51 | PASS | issue #950 US-005 / D10 — `oh sandbox install` owns sandbox creation from a |

--- a/.agro/evals/probes/pnpm-audit-ci-gate.sh
+++ b/.agro/evals/probes/pnpm-audit-ci-gate.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 # tier: A
-# source: issue #171 — pnpm security audits must run in CI; #943 — GHSA-82fw-gwwq-j7x9 turned a live `pnpm:devPreinstall` advisory query into a sandbox boot failure
-# desc: string/order guard — the security audit must run only as an explicit CI/release workflow step, before dependency install, and never as an npm/pnpm lifecycle hook that fires on every `pnpm install` (and therefore on every sandbox boot that lacks node_modules)
+# source: issue #171 — pnpm security audits must run in CI; #943 — GHSA-82fw-gwwq-j7x9 turned a live `pnpm:devPreinstall` advisory query into a sandbox boot failure; #1019 — the same class of failure must not recur through a different hook
+# desc: string/order guard — the security audit must run only as an explicit CI/release workflow step, before dependency install, and never as an npm/pnpm lifecycle hook that fires on every `pnpm install` (and therefore on every sandbox boot that lacks node_modules); and no manifest that participates in the boot install may declare ANY install lifecycle hook, so no newly published advisory or other external query can block a sandbox boot
 set -euo pipefail
 
-ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+ROOT="${PNPM_AUDIT_GATE_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)}"
 PACKAGE_JSON="$ROOT/package.json"
 CI_WORKFLOW="$ROOT/.github/workflows/ci-harness.yml"
 RELEASE_WORKFLOW="$ROOT/.github/workflows/release.yml"
@@ -27,7 +27,7 @@ if grep -Fq 'GHSA-h67p-54hq-rp68' "$PACKAGE_JSON"; then
   exit 1
 fi
 
-HOOK_NAMES=(preinstall postinstall prepare pnpm:devPreinstall pnpm:devPrepare)
+HOOK_NAMES=(preinstall install postinstall prepare pnpm:devPreinstall pnpm:devPrepare)
 
 mapfile -t PACKAGE_JSONS < <(git -C "$ROOT" ls-files -- '*package.json')
 
@@ -62,6 +62,60 @@ for rel in "${PACKAGE_JSONS[@]}"; do
   fi
 done
 
+WORKSPACE_YAML="$ROOT/pnpm-workspace.yaml"
+BOOT_INSTALL_MANIFESTS=("package.json")
+if [[ -f "$WORKSPACE_YAML" ]]; then
+  shopt -s nullglob globstar
+  while IFS= read -r pattern; do
+    pattern="${pattern#./}"
+    pattern="${pattern%/}"
+    [[ -n "$pattern" ]] || continue
+    case "$pattern" in /*|../*|*/../*) continue ;; esac
+    for candidate in "$ROOT"/$pattern/package.json "$ROOT"/$pattern; do
+      [[ -f "$candidate" && "$candidate" == *package.json ]] || continue
+      BOOT_INSTALL_MANIFESTS+=("${candidate#"$ROOT"/}")
+    done
+  done < <(sed -n '/^packages:/,/^[^ -]/p' "$WORKSPACE_YAML" \
+    | sed -n "s/^[[:space:]]*-[[:space:]]*['\"]\{0,1\}\([^'\"]*\)['\"]\{0,1\}[[:space:]]*$/\1/p")
+  shopt -u nullglob globstar
+fi
+
+for rel in "${BOOT_INSTALL_MANIFESTS[@]}"; do
+  pkg="$ROOT/$rel"
+  [[ -f "$pkg" ]] || continue
+
+  hit="$(node -e '
+    const fs = require("fs");
+    const hookNames = process.argv.slice(2);
+    let pkg;
+    try {
+      pkg = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+    } catch (e) {
+      process.exit(0);
+    }
+    const scripts = pkg.scripts || {};
+    for (const name of hookNames) {
+      if (typeof scripts[name] === "string") {
+        console.log(name + "=" + scripts[name]);
+      }
+    }
+  ' "$pkg" "${HOOK_NAMES[@]}")"
+
+  if [[ -n "$hit" ]]; then
+    while IFS= read -r line; do
+      [[ -n "$line" ]] || continue
+      echo "REGRESSION: $rel takes part in the sandbox boot's \`pnpm install\`, so its lifecycle hook $line runs on every cold boot and any failure inside it aborts the boot — move the work to an explicit CI/release step" >&2
+      exit 1
+    done <<<"$hit"
+  fi
+done
+
+CLI_INSTALL_EXPECTED='npm --prefix .agro/cli ci --ignore-scripts'
+if grep -Fq 'npm --prefix .agro/cli ci' "$PACKAGE_JSON" && ! grep -Fq "$CLI_INSTALL_EXPECTED" "$PACKAGE_JSON"; then
+  echo "REGRESSION: package.json installs .agro/cli without --ignore-scripts — that manifest's prepare hook would then run from a root-driven install" >&2
+  exit 1
+fi
+
 node - "$CI_WORKFLOW" "$RELEASE_WORKFLOW" <<'NODE'
 const fs = require('fs');
 let failed = false;
@@ -90,4 +144,4 @@ if ! grep -qE 'pnpm/action-setup@v[0-9]+' "$CI_WORKFLOW"; then
   exit 1
 fi
 
-echo "PASS: pnpm audit runs only as an explicit CI/release step before install, and no package.json lifecycle hook invokes it" >&2
+echo "PASS: pnpm audit runs only as an explicit CI/release step before install, no package.json lifecycle hook invokes it, and no manifest that takes part in the sandbox boot install declares any lifecycle hook that a live external query could fail" >&2

--- a/.agro/evals/probes/sandbox-boot-advisory-recovery.sh
+++ b/.agro/evals/probes/sandbox-boot-advisory-recovery.sh
@@ -1,0 +1,348 @@
+#!/usr/bin/env bash
+# tier: A
+# source: issue #1019 — GHSA-82fw-gwwq-j7x9 turned the 0.9.0 manifest's `pnpm:devPreinstall` audit
+#         into a permanent boot failure for every workspace volume already seeded from that image
+# desc: the documented population-B recovery still holds — a failed bootstrap oneshot leaves the
+#       container running and exec-reachable, deleting the seeded manifest's pnpm:devPreinstall hook
+#       and restarting the container returns openharness-bootstrap.service to active, and the harness
+#       checkout's uncommitted change, control-plane task folder, gh credentials and 0600 .env survive
+set -euo pipefail
+
+ROOT="${BOOT_RECOVERY_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)}"
+DOC="$ROOT/docs/repair-sandbox-boot-advisory.md"
+ENTRYPOINT="$ROOT/.devcontainer/entrypoint.sh"
+UNIT="$ROOT/.devcontainer/openharness-bootstrap.service"
+COMPOSE_FILE="$ROOT/.devcontainer/docker-compose.image-only.yml"
+
+SYMPTOM='pnpm install failed — see /tmp/pnpm-install.log; aborting sandbox boot'
+HOOK_DELETE='jq --indent 2 '\''del(.scripts["pnpm:devPreinstall"])'\'' package.json'
+
+LEGACY_IMAGE="${LEGACY_IMAGE:-ghcr.io/mifunedev/openharness:0.9.0}"
+LIVE="${SANDBOX_BOOT_RECOVERY_LIVE:-0}"
+TIMEOUT="${SANDBOX_BOOT_RECOVERY_TIMEOUT_SECONDS:-600}"
+INTERVAL="${SANDBOX_BOOT_RECOVERY_INTERVAL_SECONDS:-5}"
+
+for file in "$DOC" "$ENTRYPOINT" "$UNIT" "$COMPOSE_FILE"; do
+  [[ -f "$file" ]] || { echo "SKIPPED: required file absent: $file" >&2; exit 2; }
+done
+
+fails=()
+
+grep -Fq -- "$SYMPTOM" "$ENTRYPOINT" \
+  || fails+=("entrypoint.sh no longer prints the exact abort line the runbook tells users to recognise")
+grep -Fq -- "$SYMPTOM" "$DOC" \
+  || fails+=("the runbook must quote entrypoint.sh's abort line verbatim, or the failure is unrecognisable from what a user sees")
+grep -qE '^Type=oneshot$' "$UNIT" \
+  || fails+=("openharness-bootstrap.service is no longer Type=oneshot — a failed boot would stop taking PID 1 down with it, and the recovery vector assumes it does not")
+grep -qE '^RemainAfterExit=yes$' "$UNIT" \
+  || fails+=("openharness-bootstrap.service no longer sets RemainAfterExit=yes")
+grep -Fq -- "$HOOK_DELETE" "$DOC" \
+  || fails+=("the runbook no longer names the exact manifest edit ${HOOK_DELETE}")
+grep -Fq -- 'docker restart <name>' "$DOC" \
+  || fails+=("the runbook no longer names the restart command that re-runs the bootstrap oneshot")
+grep -Fq -- 'cat "$tmp" > package.json' "$DOC" \
+  || fails+=("the runbook must write back through the existing package.json; an mv would replace it with mktemp's 0600 mode and mktemp's ownership")
+grep -Fq -- '[ -f package.json ] && [ ! -L package.json ]' "$DOC" \
+  || fails+=("the runbook no longer refuses a symlinked or non-regular package.json")
+grep -Fq -- "expected='pnpm run security:audit'" "$DOC" \
+  || fails+=("the runbook no longer pins the hook value it is allowed to delete, so it could destroy operator logic combined into that hook")
+grep -Fq -- '[ "$found" = "$expected" ]' "$DOC" \
+  || fails+=("the runbook no longer compares the found hook value against the audit-only value before deleting it")
+grep -Fq -- 'Recovery is **not** automatic' "$DOC" \
+  || fails+=("the runbook must state explicitly that recovery needs operator action rather than arriving with the next image")
+for item in '~/.config/gh' '.env' '0600' 'uncommitted'; do
+  grep -Fqi -- "$item" "$DOC" \
+    || fails+=("the runbook no longer records preservation of $item")
+done
+
+report_structural() {
+  if (( ${#fails[@]} )); then
+    echo "REGRESSION: sandbox advisory-boot recovery contract broken:" >&2
+    printf '  - %s\n' "${fails[@]}" >&2
+    exit 1
+  fi
+}
+
+if [[ "$LIVE" != "1" ]]; then
+  report_structural
+  echo "SKIPPED: structural half passed; the boot-and-recover half needs a real sandbox boot, which does not fit the eval runner's 30s per-probe cap — run it with SANDBOX_BOOT_RECOVERY_LIVE=1" >&2
+  exit 2
+fi
+
+if ! command -v docker >/dev/null 2>&1 || ! docker compose version >/dev/null 2>&1; then
+  report_structural
+  echo "SKIPPED: SANDBOX_BOOT_RECOVERY_LIVE=1 but docker compose is unavailable — structural half passed, the boot-and-recover half was not run" >&2
+  exit 2
+fi
+
+if ! docker image inspect --format '{{.Id}}' "$LEGACY_IMAGE" >/dev/null 2>&1; then
+  docker pull "$LEGACY_IMAGE" >/dev/null 2>&1 \
+    || { report_structural; echo "SKIPPED: cannot pull $LEGACY_IMAGE — structural half passed, the boot-and-recover half was not run" >&2; exit 2; }
+fi
+
+PROJECT="agro-boot-recovery-$$"
+VOLUME="${PROJECT}_workspace"
+WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/sandbox-boot-advisory-recovery.XXXXXX")"
+: > "$WORKDIR/compose-vars"
+
+compose() {
+  env -u GH_TOKEN \
+    SANDBOX_NAME="$PROJECT" \
+    AGRO_SANDBOX_IMAGE="$LEGACY_IMAGE" \
+    AGRO_PULL_POLICY=missing \
+    AGRO_HOME_MOUNT=workspace \
+    docker compose --project-name "$PROJECT" --env-file "$WORKDIR/compose-vars" -f "$COMPOSE_FILE" "$@"
+}
+
+cleanup() {
+  compose down -v --remove-orphans >/dev/null 2>&1 || true
+  docker volume rm "$VOLUME" >/dev/null 2>&1 || true
+  rm -rf "$WORKDIR"
+}
+trap cleanup EXIT
+
+live_fail() {
+  echo "REGRESSION: $*" >&2
+  if (( ${#fails[@]} )); then printf '  - %s\n' "${fails[@]}" >&2; fi
+  exit 1
+}
+
+docker volume create "$VOLUME" >/dev/null
+
+docker run --rm -i --entrypoint bash -v "$VOLUME:/home/sandbox" "$LEGACY_IMAGE" -s >"$WORKDIR/seed.log" 2>&1 <<'SEED' \
+  || live_fail "could not seed a workspace volume from $LEGACY_IMAGE's published /opt/oh-seed (see $WORKDIR/seed.log)"
+set -eu
+cp -a /opt/home-seed/. /home/sandbox/
+mkdir -p /home/sandbox/harness
+cp -a /opt/oh-seed/. /home/sandbox/harness/
+: > /home/sandbox/harness/.oh/.image-seeded
+export HOME=/home/sandbox
+cd /home/sandbox/harness
+git init -q -b main .
+git -c user.email=probe@example.com -c user.name=probe add -A
+git -c user.email=probe@example.com -c user.name=probe commit -qm "seeded from the published image"
+printf '\nprobe uncommitted edit\n' >> README.md
+tmp=$(mktemp -p .)
+jq --indent 2 '.scripts["my:check"]="./operator-check.sh --strict" | .operatorNote="operator state that must survive"' package.json > "$tmp"
+cat "$tmp" > package.json
+rm -f "$tmp"
+chmod 0644 package.json
+mkdir -p /home/sandbox/harness/.oh/tasks/boot-recovery-probe
+printf 'probe task state\n' > /home/sandbox/harness/.oh/tasks/boot-recovery-probe/notes.md
+mkdir -p /home/sandbox/.config/gh
+printf 'github.com:\n    user: probe-canary\n    oauth_token: gho_PROBE_CANARY\n    git_protocol: https\n' \
+  > /home/sandbox/.config/gh/hosts.yml
+printf 'PROBE_SECRET=probe-canary\n' > /home/sandbox/harness/.env
+chown -R 1000:1000 /home/sandbox
+chmod 0600 /home/sandbox/.config/gh/hosts.yml /home/sandbox/harness/.env
+SEED
+
+volume_snapshot() {
+  docker run --rm -i --entrypoint bash -v "$VOLUME:/home/sandbox" "$LEGACY_IMAGE" -s <<'SNAP'
+set -u
+export HOME=/home/sandbox
+h=$HOME/harness
+gh_hosts=$HOME/.config/gh/hosts.yml
+printf 'readme=%s\n' "$(sha256sum "$h/README.md" | cut -d' ' -f1)"
+printf 'readme_dirty=%s\n' "$(cd "$h" && git status --porcelain -- README.md | tr -d ' \n')"
+printf 'task=%s\n' "$( [ -f "$h/.oh/tasks/boot-recovery-probe/notes.md" ] && sha256sum "$h/.oh/tasks/boot-recovery-probe/notes.md" | cut -d' ' -f1 || echo absent)"
+printf 'gh_token=%s\n' "$( [ -f "$gh_hosts" ] && sed -n 's/^ *oauth_token: //p' "$gh_hosts" | head -1 || echo absent)"
+printf 'gh_user=%s\n' "$( [ -f "$gh_hosts" ] && sed -n 's/^ *user: //p' "$gh_hosts" | head -1 || echo absent)"
+printf 'gh_mode=%s\n' "$( [ -f "$gh_hosts" ] && stat -c '%a' "$gh_hosts" || echo absent)"
+printf 'env=%s\n' "$( [ -f "$h/.env" ] && sha256sum "$h/.env" | cut -d' ' -f1 || echo absent)"
+printf 'env_mode=%s\n' "$( [ -f "$h/.env" ] && stat -c '%a' "$h/.env" || echo absent)"
+printf 'hook=%s\n' "$(node -e 'const p=require("/home/sandbox/harness/package.json");process.stdout.write(p.scripts["pnpm:devPreinstall"]||"absent")')"
+printf 'pkg_mode=%s\n' "$(stat -c '%a' "$h/package.json")"
+printf 'pkg_dirty=%s\n' "$(cd "$h" && git status --porcelain -- package.json | tr -d ' \n')"
+printf 'pkg_custom_script=%s\n' "$(jq -r '.scripts["my:check"] // "absent"' "$h/package.json")"
+printf 'pkg_custom_top=%s\n' "$(jq -r '.operatorNote // "absent"' "$h/package.json")"
+SNAP
+}
+
+value_of() { printf '%s\n' "$1" | sed -n "s/^$2=//p"; }
+
+before="$(volume_snapshot)"
+[[ "$(value_of "$before" hook)" != "absent" ]] \
+  || live_fail "$LEGACY_IMAGE's seeded package.json no longer carries the pnpm:devPreinstall hook — this probe cannot reproduce the failure it guards"
+[[ "$(value_of "$before" pkg_custom_script)" != "absent" && "$(value_of "$before" pkg_custom_top)" != "absent" ]] \
+  || live_fail "the seed did not lay down the operator's custom package.json fields — the hard preservation case would go untested"
+[[ "$(value_of "$before" pkg_mode)" == "644" ]] \
+  || live_fail "the seeded package.json is mode $(value_of "$before" pkg_mode), not 644 — the mode-preservation check would prove nothing"
+
+compose up -d --no-build sandbox >"$WORKDIR/up.log" 2>&1 \
+  || live_fail "could not boot $LEGACY_IMAGE against the seeded volume (see $WORKDIR/up.log)"
+
+wait_for_unit() {
+  local want="$1" end state
+  end=$(( $(date +%s) + TIMEOUT ))
+  while [ "$(date +%s)" -le "$end" ]; do
+    state="$(docker exec "$PROJECT" systemctl is-active openharness-bootstrap.service 2>/dev/null || true)"
+    [[ "$state" == "$want" ]] && return 0
+    [[ "$state" == "failed" || "$state" == "active" ]] && return 1
+    sleep "$INTERVAL"
+  done
+  return 1
+}
+
+wait_for_unit failed \
+  || live_fail "openharness-bootstrap.service did not fail on the seeded 0.9.0 volume — the reproduction this recovery path guards no longer happens, so the recovery is unverified"
+
+[[ "$(docker inspect --format '{{.State.Status}}' "$PROJECT")" == "running" ]] \
+  || live_fail "the container is not running after the bootstrap oneshot failed — the recovery vector assumes the failed boot leaves the container up"
+
+docker exec -u sandbox "$PROJECT" true \
+  || live_fail "docker exec no longer reaches a shell in the failed container — the recovery procedure runs entirely through docker exec"
+
+docker logs "$PROJECT" 2>&1 | grep -aFq -- "$SYMPTOM" \
+  || live_fail "the failed boot did not print the abort line the runbook tells users to recognise"
+
+run_documented_recovery() {
+  docker exec -i -u sandbox "$PROJECT" bash -s <<'RECOVER'
+set -eu
+cd "$HOME/harness"
+expected='pnpm run security:audit'
+[ -f package.json ] && [ ! -L package.json ] || {
+  echo "refusing: $PWD/package.json is not a regular file — resolve that before retrying" >&2; exit 2; }
+found=$(jq -r '.scripts["pnpm:devPreinstall"] // ""' package.json)
+[ -n "$found" ] || {
+  echo "refusing: package.json declares no pnpm:devPreinstall hook — this procedure does not apply" >&2; exit 2; }
+[ "$found" = "$expected" ] || {
+  echo "refusing: pnpm:devPreinstall is '$found', not '$expected' — it carries logic of your own; remove or relocate that yourself" >&2; exit 2; }
+tmp=$(mktemp -p .)
+jq --indent 2 'del(.scripts["pnpm:devPreinstall"])' package.json > "$tmp"
+[ -s "$tmp" ]
+cat "$tmp" > package.json
+rm -f "$tmp"
+RECOVER
+}
+
+manifest_bytes() { docker exec -u sandbox "$PROJECT" cat /home/sandbox/harness/package.json; }
+manifest_meta() { docker exec -u sandbox "$PROJECT" stat -c '%a %U:%G %i' /home/sandbox/harness/package.json; }
+
+docker exec -i -u sandbox "$PROJECT" bash -s <<'SAVE' \
+  || live_fail "could not stash a pristine copy of the manifest before the refusal cases"
+set -eu
+cp -p "$HOME/harness/package.json" /tmp/pkg-pristine.json
+SAVE
+
+manifest_bytes > "$WORKDIR/pkg-pristine.json"
+
+rc=0
+docker exec -i -u sandbox "$PROJECT" bash -s <<'SYMLINK' >/dev/null 2>&1 || rc=$?
+set -eu
+cd "$HOME/harness"
+mv package.json real-manifest.json
+ln -s real-manifest.json package.json
+SYMLINK
+(( rc == 0 )) || live_fail "could not stage the symlink refusal case"
+
+rc=0
+run_documented_recovery >"$WORKDIR/refuse-symlink.log" 2>&1 || rc=$?
+(( rc == 2 )) \
+  || live_fail "the documented block did not refuse a symlinked package.json (exit $rc) — it must not follow the link and write through it"
+grep -Fq 'is not a regular file' "$WORKDIR/refuse-symlink.log" \
+  || live_fail "the symlink refusal did not name the reason (see $WORKDIR/refuse-symlink.log)"
+[[ "$(docker exec "$PROJECT" systemctl is-active openharness-bootstrap.service 2>/dev/null || true)" == "failed" ]] \
+  || live_fail "the bootstrap unit changed state during the symlink refusal case"
+
+rc=0
+docker exec -i -u sandbox "$PROJECT" bash -s <<'UNLINK' >/dev/null 2>&1 || rc=$?
+set -eu
+cd "$HOME/harness"
+rm package.json
+mv real-manifest.json package.json
+UNLINK
+(( rc == 0 )) || live_fail "could not restore the manifest after the symlink refusal case"
+diff -q <(manifest_bytes) "$WORKDIR/pkg-pristine.json" >/dev/null \
+  || live_fail "the symlink refusal case altered the manifest it refused to touch"
+
+rc=0
+docker exec -i -u sandbox "$PROJECT" bash -s <<'COMBINE' >/dev/null 2>&1 || rc=$?
+set -eu
+cd "$HOME/harness"
+tmp=$(mktemp -p .)
+jq --indent 2 '.scripts["pnpm:devPreinstall"]="pnpm run security:audit && ./my-checks.sh"' package.json > "$tmp"
+cat "$tmp" > package.json
+rm -f "$tmp"
+COMBINE
+(( rc == 0 )) || live_fail "could not stage the operator-modified-hook refusal case"
+
+manifest_bytes > "$WORKDIR/pkg-combined.json"
+
+rc=0
+run_documented_recovery >"$WORKDIR/refuse-combined.log" 2>&1 || rc=$?
+(( rc == 2 )) \
+  || live_fail "the documented block did not refuse a pnpm:devPreinstall carrying extra operator logic (exit $rc) — deleting it would destroy the operator's command"
+grep -Fq './my-checks.sh' "$WORKDIR/refuse-combined.log" \
+  || live_fail "the modified-hook refusal did not report the value it found (see $WORKDIR/refuse-combined.log)"
+diff -q <(manifest_bytes) "$WORKDIR/pkg-combined.json" >/dev/null \
+  || live_fail "the modified-hook refusal wrote to package.json instead of leaving it untouched"
+[[ "$(docker exec "$PROJECT" systemctl is-active openharness-bootstrap.service 2>/dev/null || true)" == "failed" ]] \
+  || live_fail "the bootstrap unit changed state during the modified-hook refusal case"
+
+rc=0
+docker exec -i -u sandbox "$PROJECT" bash -s <<'RESTORE' >/dev/null 2>&1 || rc=$?
+set -eu
+cat /tmp/pkg-pristine.json > "$HOME/harness/package.json"
+RESTORE
+(( rc == 0 )) || live_fail "could not restore the pristine manifest after the refusal cases"
+diff -q <(manifest_bytes) "$WORKDIR/pkg-pristine.json" >/dev/null \
+  || live_fail "the manifest was not restored byte-for-byte before the happy path"
+
+meta_before="$(manifest_meta)"
+
+run_documented_recovery >"$WORKDIR/recover.log" 2>&1 \
+  || live_fail "the runbook's manifest edit failed inside the container (see $WORKDIR/recover.log)"
+
+manifest_bytes > "$WORKDIR/pkg-recovered.json"
+meta_after="$(manifest_meta)"
+
+[[ "$meta_after" == "$meta_before" ]] \
+  || fails+=("package.json mode/owner/inode changed across the recovery (before '$meta_before', after '$meta_after')")
+
+mapfile -t pkg_diff < <(diff "$WORKDIR/pkg-pristine.json" "$WORKDIR/pkg-recovered.json" | grep -E '^[<>]' || true)
+if (( ${#pkg_diff[@]} != 1 )) || [[ "${pkg_diff[0]}" != *'"pnpm:devPreinstall"'* ]]; then
+  fails+=("the recovery rewrote more of package.json than the one hook line: ${pkg_diff[*]:-<no diff at all>}")
+fi
+
+docker restart "$PROJECT" >/dev/null \
+  || live_fail "the runbook's restart command failed"
+
+wait_for_unit active \
+  || live_fail "openharness-bootstrap.service did not reach active after the documented recovery — the recovery path is broken"
+
+docker exec "$PROJECT" systemctl is-active --quiet openharness-cron.service \
+  || live_fail "openharness-cron.service is not active after the documented recovery"
+
+after="$(volume_snapshot)"
+
+check_preserved() {
+  local key="$1" label="$2"
+  [[ "$(value_of "$after" "$key")" == "$(value_of "$before" "$key")" ]] \
+    || fails+=("$label changed across the recovery (before '$(value_of "$before" "$key")', after '$(value_of "$after" "$key")')")
+}
+
+check_preserved readme "the harness checkout's uncommitted README.md edit"
+check_preserved readme_dirty "the harness checkout's uncommitted-change status"
+check_preserved task "the control-plane task folder"
+check_preserved gh_token "the gh credential token"
+check_preserved gh_user "the gh credential account"
+check_preserved gh_mode "the gh credential file mode"
+check_preserved env "the .env content"
+check_preserved env_mode "the .env 0600 mode"
+check_preserved pkg_mode "package.json's 0644 mode"
+check_preserved pkg_dirty "package.json's uncommitted-change status"
+check_preserved pkg_custom_script "the operator's own scripts entry in package.json"
+check_preserved pkg_custom_top "the operator's own top-level key in package.json"
+
+[[ "$(value_of "$after" hook)" == "absent" ]] \
+  || fails+=("the pnpm:devPreinstall hook is still present after the documented edit")
+
+if (( ${#fails[@]} )); then
+  echo "REGRESSION: sandbox advisory-boot recovery contract broken:" >&2
+  printf '  - %s\n' "${fails[@]}" >&2
+  exit 1
+fi
+
+echo "PASS: a volume seeded from $LEGACY_IMAGE fails its boot with the documented symptom, stays running and exec-reachable; the documented block refuses a symlinked manifest and a pnpm:devPreinstall carrying operator logic without writing either; and on the audit-only hook it removes exactly that one line, keeping package.json's mode, owner, inode and the operator's own fields, returns openharness-bootstrap.service to active, and leaves the checkout's uncommitted change, task folder, gh credentials and 0600 .env intact" >&2
+exit 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Update policy and release automation live in [`/git`](.claude/skills/git/SKILL.m
 
 ### Fixed
 
+- Document a state-preserving recovery for a workspace volume whose boot aborts on a security advisory; it preserves the manifest's mode and refuses when the hook carries operator logic. ([#1019](https://github.com/mifunedev/agro/issues/1019))
 - Move the dependency security audit to CI-only so a new advisory can no longer block a sandbox boot. ([#943](https://github.com/mifunedev/openharness/issues/943))
 - Require verified dependency acceptance and safe resume eligibility before dispatching delegated work. ([#1004](https://github.com/mifunedev/openharness/pull/1004))
 - Point the pi banner at the Mifune GitHub organization. ([#1001](https://github.com/mifunedev/openharness/issues/1001))
@@ -22,6 +23,7 @@ Update policy and release automation live in [`/git`](.claude/skills/git/SKILL.m
 
 ### Added
 
+- Add the `sandbox-boot-advisory-recovery` probe and extend `pnpm-audit-ci-gate` to forbid every lifecycle hook in the boot install. ([#1019](https://github.com/mifunedev/agro/issues/1019))
 - Add the `advisor-execution-contract` and `plan-orchestration-contract` probes. ([#988](https://github.com/mifunedev/openharness/issues/988))
 - Add the /plan skill to the tracked tree (.oh/skills/plan/SKILL.md) with required bounded-assignment fields. ([#988](https://github.com/mifunedev/openharness/issues/988))
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -69,6 +69,7 @@ Open Harness vendors the shared skills/hooks primitive pack directly into the `.
 - [Security considerations](security-considerations.md)
 - [Open-core boundary](open-core.md)
 - [Repair-operator registry](repair-operator-registry.md)
+- [Repair a sandbox boot blocked by a security advisory](repair-sandbox-boot-advisory.md)
 - [Artifact-contract schema](artifact-contract-schema.md)
 - [Registry portability contract and exception list](../.agro/scripts/registry-portability.md)
 - [`.agro/` directory layout](oh-directory-layout.md)

--- a/docs/release-requirements-1019-boot-fix.md
+++ b/docs/release-requirements-1019-boot-fix.md
@@ -1,0 +1,147 @@
+# Release requirements — issue #1019, population A
+
+This document states requirements for the operator. Nobody has performed them.
+No image was published, no tag was moved, no release was cut, and no CI pin was
+changed as part of the work that produced this document.
+
+Population A is a **new** cold boot that seeds a fresh workspace volume from a
+published image. Only a newly published image fixes it. Population B — a volume
+already seeded from `0.9.0` — is repaired by
+[`repair-sandbox-boot-advisory.md`](repair-sandbox-boot-advisory.md), which is
+verified and needs no release.
+
+## Ground truth this rests on
+
+Every observation below is dated. Tags move; digests do not. Read a claim about
+`latest` as a snapshot, and re-check it before acting on it.
+
+- As of 2026-09-08, `ghcr.io/mifunedev/agro` held exactly two versions, pushed
+  11 seconds apart on 2026-09-06: one tagged `latest`, one tagged `0.9.0` and
+  `sha-823aabbd…`. Both resolved to image id `bbfdaf6bb8ca`, and
+  `ghcr.io/mifunedev/openharness:0.9.0` resolved to it too.
+- That build's `/opt/oh-seed/package.json` carries
+  `"pnpm:devPreinstall": "pnpm run security:audit"` and pins vitest `^3.2.6`.
+  `GHSA-82fw-gwwq-j7x9` covers `>=2.1.0 <4.1.11`, so its boot install fails for
+  as long as that advisory stands. The build itself cannot be edited.
+- The `0.9.0` and `sha-823aabbd…` tags therefore name a build that cannot cold
+  boot. As of 2026-09-08 `latest` named that same build, which is what R1 and
+  R3 exist to change — after the release described here, `latest` is expected to
+  name a working build and these sentences no longer describe it.
+- An image built locally from `development` at `b10ecac3` cold-boots: with no
+  `node_modules` present, `openharness-bootstrap.service` reached
+  `active (exited)` with `status=0/SUCCESS`, and its seeded manifest carries no
+  lifecycle hook and pins vitest `^4.1.11`. That result describes the source
+  revision. It says nothing about the published build, whose layers cannot be
+  edited.
+
+## R1 — Publish a patched image
+
+**Requirement.** Build and publish an image from a source revision whose seeded
+manifest carries no install lifecycle hook and pins vitest `>=4.1.11`.
+
+**Rationale.** The failing manifest is baked into the `0.9.0` build's image
+layers, which cannot be edited. Nothing in source, and no volume-layout trick,
+rewrites them. Only a new build carries a fixed manifest.
+
+**Acceptance.** The published image's `/opt/<seed>/package.json` has no
+`preinstall`, `install`, `postinstall`, `prepare`, `pnpm:devPreinstall`, or
+`pnpm:devPrepare` script, and its vitest pin resolves to `>=4.1.11`.
+
+## R2 — Verify the published artifact, not the source
+
+**Requirement.** After publishing, pull the published tag and cold-boot it
+against an empty workspace volume. Accept only on the observed service state:
+`systemctl is-active openharness-bootstrap.service` returns `active`, and
+`openharness-cron.service` returns `active`.
+
+**Rationale.** A container that is `running` proves nothing. systemd is PID 1
+and the bootstrap unit is a `Type=oneshot`, so a container whose boot failed
+stays `running` and stays `docker exec`-reachable. That property is what makes
+the population-B recovery possible, and it is also what makes "the container is
+up" a worthless acceptance signal.
+
+**Acceptance.** The two `is-active` results above, captured from the pulled
+published tag.
+
+## R3 — Decide whether to supersede or yank `0.9.0`
+
+**Requirement.** Record a deliberate decision. This document does not make it.
+
+**Evidence for superseding** (publish a new version and move `:latest`):
+
+- As of 2026-09-08, `:latest` resolved to the same failing build, so every new
+  user who does not pin was blocked. Moving `:latest` to a fixed build is what
+  unblocks them; re-check what `:latest` resolves to before acting.
+- `ghcr.io/mifunedev/openharness:0.9.0` is referenced by
+  `.agro/scripts/sandbox-upgrade-smoke.sh` (`LEGACY_IMAGE` default), by
+  `.github/workflows/sandbox-boot-guard.yml`, and by
+  `.agro/evals/probes/sandbox-boot-advisory-recovery.sh`. All three source the
+  real published payload from it. Keeping the version keeps those verifiable.
+- A user already running `0.9.0` recovers with the runbook and does not need
+  the version withdrawn.
+
+**Evidence for yanking** (delete the `0.9.0` package version):
+
+- The `0.9.0` build cannot cold-boot, and no republish under that version can
+  change its digest. Leaving it published means a user who pins `0.9.0` gets a
+  failure every time.
+- Yanking removes the source payload that the upgrade smoke and the recovery
+  probe extract. Both would need a replacement fixture, and the recovery
+  procedure would lose the only artifact it is verified against.
+
+## R4 — Decide the `LEGACY_IMAGE` pin in `sandbox-boot-guard.yml`
+
+**Requirement.** Review the pin once a patched image exists and record the
+reason either way. This document does not change the pin and does not choose.
+
+**Evidence for keeping the pin at `0.9.0`:**
+
+- `0.9.0` is the only published image whose seed lays down the legacy `.oh`
+  control plane. Its seed directory is `/opt/oh-seed`.
+- An image built from `development` seeds `/opt/agro-seed` and lays down
+  `.agro`. Moving the pin to such an image changes the upgrade smoke from a
+  `.oh`-to-`.agro` upgrade test into a same-layout test, and silently drops the
+  layout-migration coverage the job exists for.
+- The smoke already neutralises the advisory in its copied manifest, so the
+  broken pin does not block the job.
+
+**Evidence for moving the pin to the patched image:**
+
+- The smoke's header records a coverage reduction: it no longer boots the
+  legacy image, only extracts from it. Pinning a bootable image would let that
+  reduction be reversed.
+- The workaround that deletes `pnpm:devPreinstall` from the copied manifest
+  could then be removed, and the fixture would need no edit at all.
+
+## R5 — Tell users on the affected image what to do
+
+**Requirement.** Publish guidance to users whose volume was seeded from the
+`bbfdaf6bb8ca` build — by the `0.9.0` tag, the `sha-823aabbd…` tag, or by
+`latest` on or before 2026-09-08 — linking
+[`repair-sandbox-boot-advisory.md`](repair-sandbox-boot-advisory.md).
+
+The guidance must state four points, all verified:
+
+1. A failed boot does **not** destroy the workspace. The container stays
+   running and `docker exec` still reaches a shell.
+2. Do not run `agro destroy` and do not delete the volume.
+3. Recovery is not automatic. Pulling the patched image does not repair an
+   existing volume, because an upgrade never rewrites the workspace's own
+   `package.json`. Each affected volume needs the procedure run once.
+4. A fresh sandbox created from the patched image needs nothing.
+
+**Public documentation surface.** Check whether `mifunedev/agro-web` carries
+installation or troubleshooting copy that must match.
+
+## R6 — Optional: wire the recovery probe's live half into CI
+
+**Requirement, if wanted.** `.agro/evals/probes/sandbox-boot-advisory-recovery.sh`
+always runs a structural half. Its boot-and-recover half runs only under
+`SANDBOX_BOOT_RECOVERY_LIVE=1`, because `.agro/skills/eval/run.sh` caps every
+probe at 30 seconds and a real sandbox boot takes about two minutes. A step in
+`sandbox-boot-guard.yml` that sets `SANDBOX_BOOT_RECOVERY_LIVE=1` would exercise
+the whole path. It costs one image pull and one sandbox boot.
+
+**Rationale.** Under the eval suite the probe reports `SKIPPED` for its
+boot-and-recover half, so the recovery path is guarded there only by its
+structural assertions. Nothing in CI currently runs the live half.

--- a/docs/repair-sandbox-boot-advisory.md
+++ b/docs/repair-sandbox-boot-advisory.md
@@ -1,0 +1,206 @@
+# Repair a sandbox boot blocked by a security advisory
+
+This runbook recovers an **existing** workspace volume whose boot aborts because
+a package manifest runs a security audit as an install lifecycle hook. It does
+not delete or recreate the volume. The edit it asks you to make touches exactly
+one file, the workspace `package.json`; the restart that follows then boots the
+sandbox normally.
+
+Applies to any workspace volume whose `package.json` still carries
+`"pnpm:devPreinstall": "pnpm run security:audit"`. Every volume seeded from
+`ghcr.io/mifunedev/openharness:0.9.0` or `ghcr.io/mifunedev/agro:0.9.0` carries
+it. As of 2026-09-08, `ghcr.io/mifunedev/agro:latest` resolved to the same image
+id as `0.9.0` (`bbfdaf6bb8ca`, digest tag `sha-823aabbd…`), so volumes seeded
+from `latest` on or before that date carry it too. `latest` is a moving tag: a
+later release repoints it, and this paragraph is a dated observation, not a
+standing property.
+
+## What you see
+
+`agro shell <name>` gives you a container with nothing set up. Inside it:
+
+```
+systemctl status openharness-bootstrap.service
+× openharness-bootstrap.service - Open Harness sandbox bootstrap
+     Active: failed (Result: exit-code)
+    Process: 53 ExecStart=/usr/local/bin/entrypoint.sh (code=exited, status=1/FAILURE)
+```
+
+The boot log ends with this exact line:
+
+```
+[entrypoint] pnpm install failed — see /tmp/pnpm-install.log; aborting sandbox boot
+```
+
+`openharness-cron.service` reports `Dependency failed`. `/tmp/pnpm-install.log`
+ends with a `pnpm:devPreinstall` audit table naming an advisory, then:
+
+```
+ ELIFECYCLE  Command failed with exit code 1.
+```
+
+## Why it happens
+
+The manifest wires the audit to a pnpm install lifecycle hook. pnpm runs that
+hook on every `pnpm install`. The sandbox entrypoint runs
+`pnpm install --prefer-offline` whenever `node_modules` is absent or the
+manifest fingerprint changed. `pnpm audit` queries the live advisory database.
+When a new advisory covers a pinned version, the audit exits 1, the hook fails,
+the install fails, and the entrypoint aborts the boot.
+
+`GHSA-82fw-gwwq-j7x9` covers vitest `>=2.1.0 <4.1.11`. The `0.9.0` manifest pins
+vitest `^3.2.6`, so a boot from that manifest fails every time, and will keep
+failing for as long as the advisory stands.
+
+## Your data is safe and reachable
+
+systemd is PID 1 in the sandbox. `openharness-bootstrap.service` is
+`Type=oneshot`. A failed oneshot does not stop PID 1, so the container stays
+`running` and `docker exec` still reaches a shell as the `sandbox` user.
+
+Do not delete the volume. Do not run `agro destroy`. Do not recreate the
+sandbox. None of that is needed, and all of it loses state.
+
+## Recovery needs operator action
+
+Recovery is **not** automatic. A newer image does not repair an existing
+volume: an upgrade boot never rewrites the workspace's own `package.json`, so
+the hook survives the upgrade and the new image fails the same way on that
+volume. Run the procedure below once per affected volume.
+
+## Procedure
+
+Run every command on the host. Replace `<name>` with the container name.
+
+**1. Confirm the symptom.**
+
+```bash
+docker inspect --format '{{.State.Status}}' <name>            # expect: running
+docker exec <name> systemctl is-failed openharness-bootstrap.service   # expect: failed
+docker exec <name> tail -3 /tmp/pnpm-install.log
+```
+
+**2. Delete the one hook that blocks the install.**
+
+Run this block exactly as written. It refuses rather than guessing whenever the
+manifest is not the shape this procedure repairs.
+
+```bash
+docker exec -i -u sandbox <name> bash -s <<'RECOVER'
+set -eu
+cd "$HOME/harness"
+expected='pnpm run security:audit'
+[ -f package.json ] && [ ! -L package.json ] || {
+  echo "refusing: $PWD/package.json is not a regular file — resolve that before retrying" >&2; exit 2; }
+found=$(jq -r '.scripts["pnpm:devPreinstall"] // ""' package.json)
+[ -n "$found" ] || {
+  echo "refusing: package.json declares no pnpm:devPreinstall hook — this procedure does not apply" >&2; exit 2; }
+[ "$found" = "$expected" ] || {
+  echo "refusing: pnpm:devPreinstall is '$found', not '$expected' — it carries logic of your own; remove or relocate that yourself" >&2; exit 2; }
+tmp=$(mktemp -p .)
+jq --indent 2 'del(.scripts["pnpm:devPreinstall"])' package.json > "$tmp"
+[ -s "$tmp" ]
+cat "$tmp" > package.json
+rm -f "$tmp"
+RECOVER
+```
+
+**It refuses, and changes nothing, when:**
+
+- `package.json` is a symlink or is not a regular file. The block does not
+  follow the link and does not write through it.
+- `pnpm:devPreinstall` is absent. The failure you are looking at is not this one.
+- `pnpm:devPreinstall` holds anything other than `pnpm run security:audit` — for
+  example `pnpm run security:audit && ./my-checks.sh`. Deleting the key would
+  destroy your command. The block will not parse, split, or partially rewrite a
+  combined hook. Resolve it yourself, then re-run.
+
+Each refusal exits `2` and leaves `package.json` byte-for-byte unchanged.
+
+**3. Restart the sandbox.**
+
+```bash
+docker restart <name>
+```
+
+**4. Verify the boot.**
+
+```bash
+docker exec <name> systemctl is-active openharness-bootstrap.service   # expect: active
+docker exec <name> systemctl is-active openharness-cron.service        # expect: active
+```
+
+`agro shell <name>` now works.
+
+## What the procedure preserves
+
+Verified by observation on a volume seeded from the real published image,
+before the failed boot and after the recovered boot:
+
+| State | Result |
+|-------|--------|
+| Uncommitted change in the harness checkout | Preserved; content hash unchanged and `git status` still reports it modified |
+| Task folders under the control-plane `tasks/` directory | Preserved; content hash unchanged |
+| `~/.config/gh` credentials | Preserved; the host entry, user, and OAuth token are unchanged, and the file keeps mode `0600` |
+| `.env` | Preserved; content hash unchanged and the file keeps mode `0600` |
+| Your own keys and scripts inside `package.json` | Preserved; a custom `scripts` entry and a custom top-level key both survive intact, and the file keeps mode `0644`, its owner, and its inode |
+
+The `gh` CLI normalizes `hosts.yml` on first use during boot: it appends a
+`users:` block for the already-present account. The credential values do not
+change and the mode does not change.
+
+## What the edit does to `package.json`
+
+Step 2's block writes exactly one file, `package.json`. Be precise about it.
+
+**Mode, owner, and inode are preserved.** The block writes back through the
+existing file with `cat "$tmp" > package.json` rather than `mv`. Replacing the
+file with `mv` would hand it `mktemp`'s `0600` mode and `mktemp`'s ownership.
+Observed across a recovery: mode `644` before and `644` after, owner
+`sandbox:sandbox` before and after, same inode.
+
+**`jq` rewrites the whole file, so formatting is `jq`'s.** On the published
+`0.9.0` manifest that costs nothing: `jq --indent 2 '.'` round-trips that file
+byte for byte, so the recovered file differs from the original by exactly the
+one removed line, verified by `diff`. If you have reformatted your own
+`package.json` — a different indent, tabs, no trailing newline — `jq` normalises
+it to two-space indent with a trailing newline. Key order and every value are
+preserved, including keys and scripts you added yourself. Run
+`git diff -- package.json` after the edit and read what changed.
+
+That is all step 2 writes. Step 3 then restarts the sandbox, and a boot that now
+succeeds writes state as any normal boot does: `node_modules` appears because
+the install completes, and `gh` normalises `hosts.yml` as described above — the
+host entry, user, and OAuth token are unchanged, and the file keeps mode `0600`.
+
+## After recovery
+
+Removing the hook restores the boot. It does not remove the vulnerable
+dependency. Update the checkout to a source revision that pins vitest
+`>=4.1.11`. Current source removes the hook, pins vitest `^4.1.11`, and runs
+`pnpm run security:audit` as an explicit CI and release step instead — see
+[`.agro/evals/probes/pnpm-audit-ci-gate.sh`](../.agro/evals/probes/pnpm-audit-ci-gate.sh).
+
+## Scope
+
+This runbook repairs an existing seeded volume only. It does not repair a
+published image. The `0.9.0` build — image id `bbfdaf6bb8ca`, also tagged
+`sha-823aabbd…` — carries the hook in `/opt/oh-seed/package.json`, and that
+build cannot be edited. A cold boot that seeds a fresh volume from it fails on
+first boot and needs this same procedure, or an image from a later release.
+
+`latest` is a moving tag. As of 2026-09-08 it resolved to that same build, so
+check what `latest` resolves to before assuming either way:
+
+```bash
+docker pull ghcr.io/mifunedev/agro:latest
+docker run --rm --entrypoint bash ghcr.io/mifunedev/agro:latest \
+  -c 'jq -r ".scripts[\"pnpm:devPreinstall\"] // \"absent\"" /opt/*-seed/package.json'
+```
+
+`absent` means that image cold-boots and needs nothing from this runbook. What
+a fixed release requires is in
+[`release-requirements-1019-boot-fix.md`](release-requirements-1019-boot-fix.md).
+
+The recovery path is guarded by
+[`.agro/evals/probes/sandbox-boot-advisory-recovery.sh`](../.agro/evals/probes/sandbox-boot-advisory-recovery.sh).


### PR DESCRIPTION
**#1019 stays open.** `Refs mifunedev/agro#1019`, `Refs mifunedev/openharness-cloud#146`. This delivers the half of mifunedev/agro#1019 that can be fixed without a release; the other half needs a published image and is not authorized here. No closing trailer for mifunedev/openharness-cloud#146 or mifunedev/agro#939 either — Phase 4 is partial (10 of 12 stories) and both stay open.

## The failure

GHSA-82fw-gwwq-j7x9 turned the `0.9.0` manifest's `pnpm:devPreinstall` audit into a boot failure. The hook performs a **live** advisory query during boot; once the advisory was published the query reports a finding, the hook exits non-zero, and `openharness-bootstrap.service` fails.

An important correction to how this was first described: systemd is PID 1 in the sandbox, so **the container keeps running and `docker exec` stays reachable**. The workspace volume's data is intact. This is a stalled boot, not a lockout — which is precisely why an in-place recovery exists at all.

## Two populations, only one of which is fixable here

| | Case | Fixable without a release? |
|---|---|---|
| **A** | An **already-seeded workspace volume** | **Yes** — the manifest lives in the volume and is editable in place. This PR. |
| **B** | A **new cold boot from the published image** | **No** — the manifest is baked into an image layer. Only a newly published image resolves it. |

## What this PR adds

### 1. `docs/repair-sandbox-boot-advisory.md` — the population A runbook

The edit rewrites `package.json` through a temp file and then `cat "$tmp" > package.json` rather than `mv`. That matters: `mv` would replace the file and the manifest would inherit the temp file's mode, owner and inode. `cat` preserves all three, so a recovered workspace is not left with a subtly different manifest than it started with.

It **refuses rather than guesses** in three cases:

1. The manifest is not a regular file, or is a symlink.
2. The hook is already absent (nothing to repair; the diagnosis was wrong).
3. The hook's body is not the expected `pnpm run security:audit` — i.e. an operator has put their own logic there, which this procedure must not silently discard.

### 2. `pnpm-audit-ci-gate` extended — the regression guard

The old gate forbade a *specific* set of hooks from invoking the audit. That is too narrow: the same class of failure returns through any other hook name. The gate now forbids **any** install lifecycle hook (`preinstall`, `install`, `postinstall`, `prepare`, `pnpm:devPreinstall`, `pnpm:devPrepare`) in **any** manifest that takes part in the boot's `pnpm install`, resolved from `pnpm-workspace.yaml` rather than hardcoded. It also asserts the `.agro/cli` install carries `--ignore-scripts`, since without it that manifest's `prepare` hook runs from a root-driven install.

The durable claim is the general one: no boot-time install may depend on a live external query.

### 3. `sandbox-boot-advisory-recovery` probe

Structural half runs anywhere. The boot-and-recover half needs a real sandbox boot, which exceeds the eval runner's 30s per-probe cap, so it reports `SKIPPED` (exit 2) unless `SANDBOX_BOOT_RECOVERY_LIVE=1`.

### 4. `docs/release-requirements-1019-boot-fix.md` — population B, with two decisions left open

R1, R2, R5 and R6 are stated. **R3 (supersede vs. yank `0.9.0`) and R4 (what `LEGACY_IMAGE` should pin to in `sandbox-boot-guard.yml`) are deliberately left undecided**, with the evidence written both ways. Those are operator calls with release consequences, and nothing here presumes them.

## Test evidence — exact head `f8b72d7f5845d797039b8cfd8f87d7c23d9165c5`

| Check | Result |
|---|---|
| `pnpm-audit-ci-gate.sh` | **PASS** (exit 0) — audit is CI/release-only, no manifest in the boot install declares a lifecycle hook |
| `sandbox-boot-advisory-recovery.sh` (default) | **SKIPPED** (exit 2) — structural half passed; live half needs a real boot |
| `pnpm test` (full vitest suite) | 1246 passed, **2 failed**, 74 files |

### The 2 failures are pre-existing and environmental

Both are in `.agro/cli/src/commands/__tests__/migrate-rehearsal.test.ts`, which this branch does not touch. **Reproduced on a clean checkout of the base commit `b10ecac3` with none of this branch's changes: the identical 2 failures occur.** The test's `dockerComposeAvailable()` probes the Compose plugin binary (present) rather than daemon reachability (absent — this environment has the `docker` CLI but no `/var/run/docker.sock`), so it takes the "available" branch and asserts success against a command that legitimately cannot succeed without a daemon.

### About the live probe run

The live half (`SANDBOX_BOOT_RECOVERY_LIVE=1`) was observed passing with exit 0 **earlier in this session, while a Docker daemon was still reachable**. It **cannot be re-run at this exact head**, because the socket is now absent. I am reporting that as a prior observation rather than as evidence at this commit, because it is not the same thing.

## CI at this exact head

| Check | Result |
|---|---|
| Lint, Typecheck, Build & Test | success |
| Eval Probe Regression Gate | success |
| Boot Path Lint (shellcheck + hadolint) | success |
| Validate sandbox compose and image build | success |
| Boot a legacy volume against the fresh image | success |

### Correction to an earlier version of this description

An earlier version of this body claimed that no CI would run here, citing mifunedev/agro#1020 — an issue I filed asserting that every workflow path filter still named `.oh/**` and therefore matched nothing after the Phase 3 rename.

**That was wrong, and mifunedev/agro#1020 is closed as invalid.** I had grepped a local checkout whose working tree silently reverts tracked files to their pre-AGRO generation, and read it as repository state. `origin/development` names `.agro/**`, `.agro/skills/**`, `.agro/hooks/**`, `.agro/evals/**`, `.agro/knowledge/**`, `agro.json` and `.example.env` throughout, and always did. The five green checks above are the disproof.

## Not in this PR

No release, no image publication, no registry change, no decision on R3 or R4. Population B remains open, and mifunedev/agro#1019 stays open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Gh4FRUfcQYD6CcNNH1xRU


---

**Note on the auto-close workflow.** `close-issues-on-development.yml` parses closing keywords from the title and body with `(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s*:?\s+#(\d+)`. That pattern has no negation handling, so a sentence like "does not close #N" reads as a closing reference and would close #N on merge. The wording above is chosen so the parser sees only what is intended.
