### PR TITLE
FROM task/1032-agro-naming-cleanup TO development

### DIFF
--- a/.agro/README.md
+++ b/.agro/README.md
@@ -1,15 +1,12 @@
 # .agro/
 
-**OpenHarness's own machinery, grouped as one addressable unit.** The `oh` CLI,
-the installer/lifecycle scripts, the container-install inputs, and the
-compose config now live together here so a future version (and the `oh` CLI
-itself) can address the harness's machinery as a single namespace instead of
-hunting it across the repo root.
+**AGRO's control plane, grouped as one addressable unit.** The `agro` CLI,
+installer/lifecycle scripts, and container-install inputs live here.
+The `.devcontainer/` directory owns the sandbox definition and Compose files.
+`oh` remains a compatibility entry point; `oh update` vendors the control plane.
 
-This rescopes the removed `.openharness/` deploy-override directory under the
-short name that already matches the `oh` CLI (so `.openharness/` nested inside the
-`openharness` repo is no longer redundant), and extends it from "just deploy
-config" to "the machinery."
+The `.agro/` namespace matches the `agro` CLI. It includes the deploy-override
+machinery formerly under `.openharness/`.
 
 ## Governing principle: a dotdir namespace is earned by FUNCTION-CLASS
 
@@ -18,10 +15,10 @@ This **supersedes** the earlier "earned by EXPORT only" rule *and* the later
 `.agro/`, so there is now **one** machinery namespace (the former `.mifune` submodule
 is obsolete):
 
-- **`.agro/`** — *OpenHarness's own machinery* as one unit, including the
+- **`.agro/`** — *AGRO's own machinery* as one unit, including the
   provider-portable *primitives* — `skills/`, `hooks/` (+ `skills.lock`)
   — exported through the standard skill surface (`.agents/skills`) and provider
-  symlinks (`.claude/`, `.codex/`, `.hermes/`): the `oh` CLI (`cli/`), installer + lifecycle scripts
+  symlinks (`.claude/`, `.codex/`, `.hermes/`): the `agro` CLI (`cli/`), installer + lifecycle scripts
   (`scripts/`), container-install inputs (`install/`), the
   regression/capability eval suite (`evals/`), the durable repository-knowledge
   surface (`knowledge/`), user-local deploy
@@ -113,7 +110,7 @@ The shared skills and hooks are vendored directly under `.agro/` (`.agro/skills`
 | File / dir | Purpose |
 |------|---------|
 | `README.md` | This file — the namespace anchor (keeps `.agro/` in a fresh clone) and the surface's documentation. |
-| `cli/` | The in-tree `oh` CLI (standalone npm package; built into the image as `/opt/oh`). Old path: `packages/oh/` (no symlink — repointed). |
+| `cli/` | The in-tree `agro` CLI (`oh` is the compatibility entry point; built into the image as `/opt/oh`). Old path: `packages/oh/` (no symlink — repointed). |
 | `install/` | Container-install inputs (`.zshrc`, `.tmux.conf`, `banner.sh`, `install.sh` prerequisites) consumed by the Dockerfile + entrypoint. Old path: `install/` (no symlink — repointed). |
 | `scripts/` | Installer, lifecycle, cron-runtime, and eval-support scripts (`docker-compose.sh`, `cron-runtime.ts`, `locked-append.sh`, `harness-config.sh`, …). Old path: `scripts/` (no symlink — repointed). |
 | `evals/` | The fitness-function suite — regression probes (`probes/`), capability benchmark (`capability/`), trajectory datasets (`datasets/`), and the `RESULTS.md` scoreboard. Old path: `evals/` (no symlink — repointed). |
@@ -125,7 +122,7 @@ The shared skills and hooks are vendored directly under `.agro/` (`.agro/skills`
 
 | Belongs in `.agro/` | Stays at root |
 |------|------|
-| OpenHarness's own machinery addressed as a unit: the `oh` CLI, installer/lifecycle scripts, container-install inputs, compose config, the fitness-function eval suite (`.agro/evals/`), the durable repository-knowledge surface (`.agro/knowledge/`), and the Ralph/spec task workdirs (`.agro/tasks/`) | Human-facing Markdown docs (`docs/`) plus the scheduled-agent cron definitions (`crons/`), and surfaces **forced to root by external tooling** (`.devcontainer/`, `package.json`, `pnpm-*.yaml`, `.github/`, `.husky/`) |
+| AGRO's own machinery addressed as a unit: the `agro` CLI, installer/lifecycle scripts, container-install inputs, compose config, the fitness-function eval suite (`.agro/evals/`), the durable repository-knowledge surface (`.agro/knowledge/`), and the Ralph/spec task workdirs (`.agro/tasks/`) | Human-facing Markdown docs (`docs/`) plus the scheduled-agent cron definitions (`crons/`), and surfaces **forced to root by external tooling** (`.devcontainer/`, `package.json`, `pnpm-*.yaml`, `.github/`, `.husky/`) |
 
 ### Why these specifically stay at root
 

--- a/.agro/cli/src/__tests__/self-upgrade.test.ts
+++ b/.agro/cli/src/__tests__/self-upgrade.test.ts
@@ -55,8 +55,8 @@ Payload source precedence: --from <dir> > --from-remote > the CLI's own bundled
 .oh/ payload > a remote fetch announced on one line.
 
 Flags:
-  --from <dir>    A built OpenHarness checkout to vendor from.
-  --from-remote   Fetch the source checkout from the public OpenHarness repo
+  --from <dir>    A built AGRO checkout to vendor from.
+  --from-remote   Fetch the source checkout from the public AGRO repo
                   instead (shallow git clone into a temp dir, removed after
                   the run). Conflicts with --from.
   --ref <ref>     Branch or tag for --from-remote (default: the clone's

--- a/.agro/cli/src/cli.ts
+++ b/.agro/cli/src/cli.ts
@@ -230,8 +230,8 @@ Payload source precedence: --from <dir> > --from-remote > the CLI's own bundled
 ${stateNames(bin).controlDir}/ payload > a remote fetch announced on one line.
 
 Flags:
-  --from <dir>    A built OpenHarness checkout to vendor from.
-  --from-remote   Fetch the source checkout from the public OpenHarness repo
+  --from <dir>    A built AGRO checkout to vendor from.
+  --from-remote   Fetch the source checkout from the public AGRO repo
                   instead (shallow git clone into a temp dir, removed after
                   the run). Conflicts with --from.
   --ref <ref>     Branch or tag for --from-remote (default: the clone's

--- a/.agro/cli/src/commands/update.ts
+++ b/.agro/cli/src/commands/update.ts
@@ -64,7 +64,7 @@ export async function runUpdate(opts: UpdateOptions, io: UpdateIO): Promise<numb
         source.agroPath +
         ' or ' +
         source.legacyPath +
-        '. Pass --from <built-OpenHarness-checkout> or --from-remote [--ref <ref>].\n',
+        '. Pass --from <built-AGRO-checkout> or --from-remote [--ref <ref>].\n',
     );
     return 1;
   }

--- a/.agro/cli/src/lib/remote.ts
+++ b/.agro/cli/src/lib/remote.ts
@@ -40,7 +40,7 @@ const spawnRunner: RemoteRunner = (cmd, args, opts) => {
 };
 
 function fallbackHint(): string {
-  return "use --from <dir> to point at a local OpenHarness checkout instead";
+  return "use --from <dir> to point at a local AGRO checkout instead";
 }
 
 export function fetchRemoteSource(opts: FetchRemoteSourceOptions): string {

--- a/.agro/install/banner.sh
+++ b/.agro/install/banner.sh
@@ -153,7 +153,7 @@ fi
 
 
 printf '\n'
-printf '━━━ openharness: %s ━━━\n' "$sandbox_name"
+printf '━━━ agro: %s ━━━\n' "$sandbox_name"
 printf '  Project:   %s\n' "$project_dir"
 printf '  Timezone:  %s\n' "$timezone"
 printf '  Overlays:  %s\n' "$overlays"

--- a/.agro/scripts/__tests__/cli-first-install-smoke.test.ts
+++ b/.agro/scripts/__tests__/cli-first-install-smoke.test.ts
@@ -155,7 +155,7 @@ describe("cli-first-install-smoke.sh", () => {
     expect(source).toContain('NAME_PREFIX="agro-cli-first"');
     expect(source).toContain('if [ ! -f "$home/.profile" ]; then');
     expect(source).toContain('cd "$cli_dir"');
-    expect(source).toContain("*openharness-*.tgz");
+    expect(source).toContain("    agro-*.tgz)");
     expect(source).toContain("mifune-agro-*.tgz");
     expect(source).toContain('echo "node_after=$(command -v node) version=$(node --version)"');
     expect(source).toContain("remove_container_keep_volume");
@@ -274,7 +274,10 @@ describe("cli-first-install-smoke.sh", () => {
     expect(workflow).not.toMatch(/cli-first-install-smoke[\s\S]*continue-on-error/);
   });
 
-  it("rejects npm pack of the root openharness package", () => {
+  it.each([
+    { tarball: "agro-0.9.0.tgz", accepted: false },
+    { tarball: "mifune-agro-0.9.0.tgz", accepted: true },
+  ])("checks npm pack output $tarball (accepted=$accepted)", ({ tarball, accepted }) => {
     const dir = mkdtempSync(join(tmpdir(), "cli-first-pack-"));
     cleanups.push(dir);
     const bin = join(dir, "bin");
@@ -287,7 +290,7 @@ describe("cli-first-install-smoke.sh", () => {
       [
         "#!/usr/bin/env bash",
         "set -euo pipefail",
-        'if [[ "$*" == *pack* ]]; then',
+        'if [ "$1" = "pack" ]; then',
         "  dest=",
         "  prev=",
         '  for a in "$@"; do',
@@ -295,9 +298,13 @@ describe("cli-first-install-smoke.sh", () => {
         '    prev="$a"',
         "  done",
         '  [ -n "$dest" ] || dest="."',
-        '  : > "$dest/openharness-0.9.0.tgz"',
-        "  echo openharness-0.9.0.tgz",
+        `  : > "$dest/${tarball}"`,
+        `  echo ${tarball}`,
         "  exit 0",
+        "fi",
+        'if [ "$1" = "install" ]; then',
+        '  mkdir -p "$4/bin"',
+        `  cp ${JSON.stringify(bundle)} "$4/bin/agro"`,
         "fi",
         "exit 0",
         "",
@@ -312,8 +319,13 @@ describe("cli-first-install-smoke.sh", () => {
       {},
       { path: `${bin}:${process.env.PATH ?? ""}` },
     );
-    expect(result.status).not.toBe(0);
-    expect(result.stderr).toContain("openharness");
-    expect(result.stderr).toContain(".agro/cli");
+    if (accepted) {
+      expect(result.status, result.stderr + result.stdout).toBe(0);
+      expect(result.stdout).toContain("packed_version=9.9.9");
+    } else {
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain("root agro package");
+      expect(result.stderr).toContain(".agro/cli");
+    }
   });
 });

--- a/.agro/scripts/cli-first-install-smoke.sh
+++ b/.agro/scripts/cli-first-install-smoke.sh
@@ -195,9 +195,9 @@ phase_pack() {
   )
   tarball="$WORKDIR/${packed##*/}"
   [ -f "$tarball" ] || die "npm pack did not write $tarball"
-  case "$tarball" in
-    *openharness-*.tgz)
-      die "npm pack produced the root openharness package ($tarball) — pack must run in .agro/cli"
+  case "${packed##*/}" in
+    agro-*.tgz)
+      die "npm pack produced the root agro package ($tarball) — pack must run in .agro/cli"
       ;;
   esac
   case "${packed##*/}" in

--- a/.github/ISSUE_TEMPLATE/agent.md
+++ b/.github/ISSUE_TEMPLATE/agent.md
@@ -55,7 +55,7 @@ oh shell <agent-name>
 claude
 ```
 
-The positional argument to `oh shell` is the **container name** (defaults to `openharness`, or `name` in `agro.json`). `oh shell` always connects as the `sandbox` user; use `docker exec -it -u <user> <container> zsh` when you need another one.
+The positional argument to `oh shell` is your **sandbox name** from `agro sandbox list`. Omit it when exactly one sandbox is registered or your current checkout identifies the sandbox. `oh shell` always connects as the `sandbox` user; use `docker exec -it -u <user> <container> zsh` when you need another one.
 
 ### 3. Verify
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Update policy and release automation live in [`/git`](.claude/skills/git/SKILL.m
 
 ### Changed
 
+- Align package and display names with AGRO, correct sandbox setup guidance, and remove the stale root sandbox name. ([#1032](https://github.com/mifunedev/agro/issues/1032))
 - Publish only `@mifune/agro` on the automatic release path; keep the `@mifune/openharness` shim source and already-published versions without a new shim publish, wait, or deprecate step. ([#939](https://github.com/mifunedev/agro/issues/939))
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<h1 align="center">🏗️ Open Harness</h1>
+<h1 align="center">🏗️ AGRO</h1>
 
 <p align="center">
   <a href="LICENSE"><img alt="License: Apache-2.0" src="https://img.shields.io/badge/License-Apache--2.0-D4AF37?style=plastic&labelColor=0B1220"></a>
@@ -10,10 +10,10 @@
 </p>
 
 <p align="center">
-  <img src=".github/assets/mifune-banner.jpg" alt="Open Harness" width="100%">
+  <img src=".github/assets/mifune-banner.jpg" alt="AGRO" width="100%">
 </p>
 
-**Open Harness provides the sandbox; you choose the harness.** It's a Docker-based workspace, agent-tended over time: one `agro sandbox install docker` boots a long-lived container where the coding agent of your choice — Claude Code, Codex, Pi, Hermes, Grok, and more, each installed with one `agro harness install` command — works on its own branch and identity. Because it's just Docker, it runs **identically on your laptop or a remote VM** — and remote is the default: deployed on a VM, Open Harness becomes a **lights-out software factory**, where the agent works unattended, on a schedule and reachable over Slack, fanning out across isolated **git worktrees** — parallel branches, delegated sub-agents, even other cloned repos — while you're away and your laptop stays clean.
+**AGRO provides the sandbox; you choose the harness.** It's a Docker-based workspace, agent-tended over time: one `agro sandbox install docker` boots a long-lived container where the coding agent of your choice — Claude Code, Codex, Pi, Hermes, Grok, and more, each installed with one `agro harness install` command — works on its own branch and identity. Because it's just Docker, it runs **identically on your laptop or a remote VM** — and remote is the default: deployed on a VM, AGRO becomes a **lights-out software factory**, where the agent works unattended, on a schedule and reachable over Slack, fanning out across isolated **git worktrees** — parallel branches, delegated sub-agents, even other cloned repos — while you're away and your laptop stays clean.
 
 - **One project, one sandbox.** A single container scoped to a single repo. The agent owns its branch and its workspace; you keep your laptop clean.
 - **Parallel by design.** The worktrees skill fans one sandbox into isolated git worktrees — parallel branches, delegated sub-agents, even other cloned repos.
@@ -31,7 +31,7 @@
 
 ## 📦 Install
 
-Open Harness runs one project in one Docker sandbox, and **`agro` is the only
+AGRO runs one project in one Docker sandbox, and **`agro` is the only
 front door**. Host prerequisites: Docker (with the Compose plugin), Git, and
 Node.js ≥ 20.
 
@@ -237,7 +237,7 @@ agro --help         # every verb
 
 - Property-based testing convention: [docs/property-testing.md](docs/property-testing.md)
 
-Prefer VS Code or remote SSH? Use the Dev Containers extension's "Attach to Running Container" against `openharness` — not "Reopen in Container", which applies no overlays (see [VS Code (secondary path)](#vs-code-secondary-path)) — or SSH into your host first and then attach.
+Prefer VS Code or remote SSH? Use the Dev Containers extension's "Attach to Running Container" against your sandbox name from `agro sandbox list` — not "Reopen in Container", which applies no overlays (see [VS Code (secondary path)](#vs-code-secondary-path)) — or SSH into your host first and then attach.
 
 ## ⚙️ Configure (optional)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 <h1 align="center">🏗️ AGRO</h1>
 
+<p align="center"><strong>Agent Governance Runtime Orchestrator</strong></p>
+
 <p align="center">
   <a href="LICENSE"><img alt="License: Apache-2.0" src="https://img.shields.io/badge/License-Apache--2.0-D4AF37?style=plastic&labelColor=0B1220"></a>
   <a href="https://github.com/mifunedev/agro/actions/workflows/ci-harness.yml"><img alt="CI: Harness" src="https://img.shields.io/github/actions/workflow/status/mifunedev/agro/ci-harness.yml?branch=main&style=plastic&label=CI&labelColor=0B1220&color=D4AF37"></a>

--- a/agro.json
+++ b/agro.json
@@ -1,6 +1,5 @@
 {
   "version": 1,
-  "name": "openharness",
   "timezone": "America/Los_Angeles",
   "git": {},
   "storage": {},

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,7 +18,7 @@ identity, running identically on your laptop or an unattended, lights-out remote
 
 1. `oh sandbox install docker` — write the registry entry and boot the container.
 2. VS Code → Command Palette (Ctrl/Cmd+Shift+P) → "Dev Containers: Attach to Running
-   Container" → select `openharness`. Ports auto-forward while attached.
+   Container" → select your sandbox name from `agro sandbox list`. Ports auto-forward while attached.
 3. Open a terminal and run `oh tool install herdr`, then `herdr`. Nothing installs at boot, so install each agent the same way — `oh harness install claude-code`, `codex`, `pi`, or `hermes` — then launch it from a Herdr pane.
 
 Full terminal, VS Code, and Remote-SSH options: see [Connecting to the sandbox](connecting.md).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -139,7 +139,7 @@ Recipe: [`agro sandbox install docker`](deployment-prebuilt-image.md).
 
 | Field | Type | Default | Compose variable | What it does |
 | --- | --- | --- | --- | --- |
-| `image.ref` | string | `ghcr.io/mifunedev/openharness:latest` | `AGRO_SANDBOX_IMAGE` (legacy alias `OH_SANDBOX_IMAGE`) | Published image reference. Set it per sandbox with `agro config set --sandbox <name> image.ref <ref>`. |
+| `image.ref` | string | `ghcr.io/mifunedev/agro:latest` | `AGRO_SANDBOX_IMAGE` (legacy alias `OH_SANDBOX_IMAGE`) | Published image reference. Set it per sandbox with `agro config set --sandbox <name> image.ref <ref>`. |
 | `image.mode` | `"build"` \| `"image"` | `build` | — | Whether the lifecycle builds locally or runs `image.ref`. A build happens only when `repo` is also set. Pairs with `agro sandbox install docker --image`. |
 | `image.pullPolicy` | `"missing"` \| `"always"` \| `"never"` | `missing` | `AGRO_PULL_POLICY` (legacy alias `OH_PULL_POLICY`) | Compose pull policy for `image.ref`. |
 

--- a/docs/connecting.md
+++ b/docs/connecting.md
@@ -11,7 +11,7 @@ The sandbox is a Docker container running on your host (or a remote server). Get
 | Option | Command / action | Port forwarding to laptop |
 |--------|-----------------|--------------------------|
 | **A — Terminal** | `oh shell` from the host | None — plain shell only |
-| **B — VSCode Attach (local)** | Dev Containers extension → "Attach to Running Container" → `openharness` | Automatic while attached |
+| **B — VSCode Attach (local)** | Dev Containers extension → "Attach to Running Container" → your sandbox name from `agro sandbox list` | Automatic while attached |
 | **C — VSCode Remote-SSH + Attach (remote host)** | SSH into your host in VSCode, then Attach to Container | Automatic while attached |
 | **D — Direct SSH (opt-in)** | `ssh -p 2222 sandbox@localhost` after enabling the sshd overlay | None — SSH shell only (tunnel/proxy separately) |
 
@@ -35,7 +35,7 @@ You land inside the container as the `sandbox` user. A fresh sandbox has no `her
 
 1. Install the [Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) extension.
 2. Open the Command Palette (`Ctrl+Shift+P` / `Cmd+Shift+P`) → **Dev Containers: Attach to Running Container**.
-3. Select **openharness**.
+3. Select your sandbox name from `agro sandbox list`.
 
 VSCode opens a remote window connected to the container and **automatically forwards container ports to `localhost`** on your laptop for the duration of the session.
 
@@ -44,7 +44,7 @@ VSCode opens a remote window connected to the container and **automatically forw
 If the sandbox runs on a remote server:
 
 1. Connect to the server via **Remote-SSH** in VSCode.
-2. From that SSH window, follow Option B to attach to the `openharness` container.
+2. From that SSH window, follow Option B to attach to your sandbox container.
 
 Port forwarding works identically — VSCode tunnels the container ports through the SSH connection to your laptop `localhost`. No manual `ssh -L` required.
 
@@ -288,7 +288,7 @@ For the full convention see [`.agro/skills/t3/references/sandbox-processes.md`](
 
 ## End-to-end recipe
 
-This recipe assumes the sandbox is already running (`oh ps` confirms the `openharness` container is up). Steps run inside the sandbox unless noted.
+This recipe assumes the sandbox is already running (`agro ps <name>` confirms your sandbox container is up). Steps run inside the sandbox unless noted.
 
 ### Step 1 — Attach via VSCode
 

--- a/docs/deployment-prebuilt-image.md
+++ b/docs/deployment-prebuilt-image.md
@@ -14,11 +14,13 @@ earlier release stays at `${OH_HOME:-~/.oh}/sandboxes/<name>/` and still
 resolves; `agro migrate --home` moves it.
 
 **Running the published image is the default.** Each tagged release publishes the
-sandbox image, already built and smoke-tested, to GHCR:
+sandbox image, already built and smoke-tested, to GHCR.
+The canonical default is `ghcr.io/mifunedev/agro:latest`.
+The legacy image alias remains available. Explicit image refs in the examples below use this alias:
 
 ```
-ghcr.io/mifunedev/openharness:latest      # newest release
-ghcr.io/mifunedev/openharness:<version>   # e.g. 0.1.0 — pin for reproducibility
+ghcr.io/mifunedev/openharness:latest      # legacy alias for the newest release
+ghcr.io/mifunedev/openharness:<version>   # legacy alias, e.g. 0.1.0 — pin for reproducibility
 ```
 
 With no `--repo` there is **no checkout on the host at all**: the workspace and
@@ -53,7 +55,7 @@ run a different CPU arch, prefer a local build (`--repo` with `image.mode` set t
 ## Pinning an image ref
 
 ```bash
-agro sandbox install docker --image              # pull ghcr.io/mifunedev/openharness:latest
+agro sandbox install docker --image              # pull ghcr.io/mifunedev/agro:latest
 agro sandbox install docker --image=ghcr.io/mifunedev/openharness:2026.7.5   # pin a release
 agro shell <name>                                # zsh in the running container, as usual
 ```
@@ -70,7 +72,7 @@ the entry's `agro.json`) without pinning one — an advanced escape hatch.
 ### Which image ref wins (last wins)
 
 ```
-ghcr.io/mifunedev/openharness:latest      (built-in default)
+ghcr.io/mifunedev/agro:latest             (built-in default)
   └─ agro.json  image.ref=<ref>               (the entry's default — see docs/configuration.md)
        └─ agro sandbox install docker --image=<ref> (per-invocation override)
 ```

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -117,7 +117,7 @@ builds from that checkout's `.devcontainer/Dockerfile` instead of pulling
 **Recommended: attach with VS Code's Dev Containers extension.** Works identically whether the sandbox is on your laptop or on a remote host you're SSH'd into (with VS Code's Remote-SSH extension). One window, your normal editor, integrated terminal, file tree — the most consistent and productive setup across environments.
 
 1. Install the [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers).
-2. Open the Command Palette with `Ctrl+Shift+P` (`Cmd+Shift+P` on macOS) → **Dev Containers: Attach to Running Container...** → select `openharness`.
+2. Open the Command Palette with `Ctrl+Shift+P` (`Cmd+Shift+P` on macOS) → **Dev Containers: Attach to Running Container...** → select your sandbox name from `agro sandbox list`.
 3. When the new VS Code window opens, set the workspace folder to `/home/sandbox/harness`.
 
 > **Optional — DebugMCP (cross-harness debugging).** If you take the VS Code attach route

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "agro",
   "version": "0.9.0",
   "private": true,
-  "description": "AGRO — AI Agent Sandbox Orchestrator",
+  "description": "AGRO — Agent Governance Runtime Orchestrator",
   "license": "Apache-2.0",
   "type": "module",
   "packageManager": "pnpm@10.33.0",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "openharness",
+  "name": "agro",
   "version": "0.9.0",
   "private": true,
-  "description": "Open Harness — AI Agent Sandbox Orchestrator",
+  "description": "AGRO — AI Agent Sandbox Orchestrator",
   "license": "Apache-2.0",
   "type": "module",
   "packageManager": "pnpm@10.33.0",


### PR DESCRIPTION
## Summary
- Rename private root package metadata and selected current display text to AGRO (Agent Governance Runtime Orchestrator).
- Correct default image and sandbox-selection documentation.
- Remove the stale root agro.json name without replacing it with a deployment-specific identity.
- Update packaging guards and help snapshots; preserve legacy compatibility packages, image aliases, runtime identifiers, and external destinations.

## Verification
- 97 focused tests passed across packaging, self-upgrade, remote, and update suites.
- CLI build and typecheck passed.
- Modified shell scripts pass bash -n; git diff --check passed.
- Verified the corrected package description matches the documented acronym expansion.

Closes #1032