### PR TITLE
FROM feat/944-agro-cloud-consumer-migration TO development

### DIFF
--- a/.agro/tasks/agro-cloud-consumer-migration/CHECKPOINT.md
+++ b/.agro/tasks/agro-cloud-consumer-migration/CHECKPOINT.md
@@ -330,3 +330,103 @@ parked/deferred status. The EPIC's definition of done is NOT redefined by this n
 those items remain part of #944, and #944 remains part of #939. #945's gate — Phase 4
 complete AND 90 days AND three releases since the first public AGRO release (anchor
 v0.9.0 2026-09-06; earliest date 2026-12-05; one release observed) — is unchanged.
+
+
+## 2026-09-09 (later) — RETRACTION of #1020, website draft opened, all heads green
+
+### RETRACTION — issue #1020 was FALSE and is closed as invalid
+
+I filed mifunedev/agro#1020 claiming that every workflow path filter still named
+`.oh/**`, which has no tracked files, and therefore that control-plane changes trigger
+no CI — including the assertion that the probe added by PR #1023 was unreachable by any
+CI path.
+
+**All of that is wrong.** I ran `grep -rn '\.agro/' .github/workflows/` against the ROOT
+CHECKOUT'S WORKING TREE and read the result as repository state. All six workflow files
+are locally modified there, reverted to the pre-AGRO generation — the same silent
+working-tree divergence already recorded in this file as HAZARD 1 for `.devcontainer/`.
+I had documented that exact hazard and then walked into it again for a different
+directory.
+
+`origin/development` was correct all along: ci-harness.yml names `.agro/**`,
+`.agro/skills/**`, `.agro/hooks/**`, `.agro/evals/**`, `.agro/knowledge/**`,
+`agro.json` and `.example.env`; sandbox-boot-guard.yml names `.agro/**` and
+`.agro/scripts/*`. Both `.agro/**` and `.oh/**` are listed, which is correct during the
+alias SLA.
+
+Disproof from real runs: PR #1022 (changes confined to `.agro/cli/src/**`) and PR #1023
+(adds a probe under `.agro/evals/`) each ran 5 checks, all success, including the Eval
+Probe Regression Gate. The probe I claimed was unreachable was gated green on its own PR.
+
+#1020 is closed as not-planned with that correction written into it, and the three PR
+bodies that cited it (#1022, #1023, #1024) were edited to remove the false claim and
+carry the actual check results.
+
+**Rule for the next session: grep the ref, not the worktree.** `git show
+origin/<branch>:<path>` — never the working copy at /home/sandbox/harness.
+
+### Website: draft PR opened without triggering a deploy
+
+The operator asked whether Netlify documents a native skip directive for PR-opening
+Deploy Previews. It does, and it is title-scoped:
+
+- Netlify docs: "To avoid generating a Deploy Preview for a pull/merge request, add
+  `[skip ci]` or `[skip netlify]` to **the title of the pull/merge request**."
+- The commit-message form covers only branch and production deploys. That distinction is
+  the documented cause of the "it was ignored" support reports; Netlify staff confirmed
+  the PR title is the working mechanism and the docs were updated to say so.
+
+So website PR #66 was opened as a DRAFT titled
+`[skip netlify] FROM docs/65-agro-runtime-references TO development`. Metadata on the PR
+only — no site configuration, billing or DNS was touched, and the Netlify credit issue
+itself was not investigated.
+
+**Verified no deploy launched:** 90+ seconds after opening, the head
+5e5f34cc45ed8ab174f1354b3cd2e97f62b1c3a9 carries 0 commit statuses and 0 check-runs.
+Existing PRs (#64, #62, #60) register their `netlify/promptengineers/deploy-preview`
+check within about a minute, so a launched build would have appeared by then.
+
+**`[skip netlify]` must stay in that title** until the credit issue is resolved.
+Removing it and pushing a commit is what resumes previews.
+
+### NEW FINDING — agro-web docs build hard-fails on a rate-limit 403. Filed as agro-web#50.
+
+PR #49's first run failed with `ref mifunedev/agro@main does not resolve (... -> HTTP
+403)`. Re-running the IDENTICAL commit with no change succeeded, so the message names
+the wrong cause. Two compounding defects:
+
+1. `.github/workflows/pages.yml`'s `Build site` step sets no `env:`, so
+   `oh-source.mjs`'s `authHeaders()` finds neither GITHUB_TOKEN nor GH_TOKEN and the
+   API call goes out unauthenticated — 60 requests/hour per IP, on shared runner IPs.
+2. `isTransientStatus()` covers 408/429/5xx but NOT 403, which is what GitHub returns on
+   primary rate-limit exhaustion. Exhaustion therefore falls through to
+   "the mirror would publish something wrong" and hard-fails the deploy.
+
+`mifunedev/agro` is public and the same URL returns 200 unauthenticated from a
+non-exhausted address, so this is not a permissions problem. Not fixed here — filed,
+with the token fix and the `x-ratelimit-remaining: 0` discriminator proposed.
+
+### Final CI state — every PR verified at its exact head
+
+| PR | Head | Checks |
+|---|---|---|
+| cloud #145 (draft) | 4b4124c7caff31a84b2367b75472c7b8ef26ce2f | 4/4 success |
+| orchestra #983 (draft) | 1acc415bf347991ed2dbd3b0d0ac937b9006faa0 | 0 — `decks/**` is in test.yml's paths-ignore, and slides.yml only fires on a push to development. Absence of jobs is NOT green, and is reported as absence. |
+| agro-web #49 (ready) | 0b0a6d28da979d6eb4a92e5a798cef8c95f3e1c4 | Build docs site success; Deploy to GitHub Pages skipped |
+| agro #1022 (ready) | 909b3ec3e294a2dcfad15bd3036730a094c07610 | 5/5 success |
+| agro #1023 (ready) | f8b72d7f5845d797039b8cfd8f87d7c23d9165c5 | 5/5 success |
+| agro #1024 (ready) | 53f24aa207ceac8a608bf6f79a8f826ac3620868 | 5/5 success |
+| website #66 (draft) | 5e5f34cc45ed8ab174f1354b3cd2e97f62b1c3a9 | 0 by design — `[skip netlify]` |
+
+The accidentally committed node_modules symlink is confirmed ABSENT from every pushed
+tree: `git ls-tree -r` over bug/1021-sandbox-install-idempotent and bug/1019-boot-recovery
+returns 0 node_modules paths. #1022's head is 909b3ec3e294a2dcfad15bd3036730a094c07610 and
+was never affected — the symlink was committed on the 1019 branch and amended away before
+that branch was pushed.
+
+### Story state is STILL 10 of 12
+
+Nothing above changes it. US-007a still FAILS and its re-run is still blocked on the
+absent Docker socket. US-007b is still behind the paid-OVH gate. #944 and #939 remain
+OPEN, no PR carries a closing trailer for either, and #945's time-and-release gate is
+untouched. Host cleanup remains UNVERIFIED — nobody has checked.

--- a/.agro/tasks/agro-cloud-consumer-migration/CHECKPOINT.md
+++ b/.agro/tasks/agro-cloud-consumer-migration/CHECKPOINT.md
@@ -430,3 +430,66 @@ Nothing above changes it. US-007a still FAILS and its re-run is still blocked on
 absent Docker socket. US-007b is still behind the paid-OVH gate. #944 and #939 remain
 OPEN, no PR carries a closing trailer for either, and #945's time-and-release gate is
 untouched. Host cleanup remains UNVERIFIED — nobody has checked.
+
+
+## 2026-09-09 (final) — agro-web#50 fixed and verified; website#66 body corrected
+
+### agro-web#50 IMPLEMENTED — PR #51, head 55d4cfc5adec6fb77c1dfa0026aca6c1f55239f7
+
+Bounded fix, on a fresh worktree off origin/main (409ef10) so it does not mix with the
+docs PR:
+
+1. `.github/workflows/pages.yml` — the `Build site` step now receives the job's own
+   `secrets.GITHUB_TOKEN`. No new credential; it is the token the workflow already has.
+   Unauthenticated the mirror call ran against 60 requests/hour per shared runner IP.
+2. `scripts/oh-source.mjs` — `isTransientStatus(status)` becomes
+   `isTransientResponse(res)`, reading the response rather than the status alone. A 403
+   is transient ONLY with `x-ratelimit-remaining: 0`. Without that header a 403 stays
+   FATAL, so a genuine auth failure or a bad ref still fails the deploy — treating every
+   403 as transient would have been the dangerous fix. raw.githubusercontent.com sends no
+   such header, so a 403 there stays fatal, which is correct since it is not
+   quota-limited. Both call sites migrated, so there is one rule, not two. A
+   rate-limited failure now reports "GitHub rate limit exhausted" instead of blaming the
+   ref.
+3. Tests — the repository had NO test runner. Added `pnpm test` (`node --test`, no new
+   dependency) and `scripts/oh-source.test.mjs`, 9 tests: the exhausted-quota 403; the
+   bare 403 and remaining=1/4999; 401 and a 403 carrying only retry-after; the UNCHANGED
+   408/429/5xx behaviour; 400/404/409/410/422 still fatal; the header believed only on a
+   403; a header-less response; and case-insensitive header matching. Wired as a GATING
+   CI step on every event, unlike the advisory drift check, because this rule decides
+   whether a bad mirror ships.
+
+**Verified at the exact head, on the FIRST run — not a rerun.** Local: 9/9 tests,
+typecheck exit 0, build SUCCESS, theme-order PASS, docs-drift PASS (39 files), and the
+build exercised the real mirror path end to end (resolved agro@main at 823aabbd, wrote
+get-agro.sh, get-oh.sh, agro.js, oh.js). CI run 34386051054: `Build docs site` success,
+`Deploy to GitHub Pages` skipped. The CI LOG was read rather than trusting the green —
+the new step executed (`# tests 9 / # pass 9 / # fail 0`) and `GITHUB_TOKEN: ***`
+appears in the Build site step's env, so the token is genuinely in effect.
+
+### website#66 body corrected — metadata only, no source change
+
+Two corrections at the operator's direction:
+
+1. **Removed the claim that a new cold boot is "not locally repairable."** A volume
+   seeded during a FAILED fresh boot is repairable in place too, exactly like a
+   previously-seeded one. What a local repair does not change is the published image
+   DIGEST, so the next cold boot from that digest fails identically until a new image is
+   published. Repairability and the image fix are separate questions; the earlier wording
+   conflated them.
+2. **Reframed the deploy claim as evidence, not guarantee.** The body now says GitHub
+   reports 0 check-runs and 0 commit statuses on the head — *no deployment evidence
+   observed on the GitHub side* — and states explicitly that this is not a guarantee from
+   Netlify's backend and says nothing about billing, neither of which was queried and for
+   neither of which a credential exists here.
+
+`[skip netlify]` remains in the title and the PR remains a draft. The same conflation
+survives in `posts/openharness-getting-started.md` itself; correcting published copy is a
+content change and was explicitly out of scope, so it is flagged in the PR body rather
+than silently edited.
+
+### Story state STILL 10 of 12
+
+Unchanged. US-007a still FAILS with its re-run blocked on the absent Docker socket;
+US-007b still behind the paid-OVH gate. #944 and #939 OPEN, no closing trailer anywhere.
+#945's gate untouched. Host cleanup still UNVERIFIED.

--- a/.agro/tasks/agro-cloud-consumer-migration/CHECKPOINT.md
+++ b/.agro/tasks/agro-cloud-consumer-migration/CHECKPOINT.md
@@ -493,3 +493,64 @@ than silently edited.
 Unchanged. US-007a still FAILS with its re-run blocked on the absent Docker socket;
 US-007b still behind the paid-OVH gate. #944 and #939 OPEN, no closing trailer anywhere.
 #945's gate untouched. Host cleanup still UNVERIFIED.
+
+
+## 2026-09-09 — agro-web merged and deployed; agro source merges executed
+
+### agro-web is merged to `main`
+
+Order was **#51 first, then #49**, so the rate-limit fix was in place before the docs
+PR's own deploy build ran.
+
+| PR | Merge commit on `main` | Post-merge run | Build | Deploy |
+|---|---|---|---|---|
+| #51 mirror rate-limit fix | `c65d41b8741e70b684b89fd5916bdb88b71eb53b` | 34387266599 | success | success |
+| #49 Phase-3 drift closure | `956bb1d723100b5779b02d617620fb9cf7193090` | 34387537372 | success | success |
+
+`main` is `956bb1d723100b5779b02d617620fb9cf7193090`. Run **34387537372** is the final
+combined deployment; 34387266599 is #51's earlier one. Issues #50 and #48 are CLOSED.
+
+Correction to an earlier reading: a branch-filtered `gh run list` omitted the newest
+runs, which made the earlier run look final. Query runs by exact head SHA through the
+REST API rather than trusting a filtered listing.
+
+Independent read-only verification of the deployed contract: the canonical homepage
+returns 200; the legacy `oh` homepage redirects to an identical canonical body;
+`get-agro.sh`, `get-oh.sh` and both `install.sh` endpoints return 200 with a valid
+shebang and `bash -n` exit 0; and all four script bodies BYTE-MATCH their sources at
+agro `main` `823aabbd7324e08e3b685af6b0a5ef5c3467a15f`. That is a compatibility pass
+against the CURRENT released main. It is not a release-cutover approval.
+
+### The missing changelog entry on #1022
+
+Independent review found #1022 carried only `sandbox.ts` and its tests, with no
+`CHANGELOG.md` entry, while the root changelog policy requires one for every
+user-visible change. #1023's entries cover recovery only and do not describe it.
+
+Added as a single `### Fixed` line linked to #1021, at head
+`b17d4d35d72ca4153ca00665928d439d09c64db1`. It was placed at the END of the `### Fixed`
+list rather than the top, so it occupies a different hunk from #1023's insertion and the
+two merge without a conflict. **This makes the earlier zero-file-overlap statement
+stale**: #1022 and #1023 now share `CHANGELOG.md`.
+
+Re-verified after the change:
+
+- All 5 named CI checks pass at `b17d4d35` (conclusions read, not merely absence of pending).
+- Merging all three branches onto `development` in either order yields the IDENTICAL
+  tree `314c10a776fdb27e32a7c00b88c57b2fd6a1575b` with zero conflicts.
+- Combined suite: 1255 passed, 2 failed — the same two pre-existing `migrate-rehearsal`
+  Docker-socket failures, unchanged.
+- `parseClosingRefs` still returns `[1021]` for #1022 and `[]` for #1023 and #1024.
+
+### Nothing below changed
+
+Story state is STILL **10 of 12**. US-007a still FAILS and its re-run is still blocked on
+the absent Docker socket; US-007b is still behind the paid-OVH gate. **#939, #944, #945
+and #1019 all remain OPEN.** No PR carries a closing trailer for any of them. Host
+cleanup remains UNVERIFIED. Cloud #145, orchestra #983 and website #66 remain DRAFT and
+parked, with `[skip netlify]` intact in the website title. The root checkout's dirty
+files were not touched.
+
+Direct advisor edits this turn — the one-line changelog entry and this record — were made
+without a bounded worker at explicit operator instruction, recorded here as the exception
+the workflow requires.

--- a/.agro/tasks/agro-cloud-consumer-migration/CHECKPOINT.md
+++ b/.agro/tasks/agro-cloud-consumer-migration/CHECKPOINT.md
@@ -1,0 +1,332 @@
+# Phase 4 (#944) — durable checkpoint
+
+Written 2026-09-09 while the lifecycle-matrix worker runs. Purpose: make the next
+compaction cheap and lossless. Authoritative state remains `prd.json`; this is the
+narrative index into it.
+
+## Story state — 10 of 12
+
+PASS: US-001, US-002, US-003, US-004, US-005, US-006, US-008, US-009, US-010, US-011
+plus the US-012 prerequisite (`agro sandbox install` idempotency).
+
+OPEN:
+- **US-007a** — FAILS on measured product defects. The re-run that would clear it is BLOCKED on a missing container runtime, so the two gate gaps stay unanswered.
+- **US-007b** — blocked on Q3, paid OVH infrastructure. Nothing touched.
+
+`#939` and `#944` stay OPEN. `#945`'s gate is untouched: Phase 4 complete AND 90 days
+AND three releases since the first public AGRO release (anchor v0.9.0, 2026-09-06;
+earliest date 2026-12-05; one release observed).
+
+## Worker ledger — native IDs for resumption
+
+| ID | Native | Scope | Status |
+|---|---|---|---|
+| W1 | aa588cf40102fb5f1 | US-001 org inventory, US-008 migrate --check | ACCEPTED |
+| W2 | ae551523e1c3b9519 | US-003/4/5 bootstrap + the readiness gate | ACCEPTED |
+| W3 | ab16f3c765ba00e63 | US-006 node.rebuild, test reconciliation | ACCEPTED |
+| W4 | ab4aa8ebb14cb9fb1 | US-002 classification, US-009 docs | ACCEPTED |
+| W6 | a215de2cbdb589bf6 | US-010 website, orchestra | ACCEPTED |
+| W7 | a195edc09e0a99ae6 | US-011 agro-web docs drift | ACCEPTED |
+| W8 | a1a9a4ca502958aa1 | US-012 CLI idempotency | ACCEPTED |
+| W9 | afeb96646cba27a88 | #1019 Part A recovery + probes | ACCEPTED |
+| W10 | a29e0355c83c5e384 | US-008 migration rehearsal | ACCEPTED |
+| W11 | ae493cb0a966bd2a6 | US-008 Cloud migration delivery | ACCEPTED |
+| W12 | a4aa4d7b47120d4d2 | US-008 agro-web migration delivery | ACCEPTED |
+| W13 | a6a674efc3f0b1ca5 | US-007a lifecycle matrix | DELIVERED partial: UID assessment done; ohproxy + A/B re-run BLOCKED on missing Docker |
+| W14 | a7af21d0c2cff9458 | comment cleanup | ACCEPTED |
+
+## Trees carrying deliverable work
+
+| Repo | Worktree | Branch | Base | State |
+|---|---|---|---|---|
+| openharness-cloud | `.worktrees/944-integrate2` | feat/944-integration2 | 0aa8f99 | staged R100 migration + unstaged source/docs; green |
+| agro-web | `.worktrees/944-docs` | feat/944-docs-drift | 409ef104 = origin/main | staged R100 migration + docs; green |
+| website | `.worktrees/944-refs` | feat/944-agro-runtime-references | fd60500 | 7 files; lint+build green |
+| orchestra | `.worktrees/944-name` | feat/944-agro-runtime-name | 2c7ccd28 | 1 line |
+| agro | `.worktrees/feat/944-agro-cloud-consumer-migration` | same | b10ecac3 | task record; `.agro/tasks/*` is gitignored, needs `git add -f` |
+| agro | `.worktrees/bug/944-sandbox-install-idempotent` | bug/944-sandbox-install-preserve-config | b10ecac3 | CLI fix + 9 tests |
+| agro | `.worktrees/bug/1019-boot-recovery` | bug/1019-boot-recovery | b10ecac3 | runbook, requirements, 2 probes |
+
+Cloud suite baseline to preserve: type-check 0, test 0 — shared **119**, db 189,
+gateway 37, provisioner 84, web 2898 across 126 files.
+
+## The readiness gate — verified by the advisor, re-run still required
+
+`infra/cloud-init/cloud-config.yaml`: `:98` install → `:99` `run_step wait_sandbox_ready`
+(immediate successor) → `:102` `echo ok` → `:103` marker. Polls
+`docker exec <name> systemctl is-active openharness-bootstrap.service` using the rebuild
+helper's own constants (10s probe, 5s interval, 20 attempts, 300s deadline). `active`
+proceeds; `failed` exits immediately; deadline fails. Via `run_step`, so `fail` writes
+`failed:<code>` and exits — the harness install, `ok` and the marker are unreachable on
+failure. `failed:1` = unit failed, `failed:2` = deadline. Zero new comment lines.
+
+**Two gaps the fix cannot settle itself — the re-run must answer both:**
+1. Is that unit the completion signal on a container's FIRST boot, or only
+   post-recreate? Fails closed if not, but must be observed.
+2. Does the 300s deadline survive a cold pull plus first-boot seeding? The rebuild
+   budget assumes an already-pulled image. If config A starts failing `failed:2` the
+   answer is a larger attempt count, NOT removing the gate.
+
+## Unresolved decisions — operator only, none inferred
+
+- **OD-1 default harnesses.** Priced, not decided. Install-three was measured to fail
+  every node's bootstrap pre-gate (`status=failed:243`); availability depends on the
+  re-run confirming config B now reaches `ok` with the marker. Correct id is `pi`.
+- **Surface 4a contract.** Deliberately unresolved rather than weakening the DoD.
+  Bootstrap-watch-only (docs fix; advisor's recommendation, since README:363,
+  quickstart:591 and runtime-settings-runbook:157 already say "watch") versus a
+  persistent re-attachable session (product change delivering what index.ts:791
+  promises). Either way the silent `no sessions`/exit 1 after a SUCCESSFUL boot needs
+  fixing.
+- **Q3 paid OVH.** US-007b blocked. No live infrastructure touched.
+- **#1019 Part B.** R3 supersede-vs-yank and R4 the LEGACY_IMAGE pin written with
+  evidence both ways, deliberately undecided. Publication unauthorized.
+
+## Open defects found but NOT fixed
+
+- UID/GID divergence breaks attach surface (c); the UID-sync path is gated on a
+  checkout bind image-only nodes never have. Today's 1000/1000 is coincidence.
+  Write-up + fail-before-mutation ASSESSMENT in flight; no remap or chown permitted.
+- `sandbox rebuild` does not always recreate the container.
+- A failed rebuild leaves the sandbox stopped with no rollback.
+- `agro config set` prints `oh.json:` while writing `agro.json`.
+- AGRO Dockerfile:101-102 bakes `--dangerously-skip-permissions` /
+  `--dangerously-bypass-approvals-and-sandbox` aliases for binaries it no longer ships.
+
+## Must appear in PR bodies
+
+- Why the sandbox image is NOT pinned to 0.9.0 — the cleanup removed the only source
+  reference to #1019. The constraint survives as a test asserting
+  `doesNotMatch(/agro:0\.9\.0/)`, but the provenance does not.
+- OA-1: audit existing `nodes.container_name` values —
+  `container_name !~ '^[a-z0-9][a-z0-9-]*$'`. Empty result makes the create-boundary
+  tightening a production no-op.
+- OA-2: stage the migrating commit with `git add -A`; rename detection does not fire
+  in `git status --short` and it reads as a mass deletion until staged.
+- OA-3: operators must upgrade past CLI 0.7.0, which has no `migrate` verb.
+- Three deliberate agro-web divergences from `agro@main`: the `sshd.md` commands that
+  exit non-zero upstream, the PII placeholders where main hardcodes a real name and
+  email, and the site-served `get-agro.sh` URL.
+- No phase- or EPIC-closing trailer on any partial or prerequisite PR.
+
+## Environment blockers and gotchas
+
+- **`python3` is gone** from this environment mid-session; bookkeeping moved to node.
+- A monthly spend cap terminated two workers earlier. Resolved — a terminated
+  invocation is not a standing refusal, and stale request IDs in notifications made an
+  old failure look current.
+- The local `openharness-web` parent checkout (`bd9f104`) is an ANCESTOR of
+  `origin/main` and still carries `CNAME: oh.mifune.dev`. Working from it would
+  reintroduce the pre-Phase-3 domain. The PR worktree is correctly grounded.
+- Safety net blocks: bare `git stash`, `git checkout -- .`, `rm -rf` outside cwd,
+  `.config/` reads, compound heredocs in strict mode.
+
+## Advisor errors recorded, for the retro
+
+Misread a bare "0" as an operator confirmation that host artifacts were clean and wrote
+that into this checkpoint; it was a survey dismissal. Corrected within the turn, but it
+was a fabricated confirmation in a durable record — the exact failure mode this file
+exists to prevent.
+
+Transposed W1/W3 native IDs and sent each the other's brief (W1 caught it). Marked
+US-008 passing on rehearsal evidence. Told workers the Cloud repo's AGENTS.md forbids
+comments — it has no AGENTS.md. Invented a sibling-style exception to the comment rule
+and withdrew it. Called a moving tag immutable. Relayed a caveat's line placement from
+a worker report without opening the file — it was after the command it warned about.
+Did not notice a public quickstart concealed the #1019 cold-boot failure while
+simultaneously tracking that failure as a blocker.
+
+
+## 2026-09-09 update — US-007a re-run BLOCKED, two hazards found
+
+**Docker is gone from this environment.** Verified by the advisor and independently by review: the Docker CLI is PRESENT but /var/run/docker.sock is ABSENT — no daemon reachable,
+no socket at any path, container changed (395299dff1d9, was e73e5123a864), docker gid
+moved 117 -> 1001. Items 1 (ohproxy no-shell) and 3 (A+B re-run) are BLOCKED on a
+missing container runtime — an exact capability blocker, not a skip. US-007a stays
+FAILING and its two gaps remain unanswered:
+  a. is openharness-bootstrap.service the completion signal on a FIRST boot?
+  b. does the 300s deadline survive a cold pull plus first-boot seeding?
+Suggestive but NOT an answer: pre-fix runs showed seed-to-active ~4s twice and the
+probe sequence (empty) -> activating -> active, with (empty) treated as keep-polling
+(fail-closed). The pull was never inside the measured window.
+
+**HAZARD 1 — the live checkout's working tree silently reverts .devcontainer/ to the
+pre-AGRO generation.** Advisor-verified: HEAD b10ecac3 has AGRO_HOME_MOUNT and zero
+oh-seed; the working tree has ZERO AGRO_HOME_MOUNT and THREE oh-seed, across 4 modified
+files (129/132). A `docker build -f .devcontainer/Dockerfile .` from this tree yields a
+LEGACY image, not the AGRO candidate — a re-run would test the wrong artifact and could
+be reported as a pass. BUILD FROM HEAD OR A CLEAN WORKTREE. The checkout was left
+untouched; not stashed, not reverted, because it is not this task's to resolve.
+
+**HAZARD 2 — ohproxy confinement is partly outside the accepted generator.**
+`restrict` does NOT block command execution; confinement rests on the account's
+/usr/sbin/nologin shell plus PermitTTY no. buildHostProxyAssets() emits the key line and
+sshd block but NOT the account. So the load-bearing part of that boundary is
+ungenerated — which is exactly why the no-shell check must be observed, not reasoned.
+
+**UID/GID assessment DELIVERED** (assessment only; nothing implemented, remapped or
+chowned). Checkable condition: uid/gid(sandbox@node) == uid/gid(sandbox@image) before
+first boot; stronger form owner(P) == C AND H can write P. Container uid is pinned
+(Dockerfile:60). Node uid is ASSUMED — the cloud-config users: entry has no uid: field,
+so 1000 is emergent from base-image passwd ordering. The adaptive usermod -u path
+(entrypoint.sh:169-185) is gated at :161 on a checkout bind image-only nodes never have,
+while the destructive chown runs unconditionally: the mechanism that could save you is
+unreachable on exactly the deployment that needs it. Proposed guard is detection-only,
+sits between install_agro and agro sandbox install docker (the only window before the
+chown), compares node stat against `docker run --rm <image> id -u sandbox`, costs ~1s
+and no extra network, and yields failed:3 alongside the gate's failed:1/failed:2.
+Limits: new provisioning only; does not cover the rebuild path; reads the baked uid.
+
+**Leftover artifacts — NOT VERIFIED, and no one has confirmed them.** The worker issued
+two docker build commands before discovering the daemon was gone and could not verify
+they never started (its log redirects targeted an already-deleted scratchpad, which
+suggests they never began, but that is inference). The advisor briefly recorded here
+that the operator had confirmed zero leftovers. THAT WAS WRONG — a lone "0" in the
+transcript was a dismissal of an unrelated survey prompt, not an answer about host
+state. Corrected 2026-09-09. Nobody has checked. Still outstanding for the host:
+confirm agro-candidate:us007a, oh-node-host:us007a and any us007a-* container or volume
+are absent; removal commands are in evidence section 16.4.
+
+
+## 2026-09-09 — operator narrowed scope; PRs opened; website publication withheld
+
+**Scope change, mid-turn, by the operator.** Immediate priority narrowed to
+`mifunedev/agro` and `mifunedev/agro-web`. Cloud, orchestra and website are DEFERRED —
+their existing work is preserved on its own draft PRs at operator instruction, not
+proposed for merge. A follow-up authorization then explicitly permitted scoped
+commits/pushes/draft-PR creation for those secondary repositories as a preservation
+measure only. Nothing was reverted. No new implementation was performed on them.
+
+**Story state is unchanged at 10 of 12.** US-007a still FAILS on measured product
+defects; US-007b is still behind the unauthorized paid-OVH gate. #944 and #939 remain
+OPEN, and no PR carries a closing trailer for either. #945's gate is untouched.
+
+### Re-grounding, before anything was committed
+
+Every branch was checked against its actual current target head. All six were already
+exactly at their target — no rebase was needed:
+
+| Repo | Base recorded | origin target at check time | Match |
+|---|---|---|---|
+| openharness-cloud | 0aa8f99 | origin/development 0aa8f99 | yes |
+| agro-web | 409ef10 | origin/main 409ef10 | yes |
+| website | fd60500 | origin/development fd60500 | yes |
+| orchestra | 2c7ccd28 | origin/development 2c7ccd28 | yes |
+| agro (x3) | b10ecac3 | origin/development b10ecac3 | yes |
+
+### PRs opened
+
+| Repo | Issue | PR | Head | Status |
+|---|---|---|---|---|
+| openharness-cloud | #144 | #145 | 4b4124c7caff31a84b2367b75472c7b8ef26ce2f | DRAFT — parked, deferred |
+| orchestra | #982 | #983 | 1acc415bf347991ed2dbd3b0d0ac937b9006faa0 | DRAFT — parked, deferred |
+| agro-web | #48 | #49 | 0b0a6d28da979d6eb4a92e5a798cef8c95f3e1c4 | READY |
+| agro | #1021 | #1022 | 909b3ec3e294a2dcfad15bd3036730a094c07610 | READY |
+| agro | #1019 (not closed) | #1023 | f8b72d7f5845d797039b8cfd8f87d7c23d9165c5 | READY |
+| website | #65 (not filed) | NONE — withheld | 5e5f34cc45ed8ab174f1354b3cd2e97f62b1c3a9 | branch pushed, PR withheld |
+
+### Website: the precise gate, and why no PR was opened
+
+The operator flagged an unresolved Netlify credit/domain issue and forbade knowingly
+triggering a deployment or paid action. Measured rather than assumed:
+
+- **Opening a PR on mifunedev/website triggers a Netlify Deploy Preview build.** Verified
+  against three existing PRs (#64, #62, #60): each carries a
+  `netlify/promptengineers/deploy-preview` check plus header/redirect/pages-changed
+  checks, ~1m build each, on the `promptengineers` Netlify project.
+- **A branch push does not.** After pushing `docs/65-agro-runtime-references`, the head
+  carried 0 commit statuses and 0 check-runs.
+
+So the work is preserved on the remote branch and the PR is deliberately not opened.
+Opening it is the operator's call once the credit issue is resolved. The scoped website
+issue was also not filed, since an issue without its PR serves nothing here.
+
+Caveat on the branch-push evidence: the three no-PR branches used as controls
+(feat/21-matrix-vibes, feat/614-add-fastmcp-support, master) all predate the Netlify
+integration, so they are weak controls. The direct observation on the actual pushed head
+— 0 statuses, 0 check-runs — is the load-bearing evidence.
+
+### Verification performed at each exact head
+
+- **Cloud** — `pnpm type-check` exit 0; shared 119, db 189, gateway 37, provisioner 84,
+  web 2898 across 126 files. Matches the pre-change baseline on every count. The six
+  readiness-gate tests were confirmed to actually EXECUTE (subtests 34-39), not merely
+  to exist.
+- **agro-web** — check:docs-drift PASS (44 files), typecheck exit 0, docusaurus build
+  SUCCESS, theme-order PASS. Installer assets the new quickstart tells readers to curl
+  were fetched live: get-agro.sh 200/8527B, agro.js 200/187989B, get-oh.sh 200/9493B,
+  oh.js 200/187989B.
+- **website** — next lint 0 warnings, next build succeeded, and the llm.txt generator
+  was re-run to confirm its output matches the committed file (no drift).
+- **agro CLI fix** — typecheck exit 0; sandbox.test.ts 26 passed; full suite 1255 passed,
+  2 failed.
+- **agro #1019** — pnpm-audit-ci-gate PASS; recovery probe SKIPPED (exit 2, non-live);
+  full suite 1246 passed, 2 failed.
+
+### The 2 agro suite failures are pre-existing, and this was proved rather than assumed
+
+Both are in `.agro/cli/src/commands/__tests__/migrate-rehearsal.test.ts`, untouched by
+either branch. A clean detached worktree at the base commit b10ecac3, with none of the
+branch changes, reproduces the IDENTICAL 2 failures. Cause: `dockerComposeAvailable()`
+runs `docker compose version`, which probes the Compose plugin binary (present) rather
+than daemon reachability (absent). It therefore takes the "available" branch and asserts
+exit 0 from a command that cannot succeed without a daemon.
+
+### NEW FINDING — every CI path filter in agro is dead. Filed as #1020.
+
+`git ls-files .oh` returns **0**; `git ls-files .agro` returns **760**. No workflow in
+`.github/workflows/` references `.agro/` at all. Every path filter still names `.oh/**`,
+which now matches nothing, so a change confined to the control plane triggers NO CI.
+
+This is not cosmetic. The probe added by PR #1023 lives under `.agro/evals/` and is
+therefore unreachable by any CI path — the exact failure shape of #981, now instantiated
+repository-wide by the Phase 3 rename. `oh.json` and `.env.example` in those filters are
+stale too; the harness ships `agro.json` and `.example.env`.
+
+A coverage regression that reports green because nothing runs.
+
+### Other issues filed
+
+- **agro #1021** — `agro sandbox install` is not idempotent; a re-run discards an
+  existing sandbox's configuration, silently unpinning `storage.homePath` on a node.
+  Fixed by PR #1022.
+- **openharness-cloud #144**, **orchestra #982**, **agro-web #48** — scoped consumer
+  issues, each referencing #944/#939 without closing either.
+
+### Corrections to earlier records
+
+- CHECKPOINT.md said the agro-web docs branch needed the three deliberate divergences
+  called out; they were verified in the tree before the PR body claimed them — the
+  site-served get-agro.sh URL, `example.com` with RFC 5737 addresses instead of a real
+  name and email, and the corrected sshd commands.
+- The website post's `ghcr.io/mifunedev/openharness:0.9.0` reference was checked rather
+  than "corrected" on assumption: `ghcr.io/mifunedev/agro:0.9.0` and
+  `ghcr.io/mifunedev/openharness:0.9.0` resolve to the SAME digest,
+  sha256:5ecfe69bbc0654ca733535d710c0c61fd5f7913945bef7d1beec97506f03e60c. The reference
+  is accurate, merely legacy-named. Left as-is; not an advisor edit.
+- The agro-web drift-rule inversion was verified against the harness tree rather than
+  taken from the worker's report: agro ships `.example.env`, and `.env.example` does not
+  exist. The old rule flagged the real filename and recommended a nonexistent one.
+
+### Advisor errors this turn
+
+- **Committed a `node_modules` symlink.** I had symlinked node_modules into the
+  bug/1019-boot-recovery worktree to run its tests, then used `git add -A`. The symlink
+  landed in the commit as mode 120000. Caught on reading my own commit stat, removed
+  from the index and disk, amended before pushing. The pushed head f8b72d7f contains no
+  node_modules path; the other four commits were audited and are clean too. `git add -A`
+  after introducing untracked scaffolding is the hazard.
+- **Left a build artifact in the website worktree.** Running `npm run build` there to
+  verify the branch rewrote the TRACKED file `public/sw.js` (a minified service worker
+  whose content is build-hash churn). It was deliberately NOT staged, so it is not in
+  the commit, and NOT reverted, per the operator's instruction not to revert. It remains
+  as an uncommitted modification in that worktree.
+
+### Deferred, explicitly, and NOT counted as complete
+
+Cloud (US-002, US-003, US-004, US-005, US-006, US-009, and the Cloud half of US-008),
+orchestra, and website (US-010) are preserved and parked. Their PRs carry a stated
+parked/deferred status. The EPIC's definition of done is NOT redefined by this narrowing:
+those items remain part of #944, and #944 remains part of #939. #945's gate — Phase 4
+complete AND 90 days AND three releases since the first public AGRO release (anchor
+v0.9.0 2026-09-06; earliest date 2026-12-05; one release observed) — is unchanged.

--- a/.agro/tasks/agro-cloud-consumer-migration/consumer-inventory.md
+++ b/.agro/tasks/agro-cloud-consumer-migration/consumer-inventory.md
@@ -1,0 +1,453 @@
+# US-001 · Organization-wide downstream dependency inventory
+
+- **Issue:** [#944](https://github.com/mifunedev/agro/issues/944) (parent [#939](https://github.com/mifunedev/agro/issues/939))
+- **Scan date:** 2026-09-08 (UTC)
+- **Scope:** every repository in the `mifunedev` organization, scanned by content.
+- **Coverage:** 32 of 32 organization repositories. 32 cloned, 32 scanned, 0 clone failures.
+
+## Scan method
+
+`gh search code` was **not** used as the source of truth: it omits private
+repositories and caps results. Every repository was cloned and grepped.
+
+### 1 · Enumerate
+
+```bash
+gh repo list mifunedev --limit 100 --json name,isArchived,isFork,visibility,updatedAt,defaultBranchRef
+```
+
+Returns 32 repositories, 1 archived (`serverless-chat`), 0 forks.
+
+Coverage was cross-checked against the org record so that no repository was
+invisible to the token:
+
+```bash
+gh api orgs/mifunedev --jq '{public_repos, total_private_repos}'
+# {"public_repos":31,"total_private_repos":1}   -> 32 total, all 32 enumerated
+gh api "orgs/mifunedev/repos?per_page=100&type=all" --jq 'length'   # 32
+```
+
+The scanning identity is `ryaneggz`, an owner of `mifunedev`. The one private
+repository (`openharness-cloud`) cloned successfully.
+
+### 2 · Clone and grep
+
+For each repository:
+
+```bash
+git clone --depth 1 https://github.com/mifunedev/<name>.git <scratch>/<name>
+git -C <scratch>/<name> rev-parse HEAD                  # recorded below
+git -C <scratch>/<name> rev-parse --abbrev-ref HEAD     # default branch
+
+PATTERN='mifunedev/openharness|@mifune/openharness|ghcr\.io/mifunedev/openharness|oh\.mifune\.dev|/get-oh\.sh|/oh\.js|openharness-release|oh\.json|OH_[A-Z]|openharness|OpenHarness'
+git -C <scratch>/<name> grep -n -I -E "$PATTERN" -- .
+
+# `.oh/` as a project control plane — tracked files, not prose mentions
+git -C <scratch>/<name> ls-files | grep -E '(^|/)\.oh/'
+
+# the executable `oh`
+git -C <scratch>/<name> grep -n -I -E '(^|[`"'"'"' (])oh (shell|sandbox|tool|harness|ps|destroy|migrate|install|init|doctor|up|down|exec|run)\b' -- .
+```
+
+The pattern is deliberately **wider** than #944's list: it also matches bare
+`openharness` / `OpenHarness`, so that prose and identifier hits that #944's
+literal list would miss are still surfaced and classified. Clones were deleted
+after each scan.
+
+Root-marker presence was independently re-verified through the API, so the
+`.oh/` finding does not depend on the clone pass:
+
+```bash
+for n in $(jq -r '.[].name' repos.json); do
+  gh api "repos/mifunedev/$n/contents/" \
+    --jq '[.[].name] | map(select(. == ".oh" or . == ".agro" or . == "oh.json" or . == "agro.json")) | join(",")'
+done
+# agro -> .oh,oh.json   agro-web -> .oh   openharness-cloud -> .oh   (all others: none)
+```
+
+### 3 · Two required repositories
+
+- `mifunedev/openharness-cloud` — the shallow clone landed on
+  `0aa8f999c3ef79ff8c116517b192206e5d69ba45` (`development`), which matches the
+  operator's clone at `projects/mifunedev/openharness-cloud`
+  (`git -C … rev-parse origin/development` → the same SHA). That clone was read
+  only through `rev-parse` and was not modified.
+- `mifunedev/agro` — scanned at `823aabbd7324e08e3b685af6b0a5ef5c3467a15f`
+  (`main`).
+
+### 4 · Live-name probes
+
+```bash
+curl -s -o /dev/null -w "%{http_code} -> %{redirect_url}" https://oh.mifune.dev            # 301 -> https://agro.mifune.dev/
+curl -s -o /dev/null -w "%{http_code} -> %{redirect_url}" https://oh.mifune.dev/get-oh.sh  # 302 -> https://agro.mifune.dev/get-oh.sh
+curl -s -o /dev/null -w "%{http_code} -> %{redirect_url}" https://oh.mifune.dev/oh.js      # 302 -> https://agro.mifune.dev/oh.js
+curl -s -o /dev/null -w "%{http_code} -> %{redirect_url}" https://github.com/mifunedev/openharness  # 301 -> .../agro
+curl -sL https://api.github.com/repos/mifunedev/openharness  # 301, follows to full_name "mifunedev/agro"
+curl -sL -o /dev/null -w "%{http_code}" https://raw.githubusercontent.com/mifunedev/openharness/refs/heads/main/.oh/scripts/get-oh.sh  # 200, served directly
+```
+
+Every legacy host and repository name still resolves. A stale link is therefore
+**degraded-but-working**, not broken. A stale *command* is a different matter and
+is called out where it occurs.
+
+## Classification categories (#944)
+
+| # | Category | Disposition |
+|---|---|---|
+| 1 | AGRO runtime dependency / product-facing runtime reference | migrate now |
+| 2 | runtime compatibility contract | migrate/alias per #939 |
+| 3 | stable higher-level product/repository identity | retain |
+| 4 | stable internal persistence/API identifier | retain |
+| 5 | historical | retain |
+| — | unrelated false positive | none |
+
+## Repository table
+
+`Hits` counts matched lines from the wide pattern above, before classification.
+A high count is not a defect count: in `mifunedev/agro` and
+`mifunedev/openharness-cloud` most matches are retained categories 2–5.
+
+| Repository | Visibility | Archived | Scanned SHA | Default branch | Hits | Verdict |
+|---|---|---|---|---|---|---|
+| `12-factor-agents` | PUBLIC | no | `7a3827988d99c5b46b3857df7bcf4c9262dc5e76` | `main` | 0 | no active dependency |
+| `a2a-langgraph` | PUBLIC | no | `00da082449166e1390e9e65a3da2949cb9563dac` | `master` | 0 | no active dependency |
+| `agent-ui` | PUBLIC | no | `d8127b2f409212c72e78790572cb4ca1380b746f` | `master` | 0 | no active dependency |
+| `agents` | PUBLIC | no | `50273004fa2797fb18bab7a8b6b4cddd109887c7` | `master` | 0 | no active dependency |
+| `agro` | PUBLIC | no | `823aabbd7324e08e3b685af6b0a5ef5c3467a15f` | `main` | 2584 | compatibility to retain (plus default-branch release lag — see below) |
+| `agro-web` | PUBLIC | no | `409ef104a3bf5a0b49f4cb68a1437e75938e8de0` | `main` | 414 | consumer to migrate now (partly) |
+| `chat-extension` | PUBLIC | no | `b506ce270cef4067b002cf8693cce00a1ffc184b` | `master` | 0 | no active dependency |
+| `chat-stream-full-stack` | PUBLIC | no | `e2837f98bf41225af9377b0d8ce9136d8ac4e507` | `master` | 0 | no active dependency |
+| `chat-widget` | PUBLIC | no | `7527e289c7093f008c279d0bbbec9d5f91d0e604` | `master` | 0 | no active dependency |
+| `chatbot-with-tools` | PUBLIC | no | `7e5d65f2987a278f23fb52398b0da02a187612c5` | `master` | 0 | no active dependency |
+| `core` | PUBLIC | no | `49164102b72dd93e1d96985f7a9c5b0a664b800d` | `master` | 0 | no active dependency |
+| `deployments` | PUBLIC | no | `f17c9d9d2627db156e49042de203766c19f54aa9` | `master` | 0 | no active dependency |
+| `embed` | PUBLIC | no | `f81b0817b69cf934696e70614ff81a9ed37b961e` | `master` | 0 | no active dependency |
+| `exec-server` | PUBLIC | no | `abd6f48554f2719d62355ba40e5b08c7dbcf128f` | `main` | 0 | no active dependency |
+| `graphs` | PUBLIC | no | `4260ebc5182be0ebe35ae1ea2467b9386299604a` | `master` | 0 | no active dependency |
+| `interpreter` | PUBLIC | no | `509a96464f675e92ed9a0b484a3678d99cef58e7` | `development` | 0 | no active dependency |
+| `langserve` | PUBLIC | no | `63b0c05ba9db873cc2277567e80fd372a21208e5` | `master` | 0 | no active dependency |
+| `llm-server` | PUBLIC | no | `9a712002f1820acd08063f6124d1ce189e0ee340` | `development` | 0 | no active dependency |
+| `mcp-sse` | PUBLIC | no | `a3c10a47ec2579efa2645acc2b2695afbe2ff762` | `master` | 0 | no active dependency |
+| `multi-agent-supervisor` | PUBLIC | no | `0bf7b11e46ae431b4533c4f3bd3212101c80711e` | `master` | 0 | no active dependency |
+| `ollama` | PUBLIC | no | `24c7b9e973a047ae08fdda16573ff12f91dfc5c1` | `master` | 0 | no active dependency |
+| `openharness-cloud` | PRIVATE | no | `0aa8f999c3ef79ff8c116517b192206e5d69ba45` | `development` | 1380 | consumer to migrate now |
+| `orchestra` | PUBLIC | no | `2c7ccd281e9c69a00f30f5bd51a0ec1cd533c00d` | `development` | 1 | consumer to migrate now |
+| `plugin` | PUBLIC | no | `6d67b229b832a454a7ef53dd2c38456d5f2ca490` | `master` | 0 | no active dependency |
+| `ruska-cli` | PUBLIC | no | `89307452a865a4d900b229ead9853594fab7cd0a` | `development` | 0 | no active dependency |
+| `sandboxes` | PUBLIC | no | `7bb15a1808558372c77091071e9b7c5281f6b65f` | `master` | 0 | no active dependency |
+| `serverless-chat` | PUBLIC | **yes** | `44daefc85a1580eaac67dcb61be4186a57ba78b7` | `master` | 0 | no active dependency (archived, scanned anyway) |
+| `skills` | PUBLIC | no | `eab0a146ae3fe05bfbde6e0628c8bf22b85657d2` | `master` | 14 | historical |
+| `static` | PUBLIC | no | `fb1d7015cac0d0894a96fc5e8ff8995622b36ba3` | `master` | 0 | no active dependency |
+| `website` | PUBLIC | no | `fd6050065c5c78956cecbd5ba0c92bed2108e8c0` | `development` | 93 | consumer to migrate now |
+| `wiki` | PUBLIC | no | `da19ef5d8075ff2438b2f2832190ff941c7b2ee2` | `master` | 0 | no active dependency |
+| `workspace` | PUBLIC | no | `9312c2f946df1a71dc13ea80021fbad0fbe1fda9` | `main` | 0 | no active dependency |
+
+### Verdict counts
+
+| Verdict | Repositories |
+|---|---|
+| consumer to migrate now | 4 (`openharness-cloud`, `website`, `agro-web`, `orchestra`) |
+| compatibility to retain | 1 (`agro`) — its genuine compat surfaces are Phase 5 (#945); its `.oh/`/`oh.json` hits are default-branch release lag, not outstanding work |
+| stable identity | 0 as a whole-repository verdict; applies per occurrence inside `openharness-cloud` and `website` |
+| historical | 1 (`skills`) |
+| no active dependency | 26 |
+| not scannable | 0 |
+
+## Per-repository detail
+
+Only repositories with real hits appear here.
+
+### `mifunedev/agro` @ `823aabb` — mostly category 2, Phase 5 business; partly release lag
+
+Most of these are the deliberate Phase 0 compatibility surfaces. Per #944's
+non-goals and #939's phasing, their **removal is Phase 5 (#945)**, not this
+phase. Nothing here is proposed for removal. Summarized by surface, not
+enumerated.
+
+Two rows in the table below are **not** compatibility surfaces at all — they are
+default-branch release lag. The distinction is spelled out after the table and
+matters, because a grep cannot tell the two apart.
+
+The repository carries its own machine-readable classification at
+`.oh/compat-inventory.json` — 47 variables and 16 paths, each with a
+classification (`alias-sla`, `migrate-later`, `retained-generic`, `obsolete`), an
+owning file, and the AGRO spelling. That file, not this inventory, is the
+authority for `mifunedev/agro`'s own surfaces.
+
+| Surface | Evidence | Compat-inventory classification | #944 category |
+|---|---|---|---|
+| `.oh/` project control plane (539 tracked files) | `git ls-files \| grep '^\.oh/'` | `migrate-later`, phase 2 → `.agro/` | **not a compat surface — release lag.** Phase 2 is merged; `development` @ `b10ecac3` already has `.agro/`. `main` trails it. |
+| `oh.json` project config | repository root | `migrate-later`, phase 2 → `agro.json` | **not a compat surface — release lag.** Same: `development` already has `agro.json`. |
+| `.oh/scripts/get-oh.sh` installer | `.oh/scripts/` | `alias-sla`, phase 1, beside `get-agro.sh` | 2 |
+| `.oh/scripts/install.sh` source-checkout installer | `.oh/scripts/` | `obsolete` | 2 |
+| `dist/oh.js` CLI bundle | `.oh/cli/build.mjs` emits `dist/agro.js` and a byte-identical `dist/oh.js` | `alias-sla`, phase 1 | 2 |
+| `@mifune/openharness` npm package | `.oh/cli/package.json` is `@mifune/agro`; the legacy name ships as a delegation shim | `alias-sla`, phase 1 | 2 |
+| `ghcr.io/mifunedev/openharness` image | release workflow | `alias-sla`, phase 3 | 2 |
+| `oh` executable and `oh.mifune.dev` host | `docs/lifecycle-commands.md`, `docs/agro-compatibility.md` | alias for the SLA window | 2 |
+| 47 `OH_*` variables | `.oh/compat-inventory.json` — 11 `alias-sla`, 15 `migrate-later`, 14 `retained-generic`, 7 `obsolete` | see file | 2 (4 for the `retained-generic` ones) |
+| `openharness-release-smoke-*` CI sandbox name, `openharness-release-reservation` user-agent | `.github/workflows/release.yml:194,209,217`; `.oh/scripts/reserve-github-release.mjs:57` | not catalogued | 4 — internal CI identifier |
+| `.oh/tasks/*` (12 task folders, 52 files) | historical task records | — | 5 |
+
+**Correction to PRD finding F4.** F4 states that only two org repositories carry
+a `.oh/` directory. The scan shows **three**: `agro-web`, `openharness-cloud`,
+and `mifunedev/agro` itself — the last being the runtime's own control plane, on
+its default branch only. F4's count is correct once `mifunedev/agro` is excluded
+as the subject rather than a consumer, but the literal claim is wrong. Note that
+`agro`'s `.oh/` is neither a consumer dependency nor an unretired compatibility
+surface; see the next paragraph.
+
+**Second observation — this is release lag, not an unretired compatibility
+surface. The two look identical to a grep and must not be conflated.**
+
+The scan read `mifunedev/agro` at its **default branch**, `main` @ `823aabb`,
+which is the v0.9.0 release point. That tree carries `.oh/` and `oh.json`. The
+Phase 2 `.oh/` → `.agro/` and `oh.json` → `agro.json` namespace cutover is
+**already implemented and merged**, on `development`:
+
+```bash
+gh api repos/mifunedev/agro/branches/development --jq .commit.sha
+# b10ecac3d17d21c7abb45a2e814617e6b9b5ae50   (the PRD's record-repository SHA)
+gh api "repos/mifunedev/agro/contents/?ref=development" \
+  --jq '[.[].name] | map(select(startswith(".oh") or startswith(".agro") or . == "oh.json" or . == "agro.json")) | join(",")'
+# .agro,agro.json
+```
+
+So what the table's 2584 hits and the 539 `.oh/` files show for `main` is
+**default-branch release lag** — `main` predates the merged cutover and moves
+when the next release ships. It is **not** a compatibility surface awaiting
+Phase 5 retirement, and Phase 4 must not reimplement it.
+
+The distinction matters because both states produce the same grep output:
+
+| Observation on `main` @ `823aabb` | What it actually is |
+|---|---|
+| `.oh/` (539 files), `oh.json` at root | release lag — cutover merged to `development` @ `b10ecac3` |
+| `oh` executable, `oh.mifune.dev`, `get-oh.sh`, `oh.js`, `@mifune/openharness`, `ghcr.io/mifunedev/openharness`, the `alias-sla` `OH_*` variables | genuine compatibility surfaces, live for the SLA window, retired by Phase 5 (#945) |
+
+**Nothing in `mifunedev/agro` is Phase 4's business** under either reading.
+
+### `mifunedev/openharness-cloud` @ `0aa8f99` — the primary downstream
+
+1380 matched lines. 761 of them are Cloud's own product identity, 566 are inside
+`.oh/tasks`. The classification below follows the PRD's "Cloud naming boundary"
+table, which is not re-litigated here.
+
+#### Category 1 — migrate now
+
+| Identifier | Occurrences (file:line) | Justification |
+|---|---|---|
+| `https://github.com/mifunedev/openharness.git` clone URL | `packages/shared/src/workspace-bootstrap-assets.ts:9` (`CLONE_URL`), `infra/cloud-init/cloud-config.yaml:37`, `packages/shared/src/cloud-init.test.ts:98,457`, `infra/cloud-init/README.md:60`, `docs/browser-gateway-threat-model.md:134` | The runtime source the node clones. Replaced by artifact install (US-003), not renamed. |
+| `mifunedev/openharness` in prose describing the node bootstrap | `README.md:20`, `apps/web/components/node-setup-guide.tsx:15`, `docs/browser-gateway-threat-model.md:129`, `docs/design/console-mvp.md:254`, `packages/shared/src/index.ts:191,786`, `packages/shared/src/workspace-bootstrap-assets.ts:2`, `apps/web/lib/create-node-bootstrap.ts:53,70`, `apps/web/lib/create-node-bootstrap.test.ts:130` | Product-facing runtime reference in operator/user copy and in hand-sync provenance comments. |
+| `~/.openharness` managed source checkout (48 lines) | concentrated in `infra/cloud-init/cloud-config.yaml`, `packages/shared/src/{workspace-bootstrap-assets.ts,cloud-init.test.ts,index.ts}`, `apps/web/components/node-setup-guide.tsx`, `docs/{quickstart.md,browser-gateway-threat-model.md,design/console-mvp.md}`, `infra/cloud-init/README.md` | The checkout itself is removed by US-003. Not renamed to an AGRO-spelled checkout. |
+| `make sandbox` / `make shell` (10 files) | `README.md`, `apps/provisioner/src/provision.ts`, `apps/web/components/node-setup-guide.tsx`, `apps/web/lib/{node-setup-presentation.test.ts,walkthrough-tours.ts}`, `docs/{browser-gateway-threat-model.md,design/console-mvp.md,quickstart.md,runtime-settings-runbook.md}`, `infra/cloud-init/README.md` | The `Makefile` was deleted from the runtime by #893. These commands do not exist. Replaced by `agro sandbox install docker`. |
+| `oh cloud …` CLI invocation (≈20 lines) | `README.md:212,297,300,303,309,315,316,320`, `docs/quickstart.md:97,432,474,478,479,480,500,502,505,510,515,516` | Product-facing runtime CLI in operator docs. Migrates to `agro cloud`. |
+| `npm install -g @mifune/openharness` in the prerequisites table | `docs/quickstart.md:35` — the **only** occurrence in the repository | A documentation line telling an operator to install the legacy CLI package. Not a dependency: absent from every `package.json` and from `pnpm-lock.yaml`. Evidence in the dedicated note below. |
+| `OH_CODE_SERVER_ENABLED` (12) | node-side runtime variable | Node-side AGRO runtime variable. Migrates to `AGRO_CODE_SERVER_ENABLED` with Phase 0 compatibility (category 2 at the contract level). |
+| `OH_IMAGE_ONLY` (5) | provisioning surface | Listed `obsolete` in `agro`'s compat inventory — probes assert it never returns. Cloud must not re-emit it. |
+| `OH_CLOUD_API_URL` (1) | `agro`'s inventory marks it `migrate-later`, phase 4 — **this phase** | Cloud API base URL for the `agro cloud` CLI. |
+
+`ghcr.io/mifunedev/openharness` (the runtime image) and `oh.mifune.dev` appear in
+Cloud **only inside `.oh/tasks/*`** historical records (category 5). There is no
+live Cloud reference to either. The 38 `ghcr.io/mifunedev/openharness*` and 11
+`oh.mifune.dev` raw matches are all `openharness-cloud` images or `.oh/tasks`
+prose.
+
+#### Category 2 — migrate with a compatibility alias
+
+`OH_CODE_SERVER_ENABLED` and `OH_CLOUD_API_URL` above; treated as category 1 work
+in this phase but delivered as aliased contracts per #939.
+
+#### Category 3 — retained product identity
+
+| Identifier | Occurrences | Justification |
+|---|---|---|
+| `mifunedev/openharness-cloud`, `ghcr.io/mifunedev/openharness-cloud/{web,gateway,provisioner}`, `@openharness-cloud/*` npm scope | 761 matched lines across the repository | Cloud's own product, repository, image, and workspace identity. #944 explicitly forbids renaming these as part of runtime migration. |
+
+#### Category 4 — retained internal identifiers
+
+| Identifier | Occurrences | Justification |
+|---|---|---|
+| `OH_IMAGE_TAG` (21), `OH_ENV_FILE` (17) | `infra/control-plane/docker-compose*.yml`, `deploy/docker-compose*.yml`, `scripts/{compose.sh,oh-env.sh}`, `docs/environment-variables.md`, `.github/workflows/{compose-config.yml,runtime-settings-races.yml}` | Configure Cloud's **own** compose stack, not the AGRO runtime, and live in `.env` files on running control-plane hosts. Renaming them would break deployed hosts for grep cleanliness. |
+| `~/.openharness-bootstrap-status`, `~/.openharness-bootstrap.log`, `/run/openharness-ready` (23) | cloud-init, provisioner, gateway | The internal contract between cloud-init, the provisioner, and the gateway. Existing nodes carry these paths. Only runtime-facing prose around them changes. |
+| `docker-build-oh-sandbox` tmux session (4) | `apps/web/components/node-setup-guide.tsx`, `docs/design/console-mvp.md`, cloud-init | Internal session name that existing nodes already run under. |
+| Postgres database `openharness`, `openharness-management-ed25519` secret path, `OPENHARNESS_MANAGEMENT_PRIVATE_KEY_FILE` | `infra/control-plane/docker-compose.yml:29,35,62,90,100,127,169`, `deploy/docker-compose{,.postgres,.web}.yml`, `deploy/README.md:145,152,178,268`, `scripts/db-reset.sh` | Durable persistence and secret identifiers on live deployments. #944 names database names explicitly as not to be changed for grep cleanliness. |
+
+#### `@mifune/openharness` — a documentation line, not a dependency
+
+Cloud does **not** depend on the legacy CLI package. There is exactly one
+occurrence in the tree, and it is prose:
+
+```bash
+git grep -Fn "@mifune/openharness" 0aa8f99 -- .
+# 0aa8f99:docs/quickstart.md:35:| Open Harness CLI | ≥ 0.2.0 | `oh --version` (`npm install -g @mifune/openharness`) |
+```
+
+It appears in no `package.json`, no workspace `package.json`, and not in
+`pnpm-lock.yaml`. (The 7 `pnpm-lock.yaml` and 9 `package.json` matches counted by
+the wide scan are all `@openharness-cloud/*` workspace names — category 3.)
+
+`docs/quickstart.md:35` is therefore a **category 1 product-facing runtime
+reference in operator documentation**, dispositioned under the docs story
+(US-009) alongside the other `oh cloud …` lines in the same file. It is not a
+dependency migration.
+
+#### Category 5 — historical
+
+566 matched lines inside `.oh/tasks/*` (129 tracked files, 12+ task folders):
+prior PRDs, prompts, progress logs and evidence that record what the system *was*.
+Summarized, not enumerated, per the anchor. Content must survive US-008 unmodified.
+`docs/design/console-mvp.md` history and closed-issue links are likewise category 5.
+
+### `mifunedev/website` @ `fd60500` — 6-hit code-search lead, resolved
+
+The code-search figure of 6 undercounts. Content scanning finds **10 lines**
+containing `oh.mifune.dev` and **22 lines** matching `mifunedev/openharness`.
+Every one has an explicit disposition below.
+
+`oh.mifune.dev` still 301-redirects to `agro.mifune.dev` and
+`github.com/mifunedev/openharness` still 301-redirects to `mifunedev/agro`, so
+every *link* below is **degraded-but-working**, not broken. The exception is
+called out.
+
+| file:line | Identifier | Category | Disposition and justification |
+|---|---|---|---|
+| `src/config/offerings.ts:4` | `docs: "https://oh.mifune.dev"` | 1 | Live marketing link constant; the canonical docs host is `agro.mifune.dev`. Degraded-but-working (301). Migrate. |
+| `src/config/offerings.ts:3` | `openSource: "https://github.com/mifunedev/openharness"` | 1 | Live marketing link. Degraded-but-working (301). Migrate. **Caveat:** `src/lib/schema.ts:12` derives `OPEN_SOURCE_ID = ${OFFERING_URLS.openSource}#software`, a schema.org `@id`. Changing the URL changes a published structured-data identifier — a deliberate, acceptable change, but it must be a decision, not a side effect. |
+| `src/sections/AgentPickerSection.tsx:6` | `DOCS_BASE_URL = "https://oh.mifune.dev"` | 1 | Live docs base for every link the section renders. Degraded-but-working. Migrate. |
+| `src/sections/AgentPickerSection.tsx:233` | displayed text `mifunedev/openharness` | 1 | Product-facing runtime name rendered under a live GitHub star count. Migrate. |
+| `src/sections/AgentPickerSection.tsx:186` | `repo.fullName === "mifunedev/openharness"` | 1 | **Verified not broken.** `src/lib/github.ts:59` builds `fullName` from the curated `owner`/`name`, not from the API response, so the match still succeeds. The GitHub API call itself 301-redirects and `fetch` follows it — probe returns `full_name: mifunedev/agro`, `stargazers_count: 37`. Migrate `github.ts` and this key together, or the star card silently falls back to `starsVerified: false` / "Count unavailable". |
+| `src/lib/github.ts:34` | `name: "openharness"` in `FLAGSHIP[]` | 1 | Live GitHub API call at build time (ISR, hourly). Works via redirect today. Migrate. |
+| `src/data/faqs.ts:48` | `github.com/mifunedev/openharness` and `oh.mifune.dev` in FAQ copy | 1 | Product-facing runtime references in published copy. Migrate. |
+| `public/llm.txt:57,58,71` | `github.com/mifunedev/openharness`, `oh.mifune.dev` ×2 | 1 | **Generated artifact.** Do not hand-edit; regenerate. |
+| `scripts/generate-llm-txt.mjs:111,112,125` | the same three strings | 1 | The generator is the real source. Migrate here; `public/llm.txt` follows. |
+| `posts/openharness-getting-started.md:17,18,83,89` | `oh.mifune.dev` ×3, `github.com/mifunedev/openharness#-install` | 1 | Published tutorial. Links are degraded-but-working. |
+| `posts/openharness-getting-started.md:48-49,55-56,62,72` | `git clone https://github.com/mifunedev/openharness.git ~/.openharness`, `make harness-config`, `nano harness.yaml`, `make sandbox && make shell` | 1 — **broken, not degraded** | This is the public instance of PRD finding F1, one step worse. The clone succeeds via redirect, but `Makefile` was deleted by #893 and `harness.yaml` no longer exists, so `make harness-config`, `make sandbox`, and `make shell` all fail. The organization's public getting-started tutorial does not work. Highest-value item outside Cloud. |
+| `src/sections/{HeroSection,FooterSection,PricingSection,OpenHarnessValueSection,AboutSection}.tsx`, `src/app/{page,pricing/page,services/page}.tsx`, `src/components/brand/OpenHarnessBrandBar.tsx` (≈30 lines) | `OpenHarness*` component names, `openharness-value-heading` anchor, "Open Harness" brand copy | 1 for the rendered copy; 4 for the identifiers | The rendered strings name the runtime, which is now AGRO — category 1. The React component names and the DOM anchor id are internal identifiers with no external contract; renaming them is optional churn, so they are category 4 and may be left alone. Separating the two is what keeps this from becoming a mechanical rename. |
+| `src/config/cloud-pricing.ts:7,45` | `repo: mifunedev/openharness-cloud`, `openharness-cloud#123` | 3 | Provenance comments naming Cloud's retained repository identity. Retain. |
+| `src/lib/schema.ts:11` | `CLOUD_SERVICE_ID = ${SITE_URL}/#openharness-cloud` | 4 | Published schema.org `@id` for the Cloud service. A durable identifier; #944 forbids changing it for cleanliness. Retain. |
+| `tasks/**` (≈30 lines across `ai-partner-offer-realign`, `cloud-pricing-page`, `fleet-pricing-calculator`, `mifune-website-refactor`) | `OpenHarness` in PRDs, prompts, progress logs; `mifunedev/openharness-cloud` issue/PR links | 5 | Historical task records. Summarized, not enumerated. Retain unmodified. |
+
+Note: `text-oh-accent` / `ring-oh-focus` Tailwind tokens are lowercase design-system
+names, not `OH_*` variables, and were not matched. Unrelated.
+
+### `mifunedev/agro-web` @ `409ef10` — Phase 3 verified, **not clean**
+
+Head commit is `Merge pull request #47 from mifunedev/feat/943-agro-web-identity`
+— Phase 3 (#943). Phase 3 delivered the site's **identity**: `docusaurus.config.ts:16`
+is `url: "https://agro.mifune.dev"`, `projectName: "agro-web"`, and
+`docs/intro.md:12` documents the aliases explicitly. That much is confirmed clean.
+
+The **docs body was not re-mirrored**. `scripts/check-docs-drift.mjs:3` states that
+"the site keeps a hand-copied duplicate of the harness repo's `docs/`". Measured
+against the copy source:
+
+```
+verb counts in docs/ over (agro|oh) (shell|sandbox|ps|stop|restart|logs|config|destroy|migrate|harness|tool)
+  mifunedev/agro@823aabb   agro: 133   oh: 211
+  mifunedev/agro-web@409ef10  agro:   0   oh: 317
+```
+
+`docs/lifecycle-commands.md:6` in `agro-web` reads ``# Lifecycle commands (`oh`)``
+and "``oh`` is the only front door"; the same file in `mifunedev/agro` reads
+``# Lifecycle commands (`agro`)``. The site published at `agro.mifune.dev`
+therefore still presents `oh`, `.oh/`, `oh.json`, `~/.oh` and `OH_HOME` as the
+canonical runtime surface, and is missing 14 pages that `mifunedev/agro@main`
+now carries (including `agro-compatibility.md`, the very page the aliases refer to).
+
+| Surface | Evidence | Category | Justification |
+|---|---|---|---|
+| `oh <verb>` as the canonical command across `docs/` (≈317 occurrences in 15+ pages, led by `installation.md`, `lifecycle-commands.md`, `quickstart.md`, `connecting.md`, `configuration.md`, `runtimes/*`, `harnesses/*`) | verb counts above | 1 | The published runtime documentation presents the compatibility alias as canonical. This is a product-facing runtime reference. |
+| `docs/oh-directory-layout.md` — filename, title, and body describing `.oh/` as the control plane | whole file; line 13 links `github.com/mifunedev/agro/blob/main/.oh/README.md` | 1 | The link resolves today only because `agro@main` has not taken the Phase 2 rename. It becomes a 404 the moment it does. |
+| `ghcr.io/mifunedev/openharness:latest` as the default image (`docs/deployment-prebuilt-image.md` ×11, `docs/docker-deployment.md` ×3, `docs/configuration.md:153`, `docs/quickstart.md:59`, `docs/installation.md:270`, `docs/runtimes/microsandbox.md` ×3) | — | 2 | **Deliberate.** `scripts/check-docs-drift.mjs:41` states GHCR references are not flagged because the image name is owned by the harness release workflow. `agro`'s compat inventory puts the default image-ref switch in phase 3 and keeps the legacy tags as intentional aliases. Not a Phase 4 defect. |
+| `oh.mifune.dev/get-oh.sh` in `docs/installation.md:243,244`; `get-oh.sh`/`oh.js` mirroring in `scripts/{sync-external-scripts,build-oh-cli}.mjs`, `README.md:58,60`, `.github/workflows/pages.yml:14` | — | 2 | Deliberate compatibility mirroring. `scripts/oh-source.mjs:25` already defaults `REPO` to `mifunedev/agro` with `OH_GITHUB_REPO` as the legacy fallback, and `sourceCandidates()` falls back from `.agro/scripts/` to `.oh/scripts/`. Correct as built. |
+| `docs/intro.md:12`, `docs/quickstart.md:42` naming the aliases | — | 2 | Documenting the compatibility contract is the intended behavior; `check-docs-drift.mjs:34-42` exempts lines that carry the word "compatibility". |
+| `.github/workflows/pages.yml:19` `repository_dispatch: types: [agro-release, openharness-release]`; `contains(…, "mifunedev/openharness-web")` guards at lines 77, 83, 90 | — | 2 | Compatibility listeners. **Dormant:** `mifunedev/agro@823aabb` contains no `repository_dispatch` sender at all (`git grep -nE 'repository_dispatch\|event_type' .github .oh/scripts` → empty), matching the comment at `pages.yml:14-16`. The daily `schedule` cron is the only live refresh path. |
+| `.oh/tasks/sandbox-registry-one-door/` (6 files) | `git ls-files '.oh/*'` | 5 | Historical task record. No live reference anywhere outside `.oh/` (`git grep sandbox-registry-one-door -- . ':!.oh/'` → empty). See `migrate-check.md`. |
+| `blog/*` (49 lines), `promos/*` (9 lines) | dated posts and promo drafts | 5 | Dated records. `check-docs-drift.mjs:25-27` and `:40` deliberately exclude `blog/` and `promos/` from both the retired-command scan and the legacy-identity scan; turning them on is called an editorial decision, not a mechanical one. Retain. |
+
+### `mifunedev/orchestra` @ `2c7ccd2` — 1 hit
+
+| file:line | Identifier | Category | Justification |
+|---|---|---|---|
+| `decks/slides/onepager.html:242` | `Powered by Orchestra + OpenHarness` | **1 — decided** | The surrounding block is a present-tense "PLATFORM PROOF" panel whose own subtitle (line 243) reads "Mifune builds managed AI workers on **a production agent platform your team can inspect, extend, and own**", sitting directly above live contact routes (`mifune.dev/services`, `support@mifune.dev`, `console.mifune.dev`, lines 229–243). It names the runtime a reader is invited to go inspect and run today, not a past state — so category 1, migrate. One line, one word; lowest priority of the category-1 items. |
+
+### `mifunedev/skills` @ `eab0a14` — 14 hits, all historical
+
+No active dependency. Every hit is prose:
+
+- `skills/ste/SKILL.md:137,170`, `skills/ste/references/examples.md:70,71,72,237`,
+  `skills/ste/references/rules.md:414,444` — `openharness` used as an **illustrative
+  container/volume name** inside Simplified-Technical-English before/after examples.
+  Generic example text; renaming would not change any behavior. Category 5.
+- `skills/ship-spec/SKILL.md:78,183,184,185,344` — references to a
+  `tasks/openharness-v07-convergence/` template path **in a host repository**, not
+  in this one. Category 5.
+- `CHANGELOG.md:17` — records that the "Open Harness portability lint
+  (openharness#758)" reported five cases. A changelog entry about the past.
+  Category 5.
+
+No `.oh/`, no `oh.json`, no `OH_*`, no `oh` executable invocation, no live URL.
+
+## Action required in this phase
+
+Category 1 and category 2 items **outside** `mifunedev/agro` itself:
+
+1. **`mifunedev/openharness-cloud`** — the whole of US-003 through US-006 and
+   US-009. Concretely: the `mifunedev/openharness` clone URL and `~/.openharness`
+   checkout (removed, not renamed); `make sandbox` / `make shell` (replaced by
+   `agro sandbox install docker`); `oh cloud …` → `agro cloud …` in `README.md`
+   and `docs/quickstart.md`; `OH_CODE_SERVER_ENABLED` → `AGRO_CODE_SERVER_ENABLED`
+   with an alias; `OH_CLOUD_API_URL` (marked phase 4 in `agro`'s own compat
+   inventory); and no re-emission of the obsolete `OH_IMAGE_ONLY`. The single
+   `@mifune/openharness` line at `docs/quickstart.md:35` rides along with the
+   docs story (US-009) — Cloud has **no** dependency on that package.
+
+2. **`mifunedev/website`** — `posts/openharness-getting-started.md` is the only
+   item in the org that is **broken rather than degraded**: it publishes
+   `make harness-config`, `make sandbox`, and `make shell`, none of which exist
+   since #893 deleted the `Makefile`. Then the live constants
+   (`src/config/offerings.ts:3,4`, `src/sections/AgentPickerSection.tsx:6`),
+   the GitHub API target (`src/lib/github.ts:34` with its matching key at
+   `AgentPickerSection.tsx:186`), the FAQ copy (`src/data/faqs.ts:48`), and
+   `scripts/generate-llm-txt.mjs:111,112,125` with a regenerated `public/llm.txt`.
+   Retain `src/lib/schema.ts:11`, `src/config/cloud-pricing.ts:7,45`, and `tasks/**`.
+
+3. **`mifunedev/agro-web`** — re-mirror `docs/` from `mifunedev/agro`. The site at
+   `agro.mifune.dev` still presents `oh` as the canonical verb in ~317 places and
+   is missing 14 pages, including `agro-compatibility.md`. This reads as an
+   incomplete Phase 3 (#943) delivery rather than newly discovered Phase 4 work;
+   the routing decision belongs to the advisor. The GHCR image default and the
+   `get-oh.sh`/`oh.js` mirroring are deliberate and must **not** be swept up in it.
+
+4. **`mifunedev/orchestra`** — one word at `decks/slides/onepager.html:242`.
+   Decided as category 1: the panel is present-tense platform proof beside live
+   contact routes, not a historical note.
+
+Nothing in the remaining 28 repositories requires action.
+
+## Limitations
+
+State these rather than claiming completeness:
+
+1. **Default branch only.** Every clone was `--depth 1` on the default branch.
+   Open branches and pull requests were not scanned. A legacy identifier
+   introduced on an unmerged branch would not appear here.
+2. **Point-in-time.** Every finding is pinned to the SHA in the table. `agro-web`
+   in particular moves frequently.
+3. **Tracked files only.** `git grep` reads the index. Untracked files, release
+   assets, GitHub Pages build output, container images, and the CDN rules that
+   serve `oh.mifune.dev/install.sh` (documented at `agro-web/README.md:61` as
+   living **outside** any repository) are out of scope. The `oh.mifune.dev` →
+   `agro.mifune.dev` 301 is likewise CDN configuration and appears in no repository
+   scanned.
+4. **`mifunedev/agro` summarized, not enumerated.** By instruction. Its
+   `.oh/compat-inventory.json` is the authority for those 2584 lines; this
+   inventory does not restate them and does not propose removing any.
+5. **Default-branch lag is invisible to a grep.** Scanning `mifunedev/agro` at
+   `main` reports `.oh/` and `oh.json` that the merged `development` tree no
+   longer has. The same is true of any repository whose default branch trails a
+   merged rename. Every hit count in this inventory is a default-branch count and
+   must be read as such before it is read as outstanding work.
+6. **No runtime behavior of Cloud was exercised.** This is a static inventory.
+   PRD findings F1–F3 are cited from the PRD and corroborated by source lines;
+   they were not reproduced against a running node.

--- a/.agro/tasks/agro-cloud-consumer-migration/delegate-graph.json
+++ b/.agro/tasks/agro-cloud-consumer-migration/delegate-graph.json
@@ -1,0 +1,541 @@
+{
+  "schemaVersion": 2,
+  "slug": "agro-cloud-consumer-migration",
+  "issue": 944,
+  "owner": {
+    "role": "advisor",
+    "session": "https://claude.ai/code/session_018Gh4FRUfcQYD6CcNNH1xRU",
+    "model": "claude-opus-5[1m]",
+    "owns": [
+      "prd.json",
+      "progress.txt",
+      "delegate-graph.json",
+      "delegate-log.txt",
+      "evidence.md",
+      "every acceptance decision"
+    ]
+  },
+  "contract": {
+    "workersNeverCommit": true,
+    "workersNeverTouchGitHubState": true,
+    "ownerAcceptsEveryResult": true,
+    "statusIsAdvisorDecisionNotWorkerClaim": true,
+    "isolatedWorktreePerParallelWriter": true,
+    "provenanceNote": "The Agent tool reports no observed model or effort back to the dispatcher. `modelRequested` records what this session asked for; `modelObserved` stays \"unreported\" rather than being inferred, and effort is not an exposed dispatch parameter for this worker type."
+  },
+  "workers": [
+    {
+      "id": "W1",
+      "nativeWorkerId": "aa588cf40102fb5f1",
+      "subagentType": "general-purpose",
+      "modelRequested": "inherit (no override passed)",
+      "modelObserved": "unreported",
+      "effortRequested": "not an exposed parameter for this worker type",
+      "dispatchedAt": "2026-09-08",
+      "wave": 1,
+      "stories": [
+        "US-001",
+        "US-008"
+      ],
+      "repo": "mifunedev/agro",
+      "worktree": "/home/sandbox/harness/.worktrees/feat/944-agro-cloud-consumer-migration",
+      "branch": "feat/944-agro-cloud-consumer-migration",
+      "baseCommit": "b10ecac3",
+      "ownedWritePaths": [
+        ".agro/tasks/agro-cloud-consumer-migration/consumer-inventory.md",
+        ".agro/tasks/agro-cloud-consumer-migration/migrate-check.md"
+      ],
+      "forbiddenPaths": [
+        "everything else in the worktree",
+        "projects/mifunedev/openharness-cloud (read-only)"
+      ],
+      "evidenceDestination": ".agro/tasks/agro-cloud-consumer-migration/consumer-inventory.md, migrate-check.md",
+      "acceptanceCommands": [
+        "test -s consumer-inventory.md && test -s migrate-check.md",
+        "advisor spot-checks >= 3 classifications against the real repo content",
+        "advisor confirms every non-archived org repo appears with a scanned SHA or an explicit not-scannable reason",
+        "advisor confirms `agro migrate --check` was run with --check only and never against projects/mifunedev/openharness-cloud"
+      ],
+      "repairRoute": "same worker via SendMessage; a classification dispute is decided by the advisor against #944's five categories",
+      "status": "ACCEPTED",
+      "corrections": [
+        "2026-09-08 path correction: task folder moved into the record worktree"
+      ],
+      "acceptanceEvidence": [
+        "all 32 non-archived and archived org repos appear in the inventory table; set-compared against gh repo list, zero missing",
+        "35 forty-character scan SHAs recorded",
+        "spot-check 1 PASS: website src/config/offerings.ts:3 openSource points at github.com/mifunedev/openharness \u2014 live constant, category 1 confirmed",
+        "spot-check 2 PASS: orchestra decks/slides/onepager.html:242 'Powered by Orchestra + OpenHarness' sits in a present-tense platform panel above live contact routes \u2014 category 1 confirmed",
+        "spot-check 3 PASS on re-examination: the skills repo's make destroy and openharness strings are illustrative prose inside the ste technical-writing skill (rules.md:322-323 is a Wrong:/Right: sentence lesson; examples.md hits are before/after writing samples), not operational guidance \u2014 the historical verdict stands. The advisor initially suspected under-classification and checked rather than accepting or overriding.",
+        "no residue of the superseded Phase-5 framing remains in either deliverable"
+      ]
+    },
+    {
+      "id": "W2",
+      "nativeWorkerId": "ae551523e1c3b9519",
+      "subagentType": "general-purpose",
+      "modelRequested": "inherit (no override passed)",
+      "modelObserved": "unreported",
+      "effortRequested": "not an exposed parameter for this worker type",
+      "dispatchedAt": "2026-09-08",
+      "wave": 1,
+      "stories": [
+        "US-003",
+        "US-004",
+        "US-005"
+      ],
+      "repo": "mifunedev/openharness-cloud",
+      "worktree": "/home/sandbox/harness/projects/mifunedev/openharness-cloud/.worktrees/944-bootstrap",
+      "branch": "feat/944-agro-runtime-bootstrap",
+      "baseCommit": "0aa8f99",
+      "ownedWritePaths": [
+        "packages/shared/src/workspace-bootstrap-assets.ts",
+        "packages/shared/src/index.ts",
+        "packages/shared/src/**/*.test.ts",
+        "infra/cloud-init/cloud-config.yaml",
+        "apps/web/lib/create-node-bootstrap.ts",
+        "apps/web/lib/create-node-bootstrap.test.ts"
+      ],
+      "forbiddenPaths": [
+        "apps/provisioner/src/provision.ts (W3 owns it)",
+        "apps/provisioner/src/provision.test.ts (W3 owns it)",
+        "the record worktree",
+        "OH_IMAGE_TAG / OH_ENV_FILE / ghcr.io/mifunedev/openharness-cloud/* / @openharness-cloud/* / any persistence identifier"
+      ],
+      "evidenceDestination": "worker report -> advisor -> evidence.md; generated userData for a default node and a hermes+deepagents+agent-browser node pasted verbatim",
+      "acceptanceCommands": [
+        "grep -c 'make sandbox' on generated userData == 0",
+        "grep -E 'INSTALL_(OPENCODE|GROK_BUILD|DEEPAGENTS|HERMES|AGENT_BROWSER)' on generated userData == empty",
+        "no git clone of a runtime source repo in generated userData",
+        "no managed source checkout created, neither ~/.openharness nor a renamed equivalent",
+        "repo typecheck/lint/test for root and each affected workspace, exit 0",
+        "advisor re-runs the suite independently on the accepted tree",
+        "the browser editor workspace root and /home/sandbox/oh.code-workspace resolve to a path that exists after the new bootstrap and holds durable user state (attach surface 2 of #944)"
+      ],
+      "repairRoute": "same worker via SendMessage (coupled stories stay with one continuing worker)",
+      "status": "ACCEPTED",
+      "corrections": [
+        "2026-09-08 path correction: prd.md moved into the record worktree",
+        "2026-09-08 design constraint: removing ~/.openharness removes the browser editor's default workspace root (README.md:356); repoint it and fix the false header comment at packages/shared/src/index.ts:785-790"
+      ],
+      "knownExternalDependency": "fresh-provisioning end-to-end success is gated on the #1019 patched AGRO image; v0.9.0 is the only published image and is known broken"
+    },
+    {
+      "id": "W3",
+      "nativeWorkerId": "ab16f3c765ba00e63",
+      "subagentType": "general-purpose",
+      "modelRequested": "inherit (no override passed)",
+      "modelObserved": "unreported",
+      "effortRequested": "not an exposed parameter for this worker type",
+      "dispatchedAt": "2026-09-08",
+      "wave": 1,
+      "stories": [
+        "US-006"
+      ],
+      "repo": "mifunedev/openharness-cloud",
+      "worktree": "/home/sandbox/harness/projects/mifunedev/openharness-cloud/.worktrees/944-rebuild",
+      "branch": "feat/944-node-rebuild-ssh",
+      "baseCommit": "0aa8f99",
+      "ownedWritePaths": [
+        "apps/provisioner/src/provision.ts",
+        "apps/provisioner/src/provision.test.ts"
+      ],
+      "forbiddenPaths": [
+        "packages/shared/src/workspace-bootstrap-assets.ts (W2 owns it)",
+        "infra/cloud-init/cloud-config.yaml (W2 owns it)",
+        "packages/shared/src/index.ts (W2 owns it)",
+        "apps/web/lib/create-node-bootstrap.ts (W2 owns it)",
+        "handleProvision / handleDestroy / handleRestart / reconcileNode beyond compile necessity"
+      ],
+      "evidenceDestination": "worker report -> advisor -> evidence.md; the chosen node-side command sequence and its justification from runtime source",
+      "acceptanceCommands": [
+        "the TODO naming `git -C ~/.openharness pull && make sandbox` is absent from the tree, not reworded",
+        "no volume-destroying verb (agro destroy / down -v) appears in the rebuild path",
+        "a node-side failure does not reach NODE_STATUS.RUNNING, proven by test",
+        "apps/provisioner typecheck/lint/test, exit 0",
+        "advisor re-runs the suite independently on the accepted tree"
+      ],
+      "repairRoute": "same worker via SendMessage; scope creep beyond the D11 prerequisite is rejected by the advisor, not negotiated",
+      "status": "ACCEPTED",
+      "corrections": [
+        "2026-09-08 informational: do not pin the broken v0.9.0 image"
+      ],
+      "acceptanceEvidence": [
+        "readiness oracle is the project's own: sandbox-healthcheck.sh:72 require_unit openharness-bootstrap.service",
+        "Type=oneshot + RemainAfterExit=yes makes active a completion proof and failed a failure proof",
+        "budget literals generated from SANDBOX_REBUILD_BUDGET_SECONDS; outer = node budget + headroom; 960 removed; inversion now structurally impossible",
+        "regression test stubs running-container + failed-unit and asserts state=failed step=ready at exit 65, one probe only",
+        "TODO naming ~/.openharness pull and make sandbox absent from apps/provisioner/src",
+        "advisor re-ran pnpm type-check && pnpm test independently: exit 0"
+      ],
+      "securityBoundaryDecision": "Readiness probe adds `docker exec <name> systemctl is-active <unit>` to the root forced-command endpoint. Accepted: container name is regex-allowlisted and re-checked against the exact canonical SSH_ORIGINAL_COMMAND, unit name is a compile-time constant, probe is read-only, output is matched against a closed vocabulary and discarded rather than relayed. The endpoint already ran agro sandbox install, so a read-only exec is not a meaningful escalation. Pinned SSH surface, principal, key, option set and 0600 known-hosts pin unchanged. Disclosed by the worker, not discovered in review."
+    },
+    {
+      "id": "W4",
+      "nativeWorkerId": "ab4aa8ebb14cb9fb1",
+      "subagentType": "general-purpose",
+      "modelRequested": "inherit (no override passed)",
+      "modelObserved": null,
+      "wave": 2,
+      "stories": [
+        "US-002",
+        "US-009"
+      ],
+      "repo": "mifunedev/openharness-cloud",
+      "worktree": "/home/sandbox/harness/projects/mifunedev/openharness-cloud/.worktrees/944-docs",
+      "branch": "feat/944-cloud-classification-docs (to be cut from the accepted W2+W3 integration)",
+      "baseCommit": "pending W2/W3 acceptance",
+      "ownedWritePaths": [
+        "docs/agro-runtime-name-classification.md (new)",
+        "README.md",
+        "docs/quickstart.md",
+        "docs/browser-gateway-threat-model.md",
+        "docs/browser-gateway-runbook.md",
+        "docs/deploy-provisioner.md",
+        "deploy/README.md",
+        "infra/cloud-init/README.md",
+        "infra/control-plane/README.md",
+        "apps/web/components/node-setup-guide.tsx",
+        "apps/gateway/README.md",
+        "apps/provisioner/README.md",
+        "apps/web/README.md"
+      ],
+      "forbiddenPaths": [
+        "every source file owned by W2 and W3",
+        "docs/design/console-mvp.md (category 5 historical design record \u2014 retained as written)",
+        "docs/runtime-settings-promotion-evidence.md (category 5 historical evidence)",
+        "docs/cost.md issue links (category 5 historical)"
+      ],
+      "evidenceDestination": "docs/agro-runtime-name-classification.md in the Cloud repo",
+      "acceptanceCommands": [
+        "no retained instruction references make sandbox, a runtime source clone, or a retired INSTALL_* flag",
+        "every category 3 and 4 retention carries a written justification",
+        "setup prose matches the userData W2 actually generates, verified by the advisor against the accepted diff",
+        "repo docs/lint checks, exit 0"
+      ],
+      "repairRoute": "same worker via SendMessage",
+      "status": "ACCEPTED",
+      "blockedBy": [
+        "W2 acceptance",
+        "W3 acceptance"
+      ]
+    },
+    {
+      "id": "W5",
+      "nativeWorkerId": null,
+      "subagentType": "general-purpose",
+      "modelRequested": "inherit (no override passed)",
+      "modelObserved": null,
+      "wave": 3,
+      "stories": [
+        "US-007a"
+      ],
+      "repo": "mifunedev/openharness-cloud",
+      "worktree": "/home/sandbox/harness/projects/mifunedev/openharness-cloud/.worktrees/944-bootstrap (read-only reuse) plus a disposable local Linux host",
+      "branch": "n/a \u2014 evidence only, no tracked source edits expected",
+      "baseCommit": "pending W2/W3 acceptance",
+      "ownedWritePaths": [
+        "/home/sandbox/harness/.worktrees/feat/944-agro-cloud-consumer-migration/.agro/tasks/agro-cloud-consumer-migration/local-lifecycle-evidence.md",
+        "/home/sandbox/harness/.worktrees/feat/944-agro-cloud-consumer-migration/.agro/tasks/agro-cloud-consumer-migration/local-lifecycle-transcript.log"
+      ],
+      "forbiddenPaths": [
+        "every tracked source file in both repositories",
+        "any live or paid infrastructure",
+        "the operator's real Cloud control plane"
+      ],
+      "evidenceDestination": "local-lifecycle-evidence.md and local-lifecycle-transcript.log in the record worktree",
+      "acceptanceCommands": [
+        "the generated bootstrap ran on a real disposable Linux host, with the host identified",
+        "every assertion cites observed filesystem or container state, never a mock or a status transition",
+        "a representative legacy ~/.openharness workspace is shown recoverable",
+        "attach surface 1 (ssh + tmux attach -t docker-build-oh-sandbox) exercised and observed",
+        "attach surface 2 (real loopback code-server reached over a pinned SSH forward, workspace root holding durable state) exercised and observed",
+        "attach surface 3 (re-attach to the running sandbox container) exercised and observed",
+        "all three attach surfaces re-exercised after a restart and after a rebuild, each observing state written beforehand",
+        "advisor independently re-runs at least one assertion"
+      ],
+      "repairRoute": "same worker via SendMessage",
+      "status": "PENDING",
+      "blockedBy": [
+        "W2 acceptance",
+        "W3 acceptance",
+        "confirmation that the local host can host Docker-in-Docker faithfully"
+      ]
+    },
+    {
+      "id": "W6",
+      "nativeWorkerId": "a215de2cbdb589bf6",
+      "subagentType": "general-purpose",
+      "modelRequested": "inherit (no override passed)",
+      "modelObserved": null,
+      "wave": 2,
+      "stories": [
+        "US-010"
+      ],
+      "repo": "mifunedev/website",
+      "worktree": "to be cloned into projects/mifunedev/website with its own worktree",
+      "branch": "feat/944-agro-runtime-references",
+      "baseCommit": "pending clone",
+      "ownedWritePaths": [
+        "posts/openharness-getting-started.md",
+        "src/**/offerings.ts",
+        "src/**/AgentPickerSection.tsx",
+        "src/**/github.ts",
+        "src/**/faqs.ts",
+        "scripts/generate-llm-txt.mjs",
+        "public/llm.txt"
+      ],
+      "forbiddenPaths": [
+        "schema.ts",
+        "cloud-pricing.ts",
+        "tasks/**",
+        "any historical post other than the one publishing dead commands"
+      ],
+      "evidenceDestination": "worker report -> advisor -> evidence.md",
+      "acceptanceCommands": [
+        "no make sandbox / make shell / make harness-config / harness.yaml in published guidance",
+        "replacement commands verified against agro@main, not development",
+        "github.ts target and AgentPickerSection.tsx match key changed together and still match",
+        "public/llm.txt regenerated by its generator, not hand-edited",
+        "site build, exit 0"
+      ],
+      "repairRoute": "same worker via SendMessage",
+      "status": "ACCEPTED",
+      "blockedBy": [
+        "advisor clone of mifunedev/website"
+      ]
+    },
+    {
+      "id": "W7",
+      "nativeWorkerId": null,
+      "subagentType": "general-purpose",
+      "modelRequested": "inherit (no override passed)",
+      "modelObserved": null,
+      "wave": 2,
+      "stories": [
+        "US-011"
+      ],
+      "repo": "mifunedev/agro-web",
+      "worktree": "projects/mifunedev/openharness-web (existing clone) with its own worktree",
+      "branch": "feat/944-docs-drift",
+      "baseCommit": "pending fetch",
+      "ownedWritePaths": [
+        "docs/**"
+      ],
+      "forbiddenPaths": [
+        "check-docs-drift.mjs deliberate exceptions at :41",
+        "static/CNAME",
+        "docusaurus.config.ts identity fields",
+        "scripts/oh-source.mjs",
+        ".oh/tasks/**"
+      ],
+      "evidenceDestination": "worker report -> advisor -> evidence.md",
+      "acceptanceCommands": [
+        "docs/lifecycle-commands.md no longer presents oh as the only front door",
+        "prose mirrored from agro@main; no unreleased .agro namespace prose introduced",
+        "the 14 missing pages are mirrored or their absence justified",
+        "check-docs-drift.mjs passes, exit 0",
+        "a manual Pages build is NOT cited as evidence the drift is fixed"
+      ],
+      "repairRoute": "same worker via SendMessage",
+      "status": "ACCEPTED",
+      "blockedBy": [
+        "W1 corrected inventory accepted"
+      ]
+    },
+    {
+      "id": "W8",
+      "nativeWorkerId": "a1a9a4ca502958aa1",
+      "subagentType": "general-purpose",
+      "modelRequested": "inherit (no override passed)",
+      "modelObserved": "unreported",
+      "effortRequested": "not an exposed parameter for this worker type",
+      "dispatchedAt": "2026-09-08",
+      "wave": 2,
+      "stories": [
+        "US-012 (prerequisite fix)"
+      ],
+      "repo": "mifunedev/agro",
+      "worktree": "/home/sandbox/harness/.worktrees/bug/944-sandbox-install-idempotent",
+      "branch": "bug/944-sandbox-install-preserve-config",
+      "baseCommit": "b10ecac3",
+      "ownedWritePaths": [
+        ".agro/cli/src/commands/sandbox.ts",
+        ".agro/cli/src/__tests__/sandbox.test.ts"
+      ],
+      "forbiddenPaths": [
+        ".agro/tasks/**",
+        "release workflows",
+        "package.json version fields",
+        "the registry, wizard, compose renderer and config schema beyond the fix"
+      ],
+      "evidenceDestination": "worker report -> advisor -> evidence.md",
+      "acceptanceCommands": [
+        "re-installing an existing name preserves timezone, access.dockerSocket and git identity",
+        "the preserved values reach the compose env the recreated container receives, not only agro.json",
+        "a first install with no existing entry is unchanged",
+        "an explicit flag still overrides the preserved value",
+        "a stale entry carrying a retired or secret key does not resurrect it",
+        "advisor re-runs typecheck, test and build independently"
+      ],
+      "repairRoute": "same worker via SendMessage",
+      "status": "ACCEPTED",
+      "dispatchLedgerNote": "Registered retroactively. The dispatch preceded its ledger entry, which is the hygiene gap previously flagged; recorded rather than backdated.",
+      "acceptanceEvidence": [
+        "OH_CONFIG_FIELDS confirmed authoritative; completeness is structural, not hand-enumerated",
+        "worker demonstrated its tests are load-bearing: reverting sandbox.ts alone leaves 7 of 9 failing, with 2 declared controls",
+        "advisor re-ran typecheck + test + build independently: 74 files, 1257 tests, 205.1kb bundle, exit 0",
+        "no new flags; --repo, --image, --no-build, --yes, the wizard and nextDefaultName unchanged"
+      ]
+    },
+    {
+      "id": "W9",
+      "nativeWorkerId": "afeb96646cba27a88",
+      "subagentType": "general-purpose",
+      "modelRequested": "inherit (no override passed)",
+      "modelObserved": "unreported",
+      "effortRequested": "not an exposed parameter for this worker type",
+      "dispatchedAt": "2026-09-08",
+      "wave": 2,
+      "stories": [
+        "#1019 Part A"
+      ],
+      "repo": "mifunedev/agro",
+      "worktree": "/home/sandbox/harness/.worktrees/bug/1019-boot-recovery",
+      "branch": "bug/1019-boot-recovery",
+      "baseCommit": "b10ecac3",
+      "ownedWritePaths": [
+        ".agro/evals/probes/** (new or extended recovery and guardrail probes)",
+        ".agro/tasks/1019-boot-recovery/** (its own task folder)",
+        "docs/** for the recovery procedure"
+      ],
+      "forbiddenPaths": [
+        ".agro/tasks/agro-cloud-consumer-migration/**",
+        "any release workflow",
+        "sandbox-boot-guard.yml LEGACY_IMAGE pin",
+        "package.json version fields"
+      ],
+      "evidenceDestination": ".agro/tasks/1019-boot-recovery/ plus the Part B operator requirements document",
+      "acceptanceCommands": [
+        "the container-stays-up hypothesis is TESTED and reported either way, not assumed",
+        "population B reproduced from the real published image with representative user state seeded first",
+        "recovery restores a boot without deleting or recreating the volume",
+        "each preserved item verified by before/after observation: checkout with uncommitted changes, ~/.config/gh, .agro/tasks, .env at mode 0600",
+        "candidate image cold boot proven by the bootstrap unit reaching active, not by container liveness",
+        "lifecycle-hook audit covers preinstall, postinstall, prepare, pnpm:devPreinstall, pnpm:devPrepare across root and boot-participating workspace manifests",
+        "probe changes demonstrated by fault injection, not asserted",
+        "advisor re-runs the probe and at least one recovery assertion"
+      ],
+      "repairRoute": "same worker via SendMessage",
+      "status": "ACCEPTED",
+      "hardBoundary": "PART A ONLY. No publishing, tagging, releasing, CI pin changes, yanking, or user notification. Part B is written as operator requirements, never performed. Must never claim a local candidate repairs published artifacts.",
+      "dispatchLedgerNote": "Registered retroactively, same gap as W8."
+    },
+    {
+      "id": "W10",
+      "nativeWorkerId": "a29e0355c83c5e384",
+      "subagentType": "general-purpose",
+      "modelRequested": "inherit (no override passed)",
+      "modelObserved": "unreported",
+      "wave": 3,
+      "stories": [
+        "US-008"
+      ],
+      "repo": "mifunedev/agro (record) + scratch clones",
+      "worktree": "scratchpad clones only; one owned file in the record worktree",
+      "ownedWritePaths": [
+        ".agro/tasks/agro-cloud-consumer-migration/migration-evidence.md"
+      ],
+      "forbiddenPaths": [
+        "every other file in the record worktree",
+        "projects/mifunedev/openharness-cloud and projects/mifunedev/openharness-web (live clones with worktrees attached)",
+        "mifunedev/agro itself",
+        ".oh/tasks/** content by hand"
+      ],
+      "acceptanceCommands": [
+        "migration APPLIED without --check, exit code recorded per repo",
+        "before/after manifest compares path, mode, type, sha256 and size",
+        "tasks/** byte-identity stated explicitly",
+        "git status --short rename evidence reported, including whether detection fired",
+        "advisor independently confirms the rename-versus-rewrite distinction in migrate.ts"
+      ],
+      "repairRoute": "same worker via SendMessage",
+      "status": "ACCEPTED",
+      "dispatchLedgerNote": "Registered at acceptance time."
+    },
+    {
+      "id": "W11",
+      "nativeWorkerId": "ae493cb0a966bd2a6",
+      "subagentType": "general-purpose",
+      "modelRequested": "inherit (no override passed)",
+      "modelObserved": "unreported",
+      "wave": 4,
+      "stories": [
+        "US-008 delivery, Cloud half"
+      ],
+      "repo": "mifunedev/openharness-cloud",
+      "worktree": "projects/mifunedev/openharness-cloud/.worktrees/944-integrate2",
+      "ownedWritePaths": [
+        "the .oh -> .agro migration",
+        "docs/browser-gateway-runbook.md path repointing",
+        ".dockerignore",
+        ".gitignore"
+      ],
+      "forbiddenPaths": [
+        "the parent clone",
+        "sibling worktrees",
+        "agro migrate --home",
+        "any commit/push/PR/merge/deploy",
+        ".agro/tasks/** content by hand"
+      ],
+      "acceptanceCommands": [
+        "preflight names only the worktree root or ABORT",
+        "131/131 sha256 and modes identical",
+        ".oh/tasks/** byte-identical",
+        "both git views reported",
+        "runbook paths repointed",
+        "type-check and test exit 0 with baseline counts"
+      ],
+      "status": "ACCEPTED"
+    },
+    {
+      "id": "W12",
+      "nativeWorkerId": "a4aa4d7b47120d4d2",
+      "subagentType": "general-purpose",
+      "modelRequested": "inherit (no override passed)",
+      "modelObserved": "unreported",
+      "wave": 4,
+      "stories": [
+        "US-008 delivery, agro-web half"
+      ],
+      "repo": "mifunedev/agro-web",
+      "worktree": "projects/mifunedev/openharness-web/.worktrees/944-docs",
+      "status": "ACCEPTED"
+    }
+  ],
+  "blockedStories": [
+    {
+      "story": "US-007b",
+      "gate": "Q3 \u2014 explicit operator authorization to provision paid OVH infrastructure",
+      "note": "No live infrastructure is touched without it. Not waivable by the advisor."
+    }
+  ],
+  "crossRepoOrder": [
+    "1. mifunedev/openharness-cloud \u2014 US-002..US-006, US-009. Independent of the others.",
+    "2. mifunedev/website \u2014 US-010. Independent; grounded on agro@main. Highest user-visible urgency: its published instructions cannot work.",
+    "3. mifunedev/agro-web \u2014 US-011. Grounded on agro@main. Must NOT pre-empt unreleased namespace prose.",
+    "4. mifunedev/agro \u2014 US-001, US-008 record PR plus evidence. Lands last so it can cite the other three."
+  ],
+  "integration": {
+    "worktree": "projects/mifunedev/openharness-cloud/.worktrees/944-integrate2",
+    "base": "0aa8f99",
+    "files": 19,
+    "conflicts": 0,
+    "sharedFiles": [
+      "packages/shared/src/host-management-assets.ts",
+      "packages/shared/src/host-management-assets.test.ts"
+    ],
+    "result": "pnpm install --frozen-lockfile && pnpm type-check && pnpm test -> exit 0",
+    "counts": "shared 113, db 189, gateway 37, web 2898/126 files, provisioner 84; 0 failures"
+  }
+}

--- a/.agro/tasks/agro-cloud-consumer-migration/delegate-log.txt
+++ b/.agro/tasks/agro-cloud-consumer-migration/delegate-log.txt
@@ -1,0 +1,219 @@
+# delegate-log.txt — append-only. Advisor writes; workers never write here.
+# slug=agro-cloud-consumer-migration issue=944 owner=advisor session_018Gh4FRUfcQYD6CcNNH1xRU
+
+2026-09-08  PLAN     Task folder scaffolded after read-only grounding of mifunedev/agro@b10ecac3 and
+                     mifunedev/openharness-cloud@0aa8f99. 9 stories, later 10 after the US-007 split.
+2026-09-08  DECIDE   Q1/Q2 resolved as grounded applications of #944's own retention boundary, not as new
+                     naming decisions: OH_IMAGE_TAG, OH_ENV_FILE, the bootstrap marker/log/readiness paths
+                     and the docker-build-oh-sandbox tmux session are retained (category 4). Runtime-facing
+                     prose only. Recorded in prd.json.resolvedDecisions.
+2026-09-08  DECIDE   US-007 split by what actually needs the provider. US-007a (node bootstrap on a real
+                     local Linux host) is executable without paid infrastructure. US-007b (OVH create /
+                     destroy / suspend / resume / reconciliation) is genuinely gated on Q3. A mock, fixture
+                     or status transition is never accepted as observed state for either half.
+2026-09-08  WORKTREE .worktrees/feat/944-agro-cloud-consumer-migration off origin/development b10ecac3 (record)
+2026-09-08  WORKTREE cloud .worktrees/944-bootstrap off origin/development 0aa8f99 (W2)
+2026-09-08  WORKTREE cloud .worktrees/944-rebuild   off origin/development 0aa8f99 (W3)
+2026-09-08  DISPATCH W1 ab16f3c765ba00e63  US-001,US-008  record worktree, 2 owned files. RUNNING.
+2026-09-08  DISPATCH W3 aa588cf40102fb5f1  US-006         cloud .worktrees/944-rebuild, 2 owned files. RUNNING.
+2026-09-08  DISPATCH W2 ae551523e1c3b9519  US-003/4/5     cloud .worktrees/944-bootstrap. RUNNING.
+2026-09-08  CORRECT  Task folder relocated from the uncommitted development-branch copy into the record
+                     worktree; the old path was removed to keep development clean. Path correction sent to
+                     W1 and W2 (both were briefed against the old path) and an informational note to W3.
+2026-09-08  CORRECT  Informed W3 that the only published AGRO image (v0.9.0) is the broken one from #1019,
+                     so no rebuild path may pin it and no end-to-end image claim may be made.
+2026-09-08  LEDGER   delegate-graph.json upgraded to schemaVersion 2 with native worker IDs, model/effort
+                     provenance (modelObserved recorded as unreported rather than inferred — the Agent tool
+                     returns no model attestation), owned write paths, forbidden paths, acceptance commands,
+                     evidence destination, repair route and status per worker. W4 and W5 given explicit
+                     owned write paths before launch, per the acceptance note.
+2026-09-08  CORRECT  DoD coverage gap caught in review: the US-007 split lost the `attach` leg of #944's
+                     suspend/resume/rebuild/attach criterion. Restored, and the three node-side attach
+                     surfaces identified from source (ssh+tmux per index.ts:788; browser editor via
+                     gateway proxy.ts:86 / dialer.ts:48 to loopback code-server; container attach).
+                     US-007a now carries all three plus re-exercise after restart and after rebuild;
+                     US-007b carries live-tunnel attach across suspend/resume. prd.json gained a
+                     dodCoverage map so no leg can silently vanish at the local/provider boundary.
+2026-09-08  ESCALATE Surface 2 turned out to be a DESIGN constraint on US-003, not just a test: README.md:356
+                     records that the browser editor opens ~/.openharness by default, which is exactly the
+                     directory US-003 deletes. Sent W2 the constraint — choose the editor workspace root
+                     from the durable-state path in .devcontainer, repoint /home/sandbox/oh.code-workspace,
+                     and fix the now-false header comment at packages/shared/src/index.ts:785-790.
+2026-09-08  ERROR    Advisor transposed W1 and W3 native worker IDs when recording the dispatch, so each
+                     worker received the other's correction message. W1 (aa588cf4) recognised the mis-route,
+                     judged it outside its brief, applied only the one relevant part, and continued
+                     correctly. W3 (ab16f3c7) was re-briefed with its true scope. Ledger IDs corrected:
+                     W1=aa588cf40102fb5f1, W3=ab16f3c765ba00e63. No work was lost. Caught by W1, not by me.
+2026-09-08  DELIVER  W1 returned consumer-inventory.md and migrate-check.md. 32/32 org repos cloned and
+                     grepped by content, 0 clone failures, every scanned SHA recorded. Verdicts: 4 consumers
+                     to migrate, 1 compatibility (agro), 1 historical (skills), 26 no active dependency.
+2026-09-08  ACCEPT   Three W1 corrections to MY plan accepted as correct:
+                     (a) three repos carry .oh/ (agro, openharness-cloud, agro-web), not two — F4 was wrong;
+                     (b) agro migrate has no equipped-control-plane precondition, ROOT_MARKERS is the only
+                         gate, both candidates report ready exit 0 — my PRD hypothesis was wrong;
+                     (c) .agro/tasks/* is gitignored, so the record PR needs git add -f.
+2026-09-08  REJECT   Two W1 claims sent back for correction:
+                     (a) the "@mifune/openharness pin" in Cloud. Verified with git grep -F at 0aa8f99: one
+                         occurrence, docs/quickstart.md:35. Not in any package.json, not in pnpm-lock.yaml.
+                         Restated as a docs reference under US-009, not a dependency migration.
+                     (b) agro@main's .oh/ + oh.json framed as retirement work. It is default-branch release
+                         lag from Phase 2, which is merged to development and unreleased. Not Phase 4's
+                         business and must not be reimplemented.
+2026-09-08  VERIFY   Release facts established by ancestry, not assumption:
+                       0b292bf8 (Makefile deleted)  IS  an ancestor of main -> website guidance is BROKEN
+                       a227bbf3 (Phase 2 namespace) NOT an ancestor of main -> .oh/ on main is release lag
+                       b10ecac3 (Phase 3)           NOT an ancestor of main
+                       @mifune/agro@0.9.0 bin = agro -> the agro executable IS released
+                     Consequence: public docs must be grounded on agro@main, never on development.
+2026-09-08  SCOPE    #944 expanded from two repositories to four, with an explicit ordering, rather than
+                     declaring the original two PRs sufficient. Added US-010 (mifunedev/website — published
+                     getting-started guidance is broken, not stale) and US-011 (mifunedev/agro-web — the
+                     documentation drift Phase 3 left behind; prose is hand-copied with no sync per
+                     check-docs-drift.mjs, and a successful manual Pages build does NOT fix it).
+                     Order: openharness-cloud -> website -> agro-web -> agro record PR last so it can cite
+                     the others. Namespace prose and the install.sh redirect/Worker move stay deferred to
+                     the rename-bearing release window.
+2026-09-08  LEDGER   W6 (website) and W7 (agro-web) registered with owned and forbidden write paths and
+                     acceptance commands before launch, per the acceptance-hygiene note.
+2026-09-08  ACCEPT   W1 complete. Both corrections applied and independently re-verified by the worker
+                     before it edited. It also flagged a stale cell in migrate-check.md rather than editing
+                     a file it had been told not to touch; I authorized that single edit and it made only
+                     that one. orchestra decided: category 1, present-tense platform panel above live
+                     contact routes, names the runtime a reader is invited to run today.
+2026-09-08  DELIVER  W3 returned US-006. Scope escalation into management-ssh.ts, host-management-assets.ts
+                     and their tests ACCEPTED as load-bearing, verified independently: host-management-
+                     assets.ts:45 pins command="sudo -n ${MANAGEMENT_HELPER_PATH}" and the helper rejects
+                     any non-canonical string with exit 64, so a client-only change could not have produced
+                     a node-side effect. Client verb and node-side verb had to land together.
+2026-09-08  REJECT   W3 NOT accepted — blocking defect. MANAGEMENT_HELPER reported `complete` on a non-empty
+                     `agro ps --quiet --status running`. That proves a container exists, not that the
+                     workspace booted. systemd is PID 1 in the sandbox, so the container stays running even
+                     when boot fails — the exact published-0.9.0 failure mode (#1019), which I reproduced.
+                     Accepting it would have reinstated F3 one layer down, inside the fix for F3.
+                     Repair routed to the same worker: require observed readiness from
+                     openharness-bootstrap.service (Type=oneshot, RemainAfterExit=yes, so `active` only
+                     after a successful boot, `failed` on failure) plus whichever units genuinely gate the
+                     attach surfaces, with a regression test for running-container + failed-bootstrap.
+                     Explicitly forbade loosening the pinned SSH boundary or the forced-command grammar to
+                     obtain the signal.
+2026-09-08  REJECT   W3 timeout budgets inconsistent: helper permits 300+900+60 = 1260s while
+                     SANDBOX_REBUILD_TIMEOUT_MS is 960s, so the outer transport could kill a legitimate
+                     bounded sequence and report a failure that did not occur. Required the budgets to be
+                     derived from one another and the relationship asserted by a test.
+2026-09-08  ESCALATE W3 caveat 3 verified and found worse than reported. seedConfig seeds only from --repo
+                     and never from the existing registry entry; writeOhConfig is unconditional; and
+                     config-render maps timezone->TZ and access.dockerSocket->DOCKER_SOCKET. So the CLI's own
+                     documented recycle (stop && sandbox install) silently discards a user's Docker-socket
+                     and timezone selections. Cloud cannot work around it — no flags exist for those fields
+                     and --yes skips the wizard. Fixed upstream in the runtime rather than papered over in
+                     the consumer, because it affects every caller, not just Cloud.
+2026-09-08  DISPATCH W8 a1a9a4ca502958aa1  bug/944-sandbox-install-preserve-config in
+                     .worktrees/bug/944-sandbox-install-idempotent off b10ecac3. Make agro sandbox install
+                     preserve an existing registry entry's settings. Bounded prerequisite fix; no new flags
+                     without reporting first. RUNNING.
+2026-09-08  EVIDENCE Recorded that "no down -v appears" is an argument from absence. Volume and mount
+                     preservation across a real stop + install must be OBSERVED in the local lifecycle
+                     evidence (US-007a), not inferred from the command list.
+2026-09-08  ACCEPT   W1 ACCEPTED. Advisor verification, not worker claims: all 32 org repos present in the
+                     inventory (set-compared against gh repo list, zero missing); 35 recorded scan SHAs;
+                     three classifications spot-checked against freshly cloned content.
+                     spot-check 1 website src/config/offerings.ts:3 openSource -> github.com/mifunedev/
+                       openharness. Live constant. Category 1 confirmed.
+                     spot-check 2 orchestra decks/slides/onepager.html:242 "Powered by Orchestra +
+                       OpenHarness" in a present-tense platform panel above live contact routes.
+                       Category 1 confirmed.
+                     spot-check 3 skills. The advisor suspected under-classification and checked rather
+                       than accepting or overriding. The make destroy / openharness strings are
+                       illustrative prose inside the ste TECHNICAL-WRITING skill — rules.md:322-323 is a
+                       Wrong:/Right: sentence lesson, examples.md hits are before/after writing samples.
+                       Fixtures teaching style, not operational guidance. W1's historical verdict stands
+                       and the advisor's suspicion was wrong.
+                     US-001 -> passes true. US-008 stays false: a --check plan is not an applied migration
+                     and preservation is read from the plan rather than observed.
+2026-09-08  DELIVER  W3 returned its repair. Advisor verification of the three load-bearing claims:
+                     (a) readiness oracle. VERIFIED. .agro/scripts/sandbox-healthcheck.sh:72 is
+                         `require_unit openharness-bootstrap.service` and :75 makes the cron unit
+                         conditional, exactly as W3 described. The unit is the project's own definition of
+                         ready, not one the worker invented. Its Type=oneshot + RemainAfterExit=yes shape
+                         makes `active` a completion proof and `failed` a failure proof.
+                     (b) budget derivation. VERIFIED. host-management-assets.ts:158-172 defines the budget
+                         and derives SANDBOX_REBUILD_NODE_BUDGET_SECONDS from its parts; the shell literals
+                         at :201-206 are generated from the same constant so they cannot drift;
+                         management-ssh.ts:20-22 derives the outer timeout as node budget + headroom. The
+                         independently chosen 960 is gone. The 1260-over-960 inversion is now structurally
+                         impossible rather than merely corrected.
+                     (c) regression coverage. VERIFIED. host-management-assets.test.ts:260 stubs a running
+                         container with a failed unit and asserts the exact record
+                         `state=failed step=ready` at exit 65, plus that a failed unit is decided on the
+                         first probe and never polled out. provision.test.ts:724 is the handler-level twin
+                         and :743 asserts the outer budget exceeds the node-side budget. The TODO naming
+                         `~/.openharness pull` and `make sandbox` is absent from apps/provisioner/src.
+2026-09-08  SECURITY Recorded as a deliberate boundary decision, disclosed by the worker rather than
+                     hidden: the readiness probe adds `docker exec <name> systemctl is-active <unit>` to
+                     the root forced-command endpoint. Assessed acceptable — the container name is regex
+                     allowlisted and re-checked against the exact canonical SSH_ORIGINAL_COMMAND, the unit
+                     name is a compile-time constant, the probe is read-only, and its output is matched
+                     against a closed vocabulary and discarded rather than relayed. The endpoint already
+                     ran `agro sandbox install`, so a read-only exec is not a meaningful escalation. The
+                     pinned SSH surface, principal, key, option set and 0600 known-hosts pin are unchanged.
+2026-09-08  EVIDENCE W3 correctly withdrew the volume-preservation claim when challenged. It now states
+                     only that no volume-deleting verb appears in the rebuild path, and records that actual
+                     re-attachment of the named workspace volume across a real stop + install is an
+                     inference from the compose model, not an observation. That observation is owned by
+                     US-007a.
+2026-09-08  ACCEPT   W8 ACCEPTED (US-012 prerequisite). Advisor verification: OH_CONFIG_FIELDS confirmed as
+                     the registry backing agro config set/show, so the completeness argument is structural
+                     rather than hand-enumerated; advisor re-ran typecheck + test + build independently —
+                     74 files, 1257 tests, dist/agro.js 205.1kb, exit 0.
+2026-09-08  CORRECT  The defect W8 fixed was WIDER than the advisor diagnosed. I described it as losing
+                     timezone and access.dockerSocket. config.repo was also lost, and registry.ts selects
+                     docker-compose.image-only.yml versus the build base off config.repo — pinned by the
+                     pre-existing test "picks the image-only base without a repo and the build base with
+                     one". A recycle would have silently flipped a node from build mode to image-only and
+                     dropped the harness bind mount. Correction recorded against my own finding.
+2026-09-08  DECIDE   W8 open questions ruled: corrupt agro.json ABORTS install with exit 2 rather than
+                     overwriting — silently discarding a user's settings is the exact bug class being
+                     fixed, and the error names the path. Precedence accepted as
+                     default < existing entry < --repo seed < flags < wizard. nonEmpty() guard accepted.
+                     Noted that cli.ts:141, docs/configuration.md:51 and docs/quickstart.md:335 already
+                     documented this recycle; the instruction was false before the fix and is now true.
+2026-09-08  ERROR    Advisor ownership-map failure. When I accepted W3's escalation into
+                     packages/shared/src/host-management-assets.ts and its test, I did NOT move those paths
+                     out of W2's ownership or record the shared claim. Two workers consequently edited the
+                     same two files in separate worktrees. W3 caught it and flagged it; I did not. Separate
+                     worktrees contained the damage, but the ledger was wrong for the whole overlap window.
+2026-09-08  VERIFY   Trial three-way merge of the overlap, rather than trusting the prediction: extracted
+                     both workers' diffs for the two shared files and applied them in sequence into a fresh
+                     integration worktree at 0aa8f99. Both applied cleanly, no conflict. W3's disjoint-region
+                     analysis (its readiness/budget constants and sandbox_* block versus W2's observe()
+                     env-state read and apply-branch printf) is confirmed empirically.
+2026-09-08  DELIVER  W3 returned the cross-worker test reconciliation and exceeded the brief in the right
+                     direction: rather than writing to my specification, it observed that provision.ts is
+                     byte-identical in both worktrees and ran a scratch generator importing each tree's
+                     modules, then validated all five updated assertions against BOTH real outputs — pass
+                     against the integrated generator, fail against the pre-integration one, which is the
+                     correct signature. It also confirmed the :342 assertion had been passing incidentally.
+                     Its replacement is anchored to the 6-space write_files indent so it can no longer match
+                     the compat alternation — tighter than the original, not looser.
+2026-09-08  REJECT   W2 NOT accepted. nodeContainerNameSchema was tightened from
+                     /^[a-zA-Z0-9][a-zA-Z0-9_.-]*$/ to /^[a-z0-9][a-z0-9-]*$/, which would fail
+                     re-provisioning for any existing node row containing _, . or uppercase. #944 forbids
+                     exactly this: "Do not make an existing node appear fresh or orphaned merely because the
+                     control-plane source, image, CLI, or namespace has changed." The goal is right and the
+                     blast radius is wrong. Required: tighten at the CREATE boundary only; existing rows must
+                     still parse; a non-conforming name yields an explicit typed provisioning error naming
+                     the node and the remedy; never a silent rename, which would disconnect a node from its
+                     own container. Tests required in both directions.
+2026-09-08  DECISION Raised to the operator, not decided by the advisor: the old flow baked claude-code,
+                     codex and pi into the image via ARG AGENTS, so every node arrived with three agents.
+                     The AGRO image installs none at boot, so new nodes would arrive with no agent unless
+                     the user picked one — a silent capability regression of the class #944 forbids. W2 was
+                     correct to defer it rather than make an unrequested behaviour change. Advisor
+                     recommendation is to preserve prior behaviour by installing the three explicitly;
+                     evidence requested from W2 on cost and on whether any need interactive auth that would
+                     break an unattended tmux bootstrap.
+2026-09-08  ACTION   Operator action item recorded: audit existing container_name values in the Cloud
+                     database. Neither advisor nor worker can query production from here.
+2026-09-08  EVIDENCE W2's UID-alignment gap recorded against US-007a: node-host `sandbox` versus the
+                     container's uid 1000. A mismatch would take the host bind directory away from the
+                     host-native code-server, breaking attach surface 2. Must be observed, not assumed.

--- a/.agro/tasks/agro-cloud-consumer-migration/local-lifecycle-evidence.md
+++ b/.agro/tasks/agro-cloud-consumer-migration/local-lifecycle-evidence.md
@@ -1,0 +1,1390 @@
+# US-007a — Observed local lifecycle matrix
+
+Raw command transcript: `local-lifecycle-transcript.log` (same directory).
+
+This story could not be discharged by a unit suite, and it was not. Every
+verdict below cites observed filesystem, process, unit or container state on a
+real Linux host running systemd as PID 1 with its own Docker daemon. No mock,
+fixture or status field is used as evidence of readiness anywhere in this
+document.
+
+---
+
+## 0. Readiness oracle
+
+`openharness-bootstrap.service` is `Type=oneshot` with `RemainAfterExit=yes`,
+so `systemctl is-active` returning `active` is a COMPLETION proof and `failed`
+is a FAILURE proof. Observed directly on the unit under test:
+
+```
+Type=oneshot
+RemainAfterExit=yes
+Result=success
+ExecMainStatus=0
+ActiveState=active
+SubState=exited
+```
+
+The oracle was seen to distinguish all three states during this run —
+`activating` while the entrypoint was still executing, then `active` on
+success, and `failed` on the published image (section 8). Container liveness
+was observed to prove nothing: the published image's container reported
+`Up 5 seconds (health: starting)` at the same moment its bootstrap unit
+reported `ActiveState=failed`.
+
+---
+
+## 1. Artifacts under test — ALL CANDIDATES
+
+Every result in this document was produced with locally built artifacts. None
+of them is a published release, and none of them repairs, supersedes or
+substitutes for one.
+
+| Artifact | Identity | Provenance |
+| --- | --- | --- |
+| **CANDIDATE sandbox image** | `agro-candidate:us007a`, `sha256:d963de3d2b25…`, built 2026-09-09T05:50:17Z | `docker build -f .devcontainer/Dockerfile .` from `/home/sandbox/harness`, branch `development`, commit `b10ecac3d17d21c7abb45a2e814617e6b9b5ae50`, `vitest ^4.1.11` |
+| **CANDIDATE CLI** | `agro` 0.9.0 | `OH_ASSET_ROOT=<worktree> node build.mjs` in `.worktrees/bug/944-sandbox-install-idempotent` (branch `bug/944-sandbox-install-preserve-config`, commit `b10ecac3`, with the accepted `sandbox install` idempotency fix present as working-tree modifications to `.agro/cli/src/commands/sandbox.ts`) |
+| **PUBLISHED image (contrast only)** | `ghcr.io/mifunedev/agro:latest`, `sha256:bbfdaf6bb8ca…`, created 2026-09-06T19:52:35Z | pulled; identical id to `ghcr.io/mifunedev/openharness:0.9.0` — the #1019 build |
+| **PATH CLI (pre-existing, not used)** | `/usr/local/bin/oh` 0.7.0 | no `agro` binary on PATH; no `migrate` verb |
+
+**Which results depend on candidate artifacts.** Sections 3, 4, 5, 6, 7 and 9
+all ran against the candidate image and candidate CLI, and every PASS in them
+must be re-run against the published patched image and published CLI before it
+can be claimed of a released node. Section 8 is the only section that
+exercises a published artifact, and it FAILS. Section 2 (bootstrap script
+generation) and section 10 (the config-B defect) are structural findings in
+accepted Cloud source and do not depend on the candidate substitution — see
+the attribution note in section 10.
+
+### The two candidate substitutions, stated plainly
+
+1. **`install_agro()`** in the generated bootstrap script downloads
+   `get-agro.sh` from the latest GitHub release. That function body — and only
+   that body — was replaced with
+   `install -D -m 0755 /opt/agro-candidate/agro.js "$HOME/.local/bin/agro"`.
+   Every other line of the script is the generator's own output.
+2. **`sandboxImage`** was passed as the candidate tag instead of the generator's
+   default `ghcr.io/mifunedev/agro:latest`.
+
+---
+
+## 2. What was actually exercised, and how
+
+The bootstrap script was **not** hand-written. It was emitted by the accepted
+Cloud generator `buildWorkspaceBootstrapAssets()` from
+`packages/shared/src/workspace-bootstrap-assets.ts` in
+`projects/mifunedev/openharness-cloud/.worktrees/944-integrate2`, invoked with
+`containerName: "oh-a"`, the cloud-config's git identity, and the two harness
+configurations of section 9. The `ohmanage` and `ohproxy` SSH principals were
+likewise emitted by `buildHostManagementAssets()` and `buildHostProxyAssets()`
+from `packages/shared/src/host-management-assets.ts`, including the real
+`MANAGEMENT_HELPER` used for the rebuild leg.
+
+**The host.** A disposable Ubuntu 24.04 container, `--privileged
+--cgroupns=host`, systemd as PID 1, its own `dockerd` on a dedicated ext4
+volume, `sshd`, `tmux`, and a host-native code-server 4.129.0 (the pinned
+version and sha256 from `code-server-assets.ts`). Observed on start:
+
+```
+systemctl is-system-running  ->  running
+docker info                  ->  29.8.0 storage=overlayfs (later overlay2)
+```
+
+The node was then provisioned by replaying the accepted
+`infra/cloud-init/cloud-config.yaml` — its `users:`, `write_files:`, `runcmd:`
+and `codeServerRuncmd` blocks — verbatim, except that the package installation
+and the code-server tarball download were pre-baked into the node image.
+
+**Deviations from a real cloud node, disclosed.**
+
+- The node is a privileged container, not a VM. cloud-init itself did not run;
+  its blocks were replayed by a script.
+- The node's `dockerd` was switched to the classic `overlay2` graph driver
+  (`{"features":{"containerd-snapshotter":false}}`) because the containerd
+  snapshotter could not extract the image inside this nesting:
+  `failed to convert whiteout file "etc/alternatives/.wh.pager.1.gz":
+  operation not permitted`. This is a nesting artifact of the test host, not a
+  product behaviour.
+- `openharness-register-runtime-settings` was not run — it posts to a live
+  control plane that does not exist here.
+- For the rebuild leg only, the candidate image was pushed to a
+  `registry:2` on the node's loopback so that the helper's
+  `AGRO_PULL_POLICY=always` had something genuine to pull. See section 5.
+
+---
+
+## 3. LEG 1 — FRESH — **PASS**
+
+The bootstrap was launched exactly as the cloud-config `runcmd` line launches
+it:
+
+```
+sudo -u sandbox -i tmux new-session -d -s docker-build-oh-sandbox \
+  /usr/local/libexec/openharness-bootstrap-workspace
+```
+
+Observed result:
+
+```
+/home/sandbox/.openharness-bootstrap-status  ->  ok
+/run/openharness-ready                       ->  -rw-r--r-- 1 root root 0
+```
+
+**Readiness asserted by the unit, not the container.** Inside `oh-a`:
+
+```
+Type=oneshot   RemainAfterExit=yes
+Result=success ExecMainStatus=0
+ActiveState=active  SubState=exited
+ExecMainStartTimestamp = 2026-09-09 05:56:22 UTC
+ExecMainExitTimestamp  = 2026-09-09 05:56:26 UTC
+```
+
+The boot was genuine, not a no-op — the journal shows the whole cold path:
+
+```
+[entrypoint] no checkout bind at /home/sandbox/harness — seeding from /opt/agro-seed
+[entrypoint] seeded control plane into /home/sandbox/harness from /opt/agro-seed
+[entrypoint] repairing sandbox home mount ownership as 1000:1000
+[entrypoint] node_modules missing — running pnpm install at /home/sandbox/harness
+[entrypoint] pnpm install completed (log: /tmp/pnpm-install.log)
+Finished openharness-bootstrap.service - Open Harness sandbox bootstrap.
+```
+
+A second, independent FRESH run (section 9, config A control) reproduced
+`status=ok`, the readiness marker, and `ActiveState=active Result=success`.
+
+### FINDING 1 — the bootstrap's own `ok` is not a readiness proof
+
+`status=ok` and `/run/openharness-ready` were written 0 seconds after
+`agro sandbox install docker` returned, which is when Compose reported
+`Container oh-a Started`. At that instant the container's bootstrap unit had
+not finished. The script never consults `openharness-bootstrap.service`. The
+node therefore signals ready on container *start*, not on sandbox *boot*. This
+is benign for a config-A node only because nothing else in the script depends
+on the boot having completed; section 10 shows what happens when something
+does.
+
+---
+
+## 4. LEG 2 — LEGACY STATE — **PASS** (with one observed mutation)
+
+Representative user state was seeded **first**, as the node's `sandbox` user,
+into the persistent home mount (node `/home/sandbox/workspace`, which is the
+sandbox container's `/home/sandbox`), and each item was verified by before /
+after observation of sha256 + uid + gid + mode.
+
+Seeded:
+
+1. a real git checkout with an **uncommitted** modification and an untracked
+   file (`projects/us007a-demo`);
+2. a task folder (`.agro/tasks/us007a-user-task/notes.md`);
+3. a `.env` at mode **0600**;
+4. a gh-credential stand-in (`hosts.yml`, mode **0600**) under the workspace's
+   gh configuration directory;
+5. **OpenHarness-era `~/.openharness` checkout content** — `README.md` plus a
+   `scripts/` subtree — which is the legacy checkout directory AGRO's compat
+   layer probes as `LEGACY_CHECKOUT_DIR` (`.agro/cli/src/lib/compat.ts:40`);
+6. a **legacy OpenHarness-era project**: a `.oh/` control directory and an
+   `oh.json` beside it.
+
+**Remains recoverable and operable.** After `agro restart oh-a` the container
+rebooted and the unit re-ran on the new boot and completed:
+
+```
+container StartedAt = 2026-09-09T05:58:45Z   restartCount=0
+ExecMainStartTimestamp = 2026-09-09 05:58:45 UTC
+ExecMainExitTimestamp  = 2026-09-09 05:58:46 UTC
+Result=success  ActiveState=active  SubState=exited
+[entrypoint] dependencies current
+```
+
+The before/after diff of the state oracle was empty for every seeded item
+except the one noted below, and the git working tree was intact:
+
+```
+ M tracked.txt
+?? untracked.txt
+86f48d1 us007a: baseline commit
+```
+
+**AGRO operates existing legacy project state.** Run against the seeded legacy
+project, the candidate CLI read it and produced a plan:
+
+```
+agro migrate: plan for …/us007a-legacy-project
+  rename  …/.oh      -> …/.agro
+  rename  …/oh.json  -> …/agro.json
+  noop    …/.claude/skills (link absent)
+  …
+status: ready
+```
+
+The `.openharness` content was also visible unchanged from inside the
+container.
+
+### FINDING 2 — the gh-credential stand-in is rewritten, but not lost
+
+`hosts.yml` was the one seeded path whose sha256 changed across the first boot
+(`ac438dc1…` → `fe64ca26…`). Investigated rather than assumed:
+
+- mode preserved at **0600**, owner preserved at 1000:1000;
+- the file gained gh's canonical `users:` sub-map — it was normalised by the
+  `gh` CLI, not corrupted;
+- the credential **value** was proved unchanged without printing it: the
+  sha256 of every token value in the file equals the sha256 of the seeded
+  value (`da5358c5…`, `match=YES` twice).
+
+After that one normalisation the file was byte-stable across the restart, both
+rebuilds and every later observation. Verdict: preserved, with a one-time
+canonicalisation.
+
+---
+
+## 5. LEG 3 — REBUILD — **PASS**, with an important semantic caveat
+
+The recycle was driven through the accepted path, not a re-implementation: the
+real `MANAGEMENT_HELPER` installed as
+`/usr/local/libexec/openharness-code-server-apply`, reached over the pinned
+`ohmanage` forced-command SSH principal whose `authorized_keys` line was
+emitted by `buildHostManagementAssets()`:
+
+```
+from="172.18.0.3/32",restrict,command="sudo -n /usr/local/libexec/openharness-code-server-apply" ssh-ed25519 … openharness-management
+```
+
+### Rebuild attempt 1 — install failure, correctly reported
+
+```
+$ ssh -i mgmt_key ohmanage@node 'sandbox rebuild --name oh-a'
+version=1 mode=sandbox action=rebuild name=oh-a state=failed step=install
+exit=65
+```
+
+Cause: the helper runs
+`AGRO_PULL_POLICY=always … agro sandbox install docker --name oh-a --yes --image`,
+and at that point the sandbox's configured image ref was a local-only tag that
+no registry could serve. This is an artifact of the candidate substitution, not
+a product defect — but two real observations came out of it:
+
+- the helper's failure reporting is accurate and specific (`step=install`);
+- **a failed rebuild leaves the node's sandbox stopped** (`oh-a Exited (0)`).
+  There is no rollback; the node is left without a running sandbox.
+
+Note also that the bare trailing `--image` is *correct*: `--image` is parsed as
+a boolean meaning "image mode, keep the configured ref"
+(`.agro/cli/src/commands/sandbox.ts:183-192`), which is what a rebuild wants.
+
+### Rebuild attempt 2 — success, with observed state survival
+
+The candidate image was pushed to a loopback `registry:2` on the node so the
+`always` pull was genuine, and the sandbox was repointed at
+`127.0.0.1:5000/agro-candidate:us007a`. Then:
+
+```
+version=1 mode=sandbox action=rebuild name=oh-a state=complete step=ready
+exit=0
+```
+
+`step=ready` means the helper's own loop observed
+`docker exec oh-a systemctl is-active openharness-bootstrap.service` return
+`active` — the same oracle this story requires.
+
+**Persistence proved by observation, not by the absence of `down -v`.**
+
+| Observation | Before rebuild | After rebuild |
+| --- | --- | --- |
+| mount type/source/dest | `bind /home/sandbox/workspace -> /home/sandbox rw=true` | identical |
+| durable root identity | `dev=bc inode=1486974 uid=1000 gid=1000 mode=755` | identical |
+| all 9 seeded paths (sha256 + uid + gid + mode) | — | **`diff` produced no output** |
+| git working tree | ` M tracked.txt` / `?? untracked.txt` / `86f48d1` | identical |
+| container id | `6b749b6673ee…` | `6a82719b33c4…` (**changed**) |
+| bootstrap unit on the new container | — | `active`, `Result=success`, started 06:06:05 |
+
+The `.env` stayed at 0600 and the credential stand-in stayed at 0600 with its
+value intact. Configuration also survived the recycle — `storage.homePath`,
+`image.ref`, git identity and every other field were still present in
+`agro.json` afterwards, which is the behaviour the accepted `sandbox install`
+idempotency fix exists to provide.
+
+### FINDING 3 — `sandbox rebuild` does not always recreate the container
+
+A **second** rebuild, run with nothing changed, also reported
+`state=complete step=ready` — but the container id was **unchanged**
+(`6a82719b33c4…` both before and after), with only a new `StartedAt`
+(06:08:12) and a fresh unit run. Compose started the existing stopped container
+rather than recreating it, because the spec had not changed.
+
+This matters for how the first rebuild's evidence should be read: the container
+id changed there because the **image ref** changed as part of the setup, not
+because `sandbox rebuild` guarantees recreation. `sandbox rebuild` is
+"stop, pull, up" — it recreates only when the resolved Compose spec differs.
+A rebuild intended to pick up a moved `:latest` tag will recreate; a rebuild
+intended to reset a wedged container will not. Both report
+`state=complete step=ready`.
+
+---
+
+## 6. LEG 4 — ATTACH, three surfaces, after a restart and after a rebuild
+
+### (a) ssh + `tmux attach -t docker-build-oh-sandbox` — **FAIL**
+
+| When | Observed |
+| --- | --- |
+| during bootstrap (t=1 of a polled run) | `docker-build-oh-sandbox: 1 windows (created Wed Sep 9 06:16:39 2026)` |
+| after bootstrap finished (t=2) | `no server running on /tmp/tmux-1000/default` |
+| after a restart | `tmux ls` → `no server running`; `tmux attach -t docker-build-oh-sandbox` → `no sessions`, exit 1 |
+| after a rebuild | `tmux ls` → `no server running`; `tmux attach -t docker-build-oh-sandbox` → `no sessions`, exit 1 |
+
+SSH itself works — the same command over the same connection returns the tmux
+error, not a connection error.
+
+### FINDING 4 — the `docker-build-oh-sandbox` session is not durable
+
+`tmux new-session -d -s docker-build-oh-sandbox <script>` terminates the
+session when the script exits, success or failure. The session exists only for
+the few seconds the bootstrap is in flight. Nothing recreates it: a restart
+does not, and the rebuild helper does not use tmux at all — it drives
+`agro stop` / `agro sandbox install` through `runuser -l` directly.
+
+The criterion for this leg is that a **re-attach lands on preserved state**.
+Surface (a) cannot satisfy it, because after the bootstrap window there is
+nothing to re-attach to. This is not a revoked-session case; `node.rebuild`'s
+deliberate browser revocation does not apply here.
+
+### (b) container attach / re-attach — **PASS** after restart and after rebuild
+
+State was written from inside the container **before** each transition and read
+back after it.
+
+After the **restart**, `agro shell oh-a` on a real pty:
+
+```
+sandbox@6b749b6673ee:~/harness$ echo MARKER-READ=$(cat /home/sandbox/us007a-preattach.txt)
+MARKER-READ=2026-09-09T05:58:16Z
+WHOAMI=sandbox HOST=6b749b6673ee UID=1000
+ M tracked.txt
+?? untracked.txt
+```
+
+After the **rebuild**, the same script against the new container:
+
+```
+sandbox@6a82719b33c4:~/harness$ echo MARKER-READ=$(cat /home/sandbox/us007a-preattach.txt)
+MARKER-READ=2026-09-09T05:58:16Z
+WROTE=2026-09-09T06:06:42Z
+WHOAMI=sandbox HOST=6a82719b33c4 UID=1000
+ M tracked.txt
+?? untracked.txt
+```
+
+A different container id, the same preserved state. `docker exec` re-attach
+confirmed the same.
+
+### FINDING 5 — `agro shell` needs a pty, and misreports why it failed
+
+With piped stdin:
+
+```
+cannot attach stdin to a TTY-enabled container because stdin is not a terminal
+container `oh-a` not running? start it with `oh sandbox install docker`
+```
+
+The container was running and healthy at that moment. The fallback message
+names the wrong cause, and it still says `oh`, not `agro`.
+
+### (c) real loopback code-server over a pinned SSH forward — **PASS** after restart and after rebuild
+
+code-server 4.129.0 runs host-native on the node under
+`openharness-code-server.service` as user `sandbox`, bound to loopback:
+
+```
+systemctl is-active openharness-code-server.service   ->  active
+ss -H -ltn 'sport = :8080'  ->  LISTEN 0 511 127.0.0.1:8080 0.0.0.0:*
+curl 127.0.0.1:8080/        ->  http=302
+```
+
+It was reached from a separate machine over the forward-only `ohproxy`
+principal emitted by `buildHostProxyAssets()`:
+
+```
+from="172.18.0.3/32",restrict,port-forwarding,permitopen="127.0.0.1:8080" ssh-ed25519 … openharness-browser-gateway
+ssh -N -L 18080:127.0.0.1:8080 ohproxy@node
+curl 127.0.0.1:18080/  ->  http=302  redirect=…/?workspace=/home/sandbox/oh.code-workspace
+curl 127.0.0.1:18080/healthz -> 200 {"status":"alive",…}
+```
+
+**The pin is real**, not merely configured: a forward to a different port on
+the same principal was refused by sshd —
+`channel 2: open failed: administratively prohibited: open failed`.
+
+**The workspace root resolves to the path that holds durable user state.** The
+`oh.code-workspace` the editor opens has exactly one folder,
+`/home/sandbox/workspace`, whose identity is `dev=bc inode=1486974` — the same
+device and inode as the bind **source** of the sandbox container's
+`/home/sandbox`. Proved end to end by reading durable state *through* the
+editor's own HTTP surface:
+
+```
+GET /vscode-remote-resource?path=/home/sandbox/workspace/us007a-attach-marker.txt
+-> 2026-09-09T06:06:42Z          (written inside the POST-REBUILD container)
+
+GET /vscode-remote-resource?path=…/us007a-demo/tracked.txt
+-> committed line
+   UNCOMMITTED EDIT do-not-lose  (the seeded uncommitted change)
+```
+
+The same forward and the same unit served this before and after the rebuild;
+the unit was untouched by the container recycle (`NRestarts=0`,
+`ExecMainStartTimestamp = 05:54:22`, still `active running` afterwards). The
+node-side surface is what was tested — the control-plane session revocation
+that `node.rebuild` performs first (`revokeNodeBrowserAccess`) was not in scope
+and was not simulated.
+
+---
+
+## 7. LEG 5 — UID ALIGNMENT — **observed, and the flagged risk is REAL**
+
+### The numbers, under the accepted cloud-config
+
+```
+node-host  id -u sandbox  ->  1000      node-host  id -g sandbox  ->  1000
+container  id -u sandbox  ->  1000      container  id -g sandbox  ->  1000
+```
+
+They **align**. The cloud-config's `users:` list contains no `- default`, so
+the distro default user is not created and `sandbox` takes uid 1000; the image
+bakes `useradd -m -u 1000 … sandbox`. So on a node provisioned by this exact
+cloud-config, attach surface (c) is not broken by the entrypoint's chown.
+
+### FINDING 6 — the alignment is load-bearing, and nothing enforces it
+
+The risk was tested directly rather than reasoned about. A second node-host
+user at uid **1500** was given its own workspace directory, and a sandbox was
+installed with that directory as its home mount:
+
+```
+BEFORE  /home/sandbox2/ws                 uid=1500 gid=1500 mode=755
+        /home/sandbox2/ws/host-owned.txt  uid=1500 gid=1500 mode=644
+
+readiness: attempt 1 (empty) -> attempt 2 activating -> attempt 3 active
+[entrypoint] repairing sandbox home mount ownership as 1000:1000
+
+AFTER   /home/sandbox2/ws                 uid=1000 gid=1000 mode=755
+        /home/sandbox2/ws/host-owned.txt  uid=1000 gid=1000 mode=644
+
+node-host uid 1500 append  -> Permission denied      HOST-WRITE=DENIED
+node-host uid 1500 create  -> Permission denied      HOST-CREATE=DENIED
+```
+
+The container entrypoint chowns the whole host bind directory to the
+container's uid, and the host-native user loses write access to its own
+directory. On a real node that host-native user is `sandbox` — the user
+`openharness-code-server.service` runs as — so attach surface (c) would be
+broken outright: the editor could read the tree but not save into it.
+
+The entrypoint does have a UID-sync path, but it is gated on a *checkout bind*
+at `$OH_PROJECT_ROOT` (`.devcontainer/entrypoint.sh:168-197`). Cloud nodes run
+image-only, with no checkout bind, so that path never fires and the
+unconditional chown is what runs. The alignment holds today only because two
+independent constants happen to both be 1000. Any node image where uid 1000 is
+already taken — for example, any cloud-config that keeps `- default` and lets
+the distro user hold 1000 — pushes `sandbox` to 1001 and breaks surface (c) on
+first boot.
+
+---
+
+## 8. Contrast — the PUBLISHED image, same node, same oracle — **FAIL**
+
+Run on the same node, with the same CLI and the same readiness oracle:
+
+```
+ref=ghcr.io/mifunedev/agro:latest  id=sha256:bbfdaf6bb8ca…  created=2026-09-06T19:52:35Z
+ref=agro-candidate:us007a         id=sha256:d963de3d2b25…  created=2026-09-09T05:50:17Z
+
+readiness: attempt 1 (empty) -> attempt 2 failed
+Result=exit-code  ExecMainStatus=1  ActiveState=failed  SubState=failed
+
+container liveness at that same moment:  oh-pub  Up 5 seconds (health: starting)
+
+[entrypoint] node_modules missing — running pnpm install at /home/sandbox/harness
+[entrypoint] pnpm install failed — see /tmp/pnpm-install.log; aborting sandbox boot
+openharness-bootstrap.service: Main process exited, code=exited, status=1/FAILURE
+Failed to start openharness-bootstrap.service - Open Harness sandbox bootstrap.
+```
+
+This reproduces mifunedev/agro#1019 on the image the accepted Cloud generator
+names by default (`DEFAULT_AGRO_SANDBOX_IMAGE = "ghcr.io/mifunedev/agro:latest"`),
+and it is a live demonstration of why container liveness is not a readiness
+proof: the container was up and "health: starting" while the boot inside it had
+already failed. It is also the reason every PASS above needed a candidate
+image, and the reason every PASS above must be re-run against the published
+patched image before it can be claimed of a released node.
+
+---
+
+## 9. The default-harness parameter — a TEST INPUT, not a product decision
+
+Whether new Cloud nodes install `claude-code`, `codex` and `pi` by default is
+an **open operator decision**. Nothing here decides it and no product default
+was changed. It was parameterised as a test input and both configurations were
+run and are reported separately.
+
+Note on ids: the correct AGRO catalog id is **`pi`**. Confirmed from the
+catalog (`claude-code, codex, pi, opencode, grok-build, hermes, muse-code,
+t3code`) and by the CLI rejecting the wrong one:
+
+```
+$ agro harness install pi-coding-agent
+oh harness: unknown harness "pi-coding-agent"
+```
+
+(The npm package behind it is `@earendil-works/pi-coding-agent`, which is where
+the confusion comes from; the catalog id is `pi`.)
+
+### Configuration A — no default harnesses
+
+Generated with `harnesses: []`. The generator emitted **no** install lines and
+no `cd` — byte-identical to a bare node.
+
+- FRESH bootstrap: `status=ok`, `/run/openharness-ready` present, unit
+  `active` / `Result=success`. Reproduced twice.
+- Installed harness state on the resulting node — none:
+  `claude-code no · codex no · pi no · opencode no · grok-build no · hermes no ·
+  muse-code no · t3code no`.
+- Everything in sections 3-7 was run in this configuration.
+
+### Configuration B — one default harness, plus explicit installs
+
+Generated with `harnesses: ["opencode"]`. The generator appended exactly:
+
+```
+cd "$AGRO_HOME/sandboxes/$sandbox_name" || fail "$?"
+run_step agro harness install opencode
+```
+
+- **FRESH bootstrap FAILS.** See section 10. Two independent runs both gave
+  `status=failed:243` and **no** `/run/openharness-ready`.
+- **The explicit install path itself works**, when run against an already-ready
+  sandbox. Both were installed and observed:
+  `agro harness install pi` → `pi: installed`;
+  `agro harness install opencode` → `opencode: installed`;
+  `agro harness list` → `pi yes · opencode yes`.
+- Both binaries land on the durable mount
+  (`/home/sandbox/.local/bin/pi`, `/home/sandbox/.local/bin/opencode`) and
+  **survived a subsequent rebuild** through the `ohmanage` path
+  (`state=complete step=ready`, `agro harness list` still `pi yes · opencode
+  yes`).
+
+---
+
+## 10. FINDING 7 (principal) — any node with a default harness fails to bootstrap
+
+This is the most consequential observation of the run.
+
+```
+config B, run 1:  t=1 status=<no status yet>   t=2 status=failed:243
+config B, run 2:  t=1 status=<none>            t=2 status=failed:243
+config A control: t=1 status=<none>            t=2 status=ok
+```
+
+The only difference between the control and the failing runs is the presence of
+the `run_step agro harness install opencode` line. Observed failure:
+
+```
+installing OpenCode into the sandbox…
+npm error code EACCES
+npm error syscall mkdir
+npm error path /home/sandbox/.local/lib
+npm error Error: EACCES: permission denied, mkdir '/home/sandbox/.local/lib'
+oh harness: installing opencode failed (exit 243).
+```
+
+**Root cause — a race, proved, not inferred.** The bootstrap script runs
+`agro sandbox install docker`, which returns as soon as Compose reports
+`Container oh-a Started`, and then immediately runs `agro harness install`. At
+that instant the container's bootstrap unit is still `activating` and the
+entrypoint has not yet seeded `/home/sandbox` or repaired its ownership, so
+`/home/sandbox/.local` is not yet writable by the container's `sandbox` user.
+
+Timeline from the container journal and the npm log path, same run:
+
+```
+06:16:40  Starting openharness-bootstrap.service
+06:16:40  [entrypoint] seeding from /opt/agro-seed
+06:16:40  npm EACCES on /home/sandbox/.local/lib   <-- the harness install
+06:16:40  [entrypoint] repairing sandbox home mount ownership as 1000:1000
+06:16:44  Finished openharness-bootstrap.service
+```
+
+The identical command, run at 06:17:10 once `is-active` returned `active` and
+`/home/sandbox/workspace/.local` was `uid=1000 gid=1000 mode=755`, **succeeded**:
+`opencode: installed`. So the install path is sound; the ordering is not.
+
+**Consequences observed.** `run_step` calls `fail 243`, so the script writes
+`failed:243` and exits before `sudo touch /run/openharness-ready` — the marker
+the control plane waits on is never created. Meanwhile the sandbox itself is
+fine: `is-active` reached `active` with `Result=success` seconds later. A
+config-B node therefore ends up with a healthy sandbox that the control plane
+can never see as ready.
+
+**Attribution.** This defect is **not** an artifact of the candidate
+substitution. The ordering comes from accepted Cloud source —
+`buildBootstrapInstallCommands()` appends the install lines straight after the
+config steps with no readiness wait
+(`packages/shared/src/workspace-bootstrap-assets.ts`). The failing write is
+inside the sandbox image entrypoint's seed/ownership sequence, which is the
+published lineage's own code. The published CLI would hit the same race; with
+the published image it would never get that far, because the boot fails first
+(section 8).
+
+**The fix this suggests** (recorded as an observation, not implemented here):
+the bootstrap script should wait on the same oracle the rebuild helper already
+uses — poll `docker exec "$sandbox_name" systemctl is-active
+openharness-bootstrap.service` until `active` — between
+`agro sandbox install docker` and the first `agro harness install`. The helper
+in `host-management-assets.ts` already contains exactly that loop, with budgets
+(`readyProbe 10 · readyInterval 5 · readyAttempts 20`). The bootstrap script
+has no equivalent.
+
+---
+
+## 11. Secondary observations
+
+- **`agro`-naming drift in the candidate CLI and image.** `agro config set`
+  reports `oh.json: set image.ref=…` while writing `agro.json`; the attach
+  banner is headed `openharness: oh-a` and recommends `oh harness install …`
+  and `oh tool install herdr`; `agro harness install <bad-id>` errors with the
+  prefix `oh harness:`. The files on disk are correctly `agro.json` and
+  `~/.agro/sandboxes/<name>/`; only the messages lag.
+- **The PATH CLI on this host is 0.7.0** and has no `migrate` verb; the
+  `migrate --check` result in section 4 depends on the 0.9.0 candidate.
+- **A failed rebuild leaves the sandbox stopped**, with no rollback
+  (section 5).
+- **`agro sandbox install docker` returns before the sandbox is usable**
+  (findings 1 and 7 are the same underlying gap seen from two angles).
+
+---
+
+## 12. Verdict table
+
+| Leg | Verdict | Proof |
+| --- | --- | --- |
+| 1 FRESH | **PASS** | `openharness-bootstrap.service` `ActiveState=active SubState=exited Result=success ExecMainStatus=0`, full cold-boot journal, reproduced twice |
+| 2 LEGACY STATE | **PASS** | empty before/after diff of sha256+uid+gid+mode across 9 seeded paths (one documented gh canonicalisation, credential value proved unchanged by hash); git working tree intact; `agro migrate --check` → `status: ready` on the seeded `.oh`/`oh.json` project; `~/.openharness` content intact and visible from inside the container |
+| 3 REBUILD | **PASS** (caveat) | `ohmanage` forced command → `state=complete step=ready`; identical bind, identical `dev=bc inode=1486974`, empty state diff, container id changed; caveat: a no-change rebuild reports the same success without recreating the container (finding 3) |
+| 4a tmux attach | **FAIL** | session present only during bootstrap; `no sessions` / exit 1 after restart and after rebuild (finding 4) |
+| 4b container re-attach | **PASS** | after restart and after rebuild, `agro shell` on a pty and `docker exec` both read state written before the transition, across a changed container id |
+| 4c code-server over pinned forward | **PASS** | unit `active`, `127.0.0.1:8080` loopback listener, reached over `permitopen`-pinned `ohproxy` forward (non-permitted port `administratively prohibited`); workspace root `/home/sandbox/workspace` = `dev=bc inode=1486974` = the container's bind source; durable state read through the editor's own HTTP surface |
+| 5 UID alignment | **PASS as configured; latent risk CONFIRMED** | node 1000 / container 1000 today; at node uid 1500 the entrypoint chowns the host bind directory to 1000 and the host user gets `HOST-WRITE=DENIED HOST-CREATE=DENIED` (finding 6) |
+| Harness config A | **PASS** | `status=ok`, marker present, unit active, zero harnesses installed |
+| Harness config B | **FAIL** | `status=failed:243`, no readiness marker, reproduced twice, root-caused to a race and proved by a succeeding re-run (finding 7) |
+| Published image (contrast) | **FAIL** | `ActiveState=failed Result=exit-code ExecMainStatus=1` while the container reported `Up 5 seconds (health: starting)` |
+
+### Nothing was BLOCKED
+
+Every leg ran. Systemd-in-container, nested Docker, sshd, tmux and a real
+loopback code-server all worked on the disposable node. The only environmental
+obstacle encountered was the containerd snapshotter's whiteout extraction under
+nesting, which was worked around by switching the node's daemon to `overlay2`
+and is disclosed in section 2.
+
+### What was NOT verified
+
+- Nothing was run against a **published patched image or a published CLI** —
+  none exists yet. Every PASS is provisional on that re-run.
+- **cloud-init itself** did not execute; its blocks were replayed by a script.
+  A real `#cloud-config` parse, `defer:`, and module ordering are unverified.
+- The **control-plane side** of the lifecycle — `provision.ts`'s state machine,
+  `revokeNodeBrowserAccess`, node token registration,
+  `openharness-register-runtime-settings` — was not exercised. Only the
+  node-side verbs the provisioner drives were.
+- The node is a **privileged container, not a VM**; kernel-level differences
+  (nested virtualisation, cgroup delegation on a real cloud kernel) are
+  untested.
+- The **browser-gateway session lifecycle** (revoke-then-rebuild) was not
+  simulated; a revoked session after a rebuild is correct by design and was
+  deliberately not preserved.
+- `ohproxy` was verified to be forward-only by the `permitopen` refusal, but
+  the check that the `ohproxy` principal **cannot obtain a shell** never
+  executed — it was queued behind a blocked `wait` in the step described in
+  section 14.1 and was not re-run. It is **NOT VERIFIED**. A full
+  negative-authorisation sweep of the `ohmanage` helper's `reject` paths was
+  also not attempted.
+
+---
+
+## 13. Cleanup — verified
+
+Everything this run created was removed:
+
+- containers: `us007a-node` (and, inside it, `oh-a`, `oh-pub`,
+  `oh-uidtest`, `us007a-registry`) — removed with the node;
+- volume: `us007a-node-docker` — removed;
+- images: `agro-candidate:us007a`, `oh-node-host:us007a`, the `ubuntu:24.04`
+  base this run pulled, and the intermediate `home` build stage
+  (`df5b78d94942`, created 05:49:57Z, inside this run's 05:49:04-05:50:17Z
+  build window) — all removed;
+- the `ssh -N -L 18080` forward — killed.
+
+Verification after cleanup:
+
+```
+docker ps -a       ->  oh-sbx-local, pgadmin   (both pre-existing)
+docker volume ls   ->  oh-sbx-local_workspace, pgadmin-data   (both pre-existing)
+docker images      ->  the exact pre-run list, no new entries
+docker system df   ->  Images 22 / 7.18GB — identical to the pre-run baseline
+stray forwards     ->  0
+```
+
+No live clone's working state, no other worktree and no published artifact was
+modified. The only files written by this worker are this document and
+`local-lifecycle-transcript.log`.
+
+---
+
+# 14. Addendum — coordinator acceptance gate
+
+Two items were raised after the run. Both are answered below from evidence
+already captured, plus one controlled experiment run specifically to identify
+the exit code. The matrix was **not** re-run, and nothing about the product
+under test was changed, repaired or re-configured to produce these answers.
+
+## 14.1 The `exit 144` step — determined, not guessed
+
+### What the failing step was
+
+One Bash invocation labelled "Editor reads durable state; verify pin",
+containing three sub-checks:
+
+1. read durable state through the code-server HTTP surface;
+2. prove the `ohproxy` `permitopen` pin refuses a non-permitted forward;
+3. prove the `ohproxy` principal cannot obtain a shell.
+
+### What 144 actually is — determined empirically
+
+144 is **not** an application exit code, and it is **not** `128 + SIGTERM`
+under the usual arithmetic. On this kernel and architecture the signal table is
+authoritative and was read directly:
+
+```
+kill -l TERM  ->  15          (so 128+SIGTERM would be 143)
+kill -l 16    ->  STKFLT      (so 128+16 would be SIGSTKFLT, which nothing sends)
+```
+
+So the arithmetic had to be tested rather than assumed. Two controlled
+experiments were run in this exact harness:
+
+**Control — deliver SIGTERM to the tool's own shell explicitly:**
+
+```
+$ echo "control: this shell terminates itself with an explicit SIGTERM"; kill -s TERM $$; echo "NOT REACHED"
+Exit code 144
+control: this shell terminates itself with an explicit SIGTERM
+```
+
+**Exact reproduction — a self-matching `pkill -f`:**
+
+```
+$ MARKER=us007a144probe7f3c; echo "repro: this command line contains the marker and pkill -f will match its own shell"; pkill -f "us007a144probe7f3c"; echo "NOT REACHED"
+Exit code 144
+repro: this command line contains the marker and pkill -f will match its own shell
+```
+
+In both cases the trailing `echo "NOT REACHED"` did not run, and the reported
+code was 144.
+
+**Conclusion, established by experiment:** in this harness, a tool shell
+terminated by **SIGTERM** is reported as **exit 144**. The `128 + N`
+convention does not describe this harness's reported number (a SIGTERM'd shell
+here reports 144, not the 143 that convention predicts), so 144 must be read
+as "the shell was signalled", not decoded as signal 16.
+
+### What sent the SIGTERM, and why
+
+I sent it, to myself. The sequence:
+
+1. Inside sub-check 2 I backgrounded `ssh -N -L 18099:127.0.0.1:22 ohproxy@node`.
+   `ssh -N` never exits by design. I then called `wait`. **My harness bug:** the
+   step's shell blocked forever *after* it had already produced and printed its
+   observation.
+2. The blocked step hit the 180s tool timeout and was moved to background as
+   task `bcde3wn97`.
+3. My very next command began
+   `pkill -f "ssh .*18099"; pkill -f "…-N -L 18099"; echo killed`.
+   `pkill -f` matches its pattern against every process's **full command line**
+   — including the command lines of the invoking shell and of the backgrounded
+   task, both of which contained the literal string `18099`. **My second
+   harness bug:** the pattern was too broad and matched its own callers.
+4. `pkill`'s default signal is SIGTERM. Both shells were terminated. The
+   foreground call reported 144 and never printed `killed`; the background task
+   `bcde3wn97` was simultaneously reported failed with 144. Two processes, one
+   cause, the same code.
+
+This is fully consistent with the reproduction above: no `killed` echo, code
+144.
+
+### Whether the underlying assertion holds — **PASS**, and the PASS does not
+### depend on any repair
+
+The step's output was preserved and was read **before** the kill. Sub-checks 1
+and 2 had already completed and were recorded with `-- exit=0`:
+
+```
+marker via editor resource API:
+2026-09-09T06:00:24Z
+
+task notes via editor resource API:
+user task notes that must survive restart and rebuild
+-- exit=0
+
+channel 2: open failed: administratively prohibited: open failed
+forward-to-22 http=000
+forward-to-22 refused (expected)
+```
+
+So the assertion was **not lost, not retried until green, and not relabelled**.
+It was captured, and it passed, inside the very run that was later killed.
+
+It was then independently reproduced in a **separate, clean tool call** at
+06:07:03 that completed normally with `-- exit=0` — the post-rebuild leg-4c
+observation already recorded in section 6(c):
+
+```
+root http=302  redirect=…/?workspace=/home/sandbox/oh.code-workspace
+marker written inside the post-rebuild container, read via the editor surface:
+2026-09-09T06:06:42Z
+seeded uncommitted file, read via the editor surface:
+committed line
+UNCOMMITTED EDIT do-not-lose
+```
+
+**What changed between the failing run and the passing run:** only my harness.
+The later step did not background a non-terminating `ssh -N` inside the
+measured command and did not call `wait`; the long-lived `-L 18080` forward was
+started in its own earlier tool call and left alone. **Nothing about the
+product under test changed** — same node, same container, same code-server
+unit, same `ohproxy` principal, same `oh.code-workspace`. No product default,
+config, mount or path was altered to make this pass.
+
+Answering the three-way question explicitly: this is the **PASS** branch — the
+editor genuinely reads durable state and my harness was faulty. It is **not**
+the FAIL branch: the `storage.homePath` / `AGRO_HOME_MOUNT` decision did **not**
+repoint the editor root away from durable user state. The editor root
+`/home/sandbox/workspace` was observed to be `dev=bc inode=1486974`, the exact
+device and inode of the bind **source** of the sandbox container's
+`/home/sandbox`, and durable state written *inside* the container was read back
+*through the editor's own HTTP surface* on the far side of both a restart and a
+rebuild.
+
+### One casualty, reported rather than hidden
+
+**Sub-check 3 — "the `ohproxy` principal cannot obtain a shell" — never
+executed.** It was queued behind the `wait` that blocked, and it was never
+re-run. It is therefore **NOT VERIFIED** and is listed as such in section 12's
+"What was NOT verified". Its absence does not affect surface (c)'s verdict: it
+is a negative-authorisation hardening check on the proxy principal, not an
+attach-surface assertion. What *was* verified about that principal is that its
+`permitopen` pin is enforced by sshd (`administratively prohibited` on a
+non-permitted port) and that the account's configured login shell is
+`/usr/sbin/nologin`.
+
+## 14.2 Surface 4a — stated as a product finding
+
+**The coordinator's reading is confirmed, with one correction.**
+
+Confirmed: the `docker-build-oh-sandbox` session exists only while the
+bootstrap script runs, nothing recreates it, and it is therefore gone by the
+time any user would attach. Observed, in a single polled run:
+
+```
+t=1  status=<no status yet>  tmux: docker-build-oh-sandbox: 1 windows (created Wed Sep 9 06:16:39 2026)
+t=2  status=failed:243       tmux: no server running on /tmp/tmux-1000/default
+```
+
+and after each transition:
+
+```
+after restart:  tmux ls -> no server running;  tmux attach -t docker-build-oh-sandbox -> no sessions (exit 1)
+after rebuild:  tmux ls -> no server running;  tmux attach -t docker-build-oh-sandbox -> no sessions (exit 1)
+```
+
+The mechanism is deterministic, not incidental: `index.ts:1142` launches
+`tmux new-session -d -s <session> <script>` with no `remain-on-exit`, so tmux
+destroys the session when the script exits — on success or failure alike. The
+rebuild path never involves tmux at all; `MANAGEMENT_HELPER` drives
+`agro stop` / `agro sandbox install` through `runuser -l` directly. Nothing in
+the cloud-config runs the launch line a second time.
+
+Confirmed also: this is **not** the deliberate-revocation case. `node.rebuild`'s
+`revokeNodeBrowserAccess` governs browser sessions; it has nothing to do with
+this tmux session, which is equally absent after a plain restart and after a
+bootstrap that never rebuilt anything.
+
+**The correction.** Access to the node is *not* lost, and no persistent user
+state is disconnected. SSH to the node works — the same connection that returns
+`no sessions` also successfully ran `agro shell` and `docker exec`, both of
+which reached every durable path (section 6(b)). What fails is one specific
+documented incantation, not the operator's ability to reach their work. So the
+#944 criterion is violated in the narrow sense that a documented attach surface
+silently stops working, not in the broad sense that state becomes unreachable.
+
+### Which of the three it is
+
+**It is (ii), a docs/contract problem — with a self-contradiction inside the
+accepted source that an operator must resolve one way or the other.**
+
+The runtime is behaving exactly as `tmux new-session -d -s NAME <cmd>` is
+specified to behave. Nothing is malfunctioning. What is wrong is that the
+accepted source documents two mutually incompatible contracts for the same
+session:
+
+*Unbounded — describes it as the node's access model (wrong as written):*
+
+- `packages/shared/src/index.ts:786-791` — "…inside a detached tmux session
+  (`docker-build-oh-sandbox`) **the node owner can attach to**. … **Access
+  model**: `ssh <sshUser>@<ipv4>` then `tmux attach -t docker-build-oh-sandbox`."
+- `packages/shared/src/workspace-bootstrap-assets.ts` header — "…inside a
+  detached tmux session **the node owner can attach to from the editor
+  terminal**."
+- `infra/cloud-init/README.md:78` — an acceptance statement that
+  "`… docker-build-oh-sandbox` works."
+
+*Bounded — describes it as a build-watching window (accurate):*
+
+- `infra/cloud-init/README.md:363` and `docs/quickstart.md:591` —
+  `tmux attach -t docker-build-oh-sandbox   # watch the agro install + sandbox provision`
+- `docs/runtime-settings-runbook.md:157` — "…`tmux attach -t
+  docker-build-oh-sandbox` **watches** the node's `agro` …"
+
+The bounded framing is truthful and matches the implementation. The unbounded
+framing — in particular the words "Access model" at `index.ts:791` — is false
+for every moment after the bootstrap finishes, which is essentially all of a
+node's life.
+
+It is **not (iii), a test limitation**. The session was observed *present* at
+t=1 and *absent* at t=2 within one polled run on the same host, and absent
+again after two further transitions. That is positive evidence of the
+behaviour, not an inability to observe it.
+
+It is arguably **(i)** if the operator decides the intended contract is the one
+at `index.ts:791` — in which case the fix is a product change (a persistent
+session with the script run inside it, or `set remain-on-exit on`), not a docs
+edit. **I am not making that call and have changed nothing.** What the evidence
+establishes is that the current implementation cannot satisfy the unbounded
+contract, and that the two contracts cannot both stand.
+
+**Secondary UX observation:** the failure is silent and uninformative. After a
+*successful* bootstrap, the documented command returns a bare `no sessions` and
+exit 1, with nothing to distinguish "the build finished successfully an hour
+ago" from "the build never started" or "you typed the wrong session name". A
+user following `docs/quickstart.md:591` on a healthy node gets an error that
+reads like a broken node.
+
+---
+
+# 15. Acceptance criteria, checked one at a time
+
+Stated per criterion, as requested, rather than crediting the story because the
+run finished. **The story does not pass.**
+
+| # | Criterion | Verdict | The observed state that decides it |
+| --- | --- | --- | --- |
+| 1 | Fresh provisioning, readiness by the bootstrap unit reaching `active` (NOT container liveness) | **PASS** | `Type=oneshot RemainAfterExit=yes`, `ActiveState=active SubState=exited Result=success ExecMainStatus=0`, `ExecMainStart 05:56:22 → ExecMainExit 05:56:26`; full cold-boot journal (seed → ownership repair → `pnpm install completed` → `Finished`); reproduced in a second independent fresh run. Container liveness explicitly **not** used — and shown worthless in criterion 8. |
+| 2 | Legacy `~/.openharness` state recoverable and operable, each seeded item verified before/after | **PASS** (one documented mutation) | 6 seeded classes, 9 tracked paths; `diff` of the sha256+uid+gid+mode oracle across the restart was empty except `hosts.yml`; git tree intact (` M tracked.txt` / `?? untracked.txt` / `86f48d1`); `.env` and the credential stand-in both still 0600; `~/.openharness` content intact and visible from inside the container; `agro migrate --check` on the seeded `.oh`/`oh.json` project → `status: ready`. The one mutation was investigated, not waved through: `hosts.yml` was canonicalised by the `gh` CLI (gained a `users:` sub-map) and the credential **value** was proved unchanged by hash comparison (`da5358c5…`, `match=YES`) without printing it. |
+| 3 | Rebuild preserving persistent user state, proven by OBSERVED volume identity and contents | **PASS** (with finding 3) | Driven through the real `MANAGEMENT_HELPER` over the pinned `ohmanage` forced command → `state=complete step=ready`. Identity observed on both sides, not inferred from the absence of `down -v`: mount `bind /home/sandbox/workspace -> /home/sandbox rw=true` identical; durable root `dev=bc inode=1486974 uid=1000 gid=1000 mode=755` identical; the 9-path content/mode `diff` **produced no output**; container id changed `6b749b6673ee…` → `6a82719b33c4…`; config (`storage.homePath`, `image.ref`) survived. Caveat recorded as finding 3: a no-change rebuild reports the same success **without** recreating the container. |
+| 4a | Attach — ssh + `tmux attach -t docker-build-oh-sandbox` | **FAIL** | Session present at t=1 during bootstrap, `no server running` at t=2; `no sessions` / exit 1 after restart and after rebuild. SSH itself works on the same connection. Classified in section 14.2 as a docs/contract defect with a self-contradiction in accepted source. |
+| 4b | Attach — container re-attach | **PASS** | State written inside the container before each transition, read back after: after restart `MARKER-READ=2026-09-09T05:58:16Z` on `6b749b6673ee`; after rebuild the same marker on the **different** container `6a82719b33c4`, plus the seeded uncommitted git change. Both via `agro shell` on a real pty and via `docker exec`. |
+| 4c | Attach — real loopback code-server over a pinned SSH forward | **PASS** | Host-native unit `active`; `LISTEN 0 511 127.0.0.1:8080`; reached from another machine over the `permitopen`-pinned `ohproxy` forward; pin proved real (`administratively prohibited` on a non-permitted port); root redirects to `?workspace=/home/sandbox/oh.code-workspace` whose single folder `/home/sandbox/workspace` is `dev=bc inode=1486974` — the container's bind source; durable state read **through the editor's own HTTP surface** on both sides of the rebuild. The `exit 144` incident is fully accounted for in section 14.1: harness fault, assertion already captured with `exit=0`, independently reproduced in a clean run, nothing in the product changed. |
+| 5 | Each attach surface re-exercised AFTER a restart and AFTER a rebuild | **PARTIAL** | (a) exercised after both — **failed** after both. (b) exercised after both — passed after both. (c) exercised after both — passed after both. So the *exercise* requirement is met for all three; the *outcome* is a fail for (a). |
+| 6 | UID alignment numbers | **PASS as configured; latent risk CONFIRMED** | Stated explicitly: node-host `id -u sandbox` = **1000**, container `id -u sandbox` = **1000**; gids **1000** and **1000**. They do **not** diverge under the accepted cloud-config, because its `users:` list has no `- default` so the distro user never takes 1000. They are equal by coincidence of two independent constants, and nothing enforces it: at node uid **1500** the entrypoint's `repairing sandbox home mount ownership as 1000:1000` chowned the host bind directory `1500:1500 → 1000:1000` and the host-native user got `HOST-WRITE=DENIED HOST-CREATE=DENIED`. The entrypoint's UID-sync path is gated on a checkout bind that image-only cloud nodes never have. Reported as a finding about the Cloud bootstrap, not worked around. |
+| 7 | Both default-harness configurations, as a test parameter only | **A PASS / B FAIL** | Config A (no default harnesses): `status=ok`, readiness marker present, unit `active`, zero harnesses installed; reproduced twice. Config B (one default harness): `status=failed:243`, **no** readiness marker, reproduced twice, root-caused to a race and proved by the identical command succeeding once the unit reached `active`. No product default was changed and the operator decision is untouched. |
+
+**Overall:** the matrix does not pass. Criterion 4a fails, criterion 7 fails for
+config B, criterion 5 is partial, and every PASS above is provisional on being
+re-run against a published patched image and CLI, because no published artifact
+can currently cold-boot (section 8).
+
+---
+
+# 16. Addendum 2 — resumed invocation: one deliverable, two blockers
+
+Three items were requested. **Item 2 is delivered below.** **Items 1 and 3 are
+BLOCKED** by an environment change that happened between invocations, with the
+exact blocker recorded. Nothing was silently skipped, retried until green, or
+substituted with a mock.
+
+## 16.0 The blocker — Docker is unreachable in this container
+
+The previous run executed in container `e73e5123a864` with the host Docker
+socket mounted. This invocation is running in a **different container**,
+`395299dff1d9`, which has **no Docker socket at all**. Observed:
+
+```
+$ hostname
+395299dff1d9                     (previous run: e73e5123a864)
+
+$ echo $DOCKER_HOST
+DOCKER_HOST=[unset]
+
+$ command -v docker
+/usr/bin/docker                  (client present, 29.8.0)
+
+$ docker info
+... failed to connect to the docker API at unix:///var/run/docker.sock;
+    check if the path is correct and if the daemon is running:
+    dial unix /var/run/docker.sock: connect: no such file or directory
+
+$ ls -la /var/run/docker.sock /run/docker.sock /run/user/1000/docker.sock
+ls: cannot access '/var/run/docker.sock': No such file or directory
+ls: cannot access '/run/docker.sock': No such file or directory
+ls: cannot access '/run/user/1000/docker.sock': No such file or directory
+
+$ find / -maxdepth 5 -name docker.sock
+(no results)
+
+$ getent group docker
+docker:x:1001:sandbox            (previous run: gid 117 — a different container)
+
+$ curl http://host.docker.internal:2375/_ping
+curl: (7) Failed to connect to host.docker.internal port 2375 ...
+```
+
+**Missing capability:** access to a container runtime. Both remaining items
+require creating containers — item 1 needs an `sshd` host carrying the
+`ohproxy` principal, item 3 needs the disposable systemd node host with its own
+nested `dockerd`. Neither can run without a Docker daemon.
+
+**What would be needed:** this sandbox started with the host Docker socket bound
+(as `oh-sbx-local` was), or an equivalent reachable daemon via `DOCKER_HOST`.
+
+**Also lost:** the previous run's scratchpad
+(`…/scratchpad/w13`) no longer exists, so the generated `ohmanage`/`ohproxy`
+key material and the generator-emitted SSH assets are gone. They are cheap to
+regenerate from the accepted Cloud builders — that is not the blocker; the
+absent runtime is.
+
+## 16.1 Item 1 — `ohproxy` cannot obtain a shell — **BLOCKED**
+
+Still **NOT VERIFIED**, for the reason above, not for the original reason. The
+original cause (my blocked `wait` plus an over-broad `pkill -f`) is fully
+explained in section 14.1 and is not what stops it now.
+
+**The exact procedure, ready to run**, incorporating the PID-scoped cleanup the
+coordinator specified — recorded here so the leg is unambiguous when a runtime
+is available:
+
+```bash
+# positive control FIRST: the same key must successfully forward, so that a
+# later refusal proves "no shell", not "bad key".
+ssh -i "$KEYS/proxy_key" -o StrictHostKeyChecking=no \
+    -o UserKnownHostsFile="$SP/known_hosts" -o ExitOnForwardFailure=yes \
+    -N -L 18080:127.0.0.1:8080 ohproxy@"$NODEIP" &
+FWD_PID=$!                                  # PID captured explicitly
+sleep 5
+curl -sS -o /dev/null -w 'forward http=%{http_code}\n' http://127.0.0.1:18080/
+
+# THE ASSERTION — three shapes, all must be refused:
+ssh -i "$KEYS/proxy_key" … ohproxy@"$NODEIP" 'id; echo SHELL-OBTAINED'
+ssh -i "$KEYS/proxy_key" … -T ohproxy@"$NODEIP"      # no command, no pty
+ssh -i "$KEYS/proxy_key" … -tt ohproxy@"$NODEIP"     # force a pty
+sftp -i "$KEYS/proxy_key" … ohproxy@"$NODEIP"        # subsystem
+
+# cleanup: kill the captured PID only. No pattern matching, ever, and no
+# `wait` on a non-terminating process inside the measured step.
+kill "$FWD_PID" 2>/dev/null
+```
+
+**Why this shape avoids the earlier trap:** cleanup targets a numeric PID
+recorded at launch. Nothing matches a string, so nothing can match the
+invoking shell's own command line — which is precisely how the previous attempt
+killed itself and its own background task (section 14.1). The forward is never
+`wait`ed on.
+
+**What the refusal is expected to come from, and why it is worth observing
+rather than assuming.** The `ohproxy` principal is deliberately built *without*
+a forced command — `buildHostProxyAssets()`'s own comment states "there is NO
+`command=` — the gateway dials with `ssh -N` direct-tcpip and never runs a
+shell (the account's login shell is `/usr/sbin/nologin`)". So confinement rests
+on three independent mechanisms, none of which is a forced command:
+
+1. the account's login shell `/usr/sbin/nologin`;
+2. `PermitTTY no` in the generated `Match User ohproxy` block;
+3. `restrict` in the authorized_keys line, re-enabling only `port-forwarding`
+   and pinning `permitopen="127.0.0.1:8080"`.
+
+Note that OpenSSH's `restrict` does **not** by itself block command execution —
+it disables pty, agent/X11 forwarding, port forwarding and user-rc. Command
+execution is blocked by `nologin`, not by `restrict`. That is exactly why this
+check is worth running rather than reasoning about: the confinement depends on
+a user-account property (`nologin`) that lives outside the generated
+authorized_keys line and outside the sshd Match block, and nothing in the
+accepted generator asserts it. `buildHostProxyAssets()` emits the key line and
+the sshd block; the `nologin` shell is set by whatever creates the `ohproxy`
+account.
+
+**What IS already verified about this principal** (section 6(c)): its
+`permitopen` pin is enforced by sshd — a forward to a non-permitted port on the
+same key was refused with `channel 2: open failed: administratively
+prohibited: open failed`. So the key is confined in the forwarding dimension.
+The shell dimension remains unverified.
+
+## 16.2 Item 2 — the UID/GID contract — **DELIVERED (assessment only)**
+
+Nothing was implemented, remapped, or chowned. This section is analysis.
+
+> **Citation note.** All line numbers below are pinned to **HEAD `b10ecac3`**,
+> which is the tree the candidate image was built from and the tree the matrix
+> ran against. The live checkout's *working tree* currently reverts
+> `.devcontainer/` to the pre-AGRO `.oh` generation (see 16.3), so working-tree
+> line numbers do not match. Cite via `git show HEAD:<path>` to reproduce.
+
+### A. The required contract, as a checkable condition
+
+Three identities decide whether attach surface (c) works on an image-only node:
+
+| Symbol | Meaning | Where it comes from |
+| --- | --- | --- |
+| **H** | the uid:gid that `openharness-code-server.service` runs as on the node | the unit's `User=sandbox` / `Group=sandbox` (`packages/shared/src/index.ts`, code-server unit block) |
+| **P** | the node-host path bound to the container's `/home/sandbox` | `storage.homePath` / `AGRO_HOME_MOUNT`, default `/home/sandbox/workspace`; bound by `docker-compose.image-only.yml:9` — `${AGRO_HOME_MOUNT:-${OH_HOME_MOUNT:-workspace}}:/home/sandbox` |
+| **C** | the uid:gid the container chowns P to on every boot | `sandbox_ownership()` = `id -u sandbox`:`id -g sandbox` *inside the container* (`entrypoint.sh:37`), applied at `entrypoint.sh:70-71` |
+
+**The condition, checkable before first boot:**
+
+```
+uid(sandbox @ node) == uid(sandbox @ container image)
+        AND
+gid(sandbox @ node) == gid(sandbox @ container image)
+```
+
+**A stronger and more honest form of the same condition** — because the real
+requirement is about the owner of the path, not about a name:
+
+```
+owner(P) as the node sees it  ==  C
+        AND
+H can write P
+```
+
+The second form catches a case the first misses: a node whose
+`storage.homePath` points at a directory owned by some *other* user fails
+identically even when the two `sandbox` uids match.
+
+Observed values this run: node `1000:1000`, container `1000:1000` — condition
+**holds**. Forced to node `1500:1500` — condition **violated**, and the observed
+consequence was `HOST-WRITE=DENIED` / `HOST-CREATE=DENIED` for the host-native
+user after the entrypoint rewrote P to `1000:1000` (section 7).
+
+### B. Where the contract is established, and where it is merely assumed
+
+**Established — genuinely pinned in code:**
+
+- **Container uid/gid.** `Dockerfile:60` — `useradd -m -u 1000 -s /bin/zsh
+  sandbox`. A hard-coded constant baked into the image. This half of the
+  contract is real.
+- **The mutation itself.** `entrypoint.sh:70-71` —
+  `find /home/sandbox -path "$OH_PROJECT_ROOT" -prune -o -exec chown -h "$owner" {} +`,
+  where `$owner` is `sandbox_ownership()` (`entrypoint.sh:37`). Unconditional,
+  every boot, called at `entrypoint.sh:207`.
+- **The bind.** `docker-compose.image-only.yml:9`.
+- **code-server's identity.** `User=sandbox` / `Group=sandbox` in the unit.
+
+**Merely assumed — nothing pins it:**
+
+- **The node-side uid.** The cloud-config `users:` block creates `sandbox` with
+  **no `uid:` field** and the list contains **no `- default` entry**. The value
+  1000 is an *emergent* property of the base image's existing passwd entries
+  plus `useradd`'s first-free-uid policy. Nothing in the cloud-config, the
+  provisioner, or AGRO asserts it. A base image that already occupies 1000 — or
+  restoring `- default` so the distro user takes it — silently yields 1001.
+- **The equality itself.** No code anywhere compares H, C or `owner(P)`. There
+  is no assertion, no probe, no test, and no runtime check. The two constants
+  are set in two repositories that never consult each other.
+
+**The one mechanism that could adapt is structurally unreachable here.** The
+entrypoint *does* contain UID reconciliation — `entrypoint.sh:169-185` reads
+`HOST_UID=$(stat -c '%u' "$HARNESS_DIR")`, compares with `SANDBOX_UID=$(id -u
+sandbox)`, and calls `usermod -u "$HOST_UID" sandbox`. But it is gated at
+`entrypoint.sh:161` on `mountpoint -q "$HARNESS_DIR"` with a control directory
+present — a **checkout bind** at `/home/sandbox/harness`. Image-only cloud
+nodes have no checkout bind; the observed journal line on every boot in this
+run was `[entrypoint] no checkout bind at /home/sandbox/harness — seeding from
+/opt/agro-seed` (`entrypoint.sh:193`). Control falls straight through to
+`repair_home_mount_ownership` at `entrypoint.sh:207`.
+
+So the adaptive path exists and is disabled on exactly the deployment that
+needs it, while the destructive path runs unconditionally.
+
+### C. Assessment of a fail-before-mutation guard
+
+**Could the bootstrap detect divergence and fail loudly before anything is
+chowned? Yes — cleanly, under the existing spec, using pieces the spec already
+has.**
+
+**Where it must go.** In the generated bootstrap script, after
+`install_agro`/`activate_node` and **before**
+`run_step agro sandbox install docker …`. That is the only safe window: the
+chown happens on the first boot of the container that mounts P, and that boot
+is inside `agro sandbox install docker`. A guard placed after the install has
+already lost.
+
+**What it would check.**
+
+1. Node side — the owner of the path that will actually be bound:
+   `stat -c '%u %g' "$sandbox_home"`. Preferred over `id -u sandbox`, per the
+   stronger condition in A.
+2. Image side — the baked identity, obtained **without mounting anything**:
+   `docker run --rm "$sandbox_image" id -u sandbox` (and `-g`). No bind, no
+   volume, no systemd, therefore no chown; a throwaway container that cannot
+   touch user state. This is exactly the probe already run during this matrix:
+   `docker run --rm agro-candidate:us007a id sandbox` →
+   `uid=1000(sandbox) gid=1000(sandbox)`.
+3. Compare both uid and gid; on mismatch, call the existing `fail` with a
+   distinct code.
+
+**What it would cost.**
+
+- **Network: zero additional.** The image must be resolved for the guard, but
+  it must be pulled for the install regardless. Hoisting an explicit
+  `docker pull "$sandbox_image"` ahead of the guard makes it free in transfer
+  terms; the install then finds the image present.
+- **Time: ~1 second.** One short-lived container start of an already-present
+  image. Comparable probes in this run returned immediately.
+- **Code: it fits the existing idiom exactly.** It is a `run_step`-shaped
+  function in the same mould as the newly added `wait_sandbox_ready`, using the
+  same `fail` path, producing the same observable `failed:<code>` in the status
+  file the control plane already reads, and — because `fail` exits — leaving
+  the `ok` write and the `/run/openharness-ready` touch unreachable. Same
+  fail-closed shape the readiness gate now uses. A distinct code (e.g.
+  `failed:3`, alongside `failed:1` unit-failed and `failed:2` deadline) keeps it
+  diagnosable.
+- **Risk: low, and deliberately detection-only.** It must not `usermod`, must
+  not remap, must not chown. That restraint is the point: the alternative —
+  opportunistic remediation — would silently rewrite the ownership of a user's
+  workspace, which is the class of action this epic forbids. A node that fails
+  this guard should stop and surface a decision to a human.
+
+**Limits, stated honestly.**
+
+- It protects **new provisioning only**. A node already provisioned with
+  divergent uids has already had P rewritten. A guard cannot undo that, and
+  undoing it is an operator decision, not an automatic one.
+- It does **not** cover the rebuild path. `MANAGEMENT_HELPER` never runs the
+  bootstrap script; it calls `agro stop` / `agro sandbox install` directly. If
+  the guard is wanted there too it needs a second placement before the helper's
+  install step.
+- It reads the image's **baked** uid. If a future image resolved its uid at
+  runtime instead of baking it at `Dockerfile:60`, the probe would need to
+  change with it.
+- A guard is a detector, not the contract. The durable fix is to make one side
+  authoritative — for example pinning `uid: 1000` explicitly in the
+  cloud-config `users:` entry so the node-side value stops being emergent. That
+  is an operator/owner decision and is **not** proposed here as an action.
+
+## 16.3 Item 3 — A+B re-run against the fixed bootstrap — **BLOCKED**
+
+Cannot run: no container runtime (16.0).
+
+**The fix was verified present by reading**, which is all that was possible:
+
+- `infra/cloud-init/cloud-config.yaml` — `wait_sandbox_ready()` polls
+  `docker exec "$sandbox_name" systemctl is-active "$ready_unit"`, `active`
+  → `return 0`, `failed` → `return 1`, loop exhaustion → `return 2`; wired as
+  `run_step wait_sandbox_ready` immediately after
+  `run_step agro sandbox install docker …` and before
+  `agro config set storage.homePath`, `echo ok`, and
+  `sudo touch /run/openharness-ready`.
+- `packages/shared/src/workspace-bootstrap-assets.ts:215-219` — the constants
+  are taken from `SANDBOX_READY_UNIT` and `SANDBOX_REBUILD_BUDGET_SECONDS`
+  (the rebuild helper's own), with `ready_deadline` from
+  `WORKSPACE_READY_DEADLINE_SECONDS`; the gate is emitted at line 290.
+
+That is a source reading, **not** an observation, and it discharges nothing. In
+particular the two gaps the bootstrap owner raised remain **unanswered**, and
+both are exactly the kind of claim that cannot be settled by reading:
+
+- **(a) Is `openharness-bootstrap.service` the completion signal on a
+  container's FIRST boot, or only post-recreate?** Partially informed by prior
+  observation but **not** answered. In the previous run the unit *was* observed
+  reaching `active` with `Result=success` on first boots of freshly created
+  containers, and the probe sequence `(empty) → activating → active` was
+  observed directly. The `(empty)` first sample is `docker exec` failing while
+  the container is not yet accepting exec — which the gate treats as
+  "not ready, keep polling", i.e. fail-closed. That is consistent with the gate
+  working on first boot, but it was observed against the *pre-fix* script and
+  must be re-observed against the gate itself.
+- **(b) Does the 300s deadline survive a cold published-lineage pull plus
+  first-boot seeding?** **Unanswered.** Prior timings are suggestive but were
+  measured with the image already present in the node's daemon: first boot
+  seed-to-`active` ran 05:56:22 → 05:56:26 (~4s) and 06:16:40 → 06:16:44 (~4s).
+  The pull component was never inside the measured window, so the sum against
+  300s is unknown. If config A ever fails `failed:2`, the answer is a larger
+  attempt count, not removing the gate.
+
+**A reproducibility warning that must be settled before the re-run.** The live
+checkout `/home/sandbox/harness` now has a **dirty working tree** in which
+`.devcontainer/` has been reverted to the pre-AGRO `.oh` generation:
+
+```
+$ git rev-parse --abbrev-ref HEAD; git rev-parse --short HEAD
+development
+b10ecac3
+
+$ git status --short | grep devcontainer
+ M .devcontainer/Dockerfile
+ M .devcontainer/docker-compose.image-only.yml
+ M .devcontainer/docker-compose.yml
+ M .devcontainer/entrypoint.sh
+
+$ git diff --stat HEAD -- .devcontainer/
+ 4 files changed, 129 insertions(+), 132 deletions(-)
+
+# HEAD (what the matrix was built from):     /opt/agro-seed, AGRO_HOME_MOUNT, compat_control_dir
+# working tree (what a build would use now): /opt/oh-seed,  OH_HOME_MOUNT,  no compat_control_dir
+```
+
+`docker build -f .devcontainer/Dockerfile .` against the working tree **today
+would produce a legacy `.oh`-generation image, not the AGRO candidate the matrix
+tested.** The re-run must build from HEAD or from a clean worktree, or its
+results will not be comparable to anything in this document. I have **not**
+touched the live checkout's working state.
+
+## 16.4 Cleanup integrity — one item I can no longer verify
+
+The previous invocation ended with cleanup verified against the pre-run
+baseline (section 13): 22 images / 7.18GB, 2 pre-existing containers, 2
+pre-existing volumes, no stray forwards. That verification stands as of the
+moment it was taken.
+
+**One caveat, disclosed rather than assumed away.** At the start of this
+invocation — before discovering the runtime was gone — I issued two
+`docker build` commands for `agro-candidate:us007a` and `oh-node-host:us007a`.
+Their output redirects targeted the scratchpad directory, and those log files
+do not exist, which indicates the redirects failed because the directory was
+already gone and therefore that the builds never started. I cannot confirm this
+by inspection, because no Docker daemon is reachable from this container.
+
+**Requested of the operator/coordinator:** on the host, confirm that
+`agro-candidate:us007a` and `oh-node-host:us007a` are absent and that no
+`us007a-*` container or volume exists. If any are present they are mine and
+should be removed:
+
+```
+docker rm -f us007a-node 2>/dev/null; docker volume rm us007a-node-docker 2>/dev/null
+docker rmi -f agro-candidate:us007a oh-node-host:us007a 2>/dev/null
+```
+
+No live clone's working state, no other worktree and no published artifact was
+modified in this invocation. The only files written remain this evidence
+document and `local-lifecycle-transcript.log`.
+
+## 16.5 Status of the three items
+
+| Item | Status | Basis |
+| --- | --- | --- |
+| 1 — `ohproxy` cannot obtain a shell | **BLOCKED** (still NOT VERIFIED) | no container runtime: `dial unix /var/run/docker.sock: connect: no such file or directory`, no socket on disk, `DOCKER_HOST` unset, no TCP daemon. Procedure with PID-scoped cleanup recorded in 16.1, ready to run. |
+| 2 — UID/GID contract | **DELIVERED** | 16.2 — checkable condition, established-vs-assumed with HEAD-pinned citations, fail-before-mutation guard assessed. Assessment only; nothing implemented, remapped or chowned. |
+| 3 — A+B re-run | **BLOCKED** | same missing runtime. Fix confirmed present by source reading only, which discharges nothing; gaps (a) and (b) remain unanswered. Reproducibility warning in 16.3 must be settled first. |
+
+Surface 4a is untouched and remains unresolved, as instructed. No product
+default was changed anywhere in this invocation.

--- a/.agro/tasks/agro-cloud-consumer-migration/local-lifecycle-transcript.log
+++ b/.agro/tasks/agro-cloud-consumer-migration/local-lifecycle-transcript.log
@@ -1,0 +1,1572 @@
+US-007a — observed local lifecycle matrix — raw command transcript
+Worker: bounded worker W13 (mifunedev/agro#944)
+Executed from inside sandbox container oh-sbx-local (host Docker socket available).
+All artifacts under test are LOCAL CANDIDATES, not published releases.
+
+=== [2026-09-09T05:51:12Z] harness tree identity (candidate image source)
+$ bash -c cd /home/sandbox/harness && git rev-parse --abbrev-ref HEAD && git rev-parse HEAD && grep -n "\"vitest\"" package.json
+development
+b10ecac3d17d21c7abb45a2e814617e6b9b5ae50
+28:    "vitest": "^4.1.11"
+-- exit=0
+
+=== [2026-09-09T05:51:12Z] candidate CLI source tree identity
+$ bash -c cd /home/sandbox/harness/.worktrees/bug/944-sandbox-install-idempotent && git rev-parse --abbrev-ref HEAD && git rev-parse HEAD && git status --short
+bug/944-sandbox-install-preserve-config
+b10ecac3d17d21c7abb45a2e814617e6b9b5ae50
+ M .agro/cli/src/__tests__/sandbox.test.ts
+ M .agro/cli/src/commands/sandbox.ts
+-- exit=0
+
+=== [2026-09-09T05:51:12Z] candidate image built
+$ docker images --format {{.Repository}}:{{.Tag}} {{.ID}} {{.CreatedSince}} agro-candidate:us007a
+agro-candidate:us007a d963de3d2b25 55 seconds ago
+-- exit=0
+
+=== [2026-09-09T05:51:12Z] PATH CLI version (published-lineage, pre-existing)
+$ bash -c command -v oh; oh --version; command -v agro || echo "agro NOT on PATH"
+/usr/local/bin/oh
+0.7.0
+agro NOT on PATH
+-- exit=0
+
+=== [2026-09-09T05:51:12Z] candidate CLI version
+$ bash -c node /tmp/claude-1000/-home-sandbox-harness/8b200f3c-07b0-487b-9533-aae682bf912f/scratchpad/w13/agro-candidate.js --version
+0.9.0
+-- exit=0
+
+=== [2026-09-09T05:53:32Z] LEG-0 start disposable node host (systemd PID1, own dockerd)
+$ docker run -d --name us007a-node --hostname us007a-node --privileged --cgroupns=host -v /sys/fs/cgroup:/sys/fs/cgroup:rw --tmpfs /run --tmpfs /run/lock -v us007a-node-docker:/var/lib/docker --network oh-sbx-local_default --stop-signal SIGRTMIN+3 oh-node-host:us007a
+20ce76d77c70789f42909b9693a19aa7f59ac1472010052953b0e40648d910d5
+-- exit=0
+
+=== [2026-09-09T05:53:44Z] node systemd state
+$ docker exec us007a-node systemctl is-system-running
+running
+-- exit=0
+
+=== [2026-09-09T05:53:44Z] node dockerd
+$ docker exec us007a-node docker info --format {{.ServerVersion}} storage={{.Driver}}
+29.8.0 storage=overlayfs
+-- exit=0
+
+=== [2026-09-09T05:54:12Z] LEG-0 replay cloud-config users/write_files/runcmd on the node
+$ docker exec us007a-node bash /opt/us007a/node-provision.sh
++ userdel -r ubuntu
++ groupadd -f docker
++ useradd -m -u 1000 -s /bin/bash -G sudo,docker sandbox
++ printf 'sandbox ALL=(ALL) NOPASSWD:ALL\n'
++ chmod 0440 /etc/sudoers.d/90-sandbox
++ install -d -o sandbox -g sandbox -m 0700 /home/sandbox/.ssh
++ cp /opt/us007a/sandbox-authorized-key /home/sandbox/.ssh/authorized_keys
++ chown sandbox:sandbox /home/sandbox/.ssh/authorized_keys
++ chmod 0600 /home/sandbox/.ssh/authorized_keys
++ printf 'PasswordAuthentication no\nPermitRootLogin no\n'
++ install -o root -g root -m 0755 /opt/us007a/bootstrap-workspace /usr/local/libexec/openharness-bootstrap-workspace
+install: cannot create regular file '/usr/local/libexec/openharness-bootstrap-workspace': No such file or directory
+-- exit=1
+
+=== [2026-09-09T05:54:16Z] LEG-0 replay cloud-config users/write_files/runcmd on the node (retry)
+$ docker exec us007a-node bash /opt/us007a/node-provision.sh
++ userdel -r ubuntu
++ true
++ groupadd -f docker
++ useradd -m -u 1000 -s /bin/bash -G sudo,docker sandbox
+useradd: user 'sandbox' already exists
+-- exit=9
+
+=== [2026-09-09T05:54:21Z] LEG-0 replay cloud-config users/write_files/runcmd on the node (retry 2)
+$ docker exec us007a-node bash /opt/us007a/node-provision.sh
++ userdel -r ubuntu
++ true
++ groupadd -f docker
++ id -u sandbox
++ printf 'sandbox ALL=(ALL) NOPASSWD:ALL\n'
++ chmod 0440 /etc/sudoers.d/90-sandbox
++ install -d -o sandbox -g sandbox -m 0700 /home/sandbox/.ssh
++ cp /opt/us007a/sandbox-authorized-key /home/sandbox/.ssh/authorized_keys
++ chown sandbox:sandbox /home/sandbox/.ssh/authorized_keys
++ chmod 0600 /home/sandbox/.ssh/authorized_keys
++ printf 'PasswordAuthentication no\nPermitRootLogin no\n'
++ install -o root -g root -m 0755 /opt/us007a/bootstrap-workspace /usr/local/libexec/openharness-bootstrap-workspace
++ cat
++ chown sandbox:sandbox /home/sandbox/oh.code-workspace
++ chmod 0644 /home/sandbox/oh.code-workspace
++ install -d -o root -g root -m 0755 /etc/openharness
++ printf 'AGRO_CODE_SERVER_ENABLED=true\n'
++ chmod 0600 /etc/openharness/runtime-settings.env
++ cat
++ chmod 0644 /etc/openharness/code-server.yaml
++ cat
++ chmod 0755 /usr/local/libexec/openharness-code-server-enabled
++ cat
++ systemctl enable --now docker
+Synchronizing state of docker.service with SysV service script with /usr/lib/systemd/systemd-sysv-install.
+Executing: /usr/lib/systemd/systemd-sysv-install enable docker
++ usermod -aG docker sandbox
++ systemctl restart ssh
++ install -d -o root -g root -m 0755 /etc/ssh/authorized_keys
++ install -d -o root -g root -m 0700 /var/lib/openharness
++ install -o root -g root -m 0600 /dev/null /var/lib/openharness/runtime-settings-apply.lock
++ id -u ohmanage
++ useradd --create-home --shell /bin/sh ohmanage
++ passwd -l ohmanage
+passwd: password changed.
++ install -d -o sandbox -g sandbox -m 0755 /home/sandbox/.local
++ install -d -o sandbox -g sandbox -m 0755 /home/sandbox/.local/share
++ install -d -o sandbox -g sandbox -m 0750 /home/sandbox/.local/share/code-server
++ install -d -o sandbox -g sandbox -m 0755 /home/sandbox/workspace
++ systemctl daemon-reload
++ /usr/local/libexec/openharness-code-server-enabled
++ systemctl enable --now openharness-code-server.service
+Created symlink /etc/systemd/system/multi-user.target.wants/openharness-code-server.service → /etc/systemd/system/openharness-code-server.service.
+US007A-NODE-PROVISION-OK
++ echo US007A-NODE-PROVISION-OK
+-- exit=0
+
+=== [2026-09-09T05:54:28Z] LEG-0 install ohmanage + ohproxy principals (Cloud builders' output)
+$ docker exec us007a-node bash /opt/us007a/node-provision-ssh.sh
++ install -o root -g root -m 0644 /opt/us007a/assets/ohmanage.authorized_keys /etc/ssh/authorized_keys/ohmanage
++ install -o root -g root -m 0644 /opt/us007a/assets/30-openharness-management.conf /etc/ssh/sshd_config.d/30-openharness-management.conf
++ install -o root -g root -m 0440 /opt/us007a/assets/openharness-ohmanage.sudoers /etc/sudoers.d/openharness-ohmanage
++ install -o root -g root -m 0755 /opt/us007a/assets/openharness-code-server-apply /usr/local/libexec/openharness-code-server-apply
++ id -u ohproxy
++ useradd --create-home --shell /usr/sbin/nologin ohproxy
++ passwd -l ohproxy
+passwd: password changed.
++ install -o root -g root -m 0644 /opt/us007a/assets/ohproxy.authorized_keys /etc/ssh/authorized_keys/ohproxy
++ install -o root -g root -m 0644 /opt/us007a/assets/40-openharness-proxy.conf /etc/ssh/sshd_config.d/40-openharness-proxy.conf
++ visudo -cf /etc/sudoers.d/openharness-ohmanage
+/etc/sudoers.d/openharness-ohmanage: parsed OK
++ sshd -t
++ systemctl restart ssh
+US007A-SSH-PRINCIPALS-OK
++ echo US007A-SSH-PRINCIPALS-OK
+-- exit=0
+
+=== [2026-09-09T05:54:28Z] LEG-4c code-server unit state on node (host-native, loopback)
+$ docker exec us007a-node bash -c systemctl is-active openharness-code-server.service; ss -H -ltn "sport = :8080"; curl -fsS -o /dev/null -w "http=%{http_code}\n" --max-time 5 http://127.0.0.1:8080/
+active
+LISTEN 0      511    127.0.0.1:8080 0.0.0.0:*
+http=302
+-- exit=0
+
+=== [2026-09-09T05:54:43Z] LEG-5 node-host sandbox uid/gid (before any container)
+$ docker exec us007a-node bash -c id sandbox; stat -c "%n uid=%u gid=%g mode=%a" /home/sandbox /home/sandbox/workspace /home/sandbox/oh.code-workspace
+uid=1000(sandbox) gid=1000(sandbox) groups=1000(sandbox),27(sudo),997(docker)
+/home/sandbox uid=1000 gid=1000 mode=750
+/home/sandbox/workspace uid=1000 gid=1000 mode=755
+/home/sandbox/oh.code-workspace uid=1000 gid=1000 mode=644
+-- exit=0
+
+=== [2026-09-09T05:56:20Z] candidate image seeded into node dockerd (overlay2) and layer-usable
+$ docker exec us007a-node bash -c docker images --format "{{.Repository}}:{{.Tag}} {{.ID}}"; docker run --rm agro-candidate:us007a id sandbox
+agro-candidate:us007a d963de3d2b25
+uid=1000(sandbox) gid=1000(sandbox) groups=1000(sandbox),1001(docker)
+-- exit=0
+
+=== [2026-09-09T05:56:21Z] LEG-1 FRESH: launch bootstrap exactly as cloud-init runcmd does
+$ docker exec us007a-node bash -c sudo -u sandbox -i tmux new-session -d -s docker-build-oh-sandbox /usr/local/libexec/openharness-bootstrap-workspace; sleep 2; sudo -u sandbox -i tmux ls
+no server running on /tmp/tmux-1000/default
+-- exit=1
+
+=== [2026-09-09T05:56:26Z] LEG-1 bootstrap status + log
+$ docker exec us007a-node bash -c cat /home/sandbox/.openharness-bootstrap-status 2>&1; echo "--- log ---"; cat /home/sandbox/.openharness-bootstrap.log 2>&1
+ok
+--- log ---
+image mode: agro-candidate:us007a (skipping local build)
+ Network oh-a_default Creating 
+ Network oh-a_default Creating 
+ Network oh-a_default Created 
+ Network oh-a_default Created 
+ Container oh-a Creating 
+ Container oh-a Created 
+ Container oh-a Starting 
+ Container oh-a Started 
+next: oh shell oh-a
+oh.json: set storage.homePath=/home/sandbox/workspace (added)
+-- exit=0
+
+=== [2026-09-09T05:56:35Z] LEG-1 node state right after bootstrap reported ok
+$ docker exec us007a-node bash -c ls -l /run/openharness-ready; docker ps --format "{{.Names}} {{.Status}}"; docker exec oh-a systemctl is-active openharness-bootstrap.service; echo "unit-exit=$?"
+-rw-r--r-- 1 root root 0 Sep  9 05:56 /run/openharness-ready
+oh-a Up 14 seconds (healthy)
+active
+unit-exit=0
+-- exit=0
+
+=== [2026-09-09T05:56:45Z] LEG-1 bootstrap unit detail (completion proof)
+$ docker exec us007a-node docker exec oh-a systemctl show openharness-bootstrap.service -p Type -p RemainAfterExit -p ActiveState -p SubState -p Result -p ExecMainStatus -p ExecMainStartTimestamp -p ExecMainExitTimestamp
+Type=oneshot
+RemainAfterExit=yes
+Result=success
+ExecMainStartTimestamp=Wed 2026-09-09 05:56:22 UTC
+ExecMainExitTimestamp=Wed 2026-09-09 05:56:26 UTC
+ExecMainStatus=0
+ActiveState=active
+SubState=exited
+-- exit=0
+
+=== [2026-09-09T05:56:45Z] LEG-1 seeded workspace contents inside sandbox
+$ docker exec us007a-node docker exec oh-a bash -c ls /home/sandbox/harness | head -20; echo "--- node_modules:"; ls -d /home/sandbox/harness/node_modules 2>&1 | head -2; echo "--- marker:"; ls -la /home/sandbox/harness/.image-seeded 2>&1 | head -2
+AGENTS.md
+CHANGELOG.md
+CLAUDE.md
+CONTRIBUTING.md
+LICENSE
+NOTICE
+README.md
+SECURITY.md
+agro.json
+crons
+docs
+node_modules
+package.json
+pnpm-lock.yaml
+pnpm-workspace.yaml
+projects
+vitest.config.ts
+--- node_modules:
+/home/sandbox/harness/node_modules
+--- marker:
+ls: cannot access '/home/sandbox/harness/.image-seeded': No such file or directory
+-- exit=0
+
+=== [2026-09-09T05:56:54Z] LEG-1 bootstrap journal (full cold-boot log)
+$ docker exec us007a-node docker exec oh-a journalctl -u openharness-bootstrap.service --no-pager -o cat
+Starting openharness-bootstrap.service - Open Harness sandbox bootstrap...
+[entrypoint] no checkout bind at /home/sandbox/harness — seeding from /opt/agro-seed
+[entrypoint] seeded control plane into /home/sandbox/harness from /opt/agro-seed
+pam_unix(chpasswd:chauthtok): password changed for sandbox
+[entrypoint] repairing sandbox home mount ownership as 1000:1000
+Providers OK: .agents/.pi/.claude/.codex skills -> .agro/skills (vendored pack present)
+[provision-python] ensuring managed Python 3.11 in /home/sandbox/.local/share/uv/python
+Python 3.11 is already installed
+[provision-python] installing kernel packages: ipykernel
+Using Python 3.11.16 environment at: /home/sandbox/.local/share/oh/kernel
+Checked 1 package in 34ms
+[provision-python] OK  python=/home/sandbox/.local/share/uv/python/cpython-3.11-linux-x86_64-gnu/bin/python3.11
+[provision-python] OK  kernel=/home/sandbox/.local/share/oh/kernel/bin/python (ipykernel present)
+[entrypoint] attach banner wired into .bashrc
+[entrypoint] node_modules missing — running pnpm install at /home/sandbox/harness
+[entrypoint] pnpm install completed (log: /tmp/pnpm-install.log)
+[entrypoint] Slack not configured (or pi missing) — skipping client-slack-pi
+  ┌─────────────────────────────────────────────────┐
+  │  First boot detected.                           │
+  │  Optional Slack bridge setup:                   │
+  │    see docs/integrations/slack.md           │
+  │  First command after attaching:                 │
+  │    oh tool install herdr   # then run herdr     │
+  └─────────────────────────────────────────────────┘
+Finished openharness-bootstrap.service - Open Harness sandbox bootstrap.
+-- exit=0
+
+=== [2026-09-09T05:57:49Z] LEG-2 seed representative user state + OpenHarness-era legacy content
+$ docker exec -u sandbox us007a-node bash /opt/us007a/seed-user-state.sh
++ W=/home/sandbox/workspace
++ mkdir -p /home/sandbox/workspace/harness/projects/us007a-demo
++ cd /home/sandbox/workspace/harness/projects/us007a-demo
++ '[' '!' -d .git ']'
++ git init -q
++ git config user.name openharness
++ git config user.email agent@openharness.cloud
++ printf 'committed line\n'
++ git add tracked.txt
++ git commit -qm 'us007a: baseline commit'
++ printf 'UNCOMMITTED EDIT do-not-lose\n'
++ printf 'untracked scratch\n'
++ mkdir -p /home/sandbox/workspace/harness/.agro/tasks/us007a-user-task
++ printf 'user task notes that must survive restart and rebuild\n'
++ printf 'US007A_SECRET=do-not-lose\n'
++ chmod 0600 /home/sandbox/workspace/harness/.env
++ mkdir -p /home/sandbox/workspace/.config/gh
++ printf 'github.com:\n    oauth_token: us007a-stand-in-token\n    user: openharness\n'
++ chmod 0600 /home/sandbox/workspace/.config/gh/hosts.yml
++ mkdir -p /home/sandbox/workspace/.openharness/scripts
++ printf 'openharness-era checkout content\n'
++ printf '#!/bin/sh\necho legacy\n'
++ mkdir -p /home/sandbox/workspace/harness/projects/us007a-legacy-project/.oh/scripts
++ printf 'legacy project control plane\n'
++ printf '{\n  "version": 1,\n  "name": "us007a-legacy"\n}\n'
++ echo US007A-SEED-OK
+US007A-SEED-OK
+-- exit=0
+
+=== [2026-09-09T05:57:50Z] LEG-2 BEFORE observation (durable state oracle)
+$ docker exec us007a-node bash /opt/us007a/observe-state.sh
+### mount identity (docker inspect oh-a)
+type=bind name= src=/home/sandbox/workspace dst=/home/sandbox rw=true
+
+### device+inode of the durable root
+path=/home/sandbox/workspace dev=bc inode=1486974 uid=1000 gid=1000 mode=755
+### per-path sha256 / owner / mode
+/home/sandbox/workspace/harness/projects/us007a-demo/tracked.txt sha256=f6ef6719a2a51ef5dddc5095a16fd68ae989932416e860c10567033459a838e7 uid=1000 gid=1000 mode=644
+/home/sandbox/workspace/harness/projects/us007a-demo/untracked.txt sha256=ecf290b2fa879dc84fd5b1f3ffb37b3ac9bdd6795a82e9f74d5ca3f49ab7b9dc uid=1000 gid=1000 mode=644
+/home/sandbox/workspace/harness/.agro/tasks/us007a-user-task/notes.md sha256=2408e4ae8f6a4eae664411ec5ab596bcc1cbb370f2e3f9babf23692370dfeabf uid=1000 gid=1000 mode=644
+/home/sandbox/workspace/harness/.env sha256=24f472dcb4dba237a00169fa9c97534183bfb76546409dc38b03c6347ed33d3a uid=1000 gid=1000 mode=600
+/home/sandbox/workspace/.config/gh/hosts.yml sha256=ac438dc1d98ed7c7611adb381b9a917b087c2b40d9784551228491b90792aebc uid=1000 gid=1000 mode=600
+/home/sandbox/workspace/.openharness/README.md sha256=6d94361ea14087cae70915f5f2cac79204aa4909b208092b4efd30aeea281706 uid=1000 gid=1000 mode=644
+/home/sandbox/workspace/.openharness/scripts/legacy.sh sha256=5b1ae9cb23230c17e3bcd99a908f79b3e3a2e301765d7b208a2e07a06a553640 uid=1000 gid=1000 mode=644
+/home/sandbox/workspace/harness/projects/us007a-legacy-project/.oh/README.md sha256=cec1415f3dc0650dd3126de5d3c8a6bafe81eef681dbc8416f00e793e0ef5a94 uid=1000 gid=1000 mode=644
+/home/sandbox/workspace/harness/projects/us007a-legacy-project/oh.json sha256=f1049d5b66ca21494aecbf71b895aa706048a4a2a63ebf75b1b9d01d5c90621a uid=1000 gid=1000 mode=644
+### git working-tree status of the seeded checkout
+fatal: detected dubious ownership in repository at '/home/sandbox/workspace/harness/projects/us007a-demo'
+To add an exception for this directory, call:
+
+	git config --global --add safe.directory /home/sandbox/workspace/harness/projects/us007a-demo
+fatal: detected dubious ownership in repository at '/home/sandbox/workspace/harness/projects/us007a-demo'
+To add an exception for this directory, call:
+
+	git config --global --add safe.directory /home/sandbox/workspace/harness/projects/us007a-demo
+### attach-marker files (written from inside the container)
+/home/sandbox/workspace/us007a-attach-marker.txt MISSING
+/home/sandbox/workspace/us007a-preattach.txt MISSING
+-- exit=0
+
+=== [2026-09-09T05:57:57Z] LEG-2 BEFORE observation (as node sandbox user)
+$ docker exec -u sandbox us007a-node bash /opt/us007a/observe-state.sh
+### mount identity (docker inspect oh-a)
+type=bind name= src=/home/sandbox/workspace dst=/home/sandbox rw=true
+
+### device+inode of the durable root
+path=/home/sandbox/workspace dev=bc inode=1486974 uid=1000 gid=1000 mode=755
+### per-path sha256 / owner / mode
+/home/sandbox/workspace/harness/projects/us007a-demo/tracked.txt sha256=f6ef6719a2a51ef5dddc5095a16fd68ae989932416e860c10567033459a838e7 uid=1000 gid=1000 mode=644
+/home/sandbox/workspace/harness/projects/us007a-demo/untracked.txt sha256=ecf290b2fa879dc84fd5b1f3ffb37b3ac9bdd6795a82e9f74d5ca3f49ab7b9dc uid=1000 gid=1000 mode=644
+/home/sandbox/workspace/harness/.agro/tasks/us007a-user-task/notes.md sha256=2408e4ae8f6a4eae664411ec5ab596bcc1cbb370f2e3f9babf23692370dfeabf uid=1000 gid=1000 mode=644
+/home/sandbox/workspace/harness/.env sha256=24f472dcb4dba237a00169fa9c97534183bfb76546409dc38b03c6347ed33d3a uid=1000 gid=1000 mode=600
+/home/sandbox/workspace/.config/gh/hosts.yml sha256=ac438dc1d98ed7c7611adb381b9a917b087c2b40d9784551228491b90792aebc uid=1000 gid=1000 mode=600
+/home/sandbox/workspace/.openharness/README.md sha256=6d94361ea14087cae70915f5f2cac79204aa4909b208092b4efd30aeea281706 uid=1000 gid=1000 mode=644
+/home/sandbox/workspace/.openharness/scripts/legacy.sh sha256=5b1ae9cb23230c17e3bcd99a908f79b3e3a2e301765d7b208a2e07a06a553640 uid=1000 gid=1000 mode=644
+/home/sandbox/workspace/harness/projects/us007a-legacy-project/.oh/README.md sha256=cec1415f3dc0650dd3126de5d3c8a6bafe81eef681dbc8416f00e793e0ef5a94 uid=1000 gid=1000 mode=644
+/home/sandbox/workspace/harness/projects/us007a-legacy-project/oh.json sha256=f1049d5b66ca21494aecbf71b895aa706048a4a2a63ebf75b1b9d01d5c90621a uid=1000 gid=1000 mode=644
+### git working-tree status of the seeded checkout
+ M tracked.txt
+?? untracked.txt
+86f48d1 us007a: baseline commit
+### attach-marker files (written from inside the container)
+/home/sandbox/workspace/us007a-attach-marker.txt MISSING
+/home/sandbox/workspace/us007a-preattach.txt MISSING
+-- exit=0
+
+=== [2026-09-09T05:58:16Z] LEG-4b write state from INSIDE the sandbox before restart
+$ docker exec us007a-node docker exec -u sandbox oh-a bash -c date -u +%Y-%m-%dT%H:%M:%SZ > /home/sandbox/us007a-preattach.txt; cat /home/sandbox/us007a-preattach.txt; echo "container view of legacy checkout dir:"; ls /home/sandbox/.openharness; echo "container view of seeded task:"; ls /home/sandbox/harness/.agro/tasks/us007a-user-task
+2026-09-09T05:58:16Z
+container view of legacy checkout dir:
+README.md
+scripts
+container view of seeded task:
+notes.md
+-- exit=0
+
+=== [2026-09-09T05:58:16Z] LEG-2 AGRO operates existing legacy project state (migrate --check)
+$ docker exec -u sandbox us007a-node bash -lc export PATH=$HOME/.local/bin:$PATH; cd /home/sandbox/workspace/harness/projects/us007a-legacy-project && agro migrate --check; echo "exit=$?"
+agro migrate: plan for /home/sandbox/workspace/harness/projects/us007a-legacy-project
+  rename  /home/sandbox/workspace/harness/projects/us007a-legacy-project/.oh -> /home/sandbox/workspace/harness/projects/us007a-legacy-project/.agro
+  rename  /home/sandbox/workspace/harness/projects/us007a-legacy-project/oh.json -> /home/sandbox/workspace/harness/projects/us007a-legacy-project/agro.json
+  noop    /home/sandbox/workspace/harness/projects/us007a-legacy-project/.claude/skills (link absent)
+  noop    /home/sandbox/workspace/harness/projects/us007a-legacy-project/.claude/hooks (link absent)
+  noop    /home/sandbox/workspace/harness/projects/us007a-legacy-project/.codex/skills (link absent)
+  noop    /home/sandbox/workspace/harness/projects/us007a-legacy-project/.agents/skills (link absent)
+  noop    /home/sandbox/workspace/harness/projects/us007a-legacy-project/.pi/skills (link absent)
+status: ready
+exit=0
+-- exit=0
+
+=== [2026-09-09T05:58:30Z] LEG-4a ssh to node as sandbox, then tmux attach -t docker-build-oh-sandbox
+$ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/tmp/claude-1000/-home-sandbox-harness/8b200f3c-07b0-487b-9533-aae682bf912f/scratchpad/w13/known_hosts -i /tmp/claude-1000/-home-sandbox-harness/8b200f3c-07b0-487b-9533-aae682bf912f/scratchpad/w13/keys/sandbox_key sandbox@172.18.0.4 tmux ls; echo "tmux-ls-exit=$?"; tmux attach -t docker-build-oh-sandbox; echo "attach-exit=$?"
+Warning: Permanently added '172.18.0.4' (ED25519) to the list of known hosts.
+no server running on /tmp/tmux-1000/default
+tmux-ls-exit=1
+no sessions
+attach-exit=1
+-- exit=0
+
+=== [2026-09-09T05:58:44Z] LEG-2/4 RESTART the sandbox via the candidate CLI
+$ docker exec -u sandbox us007a-node bash -lc export PATH=$HOME/.local/bin:$PATH; export AGRO_HOME=$HOME/.agro; cd $AGRO_HOME/sandboxes/oh-a && agro restart oh-a; echo "restart-exit=$?"
+ Container oh-a Restarting 
+ Container oh-a Started 
+restart-exit=0
+-- exit=0
+
+=== [2026-09-09T05:58:50Z] LEG-2/4 post-restart readiness by the bootstrap unit oracle
+$ docker exec us007a-node bash -c docker ps --format "{{.Names}} {{.Status}}"; for i in $(seq 1 40); do s=$(docker exec oh-a systemctl is-active openharness-bootstrap.service 2>/dev/null); echo "attempt $i: $s"; case $s in active) break;; failed) break;; esac; sleep 5; done; docker exec oh-a systemctl show openharness-bootstrap.service -p ActiveState -p SubState -p Result -p ExecMainStatus
+oh-a Up 5 seconds (healthy)
+attempt 1: active
+Result=success
+ExecMainStatus=0
+ActiveState=active
+SubState=exited
+-- exit=0
+
+=== [2026-09-09T05:58:56Z] LEG-2/4 post-restart: unit ran again on the new boot (timestamps)
+$ docker exec us007a-node bash -c docker inspect oh-a --format "container StartedAt={{.State.StartedAt}} restartCount={{.RestartCount}}"; docker exec oh-a systemctl show openharness-bootstrap.service -p ExecMainStartTimestamp -p ExecMainExitTimestamp -p NRestarts; docker exec oh-a journalctl -u openharness-bootstrap.service --no-pager -o cat -b | tail -12
+container StartedAt=2026-09-09T05:58:45.274110966Z restartCount=0
+NRestarts=0
+ExecMainStartTimestamp=Wed 2026-09-09 05:58:45 UTC
+ExecMainExitTimestamp=Wed 2026-09-09 05:58:46 UTC
+[provision-python] OK  python=/home/sandbox/.local/share/uv/python/cpython-3.11-linux-x86_64-gnu/bin/python3.11
+[provision-python] OK  kernel=/home/sandbox/.local/share/oh/kernel/bin/python (ipykernel present)
+[entrypoint] dependencies current
+[entrypoint] Slack not configured (or pi missing) — skipping client-slack-pi
+  ┌─────────────────────────────────────────────────┐
+  │  First boot detected.                           │
+  │  Optional Slack bridge setup:                   │
+  │    see docs/integrations/slack.md           │
+  │  First command after attaching:                 │
+  │    oh tool install herdr   # then run herdr     │
+  └─────────────────────────────────────────────────┘
+Finished openharness-bootstrap.service - Open Harness sandbox bootstrap.
+-- exit=0
+
+=== [2026-09-09T05:59:02Z] LEG-2/3 AFTER-RESTART observation
+$ cat /tmp/claude-1000/-home-sandbox-harness/8b200f3c-07b0-487b-9533-aae682bf912f/scratchpad/w13/state-after-restart.txt
+### mount identity (docker inspect oh-a)
+type=bind name= src=/home/sandbox/workspace dst=/home/sandbox rw=true
+
+### device+inode of the durable root
+path=/home/sandbox/workspace dev=bc inode=1486974 uid=1000 gid=1000 mode=755
+### per-path sha256 / owner / mode
+/home/sandbox/workspace/harness/projects/us007a-demo/tracked.txt sha256=f6ef6719a2a51ef5dddc5095a16fd68ae989932416e860c10567033459a838e7 uid=1000 gid=1000 mode=644
+/home/sandbox/workspace/harness/projects/us007a-demo/untracked.txt sha256=ecf290b2fa879dc84fd5b1f3ffb37b3ac9bdd6795a82e9f74d5ca3f49ab7b9dc uid=1000 gid=1000 mode=644
+/home/sandbox/workspace/harness/.agro/tasks/us007a-user-task/notes.md sha256=2408e4ae8f6a4eae664411ec5ab596bcc1cbb370f2e3f9babf23692370dfeabf uid=1000 gid=1000 mode=644
+/home/sandbox/workspace/harness/.env sha256=24f472dcb4dba237a00169fa9c97534183bfb76546409dc38b03c6347ed33d3a uid=1000 gid=1000 mode=600
+/home/sandbox/workspace/.config/gh/hosts.yml sha256=fe64ca26c1acdaa7578456cd7e6e89d2eac6f59e3c2a72646b01f14541a014f7 uid=1000 gid=1000 mode=600
+/home/sandbox/workspace/.openharness/README.md sha256=6d94361ea14087cae70915f5f2cac79204aa4909b208092b4efd30aeea281706 uid=1000 gid=1000 mode=644
+/home/sandbox/workspace/.openharness/scripts/legacy.sh sha256=5b1ae9cb23230c17e3bcd99a908f79b3e3a2e301765d7b208a2e07a06a553640 uid=1000 gid=1000 mode=644
+/home/sandbox/workspace/harness/projects/us007a-legacy-project/.oh/README.md sha256=cec1415f3dc0650dd3126de5d3c8a6bafe81eef681dbc8416f00e793e0ef5a94 uid=1000 gid=1000 mode=644
+/home/sandbox/workspace/harness/projects/us007a-legacy-project/oh.json sha256=f1049d5b66ca21494aecbf71b895aa706048a4a2a63ebf75b1b9d01d5c90621a uid=1000 gid=1000 mode=644
+### git working-tree status of the seeded checkout
+ M tracked.txt
+?? untracked.txt
+86f48d1 us007a: baseline commit
+### attach-marker files (written from inside the container)
+/home/sandbox/workspace/us007a-attach-marker.txt MISSING
+/home/sandbox/workspace/us007a-preattach.txt = 2026-09-09T05:58:16Z
+-- exit=0
+
+=== [2026-09-09T05:59:02Z] LEG-2/3 diff BEFORE vs AFTER-RESTART (empty == byte/mode/mount identical)
+$ diff /tmp/claude-1000/-home-sandbox-harness/8b200f3c-07b0-487b-9533-aae682bf912f/scratchpad/w13/state-before.txt /tmp/claude-1000/-home-sandbox-harness/8b200f3c-07b0-487b-9533-aae682bf912f/scratchpad/w13/state-after-restart.txt
+11c11
+< /home/sandbox/workspace/.config/gh/hosts.yml sha256=ac438dc1d98ed7c7611adb381b9a917b087c2b40d9784551228491b90792aebc uid=1000 gid=1000 mode=600
+---
+> /home/sandbox/workspace/.config/gh/hosts.yml sha256=fe64ca26c1acdaa7578456cd7e6e89d2eac6f59e3c2a72646b01f14541a014f7 uid=1000 gid=1000 mode=600
+22c22
+< /home/sandbox/workspace/us007a-preattach.txt MISSING
+---
+> /home/sandbox/workspace/us007a-preattach.txt = 2026-09-09T05:58:16Z
+-- exit=1
+
+=== [2026-09-09T05:59:27Z] LEG-2 gh-credential stand-in: what the sandbox entrypoint changed
+$ docker exec us007a-node bash /opt/us007a/inspect-ghcred.sh
+### size / mode
+path=/home/sandbox/workspace/.config/gh/hosts.yml bytes=152 uid=1000 gid=1000 mode=600
+### content, secret values redacted
+github.com:
+    oauth_token: <redacted>
+    user: openharness
+    users:
+        openharness:
+            oauth_token: <redacted>
+### entrypoint journal lines mentioning gh
+-- exit=0
+
+=== [2026-09-09T05:59:39Z] LEG-2 credential VALUE preservation check (hash comparison, value never printed)
+$ docker exec us007a-node bash /opt/us007a/check-token.sh
+expected-seeded-value-sha256=da5358c5b27ed2a07927bd6305ca380fa7c112721470435f19e40ee2b0908eae
+found-token-value-sha256=da5358c5b27ed2a07927bd6305ca380fa7c112721470435f19e40ee2b0908eae match=YES
+found-token-value-sha256=da5358c5b27ed2a07927bd6305ca380fa7c112721470435f19e40ee2b0908eae match=YES
+-- exit=0
+
+=== [2026-09-09T05:59:52Z] LEG-4a AFTER-RESTART: ssh + tmux attach -t docker-build-oh-sandbox
+$ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/tmp/claude-1000/-home-sandbox-harness/8b200f3c-07b0-487b-9533-aae682bf912f/scratchpad/w13/known_hosts -i /tmp/claude-1000/-home-sandbox-harness/8b200f3c-07b0-487b-9533-aae682bf912f/scratchpad/w13/keys/sandbox_key sandbox@172.18.0.4 tmux ls 2>&1; tmux attach -t docker-build-oh-sandbox 2>&1; echo "attach-exit=$?"
+/tmp/claude-1000/-home-sandbox-harness/8b200f3c-07b0-487b-9533-aae682bf912f/scratchpad/w13/run.sh: line 9: ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/tmp/claude-1000/-home-sandbox-harness/8b200f3c-07b0-487b-9533-aae682bf912f/scratchpad/w13/known_hosts -i /tmp/claude-1000/-home-sandbox-harness/8b200f3c-07b0-487b-9533-aae682bf912f/scratchpad/w13/keys/sandbox_key sandbox@172.18.0.4: No such file or directory
+-- exit=127
+
+=== [2026-09-09T05:59:52Z] LEG-4b AFTER-RESTART: re-attach via agro shell (pty) reading state written before the restart
+$ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/tmp/claude-1000/-home-sandbox-harness/8b200f3c-07b0-487b-9533-aae682bf912f/scratchpad/w13/known_hosts -i /tmp/claude-1000/-home-sandbox-harness/8b200f3c-07b0-487b-9533-aae682bf912f/scratchpad/w13/keys/sandbox_key sandbox@172.18.0.4 -tt export PATH=$HOME/.local/bin:$PATH; export AGRO_HOME=$HOME/.agro; cd $AGRO_HOME/sandboxes/oh-a; printf "cat /home/sandbox/us007a-preattach.txt; date -u +%%Y-%%m-%%dT%%H:%%M:%%SZ > /home/sandbox/us007a-attach-marker.txt; git -C /home/sandbox/harness/projects/us007a-demo status --porcelain; exit\n" | agro shell oh-a 2>&1 | tr -d "\r" | tail -20
+/tmp/claude-1000/-home-sandbox-harness/8b200f3c-07b0-487b-9533-aae682bf912f/scratchpad/w13/run.sh: line 9: ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/tmp/claude-1000/-home-sandbox-harness/8b200f3c-07b0-487b-9533-aae682bf912f/scratchpad/w13/known_hosts -i /tmp/claude-1000/-home-sandbox-harness/8b200f3c-07b0-487b-9533-aae682bf912f/scratchpad/w13/keys/sandbox_key sandbox@172.18.0.4: No such file or directory
+-- exit=127
+
+=== [2026-09-09T05:59:58Z] LEG-4a AFTER-RESTART: ssh + tmux attach -t docker-build-oh-sandbox
+$ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/tmp/claude-1000/-home-sandbox-harness/8b200f3c-07b0-487b-9533-aae682bf912f/scratchpad/w13/known_hosts -i /tmp/claude-1000/-home-sandbox-harness/8b200f3c-07b0-487b-9533-aae682bf912f/scratchpad/w13/keys/sandbox_key sandbox@172.18.0.4 tmux ls 2>&1; tmux attach -t docker-build-oh-sandbox 2>&1; echo "attach-exit=$?"
+no server running on /tmp/tmux-1000/default
+no sessions
+attach-exit=1
+-- exit=0
+
+=== [2026-09-09T05:59:59Z] LEG-4b AFTER-RESTART: re-attach via agro shell (pty) reading state written before the restart
+$ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/tmp/claude-1000/-home-sandbox-harness/8b200f3c-07b0-487b-9533-aae682bf912f/scratchpad/w13/known_hosts -i /tmp/claude-1000/-home-sandbox-harness/8b200f3c-07b0-487b-9533-aae682bf912f/scratchpad/w13/keys/sandbox_key -tt sandbox@172.18.0.4 export PATH=$HOME/.local/bin:$PATH; export AGRO_HOME=$HOME/.agro; cd $AGRO_HOME/sandboxes/oh-a; printf "cat /home/sandbox/us007a-preattach.txt\ndate -u +%%Y-%%m-%%dT%%H:%%M:%%SZ > /home/sandbox/us007a-attach-marker.txt\ngit -C /home/sandbox/harness/projects/us007a-demo status --porcelain\nexit\n" | agro shell oh-a 2>&1 | tr -d "\r" | tail -20
+cannot attach stdin to a TTY-enabled container because stdin is not a terminal
+container `oh-a` not running? start it with `oh sandbox install docker`
+Connection to 172.18.0.4 closed.
+-- exit=0
+
+=== [2026-09-09T06:00:14Z] LEG-4b AFTER-RESTART: agro shell on a real pty (tmux), reading pre-restart state
+$ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/tmp/claude-1000/-home-sandbox-harness/8b200f3c-07b0-487b-9533-aae682bf912f/scratchpad/w13/known_hosts -i /tmp/claude-1000/-home-sandbox-harness/8b200f3c-07b0-487b-9533-aae682bf912f/scratchpad/w13/keys/sandbox_key sandbox@172.18.0.4 bash /opt/us007a/attach-shell.sh
+### tmux pane capture of the agro shell session
+
+━━━ openharness: oh-a ━━━
+  Project:   /home/sandbox/harness
+  Timezone:  UTC
+  Overlays:  (none)
+
+  Onboarding:
+    [✗]  gh          not authenticated — run: gh auth login
+    [✗]  claude      not authenticated — run: claude
+    [✗]  codex       not authenticated — run: codex
+    [✗]  opencode    not installed — run: oh harness install opencode
+    [✗]  grok        not installed — run: oh harness install grok-build
+    [✗]  pi          not authenticated — run: pi
+    [✗]  hermes      not installed — run: oh harness install hermes
+    [✓]  oh          0.9.0
+
+  Recovery commands: claude · codex · systemctl status openharness-cron.service
+
+  Next: run `oh tool install herdr`, then `herdr`, to open your persistent Open Harness workspace.
+  Complete setup, authentication, agents, tests, and servers inside Herdr.
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+sandbox@6b749b6673ee:~/harness$ echo MARKER-READ=$(cat /home/sandbox/us007a-preattach.txt)                                                                                                      [oh-a]
+MARKER-READ=2026-09-09T05:58:16Z
+sandbox@6b749b6673ee:~/harness$ date -u +%Y-%m-%dT%H:%M:%SZ > /home/sandbox/us007a-attach-marker.txt; echo WROTE=$(cat /home/sandbox/us007a-attach-marker.txt)                                  [oh-a]
+WROTE=2026-09-09T06:00:24Z
+sandbox@6b749b6673ee:~/harness$ echo WHOAMI=$(whoami) HOST=$(hostname) UID=$(id -u)                                                                                                             [oh-a]
+WHOAMI=sandbox HOST=6b749b6673ee UID=1000
+sandbox@6b749b6673ee:~/harness$ git -C /home/sandbox/harness/projects/us007a-demo status --porcelain; echo GIT-DONE                                                                             [oh-a]
+ M tracked.txt
+?? untracked.txt
+GIT-DONE
+sandbox@6b749b6673ee:~/harness$                                                                                                                                                                 [oh-a]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+### session closed
+-- exit=0
+
+=== [2026-09-09T06:00:53Z] LEG-4c AFTER-RESTART: code-server over the pinned ohproxy SSH forward
+$ bash -c curl -sS -o /dev/null -w "root http=%{http_code} redirect=%{redirect_url}\n" --max-time 10 http://127.0.0.1:18080/; curl -sS --max-time 10 -o /dev/null -w "healthz http=%{http_code}\n" http://127.0.0.1:18080/healthz; curl -sS --max-time 10 http://127.0.0.1:18080/healthz
+root http=302 redirect=http://127.0.0.1:18080/?workspace=/home/sandbox/oh.code-workspace
+healthz http=200
+{"status":"alive","lastHeartbeat":1788933653231}-- exit=0
+
+=== [2026-09-09T06:00:53Z] LEG-4c workspace root the editor actually opens
+$ docker exec us007a-node bash -c cat /home/sandbox/oh.code-workspace; echo "--- durable root identity:"; stat -c "path=%n dev=%D inode=%i" /home/sandbox/workspace; echo "--- the sandbox container bind source:"; docker inspect oh-a --format "{{range .Mounts}}{{.Source}} -> {{.Destination}}{{println}}{{end}}"
+{
+  "folders": [
+    { "name": "sandbox", "path": "/home/sandbox/workspace" }
+  ],
+  "settings": {
+    "workbench.colorTheme": "Default Dark+"
+  }
+}
+--- durable root identity:
+path=/home/sandbox/workspace dev=bc inode=1486974
+--- the sandbox container bind source:
+/home/sandbox/workspace -> /home/sandbox
+
+-- exit=0
+
+=== [2026-09-09T06:01:07Z] LEG-4c read durable state THROUGH the code-server HTTP surface
+$ bash -c echo "marker via editor resource API:"; curl -sS --max-time 10 "http://127.0.0.1:18080/vscode-remote-resource?path=%2Fhome%2Fsandbox%2Fworkspace%2Fus007a-attach-marker.txt" ; echo; echo "task notes via editor resource API:"; curl -sS --max-time 10 "http://127.0.0.1:18080/vscode-remote-resource?path=%2Fhome%2Fsandbox%2Fworkspace%2Fharness%2F.agro%2Ftasks%2Fus007a-user-task%2Fnotes.md"
+marker via editor resource API:
+2026-09-09T06:00:24Z
+
+task notes via editor resource API:
+user task notes that must survive restart and rebuild
+-- exit=0
+
+=== [2026-09-09T06:01:07Z] LEG-4c ohproxy pin is real: a non-permitopen forward is refused
+$ bash -c ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/tmp/claude-1000/-home-sandbox-harness/8b200f3c-07b0-487b-9533-aae682bf912f/scratchpad/w13/known_hosts -o ExitOnForwardFailure=yes -i /tmp/claude-1000/-home-sandbox-harness/8b200f3c-07b0-487b-9533-aae682bf912f/scratchpad/w13/keys/proxy_key -N -L 18099:127.0.0.1:22 ohproxy@172.18.0.4 -o ConnectTimeout=10 & sleep 4; curl -sS --max-time 5 -o /dev/null -w "forward-to-22 http=%{http_code}\n" http://127.0.0.1:18099/ || echo "forward-to-22 refused (expected)"; wait
+channel 2: open failed: administratively prohibited: open failed
+curl: (56) Recv failure: Connection reset by peer
+forward-to-22 http=000
+forward-to-22 refused (expected)
+
+=== [2026-09-09T06:01:07Z] LEG-4c read durable state THROUGH the code-server HTTP surface
+$ bash -c echo "marker via editor resource API:"; curl -sS --max-time 10 "http://127.0.0.1:18080/vscode-remote-resource?path=%2Fhome%2Fsandbox%2Fworkspace%2Fus007a-attach-marker.txt" ; echo; echo "task notes via editor resource API:"; curl -sS --max-time 10 "http://127.0.0.1:18080/vscode-remote-resource?path=%2Fhome%2Fsandbox%2Fworkspace%2Fharness%2F.agro%2Ftasks%2Fus007a-user-task%2Fnotes.md"
+marker via editor resource API:
+2026-09-09T06:00:24Z
+
+task notes via editor resource API:
+user task notes that must survive restart and rebuild
+-- exit=0
+
+=== [2026-09-09T06:01:07Z] LEG-4c ohproxy pin is real: a non-permitopen forward is refused
+$ bash -c ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/tmp/claude-1000/-home-sandbox-harness/8b200f3c-07b0-487b-9533-aae682bf912f/scratchpad/w13/known_hosts -o ExitOnForwardFailure=yes -i /tmp/claude-1000/-home-sandbox-harness/8b200f3c-07b0-487b-9533-aae682bf912f/scratchpad/w13/keys/proxy_key -N -L 18099:127.0.0.1:22 ohproxy@172.18.0.4 -o ConnectTimeout=10 & sleep 4; curl -sS --max-time 5 -o /dev/null -w "forward-to-22 http=%{http_code}\n" http://127.0.0.1:18099/ || echo "forward-to-22 refused (expected)"; wait
+channel 2: open failed: administratively prohibited: open failed
+curl: (56) Recv failure: Connection reset by peer
+forward-to-22 http=000
+forward-to-22 refused (expected)
+
+[exited with code 144]
+
+-- note: the 18099 probe left an ssh -N in background; killed below
+
+=== [2026-09-09T06:04:46Z] pre-rebuild: registry layout + login PATH the helper's runuser -l will see
+$ docker exec us007a-node bash -c find /home/sandbox/.agro -maxdepth 3 | head -20; echo "--- login PATH:"; runuser -l sandbox -c "echo PATH=\$PATH; command -v agro || echo AGRO-NOT-ON-LOGIN-PATH"
+/home/sandbox/.agro
+/home/sandbox/.agro/sandboxes
+/home/sandbox/.agro/sandboxes/oh-a
+/home/sandbox/.agro/sandboxes/oh-a/.agro
+/home/sandbox/.agro/sandboxes/oh-a/agro.json
+/home/sandbox/.agro/sandboxes/oh-a/.devcontainer
+--- login PATH:
+PATH=/home/sandbox/.local/bin:/usr/local/bin:/usr/bin:/bin:/usr/local/games:/usr/games
+/home/sandbox/.local/bin/agro
+-- exit=0
+
+=== [2026-09-09T06:04:47Z] pre-rebuild: what the accepted helper will run
+$ grep -n sandbox_as_user\|agro stop\|agro sandbox install\|agro ps\|is-active /tmp/claude-1000/-home-sandbox-harness/8b200f3c-07b0-487b-9533-aae682bf912f/scratchpad/w13/assets/openharness-code-server-apply
+40:sandbox_as_user() {
+55:  sandbox_as_user "timeout $sandbox_stop_timeout agro stop $name" || sandbox_fail "$name" stop
+56:  sandbox_as_user "AGRO_PULL_POLICY=always timeout $sandbox_install_timeout agro sandbox install docker --name $name --yes --image" || sandbox_fail "$name" install
+57:  running=$(/usr/sbin/runuser -l "$sandbox_user" -c "timeout $sandbox_verify_timeout agro ps $name -- --quiet --status running" 2>/dev/null) || sandbox_fail "$name" verify
+61:    unit_state=$(/usr/sbin/runuser -l "$sandbox_user" -c "timeout $sandbox_ready_probe_timeout docker exec $name systemctl is-active $sandbox_ready_unit" 2>/dev/null)
+117:  /usr/bin/systemctl is-active --quiet "$unit" >/dev/null 2>&1 && unit_state=active
+-- exit=0
+
+=== [2026-09-09T06:05:18Z] LEG-3 rebuild attempt 1 — accepted helper verbatim, image ref is a LOCAL-ONLY tag
+$ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/tmp/claude-1000/-home-sandbox-harness/8b200f3c-07b0-487b-9533-aae682bf912f/scratchpad/w13/known_hosts -i /tmp/claude-1000/-home-sandbox-harness/8b200f3c-07b0-487b-9533-aae682bf912f/scratchpad/w13/keys/mgmt_key ohmanage@172.18.0.4 sandbox rebuild --name oh-a
+version=1 mode=sandbox action=rebuild name=oh-a state=failed step=install
+-- exit=65
+
+=== [2026-09-09T06:05:19Z] LEG-3 attempt 1 aftermath: container + unit state
+$ docker exec us007a-node bash -c docker ps -a --format "{{.Names}} {{.Status}}"; docker exec oh-a systemctl is-active openharness-bootstrap.service 2>&1
+oh-a Exited (0) 1 second ago
+Error response from daemon: container 6b749b6673ee93a053fb6bed5ad2bf96649239ef4cf0d32a307499eaec8edcc4 is not running
+-- exit=1
+
+=== [2026-09-09T06:05:28Z] LEG-3 make the candidate image genuinely pullable (local registry on the node)
+$ docker exec us007a-node bash -c docker run -d --restart=always --name us007a-registry -p 127.0.0.1:5000:5000 registry:2 >/dev/null && sleep 3 && docker tag agro-candidate:us007a 127.0.0.1:5000/agro-candidate:us007a && docker push 127.0.0.1:5000/agro-candidate:us007a | tail -3
+Unable to find image 'registry:2' locally
+2: Pulling from library/registry
+44cf07d57ee4: Pulling fs layer
+bbbdd6c6894b: Pulling fs layer
+8e82f80af0de: Pulling fs layer
+3493bf46cdec: Pulling fs layer
+6d464ea18732: Pulling fs layer
+3493bf46cdec: Waiting
+6d464ea18732: Waiting
+bbbdd6c6894b: Verifying Checksum
+bbbdd6c6894b: Download complete
+3493bf46cdec: Verifying Checksum
+3493bf46cdec: Download complete
+44cf07d57ee4: Download complete
+8e82f80af0de: Verifying Checksum
+8e82f80af0de: Download complete
+6d464ea18732: Download complete
+44cf07d57ee4: Pull complete
+bbbdd6c6894b: Pull complete
+8e82f80af0de: Pull complete
+3493bf46cdec: Pull complete
+6d464ea18732: Pull complete
+Digest: sha256:a3d8aaa63ed8681a604f1dea0aa03f100d5895b6a58ace528858a7b332415373
+Status: Downloaded newer image for registry:2
+719ff9a705e2: Pushed
+df2c54ede14a: Pushed
+us007a: digest: sha256:fbe38fec227ffe16303193adf19a313bf41134cf5af5d2b5db955274d019d3d5 size: 5979
+-- exit=0
+
+=== [2026-09-09T06:05:53Z] LEG-3 repoint the sandbox at the pullable ref (config only)
+$ docker exec -u sandbox us007a-node bash -lc export PATH=$HOME/.local/bin:$PATH; export AGRO_HOME=$HOME/.agro; agro config set image.ref 127.0.0.1:5000/agro-candidate:us007a --sandbox oh-a; cat $AGRO_HOME/sandboxes/oh-a/agro.json
+oh.json: set image.ref=127.0.0.1:5000/agro-candidate:us007a (updated)
+{
+  "version": 1,
+  "name": "oh-a",
+  "timezone": "UTC",
+  "git": {
+    "userName": "openharness",
+    "userEmail": "agent@openharness.cloud"
+  },
+  "storage": {
+    "homePath": "/home/sandbox/workspace"
+  },
+  "access": {
+    "ssh": false,
+    "sshPort": 2222,
+    "sshPasswordAuth": false,
+    "dockerSocket": false
+  },
+  "hermesDashboard": {
+    "enabled": false,
+    "port": 9119
+  },
+  "cron": {
+    "agentBin": "claude"
+  },
+  "build": {
+    "skipPnpmInstall": false
+  },
+  "image": {
+    "mode": "image",
+    "pullPolicy": "missing",
+    "ref": "127.0.0.1:5000/agro-candidate:us007a"
+  },
+  "cloud": {},
+  "langfuse": {},
+  "composeOverrides": [],
+  "runtime": "docker"
+}
+-- exit=0
+
+=== [2026-09-09T06:06:04Z] LEG-3 PRE-REBUILD observation (state + container identity)
+$ bash -c cat /tmp/claude-1000/-home-sandbox-harness/8b200f3c-07b0-487b-9533-aae682bf912f/scratchpad/w13/state-before-rebuild.txt; echo '### container identity'; cat /tmp/claude-1000/-home-sandbox-harness/8b200f3c-07b0-487b-9533-aae682bf912f/scratchpad/w13/container-before-rebuild.txt
+### mount identity (docker inspect oh-a)
+type=bind name= src=/home/sandbox/workspace dst=/home/sandbox rw=true
+
+### device+inode of the durable root
+path=/home/sandbox/workspace dev=bc inode=1486974 uid=1000 gid=1000 mode=755
+### per-path sha256 / owner / mode
+/home/sandbox/workspace/harness/projects/us007a-demo/tracked.txt sha256=f6ef6719a2a51ef5dddc5095a16fd68ae989932416e860c10567033459a838e7 uid=1000 gid=1000 mode=644
+/home/sandbox/workspace/harness/projects/us007a-demo/untracked.txt sha256=ecf290b2fa879dc84fd5b1f3ffb37b3ac9bdd6795a82e9f74d5ca3f49ab7b9dc uid=1000 gid=1000 mode=644
+/home/sandbox/workspace/harness/.agro/tasks/us007a-user-task/notes.md sha256=2408e4ae8f6a4eae664411ec5ab596bcc1cbb370f2e3f9babf23692370dfeabf uid=1000 gid=1000 mode=644
+/home/sandbox/workspace/harness/.env sha256=24f472dcb4dba237a00169fa9c97534183bfb76546409dc38b03c6347ed33d3a uid=1000 gid=1000 mode=600
+/home/sandbox/workspace/.config/gh/hosts.yml sha256=fe64ca26c1acdaa7578456cd7e6e89d2eac6f59e3c2a72646b01f14541a014f7 uid=1000 gid=1000 mode=600
+/home/sandbox/workspace/.openharness/README.md sha256=6d94361ea14087cae70915f5f2cac79204aa4909b208092b4efd30aeea281706 uid=1000 gid=1000 mode=644
+/home/sandbox/workspace/.openharness/scripts/legacy.sh sha256=5b1ae9cb23230c17e3bcd99a908f79b3e3a2e301765d7b208a2e07a06a553640 uid=1000 gid=1000 mode=644
+/home/sandbox/workspace/harness/projects/us007a-legacy-project/.oh/README.md sha256=cec1415f3dc0650dd3126de5d3c8a6bafe81eef681dbc8416f00e793e0ef5a94 uid=1000 gid=1000 mode=644
+/home/sandbox/workspace/harness/projects/us007a-legacy-project/oh.json sha256=f1049d5b66ca21494aecbf71b895aa706048a4a2a63ebf75b1b9d01d5c90621a uid=1000 gid=1000 mode=644
+### git working-tree status of the seeded checkout
+ M tracked.txt
+?? untracked.txt
+86f48d1 us007a: baseline commit
+### attach-marker files (written from inside the container)
+/home/sandbox/workspace/us007a-attach-marker.txt = 2026-09-09T06:00:24Z
+/home/sandbox/workspace/us007a-preattach.txt = 2026-09-09T05:58:16Z
+### container identity
+id=6b749b6673ee93a053fb6bed5ad2bf96649239ef4cf0d32a307499eaec8edcc4 created=2026-09-09T05:56:21.51602876Z
+-- exit=0
+
+=== [2026-09-09T06:06:04Z] LEG-3 REBUILD via the accepted ohmanage forced command
+$ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/tmp/claude-1000/-home-sandbox-harness/8b200f3c-07b0-487b-9533-aae682bf912f/scratchpad/w13/known_hosts -i /tmp/claude-1000/-home-sandbox-harness/8b200f3c-07b0-487b-9533-aae682bf912f/scratchpad/w13/keys/mgmt_key ohmanage@172.18.0.4 sandbox rebuild --name oh-a
+version=1 mode=sandbox action=rebuild name=oh-a state=complete step=ready
+-- exit=0
+
+=== [2026-09-09T06:06:19Z] LEG-3 POST-REBUILD observation
+$ cat /tmp/claude-1000/-home-sandbox-harness/8b200f3c-07b0-487b-9533-aae682bf912f/scratchpad/w13/state-after-rebuild.txt
+### mount identity (docker inspect oh-a)
+type=bind name= src=/home/sandbox/workspace dst=/home/sandbox rw=true
+
+### device+inode of the durable root
+path=/home/sandbox/workspace dev=bc inode=1486974 uid=1000 gid=1000 mode=755
+### per-path sha256 / owner / mode
+/home/sandbox/workspace/harness/projects/us007a-demo/tracked.txt sha256=f6ef6719a2a51ef5dddc5095a16fd68ae989932416e860c10567033459a838e7 uid=1000 gid=1000 mode=644
+/home/sandbox/workspace/harness/projects/us007a-demo/untracked.txt sha256=ecf290b2fa879dc84fd5b1f3ffb37b3ac9bdd6795a82e9f74d5ca3f49ab7b9dc uid=1000 gid=1000 mode=644
+/home/sandbox/workspace/harness/.agro/tasks/us007a-user-task/notes.md sha256=2408e4ae8f6a4eae664411ec5ab596bcc1cbb370f2e3f9babf23692370dfeabf uid=1000 gid=1000 mode=644
+/home/sandbox/workspace/harness/.env sha256=24f472dcb4dba237a00169fa9c97534183bfb76546409dc38b03c6347ed33d3a uid=1000 gid=1000 mode=600
+/home/sandbox/workspace/.config/gh/hosts.yml sha256=fe64ca26c1acdaa7578456cd7e6e89d2eac6f59e3c2a72646b01f14541a014f7 uid=1000 gid=1000 mode=600
+/home/sandbox/workspace/.openharness/README.md sha256=6d94361ea14087cae70915f5f2cac79204aa4909b208092b4efd30aeea281706 uid=1000 gid=1000 mode=644
+/home/sandbox/workspace/.openharness/scripts/legacy.sh sha256=5b1ae9cb23230c17e3bcd99a908f79b3e3a2e301765d7b208a2e07a06a553640 uid=1000 gid=1000 mode=644
+/home/sandbox/workspace/harness/projects/us007a-legacy-project/.oh/README.md sha256=cec1415f3dc0650dd3126de5d3c8a6bafe81eef681dbc8416f00e793e0ef5a94 uid=1000 gid=1000 mode=644
+/home/sandbox/workspace/harness/projects/us007a-legacy-project/oh.json sha256=f1049d5b66ca21494aecbf71b895aa706048a4a2a63ebf75b1b9d01d5c90621a uid=1000 gid=1000 mode=644
+### git working-tree status of the seeded checkout
+ M tracked.txt
+?? untracked.txt
+86f48d1 us007a: baseline commit
+### attach-marker files (written from inside the container)
+/home/sandbox/workspace/us007a-attach-marker.txt = 2026-09-09T06:00:24Z
+/home/sandbox/workspace/us007a-preattach.txt = 2026-09-09T05:58:16Z
+-- exit=0
+
+=== [2026-09-09T06:06:19Z] LEG-3 diff PRE-REBUILD vs POST-REBUILD (empty == identical)
+$ diff /tmp/claude-1000/-home-sandbox-harness/8b200f3c-07b0-487b-9533-aae682bf912f/scratchpad/w13/state-before-rebuild.txt /tmp/claude-1000/-home-sandbox-harness/8b200f3c-07b0-487b-9533-aae682bf912f/scratchpad/w13/state-after-rebuild.txt
+-- exit=0
+
+=== [2026-09-09T06:06:19Z] LEG-3 container identity changed (a real recycle, not a restart)
+$ docker exec us007a-node bash -c docker inspect oh-a --format "id={{.Id}} created={{.Created}} image={{.Config.Image}}"; docker exec oh-a systemctl show openharness-bootstrap.service -p ActiveState -p SubState -p Result -p ExecMainStatus -p ExecMainStartTimestamp
+id=6a82719b33c4e05c0ddada61f774cfa249c31a754d99eb09564277da6e5b38d3 created=2026-09-09T06:06:05.027405103Z image=127.0.0.1:5000/agro-candidate:us007a
+Result=success
+ExecMainStartTimestamp=Wed 2026-09-09 06:06:05 UTC
+ExecMainStatus=0
+ActiveState=active
+SubState=exited
+-- exit=0
+
+=== [2026-09-09T06:06:19Z] LEG-3 config survived the rebuild (idempotency fix in the candidate CLI)
+$ docker exec -u sandbox us007a-node bash -lc cat $HOME/.agro/sandboxes/oh-a/agro.json | tr -d "\n" | sed "s/  */ /g"
+{ "version": 1, "name": "oh-a", "timezone": "UTC", "git": { "userName": "openharness", "userEmail": "agent@openharness.cloud" }, "storage": { "homePath": "/home/sandbox/workspace" }, "access": { "ssh": false, "sshPort": 2222, "sshPasswordAuth": false, "dockerSocket": false }, "hermesDashboard": { "enabled": false, "port": 9119 }, "cron": { "agentBin": "claude" }, "build": { "skipPnpmInstall": false }, "image": { "mode": "image", "pullPolicy": "missing", "ref": "127.0.0.1:5000/agro-candidate:us007a" }, "cloud": {}, "langfuse": {}, "composeOverrides": [], "runtime": "docker"}-- exit=0
+
+=== [2026-09-09T06:06:31Z] LEG-4a AFTER-REBUILD: ssh + tmux attach -t docker-build-oh-sandbox
+$ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/tmp/claude-1000/-home-sandbox-harness/8b200f3c-07b0-487b-9533-aae682bf912f/scratchpad/w13/known_hosts -i /tmp/claude-1000/-home-sandbox-harness/8b200f3c-07b0-487b-9533-aae682bf912f/scratchpad/w13/keys/sandbox_key sandbox@172.18.0.4 tmux ls 2>&1; tmux attach -t docker-build-oh-sandbox 2>&1; echo "attach-exit=$?"
+no server running on /tmp/tmux-1000/default
+no sessions
+attach-exit=1
+-- exit=0
+
+=== [2026-09-09T06:06:31Z] LEG-4b AFTER-REBUILD: agro shell re-attach lands on preserved state
+$ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/tmp/claude-1000/-home-sandbox-harness/8b200f3c-07b0-487b-9533-aae682bf912f/scratchpad/w13/known_hosts -i /tmp/claude-1000/-home-sandbox-harness/8b200f3c-07b0-487b-9533-aae682bf912f/scratchpad/w13/keys/sandbox_key sandbox@172.18.0.4 bash /opt/us007a/attach-shell.sh
+### tmux pane capture of the agro shell session
+
+━━━ openharness: oh-a ━━━
+  Project:   /home/sandbox/harness
+  Timezone:  UTC
+  Overlays:  (none)
+
+  Onboarding:
+    [✗]  gh          not authenticated — run: gh auth login
+    [✗]  claude      not authenticated — run: claude
+    [✗]  codex       not authenticated — run: codex
+    [✗]  opencode    not installed — run: oh harness install opencode
+    [✗]  grok        not installed — run: oh harness install grok-build
+    [✗]  pi          not authenticated — run: pi
+    [✗]  hermes      not installed — run: oh harness install hermes
+    [✓]  oh          0.9.0
+
+  Recovery commands: claude · codex · systemctl status openharness-cron.service
+
+  Next: run `oh tool install herdr`, then `herdr`, to open your persistent Open Harness workspace.
+  Complete setup, authentication, agents, tests, and servers inside Herdr.
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+sandbox@6a82719b33c4:~/harness$ echo MARKER-READ=$(cat /home/sandbox/us007a-preattach.txt)                                                                                                      [oh-a]
+MARKER-READ=2026-09-09T05:58:16Z
+sandbox@6a82719b33c4:~/harness$ date -u +%Y-%m-%dT%H:%M:%SZ > /home/sandbox/us007a-attach-marker.txt; echo WROTE=$(cat /home/sandbox/us007a-attach-marker.txt)                                  [oh-a]
+WROTE=2026-09-09T06:06:42Z
+sandbox@6a82719b33c4:~/harness$ echo WHOAMI=$(whoami) HOST=$(hostname) UID=$(id -u)                                                                                                             [oh-a]
+WHOAMI=sandbox HOST=6a82719b33c4 UID=1000
+sandbox@6a82719b33c4:~/harness$ git -C /home/sandbox/harness/projects/us007a-demo status --porcelain; echo GIT-DONE                                                                             [oh-a]
+ M tracked.txt
+?? untracked.txt
+GIT-DONE
+sandbox@6a82719b33c4:~/harness$                                                                                                                                                                 [oh-a]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+### session closed
+-- exit=0
+
+=== [2026-09-09T06:06:51Z] LEG-4b AFTER-REBUILD: docker exec re-attach observing pre-rebuild state
+$ docker exec us007a-node docker exec -u sandbox oh-a bash -c echo PRE=$(cat /home/sandbox/us007a-preattach.txt); echo ATTACH=$(cat /home/sandbox/us007a-attach-marker.txt); git -C /home/sandbox/harness/projects/us007a-demo status --porcelain; hostname
+PRE=2026-09-09T05:58:16Z
+ATTACH=2026-09-09T06:06:42Z
+ M tracked.txt
+?? untracked.txt
+6a82719b33c4
+-- exit=0
+
+=== [2026-09-09T06:07:03Z] LEG-4c AFTER-REBUILD: same pinned SSH forward still serves code-server, and the editor reads state written inside the NEW container
+$ bash -c curl -sS -o /dev/null -w "root http=%{http_code} redirect=%{redirect_url}\n" --max-time 10 http://127.0.0.1:18080/; echo "marker written inside the post-rebuild container, read via the editor surface:"; curl -sS --max-time 10 "http://127.0.0.1:18080/vscode-remote-resource?path=%2Fhome%2Fsandbox%2Fworkspace%2Fus007a-attach-marker.txt"; echo; echo "seeded uncommitted file, read via the editor surface:"; curl -sS --max-time 10 "http://127.0.0.1:18080/vscode-remote-resource?path=%2Fhome%2Fsandbox%2Fworkspace%2Fharness%2Fprojects%2Fus007a-demo%2Ftracked.txt"
+root http=302 redirect=http://127.0.0.1:18080/?workspace=/home/sandbox/oh.code-workspace
+marker written inside the post-rebuild container, read via the editor surface:
+2026-09-09T06:06:42Z
+
+seeded uncommitted file, read via the editor surface:
+committed line
+UNCOMMITTED EDIT do-not-lose
+-- exit=0
+
+=== [2026-09-09T06:07:04Z] LEG-4c code-server unit was untouched by the container rebuild
+$ docker exec us007a-node bash -c systemctl show openharness-code-server.service -p ActiveState -p SubState -p ExecMainStartTimestamp -p NRestarts
+NRestarts=0
+ExecMainStartTimestamp=Wed 2026-09-09 05:54:22 UTC
+ActiveState=active
+SubState=running
+-- exit=0
+
+=== [2026-09-09T06:07:04Z] LEG-5 UID ALIGNMENT: node-host sandbox uid vs container sandbox uid
+$ bash -c echo -n "node-host:  "; docker exec us007a-node id -u sandbox; echo -n "container:  "; docker exec us007a-node docker exec oh-a id -u sandbox; echo -n "node-host gid: "; docker exec us007a-node id -g sandbox; echo -n "container gid: "; docker exec us007a-node docker exec oh-a id -g sandbox
+node-host:  1000
+container:  1000
+node-host gid: 1000
+container gid: 1000
+-- exit=0
+
+=== [2026-09-09T06:07:29Z] HARNESS-PARAM config A: what a no-default-harness node actually has installed
+$ docker exec -u sandbox us007a-node bash -lc export AGRO_HOME=$HOME/.agro; cd $AGRO_HOME/sandboxes/oh-a && agro harness list 2>&1
+HARNESS      KIND         INSTALLED
+claude-code  installable  no
+codex        installable  no
+pi           installable  no
+opencode     installable  no
+grok-build   installable  no
+hermes       installable  no
+muse-code    installable  no
+t3code       on-demand    no
+-- exit=0
+
+=== [2026-09-09T06:07:36Z] HARNESS-PARAM: the wrong id is rejected (pi-coding-agent is not a catalog id)
+$ docker exec -u sandbox us007a-node bash -lc export AGRO_HOME=$HOME/.agro; cd $AGRO_HOME/sandboxes/oh-a && agro harness install pi-coding-agent 2>&1; echo "exit=$?"
+oh harness: unknown harness "pi-coding-agent"
+
+Known harnesses:
+  claude-code
+  codex
+  pi
+  opencode
+  grok-build
+  hermes
+  muse-code
+  t3code
+exit=1
+-- exit=0
+
+=== [2026-09-09T06:07:36Z] HARNESS-PARAM config B: explicit agro harness install pi
+$ docker exec -u sandbox us007a-node bash -lc export AGRO_HOME=$HOME/.agro; cd $AGRO_HOME/sandboxes/oh-a && agro harness install pi 2>&1 | tail -25; echo "exit=${PIPESTATUS[0]}"
+installing Pi into the sandbox…
+npm warn deprecated node-domexception@1.0.0: Use your platform's native DOMException instead
+
+added 132 packages in 6s
+
+15 packages are looking for funding
+  run `npm fund` for details
+pi: installed — see https://github.com/mifunedev/agro/blob/main/docs/harnesses/pi.md for authentication
+exit=0
+-- exit=0
+
+=== [2026-09-09T06:07:50Z] HARNESS-PARAM config B: agro harness install opencode (the id the Cloud generator emits)
+$ docker exec -u sandbox us007a-node bash -lc export AGRO_HOME=$HOME/.agro; cd $AGRO_HOME/sandboxes/oh-a && agro harness install opencode 2>&1 | tail -12; echo "exit=${PIPESTATUS[0]}"
+installing OpenCode into the sandbox…
+
+added 3 packages in 8s
+opencode: installed — see https://github.com/mifunedev/agro/blob/main/docs/harnesses/opencode.md for authentication
+exit=0
+-- exit=0
+
+=== [2026-09-09T06:07:58Z] HARNESS-PARAM config B: observed installed state
+$ docker exec -u sandbox us007a-node bash -lc export AGRO_HOME=$HOME/.agro; cd $AGRO_HOME/sandboxes/oh-a && agro harness list 2>&1
+HARNESS      KIND         INSTALLED
+claude-code  installable  no
+codex        installable  no
+pi           installable  yes
+opencode     installable  yes
+grok-build   installable  no
+hermes       installable  no
+muse-code    installable  no
+t3code       on-demand    no
+-- exit=0
+
+=== [2026-09-09T06:08:00Z] HARNESS-PARAM where the harness binaries landed (durable mount?)
+$ docker exec us007a-node docker exec -u sandbox oh-a bash -lc command -v pi opencode; ls -l $(command -v pi) 2>&1
+/home/sandbox/.local/bin/pi
+/home/sandbox/.local/bin/opencode
+lrwxrwxrwx 1 sandbox sandbox 70 Sep  9 06:07 /home/sandbox/.local/bin/pi -> ../lib/node_modules/@earendil-works/pi-coding-agent/dist/bundle/cli.js
+-- exit=0
+
+=== [2026-09-09T06:08:11Z] HARNESS-PARAM: second REBUILD via ohmanage, with harnesses installed
+$ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/tmp/claude-1000/-home-sandbox-harness/8b200f3c-07b0-487b-9533-aae682bf912f/scratchpad/w13/known_hosts -i /tmp/claude-1000/-home-sandbox-harness/8b200f3c-07b0-487b-9533-aae682bf912f/scratchpad/w13/keys/mgmt_key ohmanage@172.18.0.4 sandbox rebuild --name oh-a
+version=1 mode=sandbox action=rebuild name=oh-a state=complete step=ready
+-- exit=0
+
+=== [2026-09-09T06:08:17Z] HARNESS-PARAM: harnesses survived the rebuild
+$ docker exec -u sandbox us007a-node bash -lc export AGRO_HOME=$HOME/.agro; cd $AGRO_HOME/sandboxes/oh-a && agro harness list 2>&1; docker inspect oh-a --format "container-id={{.Id}}"
+HARNESS      KIND         INSTALLED
+claude-code  installable  no
+codex        installable  no
+pi           installable  yes
+opencode     installable  yes
+grok-build   installable  no
+hermes       installable  no
+muse-code    installable  no
+t3code       on-demand    no
+container-id=6a82719b33c4e05c0ddada61f774cfa249c31a754d99eb09564277da6e5b38d3
+-- exit=0
+
+=== [2026-09-09T06:08:19Z] HARNESS-PARAM: user state after second rebuild (diff vs first post-rebuild)
+$ diff /tmp/claude-1000/-home-sandbox-harness/8b200f3c-07b0-487b-9533-aae682bf912f/scratchpad/w13/state-after-rebuild.txt /tmp/claude-1000/-home-sandbox-harness/8b200f3c-07b0-487b-9533-aae682bf912f/scratchpad/w13/state-after-rebuild2.txt
+21c21
+< /home/sandbox/workspace/us007a-attach-marker.txt = 2026-09-09T06:00:24Z
+---
+> /home/sandbox/workspace/us007a-attach-marker.txt = 2026-09-09T06:06:42Z
+-- exit=1
+
+=== [2026-09-09T06:08:31Z] REBUILD SEMANTICS: rebuild #2 kept the same container id — stop/start, not recreate
+$ docker exec us007a-node bash -c docker inspect oh-a --format "id={{.Id}}
+created={{.Created}}
+startedAt={{.State.StartedAt}}
+image={{.Config.Image}}"; echo "--- bootstrap unit on the current boot:"; docker exec oh-a systemctl show openharness-bootstrap.service -p ActiveState -p Result -p ExecMainStartTimestamp
+id=6a82719b33c4e05c0ddada61f774cfa249c31a754d99eb09564277da6e5b38d3
+created=2026-09-09T06:06:05.027405103Z
+startedAt=2026-09-09T06:08:12.299907168Z
+image=127.0.0.1:5000/agro-candidate:us007a
+--- bootstrap unit on the current boot:
+Result=success
+ExecMainStartTimestamp=Wed 2026-09-09 06:08:12 UTC
+ActiveState=active
+-- exit=0
+
+=== [2026-09-09T06:08:54Z] LEG-5 UID DIVERGENCE experiment (node uid 1001 vs container uid 1000)
+$ docker exec us007a-node bash /opt/us007a/uid-divergence.sh
+useradd: UID 1001 is not unique
+install: invalid user 'sandbox2'
+/opt/us007a/uid-divergence.sh: line 10: /home/sandbox2/ws/host-owned.txt: No such file or directory
+chown: cannot access '/home/sandbox2/ws/host-owned.txt': No such file or directory
+chown: invalid user: 'sandbox2:sandbox2'
+### BEFORE: ownership as the node host sees it
+stat: cannot statx '/home/sandbox2/ws': No such file or directory
+stat: cannot statx '/home/sandbox2/ws/host-owned.txt': No such file or directory
+### install a sandbox whose home mount is the uid-1001 directory
+runuser: user sandbox2 does not exist or the user entry does not contain all the required fields
+### wait for the readiness oracle
+attempt 1: 
+attempt 2: 
+attempt 3: 
+attempt 4: 
+attempt 5: 
+attempt 6: 
+attempt 7: 
+attempt 8: 
+attempt 9: 
+attempt 10: 
+attempt 11: 
+attempt 12: 
+attempt 13: 
+attempt 14: 
+attempt 15: 
+attempt 16: 
+attempt 17: 
+attempt 18: 
+attempt 19: 
+attempt 20: 
+attempt 21: 
+attempt 22: 
+attempt 23: 
+attempt 24: 
+attempt 25: 
+attempt 26: 
+attempt 27: 
+attempt 28: 
+attempt 29: 
+attempt 30: 
+attempt 31: 
+attempt 32: 
+attempt 33: 
+attempt 34: 
+attempt 35: 
+attempt 36: 
+attempt 37: 
+attempt 38: 
+attempt 39: 
+attempt 40: 
+### AFTER: ownership as the node host sees it
+stat: cannot statx '/home/sandbox2/ws': No such file or directory
+stat: cannot statx '/home/sandbox2/ws/host-owned.txt': No such file or directory
+### can the node-host uid-1001 user still write into its own directory?
+runuser: user sandbox2 does not exist or the user entry does not contain all the required fields
+HOST-WRITE=DENIED
+runuser: user sandbox2 does not exist or the user entry does not contain all the required fields
+HOST-CREATE=DENIED
+### container uid
+Error response from daemon: No such container: oh-uidtest
+### entrypoint ownership lines
+Error response from daemon: No such container: oh-uidtest
+-- exit=1
+
+=== [2026-09-09T06:12:22Z] LEG-5 UID DIVERGENCE experiment (node uid 1500 vs container uid 1000)
+$ docker exec us007a-node bash /opt/us007a/uid-divergence.sh
+useradd: warning: the home directory /home/sandbox2 already exists.
+useradd: Not copying any file from skel directory into it.
+### BEFORE: ownership as the node host sees it
+path=/home/sandbox2/ws uid=1500 gid=1500 mode=755
+path=/home/sandbox2/ws/host-owned.txt uid=1500 gid=1500 mode=644
+### install a sandbox whose home mount is the uid-1001 directory
+agro: EACCES: permission denied, mkdir '/home/sandbox2/.agro/sandboxes/oh-uidtest'
+### wait for the readiness oracle
+attempt 1: 
+attempt 2: 
+attempt 3: 
+attempt 4: 
+attempt 5: 
+attempt 6: 
+attempt 7: 
+attempt 8: 
+attempt 9: 
+attempt 10: 
+attempt 11: 
+attempt 12: 
+attempt 13: 
+attempt 14: 
+attempt 15: 
+attempt 16: 
+attempt 17: 
+attempt 18: 
+attempt 19: 
+attempt 20: 
+attempt 21: 
+attempt 22: 
+attempt 23: 
+attempt 24: 
+attempt 25: 
+attempt 26: 
+attempt 27: 
+attempt 28: 
+attempt 29: 
+attempt 30: 
+attempt 31: 
+attempt 32: 
+attempt 33: 
+attempt 34: 
+attempt 35: 
+attempt 36: 
+attempt 37: 
+attempt 38: 
+attempt 39: 
+attempt 40: 
+### AFTER: ownership as the node host sees it
+path=/home/sandbox2/ws uid=1500 gid=1500 mode=755
+path=/home/sandbox2/ws/host-owned.txt uid=1500 gid=1500 mode=644
+### can the node-host uid-1001 user still write into its own directory?
+HOST-WRITE=OK
+HOST-CREATE=OK
+### container uid
+Error response from daemon: No such container: oh-uidtest
+### entrypoint ownership lines
+Error response from daemon: No such container: oh-uidtest
+-- exit=1
+
+=== [2026-09-09T06:15:52Z] LEG-5 UID DIVERGENCE experiment (node uid 1500 vs container uid 1000), retry
+$ docker exec us007a-node bash /opt/us007a/uid-divergence.sh
+### BEFORE: ownership as the node host sees it
+path=/home/sandbox2/ws uid=1500 gid=1500 mode=755
+path=/home/sandbox2/ws/host-owned.txt uid=1500 gid=1500 mode=644
+### install a sandbox whose home mount is the uid-1001 directory
+ Network oh-uidtest_default Creating 
+ Network oh-uidtest_default Created 
+ Network oh-uidtest_default Created 
+ Container oh-uidtest Creating 
+ Container oh-uidtest Created 
+ Container oh-uidtest Starting 
+ Container oh-uidtest Started 
+next: oh shell oh-uidtest
+### wait for the readiness oracle
+attempt 1: 
+attempt 2: activating
+attempt 3: active
+### AFTER: ownership as the node host sees it
+path=/home/sandbox2/ws uid=1000 gid=1000 mode=755
+path=/home/sandbox2/ws/host-owned.txt uid=1000 gid=1000 mode=644
+### can the node-host uid-1001 user still write into its own directory?
+-bash: line 1: /home/sandbox2/ws/host-owned.txt: Permission denied
+HOST-WRITE=DENIED
+touch: cannot touch '/home/sandbox2/ws/new-host-file.txt': Permission denied
+HOST-CREATE=DENIED
+### container uid
+1000
+### entrypoint ownership lines
+[entrypoint] repairing sandbox home mount ownership as 1000:1000
+-- exit=0
+
+=== [2026-09-09T06:16:37Z] cleanup: remove the uid-divergence sandbox
+$ docker exec us007a-node bash -c runuser -l sandbox2 -c "export PATH=\$HOME/.local/bin:\$PATH; export AGRO_HOME=\$HOME/.agro; agro destroy oh-uidtest --yes" 2>&1 | tail -3; docker rm -f oh-uidtest 2>/dev/null; docker ps -a --format "{{.Names}}"
+ Network oh-uidtest_default Removing 
+ Network oh-uidtest_default Removed 
+removed the sandbox entry /home/sandbox2/.agro/sandboxes/oh-uidtest
+oh-a
+us007a-registry
+-- exit=0
+
+=== [2026-09-09T06:16:38Z] HARNESS-PARAM config B: FRESH bootstrap end to end with one default harness
+$ docker exec us007a-node bash /opt/us007a/bootstrap-b-run.sh
+### tear down the config-A sandbox and set the workspace aside
+ Container oh-a Removing 
+ Container oh-a Removed 
+ Network oh-a_default Removing 
+ Network oh-a_default Removed 
+removed the sandbox entry /home/sandbox/.agro/sandboxes/oh-a
+### install the config-B bootstrap script
+53:run_step agro harness install opencode
+### launch exactly as the cloud-init runcmd line does
+### poll the tmux session while the bootstrap is in flight
+t=1 status=<no status yet> tmux: docker-build-oh-sandbox: 1 windows (created Wed Sep  9 06:16:39 2026) 
+t=2 status=failed:243 tmux: no server running on /tmp/tmux-1000/default 
+### final status + log
+failed:243
+image mode: agro-candidate:us007a (skipping local build)
+ Network oh-a_default Creating 
+ Network oh-a_default Creating 
+ Network oh-a_default Created 
+ Network oh-a_default Created 
+ Container oh-a Creating 
+ Container oh-a Created 
+ Container oh-a Starting 
+ Container oh-a Started 
+next: oh shell oh-a
+oh.json: set storage.homePath=/home/sandbox/workspace (added)
+installing OpenCode into the sandbox…
+npm error code EACCES
+npm error syscall mkdir
+npm error path /home/sandbox/.local/lib
+npm error errno -13
+npm error Error: EACCES: permission denied, mkdir '/home/sandbox/.local/lib'
+npm error     at async mkdir (node:internal/fs/promises:858:10)
+npm error     at async Arborist.reify (/usr/local/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/arborist/reify.js:128:7)
+npm error     at async Install.exec (/usr/local/lib/node_modules/npm/lib/commands/install.js:150:5)
+npm error     at async Npm.exec (/usr/local/lib/node_modules/npm/lib/npm.js:207:9)
+npm error     at async module.exports (/usr/local/lib/node_modules/npm/lib/cli/entry.js:74:5) {
+npm error   errno: -13,
+npm error   code: 'EACCES',
+npm error   syscall: 'mkdir',
+npm error   path: '/home/sandbox/.local/lib'
+npm error }
+npm error
+npm error The operation was rejected by your operating system.
+npm error It is likely you do not have the permissions to access this file as the current user
+npm error
+npm error If you believe this might be a permissions issue, please double-check the
+npm error permissions of the file and its containing directories, or try running
+npm error the command again as root/Administrator.
+npm error A complete log of this run can be found in: /home/sandbox/.npm/_logs/2026-09-09T06_16_40_063Z-debug-0.log
+oh harness: installing opencode failed (exit 243).
+### readiness by the bootstrap unit oracle
+attempt 1: activating
+attempt 2: active
+Result=success
+ExecMainStatus=0
+ActiveState=active
+SubState=exited
+### tmux session after the bootstrap finished
+no server running on /tmp/tmux-1000/default
+no sessions
+### harness state after a config-B bootstrap
+HARNESS      KIND         INSTALLED
+claude-code  installable  no
+codex        installable  no
+pi           installable  no
+opencode     installable  no
+grok-build   installable  no
+hermes       installable  no
+muse-code    installable  no
+t3code       on-demand    no
+-- exit=0
+
+=== [2026-09-09T06:17:10Z] config-B failure is a RACE: the same install succeeds once the unit is active
+$ docker exec us007a-node bash -c docker exec oh-a systemctl is-active openharness-bootstrap.service; stat -c "%n uid=%u gid=%g mode=%a" /home/sandbox/workspace/.local 2>&1; runuser -l sandbox -c "export PATH=\$HOME/.local/bin:\$PATH; export AGRO_HOME=\$HOME/.agro; cd \$AGRO_HOME/sandboxes/oh-a && agro harness install opencode" 2>&1 | tail -6
+active
+/home/sandbox/workspace/.local uid=1000 gid=1000 mode=755
+installing OpenCode into the sandbox…
+
+added 3 packages in 10s
+opencode: installed — see https://github.com/mifunedev/agro/blob/main/docs/harnesses/opencode.md for authentication
+-- exit=0
+
+=== [2026-09-09T06:17:21Z] config-B ownership timeline: what the entrypoint had NOT yet done at install time
+$ docker exec us007a-node docker exec oh-a bash -c journalctl -u openharness-bootstrap.service --no-pager -o short-iso -b | grep -i "ownership\|seed\|Starting\|Finished" | head -10
+2026-09-09T06:16:40+00:00 25de19c63c63 systemd[1]: Starting openharness-bootstrap.service - Open Harness sandbox bootstrap...
+2026-09-09T06:16:40+00:00 25de19c63c63 entrypoint.sh[71]: [entrypoint] no checkout bind at /home/sandbox/harness — seeding from /opt/agro-seed
+2026-09-09T06:16:40+00:00 25de19c63c63 entrypoint.sh[71]: [entrypoint] seeded control plane into /home/sandbox/harness from /opt/agro-seed
+2026-09-09T06:16:40+00:00 25de19c63c63 entrypoint.sh[71]: [entrypoint] repairing sandbox home mount ownership as 1000:1000
+2026-09-09T06:16:44+00:00 25de19c63c63 systemd[1]: Finished openharness-bootstrap.service - Open Harness sandbox bootstrap.
+-- exit=0
+
+=== [2026-09-09T06:17:44Z] config-B reproducibility: second FRESH run of the identical bootstrap
+$ docker exec us007a-node bash /opt/us007a/repro-b.sh
+t=1 status=<none>
+t=2 status=failed:243
+--- tail of the bootstrap log
+npm error permissions of the file and its containing directories, or try running
+npm error the command again as root/Administrator.
+npm error A complete log of this run can be found in: /home/sandbox/.npm/_logs/2026-09-09T06_17_47_366Z-debug-0.log
+oh harness: installing opencode failed (exit 243).
+--- readiness marker the control plane waits for
+ls: cannot access '/run/openharness-ready': No such file or directory
+--- the sandbox unit, despite the failed bootstrap
+attempt 1: activating
+attempt 2: active
+-- exit=0
+
+=== [2026-09-09T06:18:15Z] CONTROL: identical FRESH bootstrap with NO default harness (config A)
+$ docker exec us007a-node bash /opt/us007a/repro-a.sh
+--- the config-A script has no harness step:
+0
+t=1 status=<none>
+t=2 status=ok
+--- readiness marker
+-rw-r--r-- 1 root root 0 Sep  9 06:18 /run/openharness-ready
+--- the sandbox unit
+attempt 1: activating
+attempt 2: active
+Result=success
+ExecMainStatus=0
+ActiveState=active
+-- exit=0
+
+=== [2026-09-09T06:19:11Z] CONTRAST: the PUBLISHED image the Cloud bootstrap names by default
+$ docker exec us007a-node bash /opt/us007a/published-contrast.sh
+### image identity
+ref=ghcr.io/mifunedev/agro:latest id=sha256:bbfdaf6bb8ca1aa8244aba4b81539f740e5d4b5eee4e6484a95bdac7ef599a82 created=2026-09-06T19:52:35.075858251Z
+ref=agro-candidate:us007a id=sha256:d963de3d2b25421b82ca6312a41a3f1b87a2ca0857182b8a2e2cb936cb1ed964 created=2026-09-09T05:50:17.048436155Z
+ Network oh-pub_default Created 
+ Container oh-pub Creating 
+ Container oh-pub Created 
+ Container oh-pub Starting 
+ Container oh-pub Started 
+next: oh shell oh-pub
+### readiness oracle on the published image
+attempt 1: 
+attempt 2: failed
+Result=exit-code
+ExecMainStatus=1
+ActiveState=failed
+SubState=failed
+### container liveness (proves nothing on its own)
+oh-pub Up 5 seconds (health: starting)
+### failure tail
+Starting openharness-bootstrap.service - Open Harness sandbox bootstrap...
+[entrypoint] no checkout bind at /home/sandbox/harness — seeding from /opt/oh-seed
+[entrypoint] seeded control plane into /home/sandbox/harness from /opt/oh-seed
+pam_unix(chpasswd:chauthtok): password changed for sandbox
+[entrypoint] repairing sandbox home mount ownership as 1000:1000
+Providers OK: .agents/.pi/.claude/.codex skills -> .oh/skills (vendored pack present)
+[provision-python] ensuring managed Python 3.11 in /home/sandbox/.local/share/uv/python
+Python 3.11 is already installed
+[provision-python] installing kernel packages: ipykernel
+Using Python 3.11.16 environment at: /home/sandbox/.local/share/oh/kernel
+Checked 1 package in 34ms
+[provision-python] OK  python=/home/sandbox/.local/share/uv/python/cpython-3.11-linux-x86_64-gnu/bin/python3.11
+[provision-python] OK  kernel=/home/sandbox/.local/share/oh/kernel/bin/python (ipykernel present)
+[entrypoint] attach banner wired into .bashrc
+[entrypoint] node_modules missing — running pnpm install at /home/sandbox/harness
+[entrypoint] pnpm install failed — see /tmp/pnpm-install.log; aborting sandbox boot
+openharness-bootstrap.service: Main process exited, code=exited, status=1/FAILURE
+openharness-bootstrap.service: Failed with result 'exit-code'.
+Failed to start openharness-bootstrap.service - Open Harness sandbox bootstrap.
+openharness-bootstrap.service: Consumed 3.478s CPU time, 517.6M memory peak.
+-- exit=0
+
+=== [2026-09-09T06:19:34Z] CLEANUP: node-internal docker state before node teardown
+$ docker exec us007a-node bash -c docker ps -a --format "{{.Names}} {{.Status}}"; docker volume ls; docker images --format "{{.Repository}}:{{.Tag}}"
+oh-pub Up 22 seconds (health: starting)
+oh-a Up About a minute (healthy)
+us007a-registry Up 14 minutes
+DRIVER    VOLUME NAME
+local     034b2adc5f7a4352bf59d66c6ca3c04ac9463d8aff8f4231d6bd5c3a6c16c0fd
+127.0.0.1:5000/agro-candidate:us007a
+agro-candidate:us007a
+ghcr.io/mifunedev/agro:latest
+registry:2
+-- exit=0
+
+=== [2026-09-09T06:19:34Z] CLEANUP: stop and remove the disposable node host
+$ bash -c docker rm -f us007a-node; docker volume rm us007a-node-docker
+us007a-node
+us007a-node-docker
+-- exit=0
+
+=== [2026-09-09T06:19:37Z] CLEANUP: remove the two images this run built
+$ bash -c docker rmi -f agro-candidate:us007a oh-node-host:us007a
+Untagged: agro-candidate:us007a
+Deleted: sha256:d963de3d2b25421b82ca6312a41a3f1b87a2ca0857182b8a2e2cb936cb1ed964
+Deleted: sha256:a23008a654d91ad13c4627c39ffcdb0b5a0064bb24794104d6f247d3f09ff32e
+Deleted: sha256:b5419b6d27b338fe5cb5f0103f4feeae4af7aa5866eb6734ba9119e19f6c6eb7
+Deleted: sha256:dd6e57605cbbff632efb11e05458f26cd49c81b140a82bbe6d9555ec5eb72543
+Deleted: sha256:335dfb44576f1fc99be20e62c6f0e4b935056d61589a03b2acf906fd20f5a081
+Deleted: sha256:2b7e682b8da677ddc3546b3fa205c3cdd844d8590d390f7891b388ef07e1d5a2
+Deleted: sha256:4905756db31376598348a6026ba045265977f9b134b4ce9cf7dd25f6d0442cd7
+Deleted: sha256:93119c90a9dbe35254a4b08e7f057d101733b9eab3dbdf88348310d80500b9d9
+Deleted: sha256:61a0d0d5d6bcb8ca315b80c812e8c9737f93286f9ba9138010cc109c471a4338
+Deleted: sha256:8f641bf19a3ac09e9ff9e09595646b08ffea57218d9f0a9ff51a91961cad236d
+Deleted: sha256:d12e895fee55bc01a22d3163a86311b068d6eafcfe028b2ee93e9ed268acc0c2
+Deleted: sha256:fc3bb30e6020d32cc7663c0ff09b672ab78d83b4a8412e93a771618f79f27f27
+Deleted: sha256:637f9ec77d0bf834a4e3513dfe12d4453dbcb17cdfb70bda34a1791eda848111
+Deleted: sha256:778a4a86bd9b7e0ecc189c43261dca93d0ab9d7e99ce4c555d0247d69b73fbbe
+Deleted: sha256:12d588aa74646edd7cc7770c76fe98f863b12a133442a543cf49c06686949c3a
+Deleted: sha256:dc7a49346f662eebedf558cf93970e49624dd0729cb596d8da9e56dd5ca183fc
+Deleted: sha256:4955f4327154ed7c1900c87bb0edbacda7c686fca474144f44bea56b01062bfd
+Deleted: sha256:a868031054c675f3798d752db9a0073c21b5e31e373cd8b3426c0e86baa90286
+Deleted: sha256:afbf71be63a0e4b7b46713096d516e5ebdd1aedc9d9def0938567302a38073e0
+Deleted: sha256:0d08b99a5b1e7c176d2bf7981c2b5b4c31d4b30749d7ded38a26a39e8af1a9df
+Deleted: sha256:a2d9ae1f2807f0ca7db1591f7d3b8ae6e52126996e42a2f74edb03d934f40d1d
+Deleted: sha256:d30b0a6c36b88a21748be3a5bd5af307196f03ee3caa130ae99b3e06a23bcf35
+Deleted: sha256:4da868b108836eb014c35aacc7c6bc244b160ec347a38500ef7f40736b0731e9
+Deleted: sha256:5c2d6796a17809f768180525e909c8df02edaadd861400142b6c7b50e4c8d76f
+Deleted: sha256:69a0776554a767b5896c7e08d2c3a2013e36bf46d481687aea61f6e4c9b57ef9
+Deleted: sha256:78eab997fcc752d549406f919dd91c51ff4f6639024814efffd5245129ad0af4
+Deleted: sha256:56040e5c805759861a96a14bd3f36b09750a51fa1c62a098a32634b9c6656783
+Deleted: sha256:102fb60a6b83d07e95227d1b77fd12d86e34ff5047bdac3140552a84da8eadaf
+Untagged: oh-node-host:us007a
+Deleted: sha256:d5c76e7fb64bc400e6aa5730bd9135953571d8acadc54a911a4cf730693f5ada
+Deleted: sha256:7a4d6db365389560944d43dc3525da68dc79f0d05111f123a147178947985abf
+Deleted: sha256:d0362dd7a882ae0955e1453635cf71f7f2b36603cfebc9c5ba93eef89f8b75ed
+Deleted: sha256:71b230c11f13a9c5736eec8c6b752ec32eebc88d5c712d2091a170a192379c11
+Deleted: sha256:06dcfea71f131f9a5ae18e3c4d0bee97e38dc3d74ec160ae734262fa4761803c
+Deleted: sha256:0e7a47ed6a1a9cf00d9f4017d4b72b058aa397fd8775638dcae9febfe2eb93d0
+Deleted: sha256:858c642c01d8b57caca3e70c057cf87775a56fc116f06b42b88c2822c29a55d6
+Deleted: sha256:fe673ffb2fe5adb4e6840c6bcfbcc8d5e7118e2f6370fd44d6d419b648a0161b
+Deleted: sha256:15f8313756b2e05fda92d82c9fc13f9a58774e9698be550d74b3ad810a97f32d
+Deleted: sha256:82bfd7df21f802a825ee99ff0c28a54ab056ef3d8c6c8734979bc493ee193540
+Deleted: sha256:b7fc156e3dc184b5bcc25ab0ad33aaae45d57e337fddcbbeb8baec5c52aadeff
+Deleted: sha256:39f07a6131eb3a9b76a51e2b565b2d7d0a7ccd33c56673e6f0e6b19ae92b459e
+Deleted: sha256:ad4c89e10fb06b6ecef091f049a875a16e5f6e893586436ca538494c76997116
+Deleted: sha256:cc09d1e1414219f1b1109cc95c07f55ee39b2b1908347b44e84dc52804e048b8
+-- exit=0
+
+=== [2026-09-09T06:19:44Z] CLEANUP VERIFICATION: containers
+$ docker ps -a
+CONTAINER ID   IMAGE                                  COMMAND                  CREATED       STATUS                  PORTS                                     NAMES
+e73e5123a864   ghcr.io/mifunedev/openharness:latest   "/usr/local/bin/entr…"   5 days ago    Up 3 days (unhealthy)   127.0.0.1:2222->22/tcp                    oh-sbx-local
+1ce557882c6e   dpage/pgadmin4:latest                  "/entrypoint.sh"         4 weeks ago   Up 3 days               0.0.0.0:5050->80/tcp, [::]:5050->80/tcp   pgadmin
+-- exit=0
+
+=== [2026-09-09T06:19:44Z] CLEANUP VERIFICATION: volumes
+$ docker volume ls
+DRIVER    VOLUME NAME
+local     oh-sbx-local_workspace
+local     pgadmin-data
+-- exit=0
+
+=== [2026-09-09T06:19:44Z] CLEANUP VERIFICATION: images
+$ docker images
+IMAGE                                                                          ID             DISK USAGE   CONTENT SIZE   EXTRA
+busybox:latest                                                                 c6348fa86ba0       4.45MB             0B        
+dpage/pgadmin4:latest                                                          78bcd13ffb0a        529MB             0B   U    
+ghcr.io/mifunedev/agro:latest                                                  bbfdaf6bb8ca       1.24GB             0B        
+ghcr.io/mifunedev/openharness:0.9.0                                            bbfdaf6bb8ca       1.24GB             0B        
+ghcr.io/mifunedev/openharness:latest                                           093f5ec72ea4       1.25GB             0B   U    
+ghcr.io/nvidia/openshell/supervisor:5541398ccbda05fd951e08e5741b9ca090717f3a   30519c706eed       31.4MB             0B        
+hello-world:latest                                                             e2ac70e7319a       10.1kB             0B        
+node:22-slim                                                                   6e6261159fd3        227MB             0B        
+node:22-trixie-slim                                                            37d261af2f28        231MB             0B        
+ubuntu:24.04                                                                   a6f81fb630d5       78.2MB             0B        
+-- exit=0
+
+=== [2026-09-09T06:19:44Z] CLEANUP VERIFICATION: no stray ssh forwards from this run
+$ bash -c ps -eo pid,args | grep -c "[1]8080:127.0.0.1:8080"; echo "(0 == none left)"
+0
+(0 == none left)
+-- exit=0
+
+=== [2026-09-09T06:19:54Z] CLEANUP: remove the ubuntu:24.04 base this run pulled (was not present before)
+$ bash -c docker rmi ubuntu:24.04; docker images --format "{{.Repository}}:{{.Tag}}"
+Untagged: ubuntu:24.04
+Untagged: ubuntu@sha256:33ceb71981b602c1a7443a53469e4dba065f7503eab3078a2d7a57a2ab987517
+Deleted: sha256:a6f81fb630d51837271b89f8193810a5fc493fa4f30a55d7ebcdb3a66f3cc63a
+Deleted: sha256:b9a65b3c65ab22d490085bd0bf5490e2409da8748b406870f2463bdc41cd6795
+ghcr.io/mifunedev/agro:latest
+ghcr.io/mifunedev/openharness:0.9.0
+ghcr.io/mifunedev/openharness:latest
+node:22-trixie-slim
+node:22-slim
+ghcr.io/nvidia/openshell/supervisor:5541398ccbda05fd951e08e5741b9ca090717f3a
+dpage/pgadmin4:latest
+busybox:latest
+hello-world:latest
+-- exit=0
+
+=== [2026-09-09T06:19:54Z] CLEANUP VERIFICATION: docker system df after cleanup
+$ docker system df
+TYPE            TOTAL     ACTIVE    SIZE      RECLAIMABLE
+Images          23        2         7.323GB   3.163GB (43%)
+Containers      2         2         2.641GB   0B (0%)
+Local Volumes   2         2         9.831GB   0B (0%)
+Build Cache     0         0         0B        0B
+-- exit=0
+
+=== [2026-09-09T06:20:07Z] CLEANUP: dangling images, newest first (checking for leftovers from this run)
+$ docker images -f dangling=true --format {{.ID}} {{.CreatedAt}} {{.Size}}
+df5b78d94942 2026-09-08 23:49:57 -0600 MDT 1.24GB
+5af39bde2037 2026-09-08 23:09:52 -0600 MDT 1.24GB
+c15970d3066c 2026-09-08 21:34:22 -0600 MDT 1.24GB
+c00d4e7e39a4 2026-09-08 21:31:15 -0600 MDT 1.24GB
+bc060bcc9e0e 2026-09-08 21:27:51 -0600 MDT 1.24GB
+bc2acefe5937 2026-09-06 22:10:45 -0600 MDT 1.27GB
+dc7475a56cfe 2026-09-06 16:31:12 -0600 MDT 1.27GB
+dc5d8e098ca9 2026-09-06 16:30:21 -0600 MDT 1.27GB
+88b86ea9f839 2026-09-06 16:29:13 -0600 MDT 1.27GB
+a17eaa57ab94 2026-09-04 22:04:03 -0600 MDT 1.24GB
+eeae1344ea53 2026-09-04 00:09:09 -0600 MDT 1.24GB
+1528c25f8567 2026-09-03 23:11:13 -0600 MDT 1.24GB
+75b958487fe0 2026-09-03 23:10:49 -0600 MDT 1.24GB
+a269cff5b4e7 2026-09-03 23:10:31 -0600 MDT 1.24GB
+602c0e9de932 2026-09-03 21:52:08 -0600 MDT 1.24GB
+-- exit=0
+
+=== [2026-09-09T06:20:17Z] CLEANUP: remove the intermediate 'home' stage left by this run's build (05:49:57Z, inside this run's build window 05:49:04-05:50:17Z)
+$ bash -c docker rmi df5b78d94942 2>&1 | tail -3; echo "--- dangling now:"; docker images -f dangling=true --format "{{.ID}} {{.CreatedAt}}" | head -3; echo "--- system df:"; docker system df | head -3
+Deleted: sha256:fe1b7d6ad4f40897f36c0e27f79d4a3fbc6d37a8187945067b889b90563e388f
+Deleted: sha256:d2c231b12ec55733d80397fd6536dfc956c1322fa6fd19615c75700f07e80ae4
+Deleted: sha256:ae86d485f3eb751813d1fafe1b9b68c523ca810826511bd2e8e84d5099d97d82
+--- dangling now:
+5af39bde2037 2026-09-08 23:09:52 -0600 MDT
+c15970d3066c 2026-09-08 21:34:22 -0600 MDT
+c00d4e7e39a4 2026-09-08 21:31:15 -0600 MDT
+--- system df:
+TYPE            TOTAL     ACTIVE    SIZE      RECLAIMABLE
+Images          22        2         7.18GB    3.028GB (42%)
+Containers      2         2         2.641GB   0B (0%)
+-- exit=0
+
+=== [2026-09-09T06:28:47Z] ADDENDUM: identifying the exit-144 step
+$ kill -l TERM   -> 15   (so 128+SIGTERM = 143, not 144)
+$ kill -l 16     -> STKFLT
+control: 'kill -s TERM $$' at top level  -> harness reports: Exit code 144, trailing echo NOT reached
+repro:   self-matching 'pkill -f <marker>' -> harness reports: Exit code 144, trailing echo NOT reached
+conclusion: 144 == this harness's report for a tool shell terminated by SIGTERM.
+cause: my own 'pkill -f "ssh .*18099"' matched the command lines of its own shell
+       and of background task bcde3wn97 (both contained the literal 18099).
+       The task was still alive only because I had called 'wait' on a
+       non-terminating 'ssh -N' I had backgrounded inside the step.
+       Sub-checks 1 and 2 had already completed with exit=0 before the kill;
+       sub-check 3 (ohproxy cannot obtain a shell) never ran and is NOT VERIFIED.
+
+=== [2026-09-09T06:28:47Z] ADDENDUM: post-run cleanup re-verified
+oh-sbx-local Up 3 days (unhealthy)
+pgadmin Up 3 days
+DRIVER    VOLUME NAME
+local     oh-sbx-local_workspace
+local     pgadmin-data
+ghcr.io/mifunedev/agro:latest
+ghcr.io/mifunedev/openharness:0.9.0
+ghcr.io/mifunedev/openharness:latest
+node:22-trixie-slim
+node:22-slim
+ghcr.io/nvidia/openshell/supervisor:5541398ccbda05fd951e08e5741b9ca090717f3a
+dpage/pgadmin4:latest
+busybox:latest
+hello-world:latest
+TYPE            TOTAL     ACTIVE    SIZE      RECLAIMABLE
+Images          22        2         7.18GB    3.028GB (42%)
+Containers      2         2         2.641GB   0B (0%)
+Local Volumes   2         2         9.832GB   0B (0%)
+
+=== [2026-09-09T17:09:28Z] RESUMED INVOCATION — environment changed, Docker unreachable
+$ hostname
+395299dff1d9
+  (previous run executed in container e73e5123a864; this is a different container)
+$ echo $DOCKER_HOST
+DOCKER_HOST=[unset]
+$ command -v docker
+/usr/bin/docker
+$ docker info
+
+Server:
+failed to connect to the docker API at unix:///var/run/docker.sock; check if the path is correct and if the daemon is running: dial unix /var/run/docker.sock: connect: no such file or directory
+$ ls -la /var/run/docker.sock /run/docker.sock /run/user/1000/docker.sock
+ls: cannot access '/var/run/docker.sock': No such file or directory
+ls: cannot access '/run/docker.sock': No such file or directory
+ls: cannot access '/run/user/1000/docker.sock': No such file or directory
+$ find / -maxdepth 5 -name docker.sock
+(no results)
+$ getent group docker
+docker:x:1001:sandbox
+$ curl http://host.docker.internal:2375/_ping
+curl: (7) Failed to connect to host.docker.internal port 2375 after 1 ms: Could not connect to server
+$ ls /tmp/claude-1000/.../scratchpad/w13  (prior run's keys, generated assets, payload)
+ls: cannot access '/tmp/claude-1000/-home-sandbox-harness/8b200f3c-07b0-487b-9533-aae682bf912f/scratchpad/w13': No such file or directory

--- a/.agro/tasks/agro-cloud-consumer-migration/migrate-check.md
+++ b/.agro/tasks/agro-cloud-consumer-migration/migrate-check.md
@@ -1,0 +1,340 @@
+# US-008 · Supported migration path check (`agro migrate --check`)
+
+- **Issue:** [#944](https://github.com/mifunedev/agro/issues/944), user story US-008
+- **Date:** 2026-09-08 (UTC)
+- **Verdict:** the supported path **applies to both repositories**. `status: ready`,
+  exit code `0`, no conflicts, in both cases.
+
+This contradicts the PRD's working hypothesis. PRD finding F4 says: "Neither is a
+fully equipped control plane — no `cli`, `scripts`, `hooks`, or config — so
+`agro migrate --check` decides whether the supported path applies." The check was
+run, and the answer is that `agro migrate` **has no equipped-control-plane
+requirement**. It is a name migration, not a control-plane migration.
+
+## Which repositories carry `.oh/` — re-verified
+
+Re-derived from the US-001 scan rather than taken from the PRD. Two independent
+methods agree.
+
+Content scan, from `consumer-inventory.md`:
+
+```bash
+git -C <clone> ls-files | grep -E '(^|/)\.oh/'
+```
+
+Root-marker scan through the API, over all 32 repositories:
+
+```bash
+for n in $(jq -r '.[].name' repos.json); do
+  gh api "repos/mifunedev/$n/contents/" \
+    --jq '[.[].name] | map(select(. == ".oh" or . == ".agro" or . == "oh.json" or . == "agro.json")) | join(",")'
+done
+```
+
+| Repository | Scanned SHA | `.oh/` tracked files | Contents |
+|---|---|---|---|
+| `mifunedev/agro` | `823aabbd7324e08e3b685af6b0a5ef5c3467a15f` | 539 | full control plane, plus root `oh.json` |
+| `mifunedev/openharness-cloud` | `0aa8f999c3ef79ff8c116517b192206e5d69ba45` | 131 | `.oh/tasks` (129), `.oh/skills` (2) |
+| `mifunedev/agro-web` | `409ef104a3bf5a0b49f4cb68a1437e75938e8de0` | 6 | `.oh/tasks` only, one folder |
+
+All other 29 repositories carry no `.oh/`, `.agro/`, `oh.json`, or `agro.json` at
+the root and no tracked file under any `.oh/` path.
+
+**Correction:** the PRD says only two repositories carry a `.oh/` directory. There
+are three. `mifunedev/agro` carries its own — but that is **default-branch
+release lag**, not a compatibility surface awaiting Phase 5 retirement: the
+Phase 2 `.oh/` → `.agro/` cutover is already merged to `development` @
+`b10ecac3` and simply unreleased, while `main` @ `823aabb` is the v0.9.0 release
+point and predates it. It is out of scope for US-008 for that reason, not
+because anything there is pending migration. The literal count in F4 is
+nonetheless wrong. `agro-web` and `openharness-cloud` are the two in scope, as
+the PRD intends.
+
+## What `agro migrate` actually requires
+
+Read from `.agro/cli/src/commands/migrate.ts` and `.agro/cli/src/lib/migrate.ts`
+in the harness checkout, and from `docs/lifecycle-commands.md:135-171`.
+
+- The **only** precondition is a root marker.
+  `migrate.ts:88` — `export const ROOT_MARKERS = [".oh", ".agro", "oh.json", "agro.json"];`
+  `findProjectRoot()` walks up from the current directory to the nearest ancestor
+  holding one. There is no check for `cli/`, `scripts/`, `hooks/`, a manifest, or
+  a config file.
+- The migration is a **wholesale rename**: `.oh/` → `.agro/` and `oh.json` →
+  `agro.json`, plus re-pointing five provider symlinks (`.claude/skills`,
+  `.claude/hooks`, `.codex/skills`, `.agents/skills`, `.pi/skills`) from
+  `../.oh/…` to `../.agro/…`.
+- It **refuses** rather than merges: a byte-identical legacy copy is retired to
+  `<name>.migrated`; divergent legacy and AGRO copies are a conflict, exit `2`,
+  and nothing is moved. There is no force option.
+- It **never touches** `~/.openharness`, `.env`, or `.git`.
+- Exit codes: `0` applied or nothing to do, `2` refused (conflict or lock held on
+  `.agro-migrate.lock`), `1` failure.
+
+## How the command was invoked
+
+`agro` is **not** on `PATH` in this sandbox. The installed executable is
+`/usr/local/bin/oh` → `/opt/oh/dist/oh.js`, version **0.7.0**, and it does not
+carry the verb:
+
+```
+$ oh --version
+0.7.0
+$ oh migrate --help
+oh: unknown command "migrate"
+```
+
+`docs/lifecycle-commands.md:142` says "`oh migrate` dispatches to the same
+command", which is true of a current build but not of the 0.7.0 binary baked into
+this image. So the CLI was built from source the way the repository builds it —
+`.agro/cli/package.json` `scripts.build` is `node build.mjs`:
+
+```bash
+cp -a /home/sandbox/harness/.agro/cli <scratch>/cli
+ln -s /opt/oh/node_modules <scratch>/cli/node_modules      # esbuild, from the image
+cd <scratch>/cli && OH_ASSET_ROOT=/home/sandbox/harness node build.mjs
+# -> dist/agro.js  203.8kb   (and a byte-identical dist/oh.js)
+
+$ node <scratch>/cli/dist/agro.js --version
+0.9.0
+```
+
+`OH_ASSET_ROOT` is `build.mjs`'s documented asset-root override
+(`build.mjs:10`), pointed at the harness checkout so the bundled assets resolve.
+Nothing was written inside `/home/sandbox/harness/.agro/cli`.
+
+Each repository was scanned into a **disposable scratchpad copy**. The real
+operator clone at `/home/sandbox/harness/projects/mifunedev/openharness-cloud`
+was never a target; it was read once with `git rev-parse origin/development` and
+otherwise untouched. `--check` was passed on every invocation. `--home` was never
+passed, so the sandbox registry was never a target either.
+
+---
+
+## `mifunedev/agro-web` @ `409ef104a3bf5a0b49f4cb68a1437e75938e8de0`
+
+### Preconditions observed
+
+```
+root markers:  .oh   (present)
+               .agro, oh.json, agro.json  -> absent
+provider link dirs: .claude, .codex, .agents, .pi  -> all absent
+.oh/ contents: .oh/tasks/sandbox-registry-one-door/{evidence.md,plan.md,prd.json,prd.md,progress.txt,simplify-rounds.json}
+```
+
+### Command
+
+```bash
+cd <scratch>/migrate-check/agro-web
+node <scratch>/cli/dist/agro.js migrate --check
+```
+
+### Full output
+
+```
+agro migrate: plan for <scratch>/migrate-check/agro-web
+  rename  <scratch>/migrate-check/agro-web/.oh -> <scratch>/migrate-check/agro-web/.agro
+  noop    <scratch>/migrate-check/agro-web/agro.json (absent in both generations)
+  noop    <scratch>/migrate-check/agro-web/.claude/skills (link absent)
+  noop    <scratch>/migrate-check/agro-web/.claude/hooks (link absent)
+  noop    <scratch>/migrate-check/agro-web/.codex/skills (link absent)
+  noop    <scratch>/migrate-check/agro-web/.agents/skills (link absent)
+  noop    <scratch>/migrate-check/agro-web/.pi/skills (link absent)
+status: ready
+```
+
+### Exit code
+
+`0`
+
+### Machine-readable plan (`--check --json`)
+
+```json
+{
+  "version": 1,
+  "root": "<scratch>/migrate-check/agro-web",
+  "status": "ready",
+  "steps": [
+    {
+      "kind": "rename",
+      "from": "<scratch>/migrate-check/agro-web/.oh",
+      "to": "<scratch>/migrate-check/agro-web/.agro",
+      "snapshot": { "type": "directory", "mode": 493, "ino": 1230964, "mtimeMs": 1788929121704.1448, "size": 4096 },
+      "createsParent": false
+    },
+    { "kind": "noop", "path": "<scratch>/migrate-check/agro-web/agro.json", "reason": "absent in both generations" },
+    { "kind": "noop", "path": "<scratch>/migrate-check/agro-web/.claude/skills", "reason": "link absent" },
+    { "kind": "noop", "path": "<scratch>/migrate-check/agro-web/.claude/hooks", "reason": "link absent" },
+    { "kind": "noop", "path": "<scratch>/migrate-check/agro-web/.codex/skills", "reason": "link absent" },
+    { "kind": "noop", "path": "<scratch>/migrate-check/agro-web/.agents/skills", "reason": "link absent" },
+    { "kind": "noop", "path": "<scratch>/migrate-check/agro-web/.pi/skills", "reason": "link absent" }
+  ],
+  "conflicts": []
+}
+```
+
+### Verdict
+
+**The supported path applies.** One `rename` step, no `rewrite` step, no
+conflict, exit `0`. `agro migrate` is the correct mechanism; an ad hoc directory
+rename is neither needed nor permitted.
+
+Historical content is preserved: the plan contains **no `rewrite` step**, so no
+file is opened or edited. The single operation is a directory `renameSync`, which
+moves the inode and leaves every byte, permission bit, and symlink target intact.
+
+No follow-up edit is required. `.oh/tasks/sandbox-registry-one-door/` has no live
+reference anywhere outside `.oh/`:
+
+```bash
+git grep -nIE 'sandbox-registry-one-door' -- . ':!.oh/'   # empty
+```
+
+The other `.oh/` strings in `agro-web` (`scripts/build-oh-cli.mjs:24`
+`CLI_DIRS = [".agro/cli", ".oh/cli"]`, `scripts/sync-external-scripts.mjs:32`
+`PRE_RENAME_SCRIPTS_DIR = ".oh/"`, and the `docs/`/`blog/` prose) all describe the
+**runtime repository's** control plane, not `agro-web`'s own directory. They are
+deliberate compatibility fallbacks and must not be touched by this migration.
+
+---
+
+## `mifunedev/openharness-cloud` @ `0aa8f999c3ef79ff8c116517b192206e5d69ba45`
+
+### Preconditions observed
+
+```
+root markers:  .oh   (present)
+               .agro, oh.json, agro.json  -> absent
+provider link dirs: .claude, .codex, .agents, .pi  -> all absent
+.oh/ contents: .oh/tasks (129 tracked files), .oh/skills (2 tracked files:
+               .oh/skills/dev-tmux/SKILL.md, .oh/skills/dev-tmux/scripts/dev-tmux.sh)
+tracked symlinks in the repository: none
+```
+
+### Command
+
+```bash
+cd <scratch>/migrate-check/openharness-cloud
+node <scratch>/cli/dist/agro.js migrate --check
+```
+
+### Full output
+
+```
+agro migrate: plan for <scratch>/migrate-check/openharness-cloud
+  rename  <scratch>/migrate-check/openharness-cloud/.oh -> <scratch>/migrate-check/openharness-cloud/.agro
+  noop    <scratch>/migrate-check/openharness-cloud/agro.json (absent in both generations)
+  noop    <scratch>/migrate-check/openharness-cloud/.claude/skills (link absent)
+  noop    <scratch>/migrate-check/openharness-cloud/.claude/hooks (link absent)
+  noop    <scratch>/migrate-check/openharness-cloud/.codex/skills (link absent)
+  noop    <scratch>/migrate-check/openharness-cloud/.agents/skills (link absent)
+  noop    <scratch>/migrate-check/openharness-cloud/.pi/skills (link absent)
+status: ready
+```
+
+### Exit code
+
+`0`
+
+### Machine-readable plan (`--check --json`)
+
+```json
+{
+  "version": 1,
+  "root": "<scratch>/migrate-check/openharness-cloud",
+  "status": "ready",
+  "steps": [
+    {
+      "kind": "rename",
+      "from": "<scratch>/migrate-check/openharness-cloud/.oh",
+      "to": "<scratch>/migrate-check/openharness-cloud/.agro",
+      "snapshot": { "type": "directory", "mode": 493, "ino": 1231221, "mtimeMs": 1788929255891.1987, "size": 4096 },
+      "createsParent": false
+    },
+    { "kind": "noop", "path": "<scratch>/migrate-check/openharness-cloud/agro.json", "reason": "absent in both generations" },
+    { "kind": "noop", "path": "<scratch>/migrate-check/openharness-cloud/.claude/skills", "reason": "link absent" },
+    { "kind": "noop", "path": "<scratch>/migrate-check/openharness-cloud/.claude/hooks", "reason": "link absent" },
+    { "kind": "noop", "path": "<scratch>/migrate-check/openharness-cloud/.codex/skills", "reason": "link absent" },
+    { "kind": "noop", "path": "<scratch>/migrate-check/openharness-cloud/.agents/skills", "reason": "link absent" },
+    { "kind": "noop", "path": "<scratch>/migrate-check/openharness-cloud/.pi/skills", "reason": "link absent" }
+  ],
+  "conflicts": []
+}
+```
+
+### Verdict
+
+**The supported path applies.** Identical shape to `agro-web`: one `rename`, no
+`rewrite`, no conflict, exit `0`. Historical `.oh/tasks` content is preserved
+unmodified for the same reason — the plan opens no file.
+
+**One follow-up edit is required in the same change.** `agro migrate` renames the
+directory; it does not rewrite prose. Cloud has **live operator references** to
+paths inside its own `.oh/`, which the rename would break:
+
+```
+docs/browser-gateway-runbook.md:200   bash .oh/skills/dev-tmux/scripts/dev-tmux.sh start \
+docs/browser-gateway-runbook.md:216   bash .oh/skills/dev-tmux/scripts/dev-tmux.sh verify \
+docs/browser-gateway-runbook.md:234   bash .oh/skills/dev-tmux/scripts/dev-tmux.sh status
+docs/browser-gateway-runbook.md:235   bash .oh/skills/dev-tmux/scripts/dev-tmux.sh attach
+docs/browser-gateway-runbook.md:236   bash .oh/skills/dev-tmux/scripts/dev-tmux.sh repair
+docs/browser-gateway-runbook.md:237   bash .oh/skills/dev-tmux/scripts/dev-tmux.sh repair --dry-run
+docs/browser-gateway-runbook.md:238   bash .oh/skills/dev-tmux/scripts/dev-tmux.sh stop
+docs/browser-gateway-runbook.md:276   `bash .oh/skills/dev-tmux/scripts/dev-tmux.sh restart-web`
+```
+
+These eight lines are the only breaking references. Every other `.oh/` mention in
+Cloud outside `.oh/` itself is a **citation of a historical task record** in a
+comment or a doc, which stays accurate either way but reads better if updated:
+
+```
+README.md:874                                  .oh/tasks/ovh-docker-replatform/prd.md
+apps/provisioner/src/billing.ts:63             .oh/tasks/billing-meter-name-mismatch/prd.md
+apps/web/lib/email/boundary.test.ts:25         .oh/tasks/transactional-email-boundary/prd.md
+apps/web/lib/email/resend-transport.ts:36      .oh/tasks/transactional-email-boundary/prd.md
+apps/web/lib/simplify-user-org-invariants.test.ts:258,281
+apps/web/lib/user-roles.test.ts:39             .oh/tasks/org-invite-email/
+apps/web/lib/users-client.test.ts:44
+docs/design/console-mvp.md:22,414              .oh/tasks/neon-inspired-console/…
+docs/email-runbook.md:34,523                   .oh/tasks/transactional-email-boundary/prd.md
+```
+
+---
+
+## Summary
+
+| Repository | `agro migrate --check` status | Exit | Supported path applies? | Disposition |
+|---|---|---|---|---|
+| `mifunedev/agro-web` | `ready` | `0` | **yes** | Run `agro migrate` (no flags). No follow-up edit needed. |
+| `mifunedev/openharness-cloud` | `ready` | `0` | **yes** | Run `agro migrate` (no flags), and in the same commit repoint the 8 live `docs/browser-gateway-runbook.md` command paths from `.oh/skills/dev-tmux/…` to `.agro/skills/dev-tmux/…`. |
+| `mifunedev/agro` | not run — out of US-008 scope | — | n/a | Its `.oh/` is **not** a compatibility surface awaiting retirement. The Phase 2 `.oh/` → `.agro/` cutover is already merged to `development` @ `b10ecac3` and simply unreleased, so `main` @ `823aabb` shows default-branch release lag. Nothing to migrate here, by this or any later phase. |
+
+No ad hoc directory rename is proposed or performed anywhere. Historical
+`.oh/tasks` content is preserved unmodified in both repositories, because the
+supported path performs a directory rename and rewrites no file.
+
+## Limitations
+
+1. **`--check` only. Nothing was applied.** `agro migrate` without `--check` was
+   never run, in the scratchpad or anywhere else. The "content is preserved"
+   claim is read from the plan (`rename` only, zero `rewrite` steps) and from
+   `applyMigration`'s use of `renameSync`, not observed after an apply.
+2. **The check ran on a scratchpad copy, not on a worktree of the target
+   repository.** The copy is byte-identical to the shallow clone at the recorded
+   SHA, and the scratchpad has no ancestor root marker, so `findProjectRoot()`
+   resolved to the copy root in both cases — visible in the `plan for …` line. A
+   real worktree nested under another marked checkout could resolve to a different
+   root; the implementer must confirm the `plan for` line names the repository
+   root before applying.
+3. **`agro` is not installed in this sandbox.** The verdict was produced by a CLI
+   built from `/home/sandbox/harness/.agro/cli` at version `0.9.0`. The image's
+   `oh` is `0.7.0` and has no `migrate` verb, so an operator on this image cannot
+   reproduce this check without upgrading the CLI first. That is a real
+   reproducibility constraint, not a scan artifact.
+4. **Git rename detection was not exercised.** `agro migrate` is a filesystem
+   rename and is not git-aware. History across the rename depends on git's own
+   rename detection at commit time, which was not verified here.
+5. **The eight `browser-gateway-runbook.md` command paths were found by static
+   grep**, not by running the runbook. Whether any other operator procedure
+   outside the repository depends on the literal path `.oh/skills/dev-tmux/` is
+   unknown and cannot be determined from the repository alone.

--- a/.agro/tasks/agro-cloud-consumer-migration/migration-evidence.md
+++ b/.agro/tasks/agro-cloud-consumer-migration/migration-evidence.md
@@ -1,0 +1,374 @@
+# US-008 · Applied migration evidence (`agro migrate`, no `--check`)
+
+- **Issue:** [#944](https://github.com/mifunedev/agro/issues/944), user story US-008
+- **Date:** 2026-09-08 (UTC)
+- **Verdict:** the supported migration **runs and preserves content exactly** in
+  both consumer repositories. Exit code `0` and `status: applied` in both cases.
+  Every file under `.oh/` appears under `.agro/` with an identical sha256, mode,
+  and byte size. Nothing lost, nothing gained, nothing rewritten.
+
+This file supersedes limitation 1 of `migrate-check.md`. That document recorded a
+**plan** (`agro migrate --check`) and read its content-preservation claim out of
+the plan shape. This document records an **applied** migration with observed
+before/after manifests.
+
+## Scope and safety
+
+Both migrations ran in **disposable scratch clones only**. The live working
+clones at `/home/sandbox/harness/projects/mifunedev/openharness-cloud` and
+`/home/sandbox/harness/projects/mifunedev/openharness-web` were never a target
+and still carry `.oh/`. No branch, commit, push, or PR was made. `--home` was
+never passed, so the sandbox registry was never a target. No file under
+`.oh/tasks/**` was edited by hand. No ad hoc directory rename was performed.
+
+The real repositories are **not** migrated by this work. That is a later,
+separately authorized step.
+
+Scratch base, written `<SCRATCH>` below:
+`/tmp/claude-1000/-home-sandbox-harness/8b200f3c-07b0-487b-9533-aae682bf912f/scratchpad/w10`
+
+## How `agro migrate` was invoked
+
+`agro` is **not** on `PATH` in this sandbox. The installed `/usr/local/bin/oh` is
+version `0.7.0` and carries no `migrate` verb. The CLI was therefore built from
+source the way the repository builds it (`.agro/cli/package.json` `scripts.build`
+is `node build.mjs`):
+
+```bash
+cp -a /home/sandbox/harness/.agro/cli <SCRATCH>/cli
+ln -sfn /opt/oh/node_modules <SCRATCH>/cli/node_modules
+cd <SCRATCH>/cli && OH_ASSET_ROOT=/home/sandbox/harness node build.mjs
+#   dist/agro.js  203.8kb
+
+$ node <SCRATCH>/cli/dist/agro.js --version
+0.9.0
+```
+
+Nothing was written inside `/home/sandbox/harness/.agro/cli`.
+
+The migration invocation, per repository, was:
+
+```bash
+cd <SCRATCH>/apply/<repo>
+node <SCRATCH>/cli/dist/agro.js migrate      # no --check, no --home, no --json
+```
+
+No ancestor of `<SCRATCH>` holds `.oh`, `.agro`, `oh.json`, or `agro.json`, so
+`findProjectRoot()` resolved to the clone root. The `plan for …` line in each
+output confirms the root it chose.
+
+Environment: git 2.47.3, Node v22.23.2, `status.renames` unset (git default).
+
+## Clone commits
+
+| Repository | Clone command | Default branch | Commit |
+|---|---|---|---|
+| `mifunedev/openharness-cloud` | `git clone https://github.com/mifunedev/openharness-cloud.git` | `development` | `0aa8f999c3ef79ff8c116517b192206e5d69ba45` |
+| `mifunedev/agro-web` | `git clone https://github.com/mifunedev/agro-web.git` | `main` | `409ef104a3bf5a0b49f4cb68a1437e75938e8de0` |
+
+Both clones were full clones with a clean working tree (`git status --short`
+empty) before the migration. In both, `.oh` was the only root marker present;
+`.agro`, `oh.json`, `agro.json`, `.claude`, `.codex`, `.agents`, and `.pi` were
+all absent. Neither repository ignores `.agro` — `git check-ignore .agro` finds
+no rule in either.
+
+---
+
+## `mifunedev/agro-web` @ `409ef104`
+
+### Command and exit code
+
+```bash
+cd <SCRATCH>/apply/agro-web
+node <SCRATCH>/cli/dist/agro.js migrate
+```
+
+Exit code **`0`**. Stderr empty.
+
+### Full stdout
+
+```
+agro migrate: plan for <SCRATCH>/apply/agro-web
+  rename  <SCRATCH>/apply/agro-web/.oh -> <SCRATCH>/apply/agro-web/.agro
+  noop    <SCRATCH>/apply/agro-web/agro.json (absent in both generations)
+  noop    <SCRATCH>/apply/agro-web/.claude/skills (link absent)
+  noop    <SCRATCH>/apply/agro-web/.claude/hooks (link absent)
+  noop    <SCRATCH>/apply/agro-web/.codex/skills (link absent)
+  noop    <SCRATCH>/apply/agro-web/.agents/skills (link absent)
+  noop    <SCRATCH>/apply/agro-web/.pi/skills (link absent)
+status: ready
+agro migrate: applied
+  done    rename  <SCRATCH>/apply/agro-web/.oh -> <SCRATCH>/apply/agro-web/.agro
+  skipped noop    <SCRATCH>/apply/agro-web/agro.json (absent in both generations)
+  skipped noop    <SCRATCH>/apply/agro-web/.claude/skills (link absent)
+  skipped noop    <SCRATCH>/apply/agro-web/.claude/hooks (link absent)
+  skipped noop    <SCRATCH>/apply/agro-web/.codex/skills (link absent)
+  skipped noop    <SCRATCH>/apply/agro-web/.agents/skills (link absent)
+  skipped noop    <SCRATCH>/apply/agro-web/.pi/skills (link absent)
+```
+
+### Before/after manifest comparison
+
+Manifest method: `find .oh` (before) and `find .agro` (after), every entry,
+recording relative path, octal mode, entry type, sha256 (files) or symlink target,
+and byte size. The two manifests were normalized by replacing the leading `.oh`
+or `.agro` segment with `<ROOT>` and then compared with `diff`.
+
+| Measure | Value |
+|---|---|
+| Entries before / after | 9 / 9 |
+| Regular files before / after | 6 / 6 |
+| Directories before / after | 3 / 3 |
+| Symlinks before / after | 0 / 0 |
+| Files compared | 6 |
+| sha256 identical | 6 / 6 |
+| Mode identical | 6 / 6 |
+| Byte size identical | 6 / 6 |
+| Files lost | 0 |
+| Files gained | 0 |
+| Total bytes before / after | 68 028 / 68 028 |
+| Normalized manifest `diff` | **empty** |
+
+Directory modes are also identical (`755` for all three, including the renamed
+root itself). File modes are `644` for all six.
+
+Example rows:
+
+```
+.oh/tasks/sandbox-registry-one-door/evidence.md    644  file  aaf9ab85…690401f  13598
+.agro/tasks/sandbox-registry-one-door/evidence.md  644  file  aaf9ab85…690401f  13598
+```
+
+### `.oh/tasks/**` byte-identity
+
+**All 6 files in this repository are under `.oh/tasks/`, and all 6 are
+byte-identical after the migration.** The sha256 digest over the sorted
+`path → sha256` list of the `tasks/` subtree is unchanged:
+
+```
+before: c3e47636fdaf0f1300bfededd4ca466faabbec4196010f12a24d97a63fe891f7
+after:  c3e47636fdaf0f1300bfededd4ca466faabbec4196010f12a24d97a63fe891f7
+```
+
+### `git status --short`
+
+Unstaged, immediately after the migration — **rename detection does not fire**:
+
+```
+ D .oh/tasks/sandbox-registry-one-door/evidence.md
+ D .oh/tasks/sandbox-registry-one-door/plan.md
+ D .oh/tasks/sandbox-registry-one-door/prd.json
+ D .oh/tasks/sandbox-registry-one-door/prd.md
+ D .oh/tasks/sandbox-registry-one-door/progress.txt
+ D .oh/tasks/sandbox-registry-one-door/simplify-rounds.json
+?? .agro/
+```
+
+After `git add -A` — **rename detection fires, all six, at 100 % similarity**:
+
+```
+R  .oh/tasks/sandbox-registry-one-door/evidence.md -> .agro/tasks/sandbox-registry-one-door/evidence.md
+R  .oh/tasks/sandbox-registry-one-door/plan.md -> .agro/tasks/sandbox-registry-one-door/plan.md
+R  .oh/tasks/sandbox-registry-one-door/prd.json -> .agro/tasks/sandbox-registry-one-door/prd.json
+R  .oh/tasks/sandbox-registry-one-door/prd.md -> .agro/tasks/sandbox-registry-one-door/prd.md
+R  .oh/tasks/sandbox-registry-one-door/progress.txt -> .agro/tasks/sandbox-registry-one-door/progress.txt
+R  .oh/tasks/sandbox-registry-one-door/simplify-rounds.json -> .agro/tasks/sandbox-registry-one-door/simplify-rounds.json
+```
+
+`git diff --cached -M --name-status`: **6 `R100`**, 0 other `R`, 0 `D`, 0 `A`,
+0 `M`. `git diff --cached -M --stat` ends with
+`6 files changed, 0 insertions(+), 0 deletions(-)`.
+
+---
+
+## `mifunedev/openharness-cloud` @ `0aa8f999`
+
+### Command and exit code
+
+```bash
+cd <SCRATCH>/apply/openharness-cloud
+node <SCRATCH>/cli/dist/agro.js migrate
+```
+
+Exit code **`0`**. Stderr empty.
+
+### Full stdout
+
+```
+agro migrate: plan for <SCRATCH>/apply/openharness-cloud
+  rename  <SCRATCH>/apply/openharness-cloud/.oh -> <SCRATCH>/apply/openharness-cloud/.agro
+  noop    <SCRATCH>/apply/openharness-cloud/agro.json (absent in both generations)
+  noop    <SCRATCH>/apply/openharness-cloud/.claude/skills (link absent)
+  noop    <SCRATCH>/apply/openharness-cloud/.claude/hooks (link absent)
+  noop    <SCRATCH>/apply/openharness-cloud/.codex/skills (link absent)
+  noop    <SCRATCH>/apply/openharness-cloud/.agents/skills (link absent)
+  noop    <SCRATCH>/apply/openharness-cloud/.pi/skills (link absent)
+status: ready
+agro migrate: applied
+  done    rename  <SCRATCH>/apply/openharness-cloud/.oh -> <SCRATCH>/apply/openharness-cloud/.agro
+  skipped noop    <SCRATCH>/apply/openharness-cloud/agro.json (absent in both generations)
+  skipped noop    <SCRATCH>/apply/openharness-cloud/.claude/skills (link absent)
+  skipped noop    <SCRATCH>/apply/openharness-cloud/.claude/hooks (link absent)
+  skipped noop    <SCRATCH>/apply/openharness-cloud/.codex/skills (link absent)
+  skipped noop    <SCRATCH>/apply/openharness-cloud/.agents/skills (link absent)
+  skipped noop    <SCRATCH>/apply/openharness-cloud/.pi/skills (link absent)
+```
+
+### Before/after manifest comparison
+
+| Measure | Value |
+|---|---|
+| Entries before / after | 171 / 171 |
+| Regular files before / after | 131 / 131 |
+| Directories before / after | 40 / 40 |
+| Symlinks before / after | 0 / 0 |
+| Files compared | 131 |
+| sha256 identical | 131 / 131 |
+| Mode identical | 131 / 131 |
+| Byte size identical | 131 / 131 |
+| Files lost | 0 |
+| Files gained | 0 |
+| Total bytes before / after | 3 063 421 / 3 063 421 |
+| Normalized manifest `diff` | **empty** |
+
+Mode histogram is preserved exactly: 130 files at `644` and 1 file at `755`
+(`skills/dev-tmux/scripts/dev-tmux.sh`) both before and after. All 40 directories
+are `755` both before and after. The executable bit survives:
+
+```
+.oh/skills/dev-tmux/scripts/dev-tmux.sh    755  file  9188a8d5…48d575b9  41006
+.agro/skills/dev-tmux/scripts/dev-tmux.sh  755  file  9188a8d5…48d575b9  41006
+```
+
+### `.oh/tasks/**` byte-identity
+
+**All 129 files under `.oh/tasks/` are byte-identical after the migration.** The
+remaining 2 files are the `.oh/skills/dev-tmux/` pair, also byte-identical. The
+sha256 digest over the sorted `path → sha256` list of the `tasks/` subtree is
+unchanged:
+
+```
+before: b60a0ab010cbda796b45adcbeffb7f5c3a5e5ae1a9894c22b691e23ce7871852
+after:  b60a0ab010cbda796b45adcbeffb7f5c3a5e5ae1a9894c22b691e23ce7871852
+```
+
+### `git status --short`
+
+Unstaged, immediately after the migration — **132 lines, no rename detected**:
+131 ` D` lines for the `.oh/` paths plus one `?? .agro/` line. First lines:
+
+```
+ D .oh/skills/dev-tmux/SKILL.md
+ D .oh/skills/dev-tmux/scripts/dev-tmux.sh
+ D .oh/tasks/billing-account-managers/audit.md
+ …
+?? .agro/
+```
+
+After `git add -A` — **131 lines, every one an `R`**, 0 `D`, 0 `A`. First lines:
+
+```
+R  .oh/skills/dev-tmux/SKILL.md -> .agro/skills/dev-tmux/SKILL.md
+R  .oh/skills/dev-tmux/scripts/dev-tmux.sh -> .agro/skills/dev-tmux/scripts/dev-tmux.sh
+R  .oh/tasks/billing-account-managers/audit.md -> .agro/tasks/billing-account-managers/audit.md
+…
+```
+
+`git diff --cached -M --name-status`: **131 `R100`**, 0 other `R`, 0 `D`, 0 `A`,
+0 `M`. `git diff --cached -M --stat` ends with
+`131 files changed, 0 insertions(+), 0 deletions(-)`.
+
+---
+
+## Cross-cutting checks
+
+### Control files outside `.oh/` are untouched
+
+`README.md`, `package.json`, and `.gitignore` in each repository were hashed
+before and after. All six hashes, modes, and sizes are unchanged.
+
+A stronger whole-repository control also holds: in both repositories,
+`git diff --cached -M --name-status -- . ':!.oh' ':!.agro'` returns **0 lines**,
+and the tracked file count is unchanged (`openharness-cloud` 764 at HEAD and 764
+in the index; `agro-web` 96 and 96). The migration changed nothing outside the
+renamed directory.
+
+### Git blob identity
+
+Beyond filesystem hashes, the git object identity is preserved. Comparing
+`git ls-tree -r HEAD` for `.oh/…` against `git ls-files -s` for `.agro/…`, with
+the leading segment normalized away, the blob OIDs **and** git file modes match
+for every path: 131/131 in `openharness-cloud`, 6/6 in `agro-web`. This is the
+same fact the `R100` rename detection reports, observed independently.
+
+### Mechanism: inode preservation
+
+A third scratch clone of `agro-web` recorded inodes across the migration:
+
+```
+BEFORE  1478696 .oh          1478702 .oh/tasks/sandbox-registry-one-door/prd.md
+AFTER   1478696 .agro        1478702 .agro/tasks/sandbox-registry-one-door/prd.md
+```
+
+The inodes are unchanged, confirming `applyMigration` performs a single
+directory `renameSync` and never copies, opens, or rewrites a file. This is the
+mechanical reason the hashes hold.
+
+### Idempotency
+
+A second `agro migrate` in each migrated clone printed `status: noop` and
+`agro migrate: noop`, exit code **`0`**.
+
+### Lock file
+
+`.agro-migrate.lock` is absent from both clones after the run. The lock is
+acquired and released within `applyMigration` and leaves no residue on success.
+
+## Findings and discrepancies
+
+1. **`git status --short` alone does not show the migration as a rename.**
+   Immediately after `agro migrate`, an operator sees 131 (or 6) ` D` lines plus a
+   single `?? .agro/` line. Git detects the rename only after the change is
+   staged, because rename detection compares the index against HEAD, and an
+   untracked directory is not in the index. Once staged, detection is complete
+   and exact: every path is `R100`. Nothing is lost either way — this is a
+   display property, not a content property — but the raw post-migration
+   `git status` reads alarmingly like a mass deletion. The migrating commit must
+   be made with `git add -A` and reviewed from `git diff --cached -M`.
+
+2. **Git stores no rename.** `R100` is a similarity heuristic computed at read
+   time, not recorded in the commit. History across the rename therefore depends
+   on the reader passing `--follow` or on default rename detection staying within
+   `diff.renameLimit` (default 1000; 131 and 6 are well inside it). This is
+   inherent to git, not a defect of `agro migrate`.
+
+3. **`agro migrate` is not reproducible from this sandbox image as shipped.**
+   `agro` is not on `PATH`; `/usr/local/bin/oh` is `0.7.0` and has no `migrate`
+   verb. The evidence above was produced by a `0.9.0` CLI built from
+   `/home/sandbox/harness/.agro/cli`. An operator on this image must upgrade the
+   CLI before running the real migration. This is a real operational
+   constraint, unchanged from `migrate-check.md` limitation 3.
+
+4. **`agro migrate` rewrites no prose, so the follow-up edits in
+   `migrate-check.md` remain required.** The applied runs confirm the plan shape:
+   one `rename` step, zero `rewrite` steps. In `openharness-cloud` this leaves the
+   eight `docs/browser-gateway-runbook.md` command paths pointing at
+   `.oh/skills/dev-tmux/…`, which the rename breaks. Those eight lines must be
+   repointed in the same commit as the migration. `agro-web` needs no follow-up
+   edit.
+
+5. **No discrepancy was found in content preservation.** Every property the story
+   asked for holds in both repositories: identical sha256, identical mode,
+   identical size, no file lost, no file gained, `.oh/tasks/**` byte-identical,
+   controls untouched.
+
+## Summary
+
+| Repository | Commit | Exit | Result | Files | sha256 identical | Modes identical | Lost | Gained | `tasks/**` byte-identical | Staged rename |
+|---|---|---|---|---|---|---|---|---|---|---|
+| `mifunedev/agro-web` | `409ef104` | `0` | `applied` | 6 | 6/6 | 6/6 | 0 | 0 | yes (6/6) | 6 × `R100` |
+| `mifunedev/openharness-cloud` | `0aa8f999` | `0` | `applied` | 131 | 131/131 | 131/131 | 0 | 0 | yes (129/129) | 131 × `R100` |
+
+The supported path applies to both repositories, runs to completion, and
+preserves content exactly. The real repositories remain unmigrated; that step is
+separately authorized.

--- a/.agro/tasks/agro-cloud-consumer-migration/prd.json
+++ b/.agro/tasks/agro-cloud-consumer-migration/prd.json
@@ -470,7 +470,8 @@
     {
       "id": "agro-web#50",
       "filed": true,
-      "summary": "The docs build's Build site step passes no token, so the GitHub API call is unauthenticated (60/hr per shared runner IP), and isTransientStatus() omits 403 — GitHub's primary rate-limit code. Exhaustion is therefore misreported as 'ref does not resolve' and hard-fails the deploy. Proved by an unchanged re-run succeeding."
+      "summary": "The docs build's Build site step passes no token, so the GitHub API call is unauthenticated (60/hr per shared runner IP), and isTransientStatus() omits 403 — GitHub's primary rate-limit code. Exhaustion is therefore misreported as 'ref does not resolve' and hard-fails the deploy. Proved by an unchanged re-run succeeding.",
+      "state": "FIXED by PR #51"
     }
   ],
   "advisorCorrections": [
@@ -641,6 +642,14 @@
       "head": "5e5f34cc45ed8ab174f1354b3cd2e97f62b1c3a9",
       "state": "DRAFT",
       "note": "Opened with [skip netlify] in the TITLE, the documented Netlify directive for PR Deploy Previews. Verified 0 statuses and 0 check-runs on the head. The directive must stay in the title until the credit issue is resolved."
+    },
+    {
+      "repo": "mifunedev/agro-web",
+      "issue": 50,
+      "pr": 51,
+      "head": "55d4cfc5adec6fb77c1dfa0026aca6c1f55239f7",
+      "state": "READY",
+      "note": "Closes #50. Token + 403-only-with-x-ratelimit-remaining:0. 9 tests, gating CI step. Verified at exact head on the first run; CI log confirms the step executed and the token is in effect."
     }
   ],
   "ciAtExactHead": {
@@ -650,6 +659,7 @@
     "agro#1022": "5/5 success",
     "agro#1023": "5/5 success",
     "agro#1024": "5/5 success",
-    "website#66": "0 by design, [skip netlify]"
+    "website#66": "0 by design, [skip netlify]",
+    "agro-web#51": "Build docs site success on first run; Deploy to GitHub Pages skipped; test step executed 9/9; GITHUB_TOKEN present"
   }
 }

--- a/.agro/tasks/agro-cloud-consumer-migration/prd.json
+++ b/.agro/tasks/agro-cloud-consumer-migration/prd.json
@@ -1,0 +1,640 @@
+{
+  "schemaVersion": 1,
+  "slug": "agro-cloud-consumer-migration",
+  "issue": 944,
+  "parentIssue": 939,
+  "branchName": "feat/944-agro-cloud-consumer-migration",
+  "repos": {
+    "record": "mifunedev/agro",
+    "implementation": "mifunedev/openharness-cloud"
+  },
+  "groundedAt": {
+    "mifunedev/agro": "b10ecac3",
+    "mifunedev/openharness-cloud": "0aa8f99"
+  },
+  "userStories": [
+    {
+      "id": "US-001",
+      "title": "Organization-wide downstream dependency inventory",
+      "repo": "mifunedev/agro",
+      "passes": true,
+      "acceptanceCriteria": [
+        "Every non-archived mifunedev repository is scanned by a recorded, reproducible command against a recorded commit SHA",
+        "The scan does not rely on gh search code alone, which omits private repositories",
+        "Every occurrence of mifunedev/openharness, @mifune/openharness, ghcr.io/mifunedev/openharness, oh.mifune.dev, /get-oh.sh, /oh.js, openharness-release, executable oh, .oh/, oh.json, and OH_* is classified into exactly one of the five #939 categories",
+        "mifunedev/website's oh.mifune.dev occurrences carry an explicit disposition",
+        "The inventory is written to .agro/tasks/agro-cloud-consumer-migration/consumer-inventory.md"
+      ],
+      "acceptedBy": "advisor, 2026-09-08, after independent verification: all 32 org repos present in the inventory table (set-compared against gh repo list), 35 recorded scan SHAs, and 3 classifications spot-checked against freshly cloned content"
+    },
+    {
+      "id": "US-002",
+      "title": "Cloud name classification record",
+      "repo": "mifunedev/openharness-cloud",
+      "passes": true,
+      "acceptanceCriteria": [
+        "A reviewable classification record lives in the Cloud repository",
+        "Every category 3 and category 4 retention carries a written justification",
+        "mifunedev/openharness-cloud, ghcr.io/mifunedev/openharness-cloud/*, and @openharness-cloud/* are explicitly retained",
+        "No durable database name, persistence identifier, or API token prefix is changed",
+        "Q1 and Q2 decisions are recorded as resolved before any dependent edit"
+      ],
+      "acceptedBy": "advisor, 2026-09-08. Re-ran pnpm type-check && pnpm test on the integrated tree AFTER these edits: exit 0, shared 113/113, db 189/189, gateway 37/37, web 2898/2898 across 126 files, provisioner 84/84 — identical to the certified baseline, so the prose work introduced no regression.",
+      "record": "docs/agro-runtime-name-classification.md",
+      "rule": "Built on a decision rule keyed on WHO OWNS THE NAME rather than on whether the string contains 'openharness'. That correctly separates ~/.openharness-bootstrap-status from github.com/mifunedev/openharness.git despite the shared substring, and it is reusable by a future reader instead of being a memorised list.",
+      "counts": {
+        "cat1_migrated": 10,
+        "cat2_compat": 2,
+        "cat3_product_identity": 5,
+        "cat4_durable_or_internal": 17,
+        "cat5_historical": 5
+      },
+      "widerThanPrd": "Category 4 is materially larger than the PRD table: the node-side systemd unit family (openharness-code-server, -code-server-apply, -install-code-server, -register-runtime-settings, -browser-gateway, ohmanage, -bootstrap-workspace), /etc/openharness/{runtime-settings.env,code-server.yaml,node-token,management-key}, the oh-keys group, /home/sandbox/oh.code-workspace, deployed container/tunnel/key names (oh-cloud-*, oh-gateway, oh-ed25519), app-openharness-cloud, and three browser localStorage keys. Category 2 gained OH_CLOUD_API_URL / OH_CLOUD_PROVISION_KEY, which the AGRO CLI itself still spells OH_CLOUD_* at v0.9.0 (PROVISION_KEY_SECRET, cloud.ts:12) — Cloud's docs quote the shipped spelling, so it changes when the CLI changes it, not before."
+    },
+    {
+      "id": "US-003",
+      "title": "Artifact-based node provisioning replaces the deleted make sandbox path",
+      "repo": "mifunedev/openharness-cloud",
+      "passes": true,
+      "acceptanceCriteria": [
+        "Generated node userData contains no git clone of a runtime source repository and no make sandbox invocation",
+        "AGRO is installed from its published artifact distribution",
+        "The sandbox is provisioned through agro sandbox install docker",
+        "No managed source checkout is created, neither ~/.openharness nor a renamed equivalent",
+        "A provisioning fixture fails if make sandbox or a runtime source clone reappears in userData",
+        "Bootstrap status, log, and readiness markers behave per the resolved Q2 decision",
+        "The browser editor workspace root and /home/sandbox/oh.code-workspace point at a path that exists after the new bootstrap and holds durable user state; no dangling folder entry survives the removal of ~/.openharness"
+      ],
+      "acceptedBy": "advisor, 2026-09-08. Integrated verification: both workers' full diffs applied cleanly into a fresh worktree at 0aa8f99 (19 files, zero conflicts, including the two files both workers touched); advisor ran pnpm install --frozen-lockfile && pnpm type-check && pnpm test on the integrated tree — exit 0, shared 113/113, db 189/189, gateway 37/37, web 2898/2898 across 126 files, provisioner 84/84. The five assertions red in the rebuild worktree flipped green on integration, as predicted.",
+      "residualLimit": "End-to-end fresh provisioning is NOT proven and is not claimed. As of 2026-09-08 every published AGRO sandbox image resolved to the #1019 build, so a real cold boot cannot succeed yet. `latest` is a moving tag: the affected artifacts are version tag 0.9.0, tag sha-823aabbd..., and their shared digest. US-003's criteria are static and unit-verifiable; the end-to-end leg belongs to US-007a and is gated on the patched release.",
+      "editorRootDecision": "Editor workspace root is /home/sandbox/workspace, pinned as the sandbox's durable home mount via storage.homePath / AGRO_HOME_MOUNT. Chosen because the default is a named volume a host-native code-server cannot open, while a host path survives container recycle and down -v. Pre-created in runcmd before code-server is enabled, with a test pinning that ordering, so it can never dangle."
+    },
+    {
+      "id": "US-004",
+      "title": "Harness and tool selections become explicit installation calls",
+      "repo": "mifunedev/openharness-cloud",
+      "passes": true,
+      "acceptanceCriteria": [
+        "Generated userData emits no INSTALL_OPENCODE, INSTALL_GROK_BUILD, INSTALL_DEEPAGENTS, INSTALL_HERMES, or INSTALL_AGENT_BROWSER",
+        "opencode, hermes, and grok_build resolve to explicit agro harness install calls, with grok_build mapped to the AGRO id grok-build",
+        "agentBrowserEnabled resolves to an explicit agro tool install agent-browser call",
+        "deepagents is reported to the user as an unsupported legacy selection and is never silently dropped or substituted",
+        "A test asserts each retired flag is absent and each supported selection produces its installation call"
+      ],
+      "acceptedBy": "advisor, 2026-09-08. Integrated verification: both workers' full diffs applied cleanly into a fresh worktree at 0aa8f99 (19 files, zero conflicts, including the two files both workers touched); advisor ran pnpm install --frozen-lockfile && pnpm type-check && pnpm test on the integrated tree — exit 0, shared 113/113, db 189/189, gateway 37/37, web 2898/2898 across 126 files, provisioner 84/84. The five assertions red in the rebuild worktree flipped green on integration, as predicted.",
+      "deepagentsDisposition": "Removed from the picker (offering it promises an installation AGRO cannot perform) but retained in NODE_HARNESS_CATALOG and nodeHarnessSchema so a stored row or an older client's in-flight request still parses. On arrival it emits a reported, logged unsupported-selection line and installs nothing, substituting nothing. The ok/failed:<n> status contract is unchanged."
+    },
+    {
+      "id": "US-005",
+      "title": "Canonical AGRO refs and variables across Cloud runtime surfaces",
+      "repo": "mifunedev/openharness-cloud",
+      "passes": true,
+      "acceptanceCriteria": [
+        "Runtime source, installer, and GHCR references resolve to the canonical AGRO repository and image",
+        "Node-side OH_* runtime variables, including OH_CODE_SERVER_ENABLED, migrate to AGRO_* with Phase 0 compatibility",
+        "Node-facing CLI invocation is agro",
+        "cloud-init, host-management assets, workspace-bootstrap assets, provisioning tests and fixtures are consistent with each other",
+        "OH_IMAGE_TAG, OH_ENV_FILE, ghcr.io/mifunedev/openharness-cloud/*, and @openharness-cloud/* are unchanged"
+      ],
+      "acceptedBy": "advisor, 2026-09-08. Integrated verification: both workers' full diffs applied cleanly into a fresh worktree at 0aa8f99 (19 files, zero conflicts, including the two files both workers touched); advisor ran pnpm install --frozen-lockfile && pnpm type-check && pnpm test on the integrated tree — exit 0, shared 113/113, db 189/189, gateway 37/37, web 2898/2898 across 126 files, provisioner 84/84. The five assertions red in the rebuild worktree flipped green on integration, as predicted.",
+      "containerNameBoundary": "The AGRO name grammar closes the CREATE boundary only. Verified independently: index.ts:304 nodeSchema.containerName is a plain z.string(), index.ts:542 applies the strict schema to createNodeRequestSchema, and db/index.ts:4379 maps row.container_name straight through. An existing non-conforming row still parses and yields a typed UnsupportedSandboxNameError at provisioning time naming the node and the remedy. No silent rename, which would disconnect a node from its own container."
+    },
+    {
+      "id": "US-006",
+      "title": "Bounded node.rebuild implementation",
+      "repo": "mifunedev/openharness-cloud",
+      "passes": true,
+      "acceptanceCriteria": [
+        "node.rebuild performs a real node-side operation through the existing management SSH path",
+        "The TODO referencing git -C ~/.openharness pull and make sandbox is gone, not merely reworded",
+        "A failed node-side operation does not advance the node to running",
+        "Persistent user state is preserved across a rebuild",
+        "Scope stays within the D11 prerequisite and introduces no lifecycle redesign",
+        "Readiness is proven by observed in-container service state, not by container liveness: a running container whose openharness-bootstrap.service has failed must land the node in failed, never running",
+        "A regression test covers running-container plus failed-bootstrap explicitly",
+        "The node-side step budgets and the outer transport timeout are derived from one another, with the relationship asserted by a test, so the outer budget cannot kill a legitimate bounded sequence",
+        "The pinned SSH boundary and the narrow forced-command grammar are not loosened to obtain the readiness signal"
+      ],
+      "acceptedBy": "advisor, 2026-09-08. Independent verification: readiness oracle confirmed at .agro/scripts/sandbox-healthcheck.sh:72 (require_unit openharness-bootstrap.service) with the cron unit conditional at :75, so the worker used the project's own definition of ready; budget derivation confirmed at host-management-assets.ts:158-172 and management-ssh.ts:20-22 with the shell literals generated from the same constant and the independently chosen 960 removed; regression coverage confirmed at host-management-assets.test.ts:260 and provision.test.ts:724/743; the TODO naming ~/.openharness pull and make sandbox is absent from apps/provisioner/src; advisor re-ran pnpm type-check && pnpm test independently, exit 0.",
+      "residualLimit": "Unit-level only. No real agro, Docker, or node was exercised. Volume re-attachment across a real stop+install is an inference from the compose model and is owned by US-007a as an observation."
+    },
+    {
+      "id": "US-007a",
+      "title": "Node-bootstrap lifecycle evidence on a real local host",
+      "repo": "mifunedev/openharness-cloud",
+      "passes": false,
+      "acceptanceCriteria": [
+        "The generated bootstrap script is executed on a real disposable Linux host, not simulated",
+        "Fresh AGRO provisioning completes and is confirmed by observed filesystem and container state",
+        "A representative OpenHarness-era ~/.openharness workspace is shown to remain recoverable and operable",
+        "AGRO is shown to operate existing legacy project state",
+        "Migration to native AGRO state is explicit and safe where performed",
+        "No mock, fixture, or status transition is accepted as evidence of node state",
+        "A rebuild is shown to preserve persistent user state, confirmed by observed state before and after",
+        "ATTACH, surface 1: ssh to the host then tmux attach -t docker-build-oh-sandbox succeeds and shows the real bootstrap session",
+        "ATTACH, surface 2: re-attach to the running sandbox container (agro shell / docker exec) succeeds and observes user state written before the transition",
+        "ATTACH, surface 3: a real loopback code-server on 127.0.0.1:8080 is reachable through a pinned SSH forward, and its workspace root resolves to the path that actually holds durable user state",
+        "ATTACH after lifecycle transitions: each of the three surfaces is re-exercised after a restart and after a rebuild, and each observes the same user state written beforehand",
+        "The criterion is re-attach landing on preserved state, not survival of an existing session: node.rebuild deliberately calls revokeNodeBrowserAccess, so a revoked session is correct and a lost workspace is not",
+        "Volume and mount preservation across a real stop-then-install sequence is OBSERVED (volume identity and contents before and after), not inferred from the absence of a down -v in the command list",
+        "A node whose container is running but whose bootstrap unit failed is exercised, confirming the rebuild path reports failure rather than readiness"
+      ],
+      "verdict": "DOES NOT PASS. Executed in full on a real disposable Linux host; nothing was BLOCKED. Three legs fail and one is partial.",
+      "perCriterion": {
+        "fresh_provisioning": "PASS — openharness-bootstrap.service ActiveState=active SubState=exited Result=success ExecMainStatus=0, reproduced twice, with the full cold-boot journal.",
+        "legacy_state": "PASS — empty before/after diff (sha256 + uid + gid + mode) across 9 seeded paths; git working tree intact; ~/.openharness content intact; agro migrate --check reports ready on a seeded .oh/oh.json project.",
+        "rebuild_state_preservation": "PASS WITH CAVEAT — real MANAGEMENT_HELPER over the pinned ohmanage forced command returned state=complete step=ready, with identical bind and identical dev=bc inode=1486974 and an empty state diff. Caveat: a no-change rebuild reported the same success with an UNCHANGED container id, so the verb does not always recreate the container; the first rebuild's id change came from the image-ref change, not the verb.",
+        "attach_a_ssh_tmux": "FAIL — structural, not environmental. See tmuxSessionFinding.",
+        "attach_b_container_reattach": "PASS after restart and after rebuild.",
+        "attach_c_code_server": "PASS after restart and after rebuild, on the second clean run. See exit144.",
+        "uid_alignment": "PARTIAL — passes as configured (1000/1000) but the latent risk is CONFIRMED REAL. See uidFinding.",
+        "harness_config_A_none": "PASS.",
+        "harness_config_B_one_harness": "FAIL — see principalFinding. This is the headline result.",
+        "published_image_contrast": "FAIL, as expected and deliberately exercised — ActiveState=failed ExecMainStatus=1 (#1019) while the container reported 'Up 5 seconds (health: starting)'."
+      },
+      "principalFinding": {
+        "title": "Any Cloud node created with a default harness fails to bootstrap",
+        "evidence": "Config B (harnesses: ['opencode']) -> status=failed:243 and NO /run/openharness-ready, twice. Config A control -> ok, twice.",
+        "rootCause": "buildBootstrapInstallCommands() runs `agro harness install` as soon as `agro sandbox install docker` returns, while the container's bootstrap unit is still `activating` and the entrypoint has not yet repaired /home/sandbox ownership. The install fails with npm EACCES mkdir '/home/sandbox/.local/lib'. The identical command 30s later, once is-active returned active, succeeded.",
+        "notAnArtifact": "The ordering is in the accepted Cloud builder and the failing write is in the published-lineage entrypoint. Not caused by the test substitution.",
+        "consequence": "The sandbox itself still reaches active/Result=success, so a config-B node ends up HEALTHY BUT PERMANENTLY INVISIBLE to the control plane.",
+        "fixAlreadyExistsNearby": "The rebuild helper contains exactly the readiness loop the bootstrap script lacks.",
+        "bearingOnOD1": "This is a hard technical precondition on operator decision OD-1. Choosing 'install three by default' today would fail every node's bootstrap."
+      },
+      "readinessProofGap": "The bootstrap's own `ok` marker fires when Compose reports Started and never consults the unit. This is the THIRD independent instance in this epic of liveness being mistaken for readiness (after handleRebuild's status advance and the first rebuild readiness check). Demonstrated live: the published image booted with the container reporting 'Up 5 seconds (health: starting)' while ActiveState=failed.",
+      "tmuxSessionFinding": {
+        "observed": "docker-build-oh-sandbox exists only while the bootstrap script runs: present at t=1, 'no server running' at t=2; 'no sessions'/exit 1 after restart and after rebuild.",
+        "deterministic": "index.ts:1142 uses `tmux new-session -d -s <session> <script>` with no remain-on-exit. The rebuild helper never uses tmux. Nothing re-runs the launch line.",
+        "correctionToAdvisorReading": "Access is NOT lost and no state is disconnected — the same SSH connection that returns 'no sessions' successfully ran agro shell and docker exec reaching every durable path. The criterion is violated in the narrow sense that a DOCUMENTED attach surface silently stops working, not the broad sense that state becomes unreachable.",
+        "workerVerdict": "(ii) a docs/contract problem, with a self-contradiction inside the accepted source: index.ts:786-791 calls it the 'Access model' and workspace-bootstrap-assets.ts says the owner can attach to it, while README.md:363, docs/quickstart.md:591 and docs/runtime-settings-runbook.md:157 all say 'watch the provision'. The bounded framing is truthful; 'Access model' is false for essentially all of a node's life.",
+        "operatorDecisionLatent": "It becomes (i) a product defect if the intended contract is index.ts:791, in which case the fix is a persistent session or remain-on-exit, not a docs edit. The worker did not make that call and changed nothing.",
+        "secondary": "The failure is silent: after a SUCCESSFUL bootstrap the documented command returns a bare 'no sessions'/exit 1, indistinguishable from a broken node."
+      },
+      "uidFinding": "At node uid 1500 the entrypoint chowned the host bind directory to 1000 and the host user got HOST-WRITE=DENIED HOST-CREATE=DENIED, breaking attach surface (c). The entrypoint's UID-sync path is gated on a checkout bind, which image-only cloud nodes never have. Today's alignment is two constants coincidentally both being 1000 — not a guarantee.",
+      "exit144": "RESOLVED, and it was the worker's own harness, not the product. Determined by experiment rather than decoded: `kill -l TERM` is 15 so 128+SIGTERM would be 143, and `kill -l 16` is STKFLT — so the arithmetic was tested. Two controlled experiments (`kill -s TERM $$`, and a self-matching pkill) both produced exit 144, establishing that in this harness a tool shell terminated by SIGTERM reports 144. Cause: the worker backgrounded a non-terminating `ssh -N -L 18099` and called `wait`, then a later `pkill -f 18099` matched its own shell and the background task. This is the PASS branch, not the FAIL branch: sub-checks 1 and 2 had already completed exit=0 BEFORE the kill, recording the editor reading durable state, and the whole thing was independently reproduced in a separate clean call at 06:07:03, exit=0. Explicitly NOT a repoint of the editor away from durable state — the editor root is dev=bc inode=1486974, the container's bind source. Nothing in the product changed between runs.",
+      "declaredNotVerified": "Sub-check 3, 'ohproxy cannot obtain a shell', never executed and was never re-run. The worker declared it NOT VERIFIED and corrected its own earlier cross-reference rather than letting the claim stand. It is a hardening check on the proxy principal, not an attach-surface assertion.",
+      "candidateDependency": "Every PASS ran on agro-candidate:us007a (sha256:d963de3d2b25) plus a candidate CLI 0.9.0 built from the idempotency-fix worktree. Every PASS is PROVISIONAL on a re-run against the published patched image and CLI. No local build repairs or substitutes for a published release.",
+      "otherDefects": [
+        "A failed rebuild leaves the sandbox stopped, with no rollback.",
+        "`agro shell` needs a pty and misreports the cause when it does not have one.",
+        "Naming drift: `agro config set` prints `oh.json:` while writing `agro.json`."
+      ],
+      "cleanup": "Verified back to the exact pre-run baseline: 22 images / 7.18 GB / 2 pre-existing containers / 2 pre-existing volumes, including the orphaned build container and dangling layers from a cancelled build."
+    },
+    {
+      "id": "US-007b",
+      "title": "Provider-level lifecycle evidence (D11 remainder)",
+      "repo": "mifunedev/openharness-cloud",
+      "passes": false,
+      "blockedBy": "Q3 explicit operator authorization to provision paid OVH infrastructure",
+      "acceptanceCriteria": [
+        "OVH instance create and destroy are exercised against disposable nodes",
+        "suspend and resume are exercised and shown not to disconnect persistent user state",
+        "ATTACH end to end through the live cloudflared tunnel and gateway to a real node, before and after suspend/resume, landing on preserved user state",
+        "Browser-session revocation and re-establishment across suspend/resume/rebuild behave as the access model documents",
+        "The provisioner's OVH-side reconciliation is exercised",
+        "No live infrastructure is touched before explicit operator authorization"
+      ]
+    },
+    {
+      "id": "US-008",
+      "title": "Equipped-repository migration through the supported path",
+      "repo": "mifunedev/agro",
+      "passes": true,
+      "acceptanceCriteria": [
+        "agro migrate --check output is recorded for mifunedev/openharness-cloud and mifunedev/agro-web",
+        "Where the supported migration path applies it is used, with no ad hoc directory rename",
+        "Where it does not apply the reason is recorded",
+        "Historical .oh/tasks content is preserved unmodified"
+      ],
+      "acceptedBy": "advisor, 2026-09-08. Both halves of the delivery are done in the branches that become the PRs, with preflight root confirmation, applied migrations, hash-and-mode manifests, byte-identical historical task content, both git views, and reference sweeps. Cloud: 131/131. agro-web: 6/6. The earlier scratch-clone run remains recorded as rehearsal evidence only.",
+      "corroboration": "git blob OIDs and git modes match across the rename for every path; an inode check shows .oh -> .agro and a file inside keep the same inodes, consistent with a single renameSync that never opened a file; a second run is noop exit 0; no .agro-migrate.lock residue.",
+      "scopeNote": "The real repositories are NOT migrated. This story's deliverable is evidence that the supported path preserves content. Applying it to the real repos is a later, separately authorized step.",
+      "advisorCorrection": "I marked this true on 2026-09-08 and that was wrong. migration-evidence.md states plainly that both applies happened in disposable scratch clones and that the real repositories remain unmigrated. That is a successful REHEARSAL of the supported path, not delivery of #944's consumer migration. The criterion says the supported path IS USED, so it is not met until the migration runs in the branches that become the PRs. The original DoD is unchanged; only my bookkeeping was wrong.",
+      "rehearsalComplete": {
+        "status": "done and accepted as rehearsal evidence",
+        "artifact": "migration-evidence.md",
+        "what_it_proves": "the supported path preserves content exactly — agro-web 6/6 and openharness-cloud 131/131 sha256 and modes identical, 0 lost, 0 gained, tasks/** byte-identical, R100 renames once staged",
+        "what_it_does_not_prove": "that either consumer repository has been migrated"
+      },
+      "deliveryOutstanding": {
+        "status": "OPEN",
+        "requirement": "Run the supported migration in the isolated implementation worktrees that become the PRs: openharness-cloud .worktrees/944-integrate2 and agro-web .worktrees/944-docs.",
+        "preflight": "MUST confirm the migrate plan targets the WORKTREE root, not the parent clone. Both worktrees are nested under a clone that itself carries .oh/, and ROOT_MARKERS resolution walks upward — the rehearsal explicitly listed this nested case as unexercised. Abort if the plan names anything but the worktree root.",
+        "alsoRequired": "The 8 .oh/skills/dev-tmux paths in docs/browser-gateway-runbook.md must be repointed in the same change, because agro migrate rewrites no prose and the rename alone would leave them dangling.",
+        "notAuthorized": "No production clone, no `agro migrate --home` registry migration, no merge, no deployment.",
+        "cloudHalf": {
+          "status": "DELIVERED and accepted",
+          "worktree": "openharness-cloud .worktrees/944-integrate2 (the PR branch)",
+          "preflightResult": "PASSED. `agro migrate --check` named ONLY the worktree root. The nested-parent hazard did not fire, and the worker explained why rather than just reporting the happy path: findProjectRoot (migrate.ts:98) stops at the FIRST ancestor carrying a marker, and cwd itself carried .oh, so it returned without walking up to the parent clone. pwd -P and realpath both resolve to the worktree root with no symlink indirection.",
+          "result": "exit 0, `applied`, stderr empty",
+          "preservation": {
+            "entries": "171 before / 171 after (131 files, 40 dirs, 0 symlinks both sides)",
+            "sha256": "131/131 identical",
+            "modes": "131/131 identical (130x644, 1x755 keeping the dev-tmux exec bit)",
+            "sizes": "131/131, total 3,063,421 bytes both sides",
+            "lost_gained": "0 / 0",
+            "tasks_byte_identity": "129/129; subtree digest b60a0ab0... unchanged, and it MATCHES the rehearsal digest for the same commit",
+            "git_corroboration": "blob OIDs and modes identical for all 131 paths between HEAD:.oh/* and index .agro/*"
+          },
+          "advisorVerification": [
+            "git diff --cached -M: 131 R100, 0 D, 0 non-R100 renames",
+            "tracked .oh/ = 0, tracked .agro/ = 131",
+            ".dockerignore:9 is .agro; .gitignore:36 is !.agro",
+            "0 remaining .oh/ references in docs/browser-gateway-runbook.md",
+            ".agro/skills/dev-tmux/scripts/dev-tmux.sh present, mode 755",
+            "parent clone status clean apart from the pre-existing untracked .worktrees/",
+            "pnpm type-check and pnpm test both exit 0, counts identical to the certified baseline"
+          ],
+          "functionalCatchBeyondBrief": ".dockerignore:9 still said .oh. Left unfixed, the rename would have pushed 131 files and ~3 MB of task records into EVERY Docker build context. This was real breakage the rename introduced, found by the worker's own sweep rather than by the brief.",
+          "crossArtifactEdit": "The worker edited docs/agro-runtime-name-classification.md:100 — another worker's accepted artifact — repointing a Category 4 'where' pointer that the rename made factually false, and flagged it for reversal. ACCEPTED: a pointer that no longer resolves is a defect, not a preserved record. It correctly left line 111 alone, which sits under 'Category 5 - historical, retained verbatim' and is prose ABOUT the pre-migration name.",
+          "leftAlone": "17 references across 16 files: source comments and doc prose citing .oh/tasks/<slug>/prd.md as provenance. None is resolved at build, test or run time; all are historical citations. No CI workflow references .oh at all.",
+          "agroWebHalf": {
+            "status": "QUEUED, not started",
+            "reason": "agro-web .worktrees/944-docs currently has a writer in it (the docs-drift worker). A second writer in an occupied worktree would break the isolation guarantee. The migration runs there once that worker lands, so the drift fix and the migration ship in one PR."
+          }
+        },
+        "agroWebHalf": {
+          "status": "DELIVERED and accepted",
+          "worktree": "agro-web .worktrees/944-docs (the PR branch)",
+          "preflightResult": "PASSED, and the worker did not assume the Cloud result carried over. It walked the ancestors explicitly and confirmed the hazard was REAL BUT INERT: the worktree carries .oh, the parent clone carries .oh, and /home/sandbox/harness carries .agro + agro.json — findProjectRoot stopped at the first marker, which was cwd. pwd, pwd -P, realpath and readlink -f all resolved identically with no symlink indirection.",
+          "result": "exit 0, `applied`, stderr empty (0 bytes); second run `noop` exit 0, so idempotent",
+          "preservation": {
+            "entries": "9 / 9",
+            "files": 6,
+            "sha256": "6/6 identical",
+            "modes": "6/6 identical (644; 3 dirs at 755)",
+            "sizes": "6/6, total 68,028 bytes both sides",
+            "lost_gained": "0 / 0",
+            "symlinks": "0 / 0",
+            "tasks_byte_identity": "all 6 files are under tasks/; subtree digest fd2c0fd1... unchanged",
+            "mechanism": "inodes identical across the rename (.oh 1402214 -> .agro 1402214; prd.md 1402223 -> 1402223), consistent with a single renameSync that never opened a file"
+          },
+          "advisorVerification": [
+            "git diff --cached -M: 6 R100 for the migration; the 5 A and 13 M are the prior accepted docs work",
+            "tracked .oh/ = 0, tracked .agro/ = 6",
+            "parent clone still carries its own .oh/ and has no .agro/"
+          ],
+          "sweepResult": "NO functional breakage in this repo, and the worker changed no file rather than inventing work. It checked each analogue of the Cloud findings and reported why each was inapplicable: .gitignore has no .oh entry; .dockerignore does not exist (this repo deploys a Pages artifact, not a Docker build context, so the Cloud 3 MB failure mode has no analogue); netlify.toml absent; docusaurus.config.ts scans only docs and blog with no root glob; no .oh reference in the workflow or package.json. It swept all 31 files mentioning .oh and found the only literal .oh/tasks hit outside the directory is a dated blog record of the HARNESS layout, not a path into this repo.",
+          "compatSurfacesPreserved": "oh-source.mjs; build-oh-cli.mjs including its CLI_DIRS ['.agro/cli', '.oh/cli'] fallback; sync-external-scripts.mjs including PRE_RENAME_SCRIPTS_DIR; the get-oh.sh / oh.js mirroring; the GHCR ghcr.io/mifunedev/openharness references; the repository-name gates in the workflow; and README.md's documented .agro -> .oh ref fallback. check-docs-drift.mjs was read first.",
+          "checks": "check-docs-drift exit 0 (PASS, 44 files); pnpm build exit 0; pnpm typecheck exit 0",
+          "honestCaveat": "Zero broken links and anchors is verified by ABSENCE of the warning block, not by a throwing gate — docusaurus.config.ts:24-25 sets onBrokenLinks: 'warn', not 'throw'. The worker stated this precisely rather than claiming a gate it does not have."
+        }
+      }
+    },
+    {
+      "id": "US-009",
+      "title": "Operator- and user-facing copy reflects the AGRO runtime contract",
+      "repo": "mifunedev/openharness-cloud",
+      "passes": true,
+      "acceptanceCriteria": [
+        "README, quickstart, threat model, deploy and gateway runbooks, cloud-init README, and the console setup guide no longer present OpenHarness as the canonical runtime name",
+        "Cloud's own product identity and historical references are retained",
+        "Setup instructions match the actual artifact-based provisioning implemented in US-003 and US-004",
+        "No instruction references make sandbox, a runtime source clone, or a retired INSTALL_* flag"
+      ],
+      "acceptedBy": "advisor, 2026-09-08. Re-ran pnpm type-check && pnpm test on the integrated tree AFTER these edits: exit 0, shared 113/113, db 189/189, gateway 37/37, web 2898/2898 across 126 files, provisioner 84/84 — identical to the certified baseline, so the prose work introduced no regression.",
+      "materialDefectFixed": "README.md and docs/quickstart.md documented the Cloud provisioning credential as living at ~/.config/openharness/cloud.json with mode 0600. The released CLI never creates that file. Verified against v0.9.0 directly: secrets.ts:6 is SECRETS_FILE = '.env', and cloud.ts:39-41's own help text says `oh cloud config` writes cloud.apiUrl to the repository oh.json and stores OH_CLOUD_PROVISION_KEY in the gitignored root .env. An operator following the old docs would have gone looking for a file that does not exist. This was a live documentation defect, not staleness.",
+      "releaseAwareness": "The prerequisite row was corrected to `AGRO CLI >= 0.9.0` because the CLI bin is `oh` at v0.5.1-v0.8.0 and becomes `agro` only at v0.9.0 — the previous `>= 0.2.0` was wrong for the agro verb, not merely stale. oh.json was documented rather than agro.json, since the namespace cutover is unreleased.",
+      "deliberateRetentions": [
+        "docs/design/console-mvp.md — densest concentration of dead commands in the repo, but it is the approved design record (category 5) and rewriting it would falsify what was approved.",
+        "docs/cost.md and docs/provider-comparison.md — dated analysis records; cost.md states outright that it records how the ORIGINAL flavors were chosen.",
+        "Six other READMEs verified against the diff and the released runtime and confirmed to need NO change; every openharness name in them is category 3 or 4."
+      ],
+      "residual": "Strings and tests asserting the always-installed-three claim are deliberately untouched pending operator decision OD-1, including create-node-form.tsx:181 which is false on both halves but sits inside the block under decision."
+    },
+    {
+      "id": "US-010",
+      "title": "mifunedev/website — repair published guidance that is broken, not merely stale",
+      "repo": "mifunedev/website",
+      "passes": true,
+      "acceptanceCriteria": [
+        "posts/openharness-getting-started.md no longer publishes make harness-config, make sandbox, make shell, or harness.yaml, none of which have existed since agro#893 deleted the Makefile",
+        "Replacement instructions are grounded on agro@main (the released v0.9.0 surface), never on unreleased development",
+        "Live constants offerings.ts:3-4 and AgentPickerSection.tsx:6 present the canonical runtime name",
+        "The GitHub API target github.ts:34 and its match key AgentPickerSection.tsx:186 resolve to the canonical repository, and are changed together so the key still matches",
+        "faqs.ts:48 is dispositioned",
+        "generate-llm-txt.mjs:111,112,125 is updated and public/llm.txt regenerated from it, not hand-edited",
+        "schema.ts:11, cloud-pricing.ts:7,45 and tasks/** are retained with a written justification"
+      ],
+      "acceptedBy": "advisor, 2026-09-08. Independent verification: LICENSE on agro@main is Apache 2.0, confirming the post contradicted its own site rather than the worker inventing a change; the '## Install' heading exists on agro@main so the #-install anchor still resolves; both worktrees are content-only dirty with exactly the reported files. Worker ran npm ci, generate-llm-txt, next lint and next build — all exit 0, 24/24 static pages, all 7 blog routes prerendered.",
+      "releaseAwareness": "Verified by the worker against agro@main rather than the working tree: root tree has .oh and oh.json and no .agro/agro.json, so no unreleased namespace prose was published. Every published command was checked to exist in v0.9.0's own README.md and docs/lifecycle-commands.md, and the get-agro.sh release asset was fetched live (200).",
+      "scopeJudgements": [
+        "Two edits beyond the enumerated targets, both flagged rather than slipped in. (a) The post claimed MIT; the repo is Apache-2.0 and the site's own generate-llm-txt.mjs already said Apache-2.0. Corrected. (b) AgentPickerSection.tsx:233 is the caption directly under the star count; repointing the fetch at :186 without it would have labelled agro's star count as openharness. Changing them together avoided introducing a new falsehood. Both accepted.",
+        "Product identity deliberately preserved: 'Open Harness' prose, OpenHarnessBrandBar, OpenHarnessValueSection, the openHarnessRepo identifier and the post slug are unchanged. Only repo identifiers and URLs migrated.",
+        "Retentions honoured with no edit: schema.ts:11 CLOUD_SERVICE_ID, cloud-pricing.ts:7,45 (where :7 names openharness-cloud, a different and still-current repo), and all of tasks/**.",
+        "public/llm.txt regenerated by its generator and never hand-edited; the build's prebuild hook reproduced it byte-identically. The incidental next-pwa public/sw.js rebuild was restored to HEAD so the diff stays content-only."
+      ],
+      "apiPairing": "github.ts builds fullName as `${owner}/${name}` (:61); after the change it yields 'mifunedev/agro', matching the key at AgentPickerSection.tsx:186. api.github.com/repos/mifunedev/agro returns 200 with stargazers_count, so the live star fetch succeeds rather than silently falling back."
+    },
+    {
+      "id": "US-011",
+      "title": "mifunedev/agro-web — close the documentation drift left by Phase 3",
+      "repo": "mifunedev/agro-web",
+      "passes": true,
+      "acceptanceCriteria": [
+        "docs prose is re-mirrored from agro@main, the released surface, so it describes what a reader can install today",
+        "docs/lifecycle-commands.md no longer presents oh as the only front door",
+        "The 14 pages present in agro@main but absent from agro-web are reconciled: mirrored, or their absence justified in writing",
+        "Namespace prose that main has not yet released (.oh -> .agro, oh.json -> agro.json) is NOT pre-emptively rewritten; it moves with the rename-bearing release",
+        "The deliberate exceptions in check-docs-drift.mjs:41 (GHCR default image, get-oh.sh, oh.js mirroring) are preserved, not swept up",
+        "A successful manual Pages build is not recorded as evidence that the drift is fixed"
+      ],
+      "acceptedBy": "advisor, 2026-09-08. Verified: check-docs-drift.mjs polarity inverted so the retired spelling is now .env.example (the one absent from agro@main) with `instead` naming .example.env; node scripts/check-docs-drift.mjs exit 0 PASS across 44 files; pnpm build exit 0; pnpm typecheck exit 0. Drift measured 0 -> 159 agro verbs and 373 -> 257 oh verbs, with the residual gap accounted for by pages deliberately not mirrored.",
+      "method": "Not a blind overwrite. The worker located the commit the site last mirrored (61f4dcd4, verified an ancestor of agro@main) and used it as a three-way merge base, which isolated real drift from the site's own edits — and preserved systemd/SYS_ADMIN prose in connecting.md and quickstart.md that exists only on the site and would have been destroyed by a copy from main.",
+      "advisorRuleWasWrong": "I told the worker check-docs-drift.mjs was authoritative. It was stale: agro#980 renamed .env.example to .example.env, released in v0.9.0, and `git ls-tree origin/main` confirms the root file is .example.env — while the checker retired that exact spelling and pointed at a file that does not exist on main. The worker obeyed a rule that was wrong; I inverted it on review. Six lines across four pages needed correcting, not one.",
+      "selfCaughtCollateral": "Reverting the spelling exposed that the worker's own earlier sed had corrupted .claude/.example.env.claude and a deny-secret-paths sentence in security-considerations.md. It found and restored both to match main rather than leaving them for review to catch.",
+      "deliberateDivergenceFromMain": [
+        "docs/integrations/sshd.md — two commands gain `install docker`, because main's bare `oh sandbox` prints help and exits non-zero. Recorded as an upstream bug; a future mirror must not 'correct' it back.",
+        "docs/deployment-prebuilt-image.md — placeholders retained where main's docker run recipe hardcodes a real name and email address. This is PII and must not pass through on any future mirror.",
+        "get-agro.sh URLs point at the site-served path, because main's spelling contains mifunedev/openharness which LEGACY_IDENTITY rejects outside a compatibility section."
+      ],
+      "notMirrored": "agro-compatibility.md and rfcs/** stay unmirrored until the rename-bearing release: the former's central table declares .agro/ and agro.json as the AGRO spellings, which is exactly the unreleased-namespace hazard on a site serving v0.9.0. Inbound links point at GitHub and will need retargeting when it ships."
+    }
+  ],
+  "resolvedDecisions": {
+    "Q1": "OH_IMAGE_TAG and OH_ENV_FILE retained as category 4; grounded application of #944's retention boundary, not a new decision",
+    "Q2": "Bootstrap marker/log/readiness paths and the docker-build-oh-sandbox tmux session retained as category 4; only runtime-facing prose changes"
+  },
+  "dodCoverage": {
+    "sourceCriterion": "#944: suspend/resume/rebuild/attach flows do not silently disconnect persistent user state",
+    "split": {
+      "suspend": "US-007b",
+      "resume": "US-007b",
+      "rebuild": "US-007a (state preservation) + US-007b (provider-level)",
+      "attach": "US-007a (all three node-side surfaces, incl. after restart and rebuild) + US-007b (live tunnel, across suspend/resume)"
+    },
+    "note": "attach was omitted when US-007 was first split; restored 2026-09-08 so no leg of the original criterion is lost to the local/provider boundary"
+  },
+  "crossRepoOrder": {
+    "note": "Four repositories, not two. Order is set by what is RELEASED, not by what is merged.",
+    "releaseFacts": {
+      "agro@main": "823aabbd = v0.9.0. Ships the agro executable (npm @mifune/agro@0.9.0 bin=agro). Still carries .oh/ and oh.json.",
+      "phase2_a227bbf3": "NOT an ancestor of main. The .oh -> .agro namespace cutover is merged to development and unreleased.",
+      "phase3_b10ecac3": "NOT an ancestor of main.",
+      "makefile_0b292bf8": "IS an ancestor of main, so make sandbox is dead in the released surface. This is why website guidance is broken rather than stale."
+    },
+    "sequence": [
+      "1. mifunedev/openharness-cloud — US-002..US-006, US-009. Independent of the others.",
+      "2. mifunedev/website — US-010. Independent; grounded on agro@main. Highest user-visible urgency: its published instructions cannot work.",
+      "3. mifunedev/agro-web — US-011. Grounded on agro@main. Must NOT pre-empt unreleased namespace prose.",
+      "4. mifunedev/agro — US-001, US-008 record PR plus evidence. Lands last so it can cite the other three."
+    ],
+    "deferredToReleaseWindow": [
+      "agro-web namespace prose (.oh -> .agro, oh.json -> agro.json) moves only when the rename-bearing release ships.",
+      "The legacy-host Cloudflare redirect rule and the oh-redirect Worker move from .oh/scripts/install.sh to .agro/scripts/install.sh in that same window."
+    ]
+  },
+  "correctionsAccepted": [
+    "F4 was wrong: three repositories carry .oh/ (agro, openharness-cloud, agro-web), not two.",
+    "The PRD hypothesis that agro migrate requires a fully equipped control plane was wrong. migrate.ts ROOT_MARKERS is the only precondition; both candidate repos report ready, exit 0.",
+    "agro@main's .oh/ and oh.json are default-branch release lag from Phase 2, NOT unfinished Phase 5 retirement work, and are not Phase 4's business.",
+    "The claimed @mifune/openharness dependency pin in Cloud does not exist. The identifier occurs once at 0aa8f99, in docs/quickstart.md:35, and is a docs reference handled under US-009."
+  ],
+  "prerequisiteFixes": [
+    {
+      "id": "US-012",
+      "repo": "mifunedev/agro",
+      "title": "agro sandbox install preserves an existing registry entry's settings",
+      "why": "seedConfig seeds only from --repo and never from the existing entry; writeOhConfig is unconditional; config-render maps timezone->TZ and access.dockerSocket->DOCKER_SOCKET. The CLI's own documented recycle therefore discards a user's Docker-socket and timezone selections, and Cloud cannot work around it because no flags exist for those fields.",
+      "authority": "plan S5: 'If incomplete Cloud lifecycle operations block D11, obtain a bounded prerequisite fix before claiming Phase 4 completion.'",
+      "worker": "W8",
+      "passes": true,
+      "acceptedBy": "advisor, 2026-09-08. Independent verification: OH_CONFIG_FIELDS confirmed as the authoritative user-settable registry (it backs agro config set/show via findOhConfigField and ohConfigFieldPaths), so the worker's completeness argument is structural rather than a hand-enumeration; advisor re-ran typecheck, test and build in the worktree: 74 files, 1257 tests, dist/agro.js 205.1kb, exit 0.",
+      "widerThanDiagnosed": "The defect was worse than the advisor described. Beyond timezone and dockerSocket, config.repo was also lost, and registry.ts selects docker-compose.image-only.yml versus the build base off config.repo (pinned by the existing test 'picks the image-only base without a repo and the build base with one'). A recycle would have silently flipped a node from build mode to image-only, dropping the harness bind mount, not merely reverting two settings.",
+      "decisions": {
+        "precedence": "defaultOhConfig < existing registry entry < --repo seed < explicit flags < wizard. Accepted: --repo is typed on this invocation, so it is a per-invocation explicit input like a flag, not stored state; this also keeps --repo's documented meaning literally true.",
+        "corruptConfig": "A corrupt agro.json now aborts install with exit 2 instead of overwriting it. ACCEPTED as correct: silently discarding a user's settings is the exact class of bug being fixed, and the error names the offending path so the user can act. No recovery path added.",
+        "emptyStringFallback": "nonEmpty() guard on timezone and git identity accepted: without it, install reading back its own first-install output would freeze a blank git identity across every future recycle, a regression against today's re-read behaviour."
+      },
+      "docsConsequence": "cli.ts:141, docs/configuration.md:51 and docs/quickstart.md:335 already instruct users to apply a config change with `agro stop <name> && agro sandbox install docker --name <name>`. That instruction was false before this fix; it is now true. No doc change required."
+    }
+  ],
+  "operatorActionItems": [
+    {
+      "id": "OA-1",
+      "title": "Audit existing nodes.container_name values before the Cloud change ships",
+      "why": "The AGRO name grammar now closes the create boundary. Existing rows still parse, but a row containing _, . or uppercase cannot be re-provisioned and will raise UnsupportedSandboxNameError.",
+      "query": "psql \"$DATABASE_URL\" -c \"select id, container_name, status, created_at from nodes where container_name !~ '^[a-z0-9][a-z0-9-]*$' or length(container_name) > 64 order by created_at;\"",
+      "note": "Read-only. status is included so already destroyed/failed rows can be dismissed. An empty result makes the tightening a no-op in production. Neither advisor nor worker can query production."
+    },
+    {
+      "id": "OA-2",
+      "title": "Stage the migrating commit with git add -A and review it from git diff --cached -M",
+      "why": "Rename detection does not fire in `git status --short` until the change is staged. Immediately after `agro migrate`, openharness-cloud shows 131 ' D' lines plus one '?? .agro/' and agro-web shows 6 ' D' — it reads like a mass deletion. After staging, every path becomes R100 with 0 insertions and 0 deletions. Content is safe either way, but an unstaged review would look alarming and could prompt someone to abort a correct migration.",
+      "extra": "Git stores no rename; R100 is read-time similarity, so history across the boundary depends on --follow and diff.renameLimit (default 1000; both repos are well under)."
+    },
+    {
+      "id": "OA-3",
+      "title": "Operators must upgrade the CLI past 0.7.0 before running the real migration",
+      "why": "The shipped sandbox image's `oh` is 0.7.0 and has no `migrate` verb, so the migration is not reproducible on this image as shipped."
+    }
+  ],
+  "operatorDecisions": [
+    {
+      "id": "OD-1",
+      "title": "Should a new Cloud node arrive with claude-code, codex and pi installed?",
+      "status": "OPEN - operator decision, not taken by the advisor",
+      "background": "The old flow baked the three into the image via ARG AGENTS. Upstream deliberately unbaked them in two steps (0b6dad57 / #905, then 55ceece1 / #949) and machine-enforces boot-installs-nothing via harness-one-door.sh, sandbox-boot-smoke.sh and verify-sandbox-image.sh. So without action, new nodes arrive with no agent unless the user picked one.",
+      "advisorRecommendation": "Install the three explicitly at bootstrap. Upstream's rule is that the IMAGE installs nothing; a consumer calling agro harness install is the supported path, not a violation. Cost is low: no TTY, no sudo, no auth at install time, idempotent via a --version short-circuit, and they land in /home/sandbox/.local inside the durable mount, so with the new host bind they survive down -v and become no-ops on later boots. CI already runs exactly these unattended.",
+      "caveats": [
+        "the correct catalog id is `pi`, not `pi-coding-agent`",
+        "CI wraps each install in a 2-attempt retry with 15s backoff; the bootstrap has none, so a registry blip fails the node fast rather than hanging",
+        "install duration is not quotable — no timing instrumentation exists anywhere in the repo"
+      ],
+      "blockingDetail": "Cloud's DEFAULT_INSTALLED_HARNESSES uses the id `pi-coding-agent`, which is NOT an AGRO catalog id (the id is `pi`). Under the install-three outcome that value must change or the install call fails. Also confirmed: the released Dockerfile writes `claude` and `codex` shell aliases at lines 101-102 for binaries it does not ship, so `claude` on a fresh node fails today.",
+      "minimalEditPerOutcome": {
+        "installThree": "Behaviour change only, user-facing copy unchanged: append unconditional `agro harness install claude-code|codex|pi` to the bootstrap install loop; fix pi-coding-agent -> pi in create-node-bootstrap.ts:79 and its test; retarget two stale comments; add one cloud-init fixture asserting the three calls reach userData.",
+        "installNone": "Larger: delete DEFAULT_INSTALLED_HARNESSES and its import, the 'Always installed' <dl> block and its explanatory paragraph, four create-node-bootstrap tests and one multi-presentation test, then rewrite node-setup-guide step 5 from 'sign in to your agents' to 'install a harness, then sign in' and update its presentation test. This removes a disclosure the create page was redesigned around."
+      },
+      "hardPrecondition": "MEASURED, not predicted: choosing 'install three by default' today would fail EVERY node's bootstrap. A node with one default harness returns status=failed:243 with no readiness marker, because the bootstrap installs harnesses before the container's unit is active. The install-three option is not available until the bootstrap gains the readiness loop the rebuild helper already has. This does not decide OD-1; it prices it."
+    }
+  ],
+  "findingsForSeparateIssues": [
+    {
+      "title": "AGRO Dockerfile bakes --dangerously-skip-permissions aliases for binaries the image no longer ships",
+      "detail": ".devcontainer/Dockerfile:101-102 defines claude='claude --dangerously-skip-permissions' and codex='codex --dangerously-bypass-approvals-and-sandbox' in .bashrc. The image ships neither binary since #905/#949, so the aliases are inert today — but they would apply silently the moment anyone installs those harnesses.",
+      "scope": "Not Phase 4. Raised to the operator for a separate issue."
+    },
+    {
+      "id": "agro#1020",
+      "filed": true,
+      "summary": "Every workflow path filter in mifunedev/agro still names .oh/**, which has 0 tracked files after the Phase 3 rename (.agro/ has 760). Control-plane changes trigger no CI. The probe added by PR #1023 is unreachable by any CI path. Same failure shape as #981."
+    },
+    {
+      "id": "migrate-rehearsal availability probe",
+      "filed": false,
+      "summary": "dockerComposeAvailable() in .agro/cli/src/commands/__tests__/migrate-rehearsal.test.ts probes the Compose plugin binary rather than daemon reachability, so it asserts success from a command that cannot succeed without a daemon. Causes 2 failures on any machine with the docker CLI but no socket. Pre-existing at b10ecac3."
+    }
+  ],
+  "advisorCorrections": [
+    {
+      "date": "2026-09-08",
+      "what": "I described ghcr.io/mifunedev/agro:latest as an immutable broken build in several places.",
+      "why_wrong": "The digest is immutable; the tag is not. `latest` moves on the next publish, so the claim expires silently and would misdirect the #1019 release decision.",
+      "correction": "Pin claims to version tag 0.9.0, tag sha-823aabbd..., or the digest. Date any observation about `latest`."
+    }
+  ],
+  "followUps": [
+    {
+      "title": "Repoint 8 .oh/skills/dev-tmux paths in docs/browser-gateway-runbook.md in the same commit as the Cloud migration",
+      "why": "agro migrate rewrites no prose — confirmed by the applied runs reporting 1 rename step and 0 rewrite steps — so these references would be left dangling by the rename alone. agro-web needs no equivalent follow-up."
+    }
+  ],
+  "completedInventoryItems": [
+    {
+      "repo": "mifunedev/orchestra",
+      "item": "decks/slides/onepager.html:242 'Powered by Orchestra + OpenHarness' -> 'Powered by Orchestra + AGRO'",
+      "category": "1 (product-facing runtime reference)",
+      "evidence": "Name taken from the live public repo description, 'AGRO — Agent Governance Runtime Orchestrator', not from the working tree. Case-insensitive repo-wide scan found exactly one occurrence, so there was no historical or dated instance to weigh; post-change scan is clean. No Orchestra product name, repository or identifier renamed. Static slide with no build target in the repo."
+    }
+  ],
+  "relatedWork": {
+    "issue1019PartA": {
+      "status": "COMPLETE and accepted by the advisor",
+      "worktree": ".worktrees/bug/1019-boot-recovery (branch bug/1019-boot-recovery, off b10ecac3)",
+      "artifacts": [
+        "docs/repair-sandbox-boot-advisory.md — the state-preserving recovery runbook",
+        "docs/release-requirements-1019-boot-fix.md — Part B requirements for the operator, R3 and R4 deliberately undecided",
+        ".agro/evals/probes/sandbox-boot-advisory-recovery.sh — new tier-A probe, live half behind SANDBOX_BOOT_RECOVERY_LIVE=1",
+        ".agro/evals/probes/pnpm-audit-ci-gate.sh — extended to forbid any lifecycle hook on any boot-install manifest"
+      ],
+      "coreFinding": "The container-stays-up hypothesis was TESTED and held. Against the real published image, the bootstrap oneshot fails while systemd keeps the container running and docker exec still reaches a shell at uid 1000. Population B therefore has intact, reachable state behind a broken boot — the same systemd property that made the rebuild readiness check wrong is what makes recovery possible.",
+      "advisorVerification": [
+        "reproduced the original defect: mktemp+mv changed package.json 644 -> 600 and reassigned ownership",
+        "reproduced the fix: cat > preserves mode 644 AND the same inode, with unrelated keys intact",
+        "confirmed the corrected block in the runbook at :100-102 (jq --indent 2, then cat > package.json)",
+        "confirmed three refusals at :93-98 — non-regular/symlink manifest, absent hook, and a hook that is not exactly the audit-only value",
+        "grep immutable across both documents returns nothing; latest observations are dated",
+        "re-ran the live probe independently after the corrections: exit 0, PASS"
+      ],
+      "threeDefectsCorrected": {
+        "1_manifest_mutation": "Recovery writes back through the existing file, preserving mode, owner and inode. Reformatting was MEASURED, not assumed: jq --indent 2 round-trips the published 0.9.0 manifest byte-identically, so the runbook states that as a property of that file and tells a reader with a reformatted manifest what will change.",
+        "2_unconditional_delete": "The hook value must equal the audit-only value or the block refuses. It never parses, splits, or partially rewrites a combined hook. Symlink and non-regular manifests refuse too.",
+        "3_moving_tag": "Absolute claims about `latest` removed from both documents; claims pinned to 0.9.0, sha-823aabbd..., or the image id, with dated observations. The requirements doc opens 'Tags move; digests do not' and R3/R5 say what to re-check before acting."
+      },
+      "faultInjection": "Every new assertion has an observed red transition, including the decisive live one: reverting the block to mv fails with mode/owner/inode changed (644 -> 600). Removing either guard fails with 'did not refuse'. The four earlier injections still go red.",
+      "notClaimed": "Nothing here repairs the published artifacts. A locally built candidate image cold-boots clean, which proves the source revision only. Boot-install network isolation was NOT proven and is not claimed.",
+      "steCheck": "11 advisory findings on the runbook, mostly line-wrap false positives on passive/pronoun heuristics. Gates nothing in CI. Deliberately not chased — churning prose for a non-gating heuristic is not worth the diff."
+    }
+  },
+  "groundingChecks": [
+    {
+      "date": "2026-09-08",
+      "check": "agro-web base currency before PR readiness",
+      "finding": "The local parent checkout HEAD bd9f104 is an ANCESTOR of origin/main (409ef104), not ahead of it — the local clone is BEHIND the remote. Proof: `git merge-base --is-ancestor bd9f104 origin/main` succeeds, `git log 409ef104..origin/main` is empty, and CNAME reads oh.mifune.dev at bd9f104 versus agro.mifune.dev at origin/main, so the stale checkout predates the Phase 3 domain cutover. The 944-docs worktree is based on 409ef104 and carries agro.mifune.dev, i.e. it is correctly grounded on current origin/main. No re-basing needed; the stale artifact is the local parent checkout, which is not a PR input."
+    }
+  ],
+  "codeGates": {
+    "newCommentCleanup": {
+      "status": "COMPLETE and verified",
+      "scope": "Newly-introduced explanatory comments in the Cloud implementation diff only. The harness-repo diff was already clean at 0.",
+      "removed": 102,
+      "retained": 87,
+      "retainedJustification": "Every retained '+' comment line has a paired '-' line: these are PRE-EXISTING comments whose text the rename made factually false (e.g. 'the provisioner writes them into .devcontainer/.env so make sandbox reads them' -> the agro harness install reality). Updating them keeps legacy comments truthful. Deleting them instead would either leave false statements in the tree or trigger the legacy sweep that was explicitly out of scope. Advisor sampled the diff with -U0 and confirmed the pairing.",
+      "namedTargetsRemoved": [
+        "SANDBOX_READY_UNIT docblock",
+        "SANDBOX_REBUILD_BUDGET_SECONDS docblock",
+        "handleRebuild header block and its inline revoke-ordering rationale",
+        "both deepagents explanation blocks",
+        "DEFAULT_AGRO_SANDBOX_IMAGE latest/#1019 rationale",
+        "UnsupportedSandboxNameError and assertSandboxName docblocks",
+        "every newly-added narrating // line across the five test files"
+      ],
+      "advisorRuleCorrection": "I first allowed a 'sibling convention' exception — keep short 'what it is' TSDoc where neighbouring symbols carry one. That invented an exception the rule does not have, and it was withdrawn. The operative rule is: keep newly-added comment text ONLY where a verified doc generator, tool or oracle consumes it, and name the consumer. Verified there is no typedoc, api-extractor, @microsoft/tsdoc, or doc script anywhere in the Cloud repo, so nothing survived on that basis; the ~9 one-liners kept under the first instruction were removed.",
+      "advisorPremiseCorrection": "I repeatedly told workers that this repository's AGENTS.md forbids explanatory comments. It does not: the Cloud repo has no AGENTS.md or CLAUDE.md and its existing code is pervasively commented. The rule lives in the harness repo. The cleanup stands on the operator's explicit instruction, not on a rule this repo carries.",
+      "preservedWithConsumerNamed": "Four lines in host-management-assets.test.ts and one in index.ts that a naive '+ comment' scan flags are NOT comments — they are shell `case`-pattern arms in an executed fake-binary fixture. The worker also checked every readFileSync-of-source test in the repo and confirmed none reads a comment in the eleven edited files; the only assertion touching one is a negative match that deletion can only help.",
+      "verification": "advisor re-checked: named docblocks absent, 0 new comment lines in provision.ts, suite exit 0 at unchanged counts (shared 113, db 189, gateway 37, web 2898/126, provisioner 84)"
+    }
+  },
+  "mustAppearInPrBody": [
+    {
+      "item": "The reason the sandbox image ref is NOT pinned to 0.9.0",
+      "why": "The cleanup removed the only place the mifunedev/agro#1019 issue number appeared in source. The CONSTRAINT is still enforced by a test — 'the sandbox image ref is configurable and defaults to the canonical AGRO image, unpinned', asserting doesNotMatch(/agro:0\\.9\\.0/) — but the provenance is no longer recoverable from the tree. The worker flagged this itself rather than letting it vanish silently. It must be stated in the PR body and the evidence record."
+    }
+  ],
+  "blockedOn": {
+    "blocker": "Anthropic monthly spend limit (HTTP 429, rate_limit). Both bounded workers terminated mid-task within seconds of each other; session limit resets 01:20 America/Denver.",
+    "requestIds": [
+      "req_011CesQ8vZ6gQzJKAgmCiqon (bootstrap owner)",
+      "req_011CesQAbALZYv1weJejyMfW (lifecycle matrix)"
+    ],
+    "advisorAction": "No workers restarted. Retrying now would be repeated 429 retries against a MONTHLY cap that does not lift until reset, which is explicitly out of bounds. No provider switch, no limit raise.",
+    "verifiedPartialState": {
+      "readiness_gate": "NOT LANDED. grep for is-active/sandbox_ready/READY_UNIT in workspace-bootstrap-assets.ts returns 0. The worker died before writing anything. The PR worktree is otherwise intact and green, carrying the accepted migration (staged R100 renames), docs and comment cleanup.",
+      "ohproxy_negative_test": "NOT RUN. local-lifecycle-evidence.md still carries the NOT VERIFIED declaration; no observed refusal recorded.",
+      "uid_gid_contract_writeup": "NOT LANDED. grep for the required-contract and fail-before-mutation headings returns 0.",
+      "evidence_file": "Intact at 51,416 bytes, 16 sections, ending at 14.2 (surface 4a). Sections 14.1 and 14.2 — the exit-144 determination and the 4a product finding — DID land and are accepted."
+    },
+    "resumeOrder": [
+      "1. Readiness-ordering repair in workspace-bootstrap-assets.ts through the bounded owner: await the rebuild helper's bounded unit-completion oracle after `agro sandbox install docker` and before any harness/tool install or the ok/ready writes; runs for config A too; fails on failed or timeout; never emits ready prematurely. Plus ordering, failure, timeout and constant-derivation tests.",
+      "2. ohproxy-no-shell negative test with PID-scoped cleanup (never a pattern the invoking shell also matches).",
+      "3. UID/GID contract write-up plus fail-before-mutation ASSESSMENT only — no remap, no chown, no opportunistic remediation.",
+      "4. Real A+B lifecycle re-run with candidate artifacts, only after item 1 is in the tree."
+    ],
+    "note": "The operator instruction was to implement item 1 THROUGH THE EXISTING BOUNDED OWNER. I am not substituting a direct advisor edit while that instruction stands; if the cap persists and the operator prefers a recorded direct-owner exception, that is their call."
+  },
+  "scopeNarrowing": {
+    "date": "2026-09-09",
+    "by": "operator",
+    "activeFinishLine": [
+      "mifunedev/agro",
+      "mifunedev/agro-web"
+    ],
+    "deferred": {
+      "mifunedev/openharness-cloud": "US-002, US-003, US-004, US-005, US-006, US-009 and the Cloud half of US-008. Preserved on draft PR #145. Not merged, not reverted.",
+      "mifunedev/orchestra": "One customer-facing credit line. Preserved on draft PR #983.",
+      "mifunedev/website": "US-010. Branch pushed; PR deliberately WITHHELD because opening it triggers a Netlify Deploy Preview build on a project with an unresolved credit issue."
+    },
+    "dodEffect": "NONE. Deferred items remain part of #944's definition of done, and #944 remains part of #939. Completion is not redefined and the EPIC is not closable because agro and agro-web are ready.",
+    "gatesRetained": "#945 still requires Phase 4 complete AND 90 days AND three releases since the first public AGRO release. Anchor v0.9.0 2026-09-06; earliest date 2026-12-05; one release observed."
+  },
+  "pullRequests": [
+    {
+      "repo": "mifunedev/openharness-cloud",
+      "issue": 144,
+      "pr": 145,
+      "head": "4b4124c7caff31a84b2367b75472c7b8ef26ce2f",
+      "state": "DRAFT",
+      "note": "parked/deferred at operator request"
+    },
+    {
+      "repo": "mifunedev/orchestra",
+      "issue": 982,
+      "pr": 983,
+      "head": "1acc415bf347991ed2dbd3b0d0ac937b9006faa0",
+      "state": "DRAFT",
+      "note": "parked/deferred at operator request"
+    },
+    {
+      "repo": "mifunedev/agro-web",
+      "issue": 48,
+      "pr": 49,
+      "head": "0b0a6d28da979d6eb4a92e5a798cef8c95f3e1c4",
+      "state": "READY"
+    },
+    {
+      "repo": "mifunedev/agro",
+      "issue": 1021,
+      "pr": 1022,
+      "head": "909b3ec3e294a2dcfad15bd3036730a094c07610",
+      "state": "READY"
+    },
+    {
+      "repo": "mifunedev/agro",
+      "issue": 1019,
+      "pr": 1023,
+      "head": "f8b72d7f5845d797039b8cfd8f87d7c23d9165c5",
+      "state": "READY",
+      "note": "does NOT close #1019; population B needs a release"
+    },
+    {
+      "repo": "mifunedev/website",
+      "issue": null,
+      "pr": null,
+      "head": "5e5f34cc45ed8ab174f1354b3cd2e97f62b1c3a9",
+      "state": "BRANCH PUSHED, PR WITHHELD",
+      "note": "opening a PR triggers a Netlify Deploy Preview build; branch push measured to trigger nothing"
+    }
+  ]
+}

--- a/.agro/tasks/agro-cloud-consumer-migration/prd.json
+++ b/.agro/tasks/agro-cloud-consumer-migration/prd.json
@@ -457,14 +457,20 @@
       "scope": "Not Phase 4. Raised to the operator for a separate issue."
     },
     {
-      "id": "agro#1020",
-      "filed": true,
-      "summary": "Every workflow path filter in mifunedev/agro still names .oh/**, which has 0 tracked files after the Phase 3 rename (.agro/ has 760). Control-plane changes trigger no CI. The probe added by PR #1023 is unreachable by any CI path. Same failure shape as #981."
-    },
-    {
       "id": "migrate-rehearsal availability probe",
       "filed": false,
       "summary": "dockerComposeAvailable() in .agro/cli/src/commands/__tests__/migrate-rehearsal.test.ts probes the Compose plugin binary rather than daemon reachability, so it asserts success from a command that cannot succeed without a daemon. Causes 2 failures on any machine with the docker CLI but no socket. Pre-existing at b10ecac3."
+    },
+    {
+      "id": "agro#1020",
+      "filed": true,
+      "state": "CLOSED AS INVALID — the defect does not exist",
+      "summary": "RETRACTED. Claimed every workflow path filter still named .oh/**. The advisor grepped the root checkout's dirty working tree, not origin/development, which names .agro/** correctly throughout. Disproved by 5 green checks each on PR #1022 and #1023, including the Eval Probe Regression Gate on the very probe claimed unreachable. Lesson: grep the ref, not the worktree."
+    },
+    {
+      "id": "agro-web#50",
+      "filed": true,
+      "summary": "The docs build's Build site step passes no token, so the GitHub API call is unauthenticated (60/hr per shared runner IP), and isTransientStatus() omits 403 — GitHub's primary rate-limit code. Exhaustion is therefore misreported as 'ref does not resolve' and hard-fails the deploy. Proved by an unchanged re-run succeeding."
     }
   ],
   "advisorCorrections": [
@@ -630,11 +636,20 @@
     },
     {
       "repo": "mifunedev/website",
-      "issue": null,
-      "pr": null,
+      "issue": 65,
+      "pr": 66,
       "head": "5e5f34cc45ed8ab174f1354b3cd2e97f62b1c3a9",
-      "state": "BRANCH PUSHED, PR WITHHELD",
-      "note": "opening a PR triggers a Netlify Deploy Preview build; branch push measured to trigger nothing"
+      "state": "DRAFT",
+      "note": "Opened with [skip netlify] in the TITLE, the documented Netlify directive for PR Deploy Previews. Verified 0 statuses and 0 check-runs on the head. The directive must stay in the title until the credit issue is resolved."
     }
-  ]
+  ],
+  "ciAtExactHead": {
+    "cloud#145": "4/4 success",
+    "orchestra#983": "0 checks — decks/** is in test.yml paths-ignore; absence of jobs is not green",
+    "agro-web#49": "Build docs site success (after an unchanged re-run cleared a rate-limit 403); Deploy to GitHub Pages skipped",
+    "agro#1022": "5/5 success",
+    "agro#1023": "5/5 success",
+    "agro#1024": "5/5 success",
+    "website#66": "0 by design, [skip netlify]"
+  }
 }

--- a/.agro/tasks/agro-cloud-consumer-migration/prd.md
+++ b/.agro/tasks/agro-cloud-consumer-migration/prd.md
@@ -1,0 +1,301 @@
+# Phase 4 — Migrate Cloud and downstream Mifune consumers to AGRO
+
+- **Issue:** [#944](https://github.com/mifunedev/agro/issues/944) (parent [#939](https://github.com/mifunedev/agro/issues/939))
+- **Plan:** `.agro/plans/agro-compatibility-migration/plan.md` — step S5, deliverables D1, D8, D11, D13, D14
+- **Depends on:** #943 (merged `b10ecac3`)
+- **Slug:** `agro-cloud-consumer-migration`
+- **Branch:** `feat/944-agro-cloud-consumer-migration` in **both** repositories
+- **Primary implementation repository:** `mifunedev/openharness-cloud` @ `0aa8f99`
+- **Record repository:** `mifunedev/agro` @ `b10ecac3` (this task folder, inventory, evidence)
+
+## Summary
+
+Phase 4 makes AGRO the canonical **runtime dependency** consumed by Mifune-managed
+infrastructure. It is explicitly *not* a product rename of Cloud.
+
+Grounding against `mifunedev/openharness-cloud@0aa8f99` and `mifunedev/agro@b10ecac3`
+found that this phase is not a string-replacement exercise. Cloud's node bootstrap
+targets three harness contracts that **no longer exist**, so parts of Cloud are
+already broken against the shipped runtime, independent of any rename.
+
+## Grounded findings — the real constraint
+
+### F1 · Fresh Cloud provisioning is broken today (blocking, pre-existing)
+
+`infra/cloud-init/cloud-config.yaml` and
+`packages/shared/src/workspace-bootstrap-assets.ts` clone
+`https://github.com/mifunedev/openharness.git` into `~/.openharness` and run
+`make sandbox`.
+
+`Makefile` was **deleted** from the runtime repository by
+[#893](https://github.com/mifunedev/agro/pull/893) (`0b292bf8`, 2026-08-29), which is
+contained in tags `v0.5.1` through `v0.9.0`. The clone takes the default branch
+(`main`), which has no `Makefile`.
+
+Consequence: every new Cloud node clones successfully, then fails `make sandbox`,
+writes `failed:127` to `~/.openharness-bootstrap-status`, and never touches
+`/run/openharness-ready`. This predates the AGRO rename and is not caused by it.
+Verified: `git ls-tree origin/main --name-only | grep -i makefile` → empty.
+
+### F2 · Harness selections are silently dropped (blocking)
+
+`packages/shared/src/workspace-bootstrap-assets.ts:52-57` maps each user harness
+selection to an `INSTALL_<X>=true` line written into `.devcontainer/.env`.
+
+All four flags — `INSTALL_OPENCODE`, `INSTALL_GROK_BUILD`, `INSTALL_DEEPAGENTS`,
+`INSTALL_HERMES` — plus `INSTALL_AGENT_BROWSER` are listed in `RETIRED_KEYS` in
+`.agro/cli/src/lib/config-render.ts:4-23`. The runtime **refuses to render them**
+(`refusing to render retired variable ${key}`) and the devcontainer no longer reads
+them.
+
+Consequence: the Cloud create-node harness multi-select is a no-op. A user selects
+Hermes, Cloud reports success, nothing is installed. The plan's Phase 4 note applies
+directly: *"Translate supported user selections into explicit harness/tool
+installation calls; do not reactivate retired boot-time installation flags. Report
+unsupported legacy selections instead of silently dropping or replacing them."*
+
+Two sub-cases:
+
+- `opencode`, `grok_build`, `hermes` map to live AGRO ids `opencode`,
+  **`grok-build`** (hyphen, not underscore), `hermes` — migrate to explicit
+  `agro harness install <id>`.
+- `deepagents` has **no AGRO id at all**. It survives only as a retired key. It is an
+  unsupported legacy selection and must be reported, never silently dropped.
+- `agentBrowserEnabled` → `agro tool install agent-browser`.
+
+### F3 · `node.rebuild` reports success without doing anything (blocking for D11)
+
+`apps/provisioner/src/provision.ts:385-401` advances
+`rebuild_requested → stopping_container → pulling_image → starting_container → running`
+with no node-side effect. The only implementation is a comment:
+
+```
+// TODO: exec `git -C ~/.openharness pull && make sandbox` on the node over SSH
+```
+
+The intended implementation references both retired contracts from F1.
+
+Consequence: `running` after a rebuild does not prove workspace readiness, so D11's
+*"suspend/resume/rebuild/attach flows do not silently disconnect persistent user
+state"* cannot be evidenced against the current handler. The plan anticipates this:
+*"If incomplete Cloud lifecycle operations block D11, obtain a bounded prerequisite
+fix before claiming Phase 4 completion."* `apps/provisioner/src/management-ssh.ts`
+already provides the SSH capability, so the fix is bounded.
+
+### F4 · The organization audit is small and bounded
+
+- 32 org repositories; 1 archived.
+- Only **two** repositories carry a `.oh/` directory: `mifunedev/agro-web` (`.oh/tasks`
+  only) and `mifunedev/openharness-cloud` (`.oh/skills`, `.oh/tasks`). Neither is a
+  fully equipped control plane — no `cli`, `scripts`, `hooks`, or config — so
+  `agro migrate --check` decides whether the supported path applies before anything
+  moves.
+- Org code search shows legacy identifiers concentrated in `mifunedev/agro` itself
+  (compatibility surfaces, Phase 5's business) plus `mifunedev/website`
+  (6 `oh.mifune.dev` hits) and the private `openharness-cloud`.
+- `mifunedev/agro-web` returns no `oh.mifune.dev` hits — Phase 3 cleared it.
+
+Code search does not index private repositories in this query, so the recorded audit
+must scan by clone or API rather than relying on `gh search code` alone.
+
+## Cloud naming boundary — classification policy
+
+`mifunedev/openharness-cloud` keeps its product and repository identity. Names are
+classified into #939's five categories; only categories 1 and 2 move.
+
+| Name | Category | Disposition |
+|---|---|---|
+| `mifunedev/openharness` clone URL, `~/.openharness` source checkout | 1 runtime | **Removed** — replaced by artifact install (see US-003); not renamed to a new checkout |
+| `make sandbox` | 1 runtime | **Removed** — replaced by `agro sandbox install docker` |
+| `INSTALL_*` harness flags | 1 runtime | **Removed** — replaced by explicit `agro harness/tool install` |
+| `OH_CODE_SERVER_ENABLED` and other node-side `OH_*` runtime vars | 2 compat | Migrate to `AGRO_*` with Phase 0 compatibility |
+| `oh` CLI invocation in node/user-facing copy | 1 runtime | Migrate to `agro` |
+| `ghcr.io/mifunedev/openharness` runtime image | 1 runtime | Migrate to `ghcr.io/mifunedev/agro` |
+| `mifunedev/openharness-cloud` repository | 3 product identity | **Retain** |
+| `ghcr.io/mifunedev/openharness-cloud/{web,gateway,provisioner}` | 3 product identity | **Retain** — Cloud's own images, not the runtime |
+| `@openharness-cloud/shared` npm workspace scope | 3 product identity | **Retain** |
+| `OH_IMAGE_TAG`, `OH_ENV_FILE` | 4 internal/operator config | **Retain** — Cloud's own compose stack, live on deployed hosts |
+| `~/.openharness-bootstrap-status`, `~/.openharness-bootstrap.log`, `/run/openharness-ready` | 4 internal contract | **Retain paths** — cloud-init/provisioner/gateway contract |
+| `docker-build-oh-sandbox` tmux session | 4 internal identifier | **Retain** |
+| Database names, durable IDs, API token prefixes | 4 persistence | **Retain** — never changed for grep cleanliness |
+| `.oh/tasks/*` historical task records | 5 historical | **Retain content**; directory moves only if `agro migrate` applies |
+| CI run URLs, closed-issue links, `docs/design/console-mvp.md` history | 5 historical | **Retain** |
+
+## Plan reconciliation
+
+The approved plan's Phase 4 intent is unchanged. Grounding **enlarged the known work**
+within that intent rather than redirecting it: the plan already required replacing
+`make sandbox` with artifact-based provisioning, already forbade a renamed source
+checkout, already required translating selections into explicit installation calls,
+and already anticipated a bounded lifecycle prerequisite fix for D11. F1–F3 are the
+concrete instances of those four instructions. No re-approval is sought on scope
+shape. The two naming questions raised during grounding were resolved as grounded
+applications of #944's own retention boundary, not as new decisions.
+
+## Knowledge context
+
+Recalled and re-grounded against current code:
+
+- `[[compose-env-boundary]]` — verified: `RETIRED_KEYS` in `config-render.ts` is the
+  live mechanism behind F2, and the retirement is enforced by a throw, not a warning.
+- `[[oh-cli-portable-lifecycle]]` — verified: `docs/lifecycle-commands.md:38-55` is the
+  current verb surface used for the replacement bootstrap.
+- `[[fresh-machine-setup]]` — verified: artifact-only installation with no host
+  checkout is the canonical model (D16).
+- `[[agro-web-pipeline]]` — orientation only; no Phase 4 dependency.
+- `[[pattern-spec-stubbed-runner-state-gap]]` — directly applicable to F3: a status
+  advance is not evidence of a runtime effect. D11 evidence must observe node state,
+  never the `running` status field.
+- `[[plan-vs-built-reconciliation]]` — applied above.
+
+## Expected knowledge impact
+
+- UPDATE `oh-cli-portable-lifecycle` — the lifecycle verbs gain a documented
+  headless/unattended provisioning consumer.
+- NEW `cloud-node-provisioning` — how Cloud installs and drives AGRO on a node,
+  including the artifact path and the retained internal contract paths.
+- REVERIFY `compose-env-boundary` — F2 is a second consumer discovering the retirement.
+- Candidate pattern: *a downstream consumer pinned to a deleted build entrypoint fails
+  only at provision time*, from F1.
+
+## Resolved decisions and the one real gate
+
+**Q1 and Q2 are resolved, not pending.** #944 already directs retention of stable
+Cloud and internal identifiers, so these need no new naming decision — they are
+grounded applications of the approved boundary:
+
+- `OH_IMAGE_TAG` and `OH_ENV_FILE` configure Cloud's own compose stack, not the AGRO
+  runtime, and live in `.env` files on running control-plane hosts. **Retained**,
+  category 4.
+- `~/.openharness-bootstrap-status`, `~/.openharness-bootstrap.log`,
+  `/run/openharness-ready`, and the `docker-build-oh-sandbox` tmux session are the
+  internal contract between cloud-init, the provisioner, and the gateway.
+  **Paths and session name retained**, category 4. Only runtime-facing prose changes.
+
+**Q3 is a genuine operator gate**, but it gates less than the whole of US-007. The
+lifecycle matrix splits by what actually requires the provider:
+
+- **Locally exercisable, faithfully:** the node bootstrap is a generated shell script
+  run by cloud-init on a Linux host. Fresh AGRO provisioning, recovery of a
+  representative legacy `~/.openharness` workspace, AGRO operating existing legacy
+  project state, and rebuild-over-SSH state preservation can all be exercised against
+  a real disposable local Linux VM or container with real observed filesystem and
+  container state. This is US-007a.
+- **Requires the provider:** OVH instance create, destroy, suspend, and resume, and
+  the provisioner's OVH-side reconciliation. This is US-007b.
+
+A mock, a fixture, or a status transition is never accepted as observed state for
+either half. US-007a's evidence must read real files and real container state on a
+real booted host.
+
+## User stories
+
+### US-001 · Organization-wide downstream dependency inventory
+Record a classified inventory of every active dependency on legacy identifiers across
+all 32 `mifunedev` repositories, scanned by an auditable, reproducible command against
+recorded commit SHAs rather than by `gh search code` alone (which omits private repos).
+Every occurrence lands in exactly one of the five categories.
+
+### US-002 · Cloud name classification record
+Publish the classification table above as a reviewable record in the Cloud repository,
+with a justification per retained name. Explicitly justify every category 3 and 4
+retention. No durable persistence identifier changes.
+
+### US-003 · Artifact-based node provisioning replaces the deleted `make sandbox` path
+Replace the source-clone bootstrap with canonical AGRO installation from artifacts and
+`agro sandbox install docker`. No managed source checkout is created — neither the old
+`~/.openharness` clone nor a renamed equivalent. Fixes F1.
+
+### US-004 · Harness and tool selections become explicit installation calls
+Emit no retired `INSTALL_*` flag. Translate supported selections into explicit
+`agro harness install` / `agro tool install` calls, mapping `grok_build` → `grok-build`.
+Report `deepagents` as an unsupported legacy selection rather than dropping it
+silently. Fixes F2.
+
+### US-005 · Canonical AGRO refs and variables across Cloud runtime surfaces
+Source URLs, installer URLs, GHCR runtime references, node-side `OH_*` → `AGRO_*` with
+compatibility, and `oh` → `agro` invocation, in cloud-init, host-management assets,
+workspace-bootstrap assets, provisioning fixtures, and tests. Category 3 and 4 names
+are untouched.
+
+### US-006 · Bounded `node.rebuild` implementation
+Give `node.rebuild` a real node-side operation over the existing SSH management path,
+so `running` reflects an observed workspace state. Scope is the prerequisite D11 needs
+and no more — this is not a Cloud lifecycle redesign. Fixes F3.
+
+## The attach surface — three places, two test homes
+
+#944 requires that "suspend/resume/rebuild/attach flows do not silently disconnect
+persistent user state". Attach is not one thing on a Cloud node, and splitting US-007 by
+provider dependency must not drop it. The three surfaces:
+
+1. **SSH + tmux.** `packages/shared/src/index.ts:788-789` documents
+   `ssh <sshUser>@<ipv4>` then `tmux attach -t docker-build-oh-sandbox`.
+2. **Browser editor.** `apps/gateway` proxies to the node's loopback code-server on
+   `127.0.0.1:8080` over a pinned SSH forward (`proxy.ts:86`, `dialer.ts:48`).
+   `README.md:356` records that this editor "opens `~/.openharness` by default".
+3. **Container attach.** VS Code Dev Containers against the compose-built sandbox.
+
+Surface 2 makes attach a **design constraint on US-003, not only a test**: the directory
+US-003 removes is the editor's default workspace root. US-003 therefore has to decide
+what that root becomes and point `/home/sandbox/oh.code-workspace` at a path that exists
+after the new bootstrap and holds durable user state.
+
+All three surfaces are exercisable on a real local host, so they live in US-007a,
+including after a restart and after a rebuild. Only the live cloudflared tunnel and
+attach across provider suspend/resume need the provider, so those go to US-007b.
+
+One nuance the evidence must respect: `node.rebuild` deliberately calls
+`revokeNodeBrowserAccess` before it does anything else. A revoked session after a rebuild
+is **correct behaviour**. The criterion is that the user's *re-attach* lands on preserved
+state — not that an open websocket survives.
+
+### US-007a · Node-bootstrap lifecycle evidence on a real local host
+Run the generated bootstrap on a real disposable Linux host. Evidence that fresh AGRO
+provisioning completes, that a representative OpenHarness-era `~/.openharness`
+workspace remains recoverable, that AGRO operates existing legacy project state, that
+migration to native AGRO state is explicit and safe, and that a rebuild preserves
+persistent user state. Every assertion reads observed filesystem or container state.
+No mock, fixture, or status transition is accepted as evidence.
+
+### US-007b · Provider-level lifecycle evidence (D11 remainder)
+OVH instance create, destroy, suspend, and resume against disposable paid nodes, and
+the provisioner's OVH-side reconciliation. **Blocked on Q3 — explicit operator
+authorization to provision paid infrastructure. No live infrastructure is touched
+without it.**
+
+### US-008 · Equipped-repository migration through the supported path
+For each `.oh/`-carrying org repository, run `agro migrate --check` first and migrate
+through the supported mechanism where it applies; where it does not apply, record why
+rather than performing an ad hoc rename.
+
+### US-009 · Operator- and user-facing copy reflects the AGRO runtime contract
+README, quickstart, threat model, deploy and gateway runbooks, cloud-init README,
+console setup guide, and API/UI copy stop presenting OpenHarness as the canonical
+runtime name, while retaining Cloud's own product identity and historical references.
+
+## Non-goals
+
+- Removing any compatibility surface defined by #939 — that is Phase 5 (#945).
+- Renaming the Cloud product, repository, images, npm scope, or persistence identifiers.
+- Any release, promotion, credential creation, or Cloudflare mutation.
+- Cloud lifecycle redesign beyond the bounded US-006 prerequisite.
+- Closing #939.
+
+## Verification
+
+- Cloud unit and integration suites on the exact implementation head.
+- A provisioning fixture asserting no retired `INSTALL_*` key and no `make sandbox`
+  reaches generated userData.
+- A fixture asserting generated userData creates no source checkout.
+- `agro migrate --check` output recorded per equipped repository.
+- Live D11 matrix per Q3, with observed-state evidence.
+- Independent read-only review from a clean candidate worktree (D13).
+
+## Ready PR contract
+
+Two coordinated pull requests, both referencing #944, with the dependency order
+recorded: the Cloud implementation PR (`mifunedev/openharness-cloud`) and the record
+PR (`mifunedev/agro`, this folder plus inventory and evidence). Dedicated worktrees per
+repository. Neither is merged without explicit operator authorization — the prior
+authorization covered #1015 only.

--- a/.agro/tasks/agro-cloud-consumer-migration/progress.txt
+++ b/.agro/tasks/agro-cloud-consumer-migration/progress.txt
@@ -388,3 +388,66 @@ Nothing above changes it. US-007a still FAILS and its re-run is still blocked on
 absent Docker socket. US-007b is still behind the paid-OVH gate. #944 and #939 remain
 OPEN, no PR carries a closing trailer for either, and #945's time-and-release gate is
 untouched. Host cleanup remains UNVERIFIED — nobody has checked.
+
+
+## 2026-09-09 (final) — agro-web#50 fixed and verified; website#66 body corrected
+
+### agro-web#50 IMPLEMENTED — PR #51, head 55d4cfc5adec6fb77c1dfa0026aca6c1f55239f7
+
+Bounded fix, on a fresh worktree off origin/main (409ef10) so it does not mix with the
+docs PR:
+
+1. `.github/workflows/pages.yml` — the `Build site` step now receives the job's own
+   `secrets.GITHUB_TOKEN`. No new credential; it is the token the workflow already has.
+   Unauthenticated the mirror call ran against 60 requests/hour per shared runner IP.
+2. `scripts/oh-source.mjs` — `isTransientStatus(status)` becomes
+   `isTransientResponse(res)`, reading the response rather than the status alone. A 403
+   is transient ONLY with `x-ratelimit-remaining: 0`. Without that header a 403 stays
+   FATAL, so a genuine auth failure or a bad ref still fails the deploy — treating every
+   403 as transient would have been the dangerous fix. raw.githubusercontent.com sends no
+   such header, so a 403 there stays fatal, which is correct since it is not
+   quota-limited. Both call sites migrated, so there is one rule, not two. A
+   rate-limited failure now reports "GitHub rate limit exhausted" instead of blaming the
+   ref.
+3. Tests — the repository had NO test runner. Added `pnpm test` (`node --test`, no new
+   dependency) and `scripts/oh-source.test.mjs`, 9 tests: the exhausted-quota 403; the
+   bare 403 and remaining=1/4999; 401 and a 403 carrying only retry-after; the UNCHANGED
+   408/429/5xx behaviour; 400/404/409/410/422 still fatal; the header believed only on a
+   403; a header-less response; and case-insensitive header matching. Wired as a GATING
+   CI step on every event, unlike the advisory drift check, because this rule decides
+   whether a bad mirror ships.
+
+**Verified at the exact head, on the FIRST run — not a rerun.** Local: 9/9 tests,
+typecheck exit 0, build SUCCESS, theme-order PASS, docs-drift PASS (39 files), and the
+build exercised the real mirror path end to end (resolved agro@main at 823aabbd, wrote
+get-agro.sh, get-oh.sh, agro.js, oh.js). CI run 34386051054: `Build docs site` success,
+`Deploy to GitHub Pages` skipped. The CI LOG was read rather than trusting the green —
+the new step executed (`# tests 9 / # pass 9 / # fail 0`) and `GITHUB_TOKEN: ***`
+appears in the Build site step's env, so the token is genuinely in effect.
+
+### website#66 body corrected — metadata only, no source change
+
+Two corrections at the operator's direction:
+
+1. **Removed the claim that a new cold boot is "not locally repairable."** A volume
+   seeded during a FAILED fresh boot is repairable in place too, exactly like a
+   previously-seeded one. What a local repair does not change is the published image
+   DIGEST, so the next cold boot from that digest fails identically until a new image is
+   published. Repairability and the image fix are separate questions; the earlier wording
+   conflated them.
+2. **Reframed the deploy claim as evidence, not guarantee.** The body now says GitHub
+   reports 0 check-runs and 0 commit statuses on the head — *no deployment evidence
+   observed on the GitHub side* — and states explicitly that this is not a guarantee from
+   Netlify's backend and says nothing about billing, neither of which was queried and for
+   neither of which a credential exists here.
+
+`[skip netlify]` remains in the title and the PR remains a draft. The same conflation
+survives in `posts/openharness-getting-started.md` itself; correcting published copy is a
+content change and was explicitly out of scope, so it is flagged in the PR body rather
+than silently edited.
+
+### Story state STILL 10 of 12
+
+Unchanged. US-007a still FAILS with its re-run blocked on the absent Docker socket;
+US-007b still behind the paid-OVH gate. #944 and #939 OPEN, no closing trailer anywhere.
+#945's gate untouched. Host cleanup still UNVERIFIED.

--- a/.agro/tasks/agro-cloud-consumer-migration/progress.txt
+++ b/.agro/tasks/agro-cloud-consumer-migration/progress.txt
@@ -288,3 +288,103 @@ parked/deferred status. The EPIC's definition of done is NOT redefined by this n
 those items remain part of #944, and #944 remains part of #939. #945's gate — Phase 4
 complete AND 90 days AND three releases since the first public AGRO release (anchor
 v0.9.0 2026-09-06; earliest date 2026-12-05; one release observed) — is unchanged.
+
+
+## 2026-09-09 (later) — RETRACTION of #1020, website draft opened, all heads green
+
+### RETRACTION — issue #1020 was FALSE and is closed as invalid
+
+I filed mifunedev/agro#1020 claiming that every workflow path filter still named
+`.oh/**`, which has no tracked files, and therefore that control-plane changes trigger
+no CI — including the assertion that the probe added by PR #1023 was unreachable by any
+CI path.
+
+**All of that is wrong.** I ran `grep -rn '\.agro/' .github/workflows/` against the ROOT
+CHECKOUT'S WORKING TREE and read the result as repository state. All six workflow files
+are locally modified there, reverted to the pre-AGRO generation — the same silent
+working-tree divergence already recorded in this file as HAZARD 1 for `.devcontainer/`.
+I had documented that exact hazard and then walked into it again for a different
+directory.
+
+`origin/development` was correct all along: ci-harness.yml names `.agro/**`,
+`.agro/skills/**`, `.agro/hooks/**`, `.agro/evals/**`, `.agro/knowledge/**`,
+`agro.json` and `.example.env`; sandbox-boot-guard.yml names `.agro/**` and
+`.agro/scripts/*`. Both `.agro/**` and `.oh/**` are listed, which is correct during the
+alias SLA.
+
+Disproof from real runs: PR #1022 (changes confined to `.agro/cli/src/**`) and PR #1023
+(adds a probe under `.agro/evals/`) each ran 5 checks, all success, including the Eval
+Probe Regression Gate. The probe I claimed was unreachable was gated green on its own PR.
+
+#1020 is closed as not-planned with that correction written into it, and the three PR
+bodies that cited it (#1022, #1023, #1024) were edited to remove the false claim and
+carry the actual check results.
+
+**Rule for the next session: grep the ref, not the worktree.** `git show
+origin/<branch>:<path>` — never the working copy at /home/sandbox/harness.
+
+### Website: draft PR opened without triggering a deploy
+
+The operator asked whether Netlify documents a native skip directive for PR-opening
+Deploy Previews. It does, and it is title-scoped:
+
+- Netlify docs: "To avoid generating a Deploy Preview for a pull/merge request, add
+  `[skip ci]` or `[skip netlify]` to **the title of the pull/merge request**."
+- The commit-message form covers only branch and production deploys. That distinction is
+  the documented cause of the "it was ignored" support reports; Netlify staff confirmed
+  the PR title is the working mechanism and the docs were updated to say so.
+
+So website PR #66 was opened as a DRAFT titled
+`[skip netlify] FROM docs/65-agro-runtime-references TO development`. Metadata on the PR
+only — no site configuration, billing or DNS was touched, and the Netlify credit issue
+itself was not investigated.
+
+**Verified no deploy launched:** 90+ seconds after opening, the head
+5e5f34cc45ed8ab174f1354b3cd2e97f62b1c3a9 carries 0 commit statuses and 0 check-runs.
+Existing PRs (#64, #62, #60) register their `netlify/promptengineers/deploy-preview`
+check within about a minute, so a launched build would have appeared by then.
+
+**`[skip netlify]` must stay in that title** until the credit issue is resolved.
+Removing it and pushing a commit is what resumes previews.
+
+### NEW FINDING — agro-web docs build hard-fails on a rate-limit 403. Filed as agro-web#50.
+
+PR #49's first run failed with `ref mifunedev/agro@main does not resolve (... -> HTTP
+403)`. Re-running the IDENTICAL commit with no change succeeded, so the message names
+the wrong cause. Two compounding defects:
+
+1. `.github/workflows/pages.yml`'s `Build site` step sets no `env:`, so
+   `oh-source.mjs`'s `authHeaders()` finds neither GITHUB_TOKEN nor GH_TOKEN and the
+   API call goes out unauthenticated — 60 requests/hour per IP, on shared runner IPs.
+2. `isTransientStatus()` covers 408/429/5xx but NOT 403, which is what GitHub returns on
+   primary rate-limit exhaustion. Exhaustion therefore falls through to
+   "the mirror would publish something wrong" and hard-fails the deploy.
+
+`mifunedev/agro` is public and the same URL returns 200 unauthenticated from a
+non-exhausted address, so this is not a permissions problem. Not fixed here — filed,
+with the token fix and the `x-ratelimit-remaining: 0` discriminator proposed.
+
+### Final CI state — every PR verified at its exact head
+
+| PR | Head | Checks |
+|---|---|---|
+| cloud #145 (draft) | 4b4124c7caff31a84b2367b75472c7b8ef26ce2f | 4/4 success |
+| orchestra #983 (draft) | 1acc415bf347991ed2dbd3b0d0ac937b9006faa0 | 0 — `decks/**` is in test.yml's paths-ignore, and slides.yml only fires on a push to development. Absence of jobs is NOT green, and is reported as absence. |
+| agro-web #49 (ready) | 0b0a6d28da979d6eb4a92e5a798cef8c95f3e1c4 | Build docs site success; Deploy to GitHub Pages skipped |
+| agro #1022 (ready) | 909b3ec3e294a2dcfad15bd3036730a094c07610 | 5/5 success |
+| agro #1023 (ready) | f8b72d7f5845d797039b8cfd8f87d7c23d9165c5 | 5/5 success |
+| agro #1024 (ready) | 53f24aa207ceac8a608bf6f79a8f826ac3620868 | 5/5 success |
+| website #66 (draft) | 5e5f34cc45ed8ab174f1354b3cd2e97f62b1c3a9 | 0 by design — `[skip netlify]` |
+
+The accidentally committed node_modules symlink is confirmed ABSENT from every pushed
+tree: `git ls-tree -r` over bug/1021-sandbox-install-idempotent and bug/1019-boot-recovery
+returns 0 node_modules paths. #1022's head is 909b3ec3e294a2dcfad15bd3036730a094c07610 and
+was never affected — the symlink was committed on the 1019 branch and amended away before
+that branch was pushed.
+
+### Story state is STILL 10 of 12
+
+Nothing above changes it. US-007a still FAILS and its re-run is still blocked on the
+absent Docker socket. US-007b is still behind the paid-OVH gate. #944 and #939 remain
+OPEN, no PR carries a closing trailer for either, and #945's time-and-release gate is
+untouched. Host cleanup remains UNVERIFIED — nobody has checked.

--- a/.agro/tasks/agro-cloud-consumer-migration/progress.txt
+++ b/.agro/tasks/agro-cloud-consumer-migration/progress.txt
@@ -1,0 +1,290 @@
+# Phase 4 (#944) — agro-cloud-consumer-migration
+
+STATE: PLANNED (awaiting operator answers to Q1/Q2/Q3 before dependent edits)
+
+## Role
+Advisor owns decisions, integration, acceptance, prd.json and this file.
+All tracked implementation edits go to bounded /delegate workers in isolated
+worktrees, per the standing operator instruction. No direct owner implementation
+edit without a recorded exception.
+
+## Grounding performed (advisor, read-only)
+- mifunedev/agro @ b10ecac3 (development, post-#1015)
+- mifunedev/openharness-cloud @ 0aa8f99 (development), fetched this session
+- 345 files in the Cloud repo match legacy identifiers; live-code subset scoped
+  by excluding .oh/tasks history.
+- 32 org repositories enumerated; 1 archived.
+
+## Findings that changed the shape of the work
+F1 Makefile deleted from the runtime repo by #893 (0b292bf8, 2026-08-29), present
+   in tags v0.5.1..v0.9.0. Cloud cloud-init runs `make sandbox` after cloning the
+   default branch. Fresh Cloud provisioning therefore fails today, before and
+   independent of any rename. Verified by git ls-tree against origin/main.
+F2 INSTALL_OPENCODE / INSTALL_GROK_BUILD / INSTALL_DEEPAGENTS / INSTALL_HERMES /
+   INSTALL_AGENT_BROWSER are RETIRED_KEYS in .agro/cli/src/lib/config-render.ts
+   and the renderer throws on them. Cloud writes exactly these into
+   .devcontainer/.env for every user harness selection, so the create-node harness
+   multi-select is a silent no-op. deepagents has no AGRO id at all.
+   grok_build (Cloud) vs grok-build (AGRO) is an id mismatch.
+F3 apps/provisioner/src/provision.ts handleRebuild advances the status machine to
+   running with no node-side effect; its only implementation is a TODO naming both
+   retired contracts. `running` does not prove workspace readiness, which blocks
+   D11 evidence. management-ssh.ts already provides the SSH capability, so the
+   prerequisite fix is bounded, as the plan anticipated.
+F4 Only two org repositories carry .oh/: agro-web (.oh/tasks) and
+   openharness-cloud (.oh/skills, .oh/tasks). Neither is a fully equipped control
+   plane. gh search code omits private repos, so the recorded audit must scan by
+   clone or API.
+
+## Decisions taken
+- Cloud product, repository, images (ghcr.io/mifunedev/openharness-cloud/*), and
+  npm scope (@openharness-cloud/*) are retained. Category 3.
+- Durable persistence identifiers are not touched. Category 4.
+- The old ~/.openharness clone is removed, not renamed to a new managed checkout,
+  per the plan's explicit instruction.
+- Two coordinated PRs, one per repository, both referencing #944.
+
+## Open questions raised to the operator
+Q1 OH_IMAGE_TAG / OH_ENV_FILE retention (recommend retain, category 4).
+Q2 bootstrap marker paths and tmux session name (recommend retain paths, adjust
+   only user-facing prose).
+Q3 live disposable Cloud nodes and credentials for the D11 matrix (US-007), and
+   whether a representative legacy node exists or must be created.
+
+## Authorization boundary held
+No release, promotion, credential creation, or Cloudflare mutation. No PR merge:
+the prior merge authorization covered #1015 only. #939 is not closed by this task.
+#945 remains blocked on Phase 4 plus 90 days plus three releases; anchor v0.9.0
+2026-09-06, earliest date 2026-12-05, one release observed.
+
+## Follow-up retained, not resolved here
+#1019 recovery triage and the patched-release plan remain open. Merged #1015
+changes do not repair immutable 0.9.0 artifacts or already-seeded manifests.
+
+## 2026-09-08 — verified cross-dependency: #1019 blocks Phase 4 fresh-provisioning acceptance
+
+Checked the published AGRO container package directly. It has exactly two versions,
+pushed eleven seconds apart on 2026-09-06:
+
+  latest                              2026-09-06T19:54:30Z
+  sha-823aabbd...,0.9.0               2026-09-06T19:54:19Z
+
+As of 2026-09-08, `latest` and `0.9.0` resolved to the same build and there was no third
+image. `latest` is a MOVING tag and will resolve elsewhere after the next release; only the
+version tags and the digest are stable references. Pulled
+ghcr.io/mifunedev/agro:latest and inspected its seeded workspace manifest:
+
+  /opt/oh-seed/package.json:19  "pnpm:devPreinstall": "pnpm run security:audit"
+  /opt/oh-seed/package.json:20  "security:audit": "pnpm audit --audit-level low --ignore-registry-errors"
+
+That is the #1019 defect, present in the only image a Cloud node could pull today.
+
+Consequence for this phase, stated plainly: US-003's criterion "new Cloud nodes
+install/invoke agro" can be implemented and unit-proven now, but a fresh Cloud node
+provisioning from a published image cannot boot successfully until the #1019 patched
+release ships. #1019 is therefore on Phase 4's critical path for the end-to-end
+acceptance criterion, not a parallel follow-up. The merged #1015 source change does not
+repair this image; only a new release can.
+
+Also observed: the published image still seeds from /opt/oh-seed, a legacy-named
+internal path. Category 4 internal identifier; noted, not actioned here.
+
+Local-execution feasibility for US-007a (asked before requesting paid infrastructure):
+Docker 29.7.2 is available with 16 GB, so a disposable privileged Linux container can
+host a real dockerd and run the generated bootstrap for real. That covers the bootstrap
+script, artifact installation of the agro executable, marker-file semantics, legacy
+~/.openharness workspace recovery, and rebuild-over-SSH state preservation, all against
+observed filesystem and container state. It does NOT cover cloud-init's own YAML
+processing under systemd on an OVH image, nor provider create/destroy/suspend/resume —
+those remain US-007b behind Q3. The fresh-provisioning leg additionally needs either the
+#1019 patched image or a locally built image from the fixed tree, pointed at via the
+sandbox image reference; if the latter is used it proves the Cloud bootstrap logic only,
+and that limit must be stated in evidence rather than glossed.
+
+
+## 2026-09-08 — correction to my own wording: moving tag versus immutable digest
+
+I wrote, more than once, that `ghcr.io/mifunedev/agro:latest` is an immutable broken build.
+That is wrong in a way that will actively mislead later. The DIGEST is immutable; the TAG is
+not. `latest` moves on the next publish, at which point every sentence of that shape becomes
+false, including in the #1019 release-decision material where it could misdirect the choice.
+
+The accurate statements are:
+
+- The affected artifacts are the version tag `0.9.0` and the tag `sha-823aabbd...`, plus the
+  digest they currently share.
+- As of 2026-09-08, `latest` resolved to that same build. That is a dated observation, not a
+  property of the tag.
+- A new published release fixes new cold boots by moving `latest` and adding a new version
+  tag. It does not alter the affected digest, and it does not repair an already-seeded
+  workspace manifest, which is why the #1019 recovery procedure exists for population B.
+
+Applied to this file; the same correction was routed to the #1019 worker for its runbook and
+its Part B requirements document.
+
+
+## 2026-09-09 — HARD BLOCKER: account spend cap, work suspended not abandoned
+
+Both remaining bounded workers terminated mid-task on the Anthropic monthly spend
+limit (HTTP 429), within seconds of each other. Session limit resets 01:20
+America/Denver. No workers were restarted: the cap is monthly, so retrying now would
+be exactly the repeated-429 behaviour that is out of bounds. No provider switch and no
+limit raise.
+
+Verified partial state, by inspection rather than assumption:
+- The readiness-ordering repair did NOT land. workspace-bootstrap-assets.ts has zero
+  occurrences of the readiness oracle; the worker died before writing.
+- The ohproxy-no-shell negative test did NOT run; the NOT VERIFIED declaration stands.
+- The UID/GID contract write-up did NOT land.
+- What DID land and is accepted: the exit-144 determination and the surface-4a product
+  finding, sections 14.1 and 14.2 of local-lifecycle-evidence.md.
+- The Cloud PR worktree is intact and green, carrying the accepted migration as staged
+  R100 renames, the docs work and the comment cleanup.
+
+Nothing is lost. Every outstanding item has a recorded resume order and the evidence to
+resume from. Ten of twelve stories pass; US-007a fails on measured defects, not on the
+cap; US-007b remains behind the unauthorized paid-infrastructure gate.
+
+
+## 2026-09-09 — operator narrowed scope; PRs opened; website publication withheld
+
+**Scope change, mid-turn, by the operator.** Immediate priority narrowed to
+`mifunedev/agro` and `mifunedev/agro-web`. Cloud, orchestra and website are DEFERRED —
+their existing work is preserved on its own draft PRs at operator instruction, not
+proposed for merge. A follow-up authorization then explicitly permitted scoped
+commits/pushes/draft-PR creation for those secondary repositories as a preservation
+measure only. Nothing was reverted. No new implementation was performed on them.
+
+**Story state is unchanged at 10 of 12.** US-007a still FAILS on measured product
+defects; US-007b is still behind the unauthorized paid-OVH gate. #944 and #939 remain
+OPEN, and no PR carries a closing trailer for either. #945's gate is untouched.
+
+### Re-grounding, before anything was committed
+
+Every branch was checked against its actual current target head. All six were already
+exactly at their target — no rebase was needed:
+
+| Repo | Base recorded | origin target at check time | Match |
+|---|---|---|---|
+| openharness-cloud | 0aa8f99 | origin/development 0aa8f99 | yes |
+| agro-web | 409ef10 | origin/main 409ef10 | yes |
+| website | fd60500 | origin/development fd60500 | yes |
+| orchestra | 2c7ccd28 | origin/development 2c7ccd28 | yes |
+| agro (x3) | b10ecac3 | origin/development b10ecac3 | yes |
+
+### PRs opened
+
+| Repo | Issue | PR | Head | Status |
+|---|---|---|---|---|
+| openharness-cloud | #144 | #145 | 4b4124c7caff31a84b2367b75472c7b8ef26ce2f | DRAFT — parked, deferred |
+| orchestra | #982 | #983 | 1acc415bf347991ed2dbd3b0d0ac937b9006faa0 | DRAFT — parked, deferred |
+| agro-web | #48 | #49 | 0b0a6d28da979d6eb4a92e5a798cef8c95f3e1c4 | READY |
+| agro | #1021 | #1022 | 909b3ec3e294a2dcfad15bd3036730a094c07610 | READY |
+| agro | #1019 (not closed) | #1023 | f8b72d7f5845d797039b8cfd8f87d7c23d9165c5 | READY |
+| website | #65 (not filed) | NONE — withheld | 5e5f34cc45ed8ab174f1354b3cd2e97f62b1c3a9 | branch pushed, PR withheld |
+
+### Website: the precise gate, and why no PR was opened
+
+The operator flagged an unresolved Netlify credit/domain issue and forbade knowingly
+triggering a deployment or paid action. Measured rather than assumed:
+
+- **Opening a PR on mifunedev/website triggers a Netlify Deploy Preview build.** Verified
+  against three existing PRs (#64, #62, #60): each carries a
+  `netlify/promptengineers/deploy-preview` check plus header/redirect/pages-changed
+  checks, ~1m build each, on the `promptengineers` Netlify project.
+- **A branch push does not.** After pushing `docs/65-agro-runtime-references`, the head
+  carried 0 commit statuses and 0 check-runs.
+
+So the work is preserved on the remote branch and the PR is deliberately not opened.
+Opening it is the operator's call once the credit issue is resolved. The scoped website
+issue was also not filed, since an issue without its PR serves nothing here.
+
+Caveat on the branch-push evidence: the three no-PR branches used as controls
+(feat/21-matrix-vibes, feat/614-add-fastmcp-support, master) all predate the Netlify
+integration, so they are weak controls. The direct observation on the actual pushed head
+— 0 statuses, 0 check-runs — is the load-bearing evidence.
+
+### Verification performed at each exact head
+
+- **Cloud** — `pnpm type-check` exit 0; shared 119, db 189, gateway 37, provisioner 84,
+  web 2898 across 126 files. Matches the pre-change baseline on every count. The six
+  readiness-gate tests were confirmed to actually EXECUTE (subtests 34-39), not merely
+  to exist.
+- **agro-web** — check:docs-drift PASS (44 files), typecheck exit 0, docusaurus build
+  SUCCESS, theme-order PASS. Installer assets the new quickstart tells readers to curl
+  were fetched live: get-agro.sh 200/8527B, agro.js 200/187989B, get-oh.sh 200/9493B,
+  oh.js 200/187989B.
+- **website** — next lint 0 warnings, next build succeeded, and the llm.txt generator
+  was re-run to confirm its output matches the committed file (no drift).
+- **agro CLI fix** — typecheck exit 0; sandbox.test.ts 26 passed; full suite 1255 passed,
+  2 failed.
+- **agro #1019** — pnpm-audit-ci-gate PASS; recovery probe SKIPPED (exit 2, non-live);
+  full suite 1246 passed, 2 failed.
+
+### The 2 agro suite failures are pre-existing, and this was proved rather than assumed
+
+Both are in `.agro/cli/src/commands/__tests__/migrate-rehearsal.test.ts`, untouched by
+either branch. A clean detached worktree at the base commit b10ecac3, with none of the
+branch changes, reproduces the IDENTICAL 2 failures. Cause: `dockerComposeAvailable()`
+runs `docker compose version`, which probes the Compose plugin binary (present) rather
+than daemon reachability (absent). It therefore takes the "available" branch and asserts
+exit 0 from a command that cannot succeed without a daemon.
+
+### NEW FINDING — every CI path filter in agro is dead. Filed as #1020.
+
+`git ls-files .oh` returns **0**; `git ls-files .agro` returns **760**. No workflow in
+`.github/workflows/` references `.agro/` at all. Every path filter still names `.oh/**`,
+which now matches nothing, so a change confined to the control plane triggers NO CI.
+
+This is not cosmetic. The probe added by PR #1023 lives under `.agro/evals/` and is
+therefore unreachable by any CI path — the exact failure shape of #981, now instantiated
+repository-wide by the Phase 3 rename. `oh.json` and `.env.example` in those filters are
+stale too; the harness ships `agro.json` and `.example.env`.
+
+A coverage regression that reports green because nothing runs.
+
+### Other issues filed
+
+- **agro #1021** — `agro sandbox install` is not idempotent; a re-run discards an
+  existing sandbox's configuration, silently unpinning `storage.homePath` on a node.
+  Fixed by PR #1022.
+- **openharness-cloud #144**, **orchestra #982**, **agro-web #48** — scoped consumer
+  issues, each referencing #944/#939 without closing either.
+
+### Corrections to earlier records
+
+- CHECKPOINT.md said the agro-web docs branch needed the three deliberate divergences
+  called out; they were verified in the tree before the PR body claimed them — the
+  site-served get-agro.sh URL, `example.com` with RFC 5737 addresses instead of a real
+  name and email, and the corrected sshd commands.
+- The website post's `ghcr.io/mifunedev/openharness:0.9.0` reference was checked rather
+  than "corrected" on assumption: `ghcr.io/mifunedev/agro:0.9.0` and
+  `ghcr.io/mifunedev/openharness:0.9.0` resolve to the SAME digest,
+  sha256:5ecfe69bbc0654ca733535d710c0c61fd5f7913945bef7d1beec97506f03e60c. The reference
+  is accurate, merely legacy-named. Left as-is; not an advisor edit.
+- The agro-web drift-rule inversion was verified against the harness tree rather than
+  taken from the worker's report: agro ships `.example.env`, and `.env.example` does not
+  exist. The old rule flagged the real filename and recommended a nonexistent one.
+
+### Advisor errors this turn
+
+- **Committed a `node_modules` symlink.** I had symlinked node_modules into the
+  bug/1019-boot-recovery worktree to run its tests, then used `git add -A`. The symlink
+  landed in the commit as mode 120000. Caught on reading my own commit stat, removed
+  from the index and disk, amended before pushing. The pushed head f8b72d7f contains no
+  node_modules path; the other four commits were audited and are clean too. `git add -A`
+  after introducing untracked scaffolding is the hazard.
+- **Left a build artifact in the website worktree.** Running `npm run build` there to
+  verify the branch rewrote the TRACKED file `public/sw.js` (a minified service worker
+  whose content is build-hash churn). It was deliberately NOT staged, so it is not in
+  the commit, and NOT reverted, per the operator's instruction not to revert. It remains
+  as an uncommitted modification in that worktree.
+
+### Deferred, explicitly, and NOT counted as complete
+
+Cloud (US-002, US-003, US-004, US-005, US-006, US-009, and the Cloud half of US-008),
+orchestra, and website (US-010) are preserved and parked. Their PRs carry a stated
+parked/deferred status. The EPIC's definition of done is NOT redefined by this narrowing:
+those items remain part of #944, and #944 remains part of #939. #945's gate — Phase 4
+complete AND 90 days AND three releases since the first public AGRO release (anchor
+v0.9.0 2026-09-06; earliest date 2026-12-05; one release observed) — is unchanged.


### PR DESCRIPTION
**#944 and mifunedev/agro#939 both stay open.** `Refs mifunedev/openharness-cloud#146`. This is the task record for Phase 4, and Phase 4 is **partial** — 10 of 12 stories pass. The record is committed so the state is durable and auditable, not because the work is finished.

## Why this PR exists

`.agro/tasks/*` is gitignored, so a task folder is force-added — matching the 255 task files already tracked under that directory. Without this the entire evidence trail for Phase 4 lives only in one machine's worktree.

## Story state — 10 of 12, and the two open ones are open for different reasons

| | Story | State |
|---|---|---|
| US-001 | Org-wide downstream dependency inventory | pass |
| US-002 | Cloud name classification record | pass |
| US-003 | Artifact-based node provisioning replaces the deleted `make sandbox` path | pass |
| US-004 | Harness/tool selections become explicit installation calls | pass |
| US-005 | Canonical AGRO refs across Cloud runtime surfaces | pass |
| US-006 | Bounded `node.rebuild` implementation | pass |
| **US-007a** | **Node-bootstrap lifecycle evidence on a real local host** | **FAILS** |
| **US-007b** | **Provider-level lifecycle evidence** | **blocked** |
| US-008 | Equipped-repository migration through the supported path | pass |
| US-009 | Operator/user-facing copy reflects the AGRO runtime contract | pass |
| US-010 | Repair published guidance that is broken, not merely stale | pass |
| US-011 | Close the documentation drift left by Phase 3 | pass |

**US-007a fails on measured product defects, not on tooling.** Config B (`harnesses: ["opencode"]`) reached `status=failed:243` with no readiness marker; the surface-4a tmux session proved non-durable; UID divergence at uid 1500 produced `HOST-WRITE=DENIED`. The re-run that would clear it is **blocked on a missing container runtime** — this environment has the `docker` CLI but no `/var/run/docker.sock`. That is a capability blocker, not a skipped check, and no source or unit result substitutes for it.

**US-007b is behind an unauthorized paid-OVH infrastructure gate.** No live infrastructure was touched.

## Scope narrowing, recorded rather than absorbed

The operator narrowed immediate priority to `mifunedev/agro` and `mifunedev/agro-web`. Cloud, orchestra and website are **deferred**, their work preserved on its own PRs and explicitly not proposed for merge.

**That narrowing does not redefine done.** The deferred items remain part of mifunedev/openharness-cloud#146, and mifunedev/openharness-cloud#146 remains part of mifunedev/agro#939. mifunedev/agro#945's gate is unchanged: Phase 4 complete **and** 90 days **and** three releases since the first public AGRO release (anchor v0.9.0 on 2026-09-06 → earliest date 2026-12-05; one release observed).

## What the record contains

- `prd.md` / `prd.json` — the approved plan and the authoritative structured state, including the deferral map and the retained gates.
- `consumer-inventory.md` — the org-wide dependency inventory.
- `migrate-check.md`, `migration-evidence.md` — `agro migrate --check` output and the delivered migration, with rehearsal separated from delivery after an earlier acceptance was corrected.
- `local-lifecycle-evidence.md` (16 sections) and `local-lifecycle-transcript.log` — the lifecycle evidence and its raw transcript. Scanned for credential-shaped content before committing (token, key-block, bearer and public-key patterns): none found.
- `delegate-graph.json`, `delegate-log.txt` — the dispatch graph and append-only ledger for 14 bounded workers.
- `progress.txt`, `CHECKPOINT.md` — the execution narrative and a durable resume checkpoint.

## The record includes its own errors, deliberately

The checkpoint carries an advisor-errors section. It records, among others, that a bare `0` in the transcript was briefly misread as operator confirmation that leftover host artifacts were clean and written into the checkpoint as fact. It was a dismissal of an unrelated survey prompt. That is retracted in place, and **host cleanup remains UNVERIFIED — nobody has checked** whether `agro-candidate:us007a`, `oh-node-host:us007a` or any `us007a-*` container or volume still exist.

Also recorded: a transposed pair of worker IDs, an acceptance granted on rehearsal evidence that had to be withdrawn, a moving tag described as immutable, and a caveat's line placement relayed from a worker report without opening the file.

A record that only lists successes is not evidence.

## Open defects captured but NOT fixed

- UID/GID divergence breaks the attach surface; the UID-sync path is gated on a checkout bind that image-only nodes never have, while the destructive `chown` runs unconditionally. Assessment only — nothing remapped, nothing chowned.
- `sandbox rebuild` does not always recreate the container.
- A failed rebuild leaves the sandbox stopped with no rollback.
- `agro config set` prints `oh.json:` while writing `agro.json`.
- The Dockerfile bakes permission-bypass aliases for binaries it no longer ships.

## Unresolved operator decisions, left unresolved

Default harness selection; the surface-4a contract (bootstrap-watch-only vs. a persistent re-attachable session); paid OVH provisioning; and mifunedev/agro#1019's R3/R4 (supersede vs. yank `0.9.0`, and the `LEGACY_IMAGE` pin) — each written with evidence both ways rather than decided.

## CI at this exact head

| Check | Result |
|---|---|
| Lint, Typecheck, Build & Test | success |
| Eval Probe Regression Gate | success |
| Boot Path Lint (shellcheck + hadolint) | success |
| Validate sandbox compose and image build | success |
| Boot a legacy volume against the fresh image | success |

### Correction to an earlier version of this description

An earlier version of this body claimed that no CI would run here, citing mifunedev/agro#1020 — an issue I filed asserting that every workflow path filter still named `.oh/**` and therefore matched nothing after the Phase 3 rename.

**That was wrong, and mifunedev/agro#1020 is closed as invalid.** I had grepped a local checkout whose working tree silently reverts tracked files to their pre-AGRO generation, and read it as repository state. `origin/development` names `.agro/**`, `.agro/skills/**`, `.agro/hooks/**`, `.agro/evals/**`, `.agro/knowledge/**`, `agro.json` and `.example.env` throughout, and always did. The five green checks above are the disproof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Gh4FRUfcQYD6CcNNH1xRU


---

**Note on the auto-close workflow.** `close-issues-on-development.yml` parses closing keywords from the title and body with `(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s*:?\s+#(\d+)`. That pattern has no negation handling, so a sentence like "does not close #N" reads as a closing reference and would close #N on merge. The wording above is chosen so the parser sees only what is intended.
