### PR TITLE
FROM task/1038-readme-install-options TO development

### DIFF
--- a/.agro/evals/probes/docs-build-fast-path.sh
+++ b/.agro/evals/probes/docs-build-fast-path.sh
@@ -106,7 +106,7 @@ release_build="$(workflow_build_run "$RELEASE_WORKFLOW")"
 for f in "$README" "$DOCS_INDEX"; do
   grep -Fq 'https://github.com/mifunedev/agro-web' "$f" || failures+=("$(basename "$f") must point to mifunedev/agro-web")
 done
-grep -Fiq 'deepwiki' "$README" || failures+=("README.md must point readers to DeepWiki for generated navigation")
+grep -Fq 'https://agro.mifune.dev' "$README" || failures+=("README.md must point readers to the maintained documentation site")
 grep -Fq 'docs/README.md' "$README" || failures+=("README.md must point readers to docs/README.md")
 
 if git -C "$ROOT" grep -nE 'docusaurus build|pnpm (run )?docs:build|pnpm --dir (\.agro/)?docs build|@openharness/docs' -- \

--- a/.agro/evals/probes/get-oh-bootstrap.sh
+++ b/.agro/evals/probes/get-oh-bootstrap.sh
@@ -3,7 +3,7 @@
 # source: get-oh.sh bootstrap — the Node-bootstrapping host-side path to the standalone `oh` CLI (also on npm as @mifune/openharness; see oh-npm-package.sh)
 # desc: STATIC guard — `.agro/scripts/get-oh.sh` exists, is executable, uses the overridable repo form,
 #       installs a PREBUILT `oh` to a bin dir WITHOUT cloning the repo, offers to install Node,
-#       and is documented in the README. Also guards link-providers.sh's non-git fallback.
+#       and is documented in the linked installation guide. Also guards link-providers.sh's non-git fallback.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
@@ -29,7 +29,8 @@ grep -q 'nvm' "$SCRIPT" || { echo 'REGRESSION get-oh.sh no longer offers to inst
 
 grep -q '_OH_SOURCED' "$SCRIPT" || { echo 'REGRESSION get-oh.sh lost sourced-vs-executed detection (same-shell PATH activation)' >&2; exit 1; }
 
-grep -q 'get-oh.sh' "$ROOT/README.md" || { echo 'REGRESSION README no longer documents get-oh.sh' >&2; exit 1; }
+grep -Fq 'docs/installation.md' "$ROOT/README.md" || { echo 'REGRESSION README no longer links the installation guide' >&2; exit 1; }
+grep -Fq 'get-oh.sh' "$ROOT/docs/installation.md" || { echo 'REGRESSION installation guide no longer documents get-oh.sh' >&2; exit 1; }
 
 LP="$ROOT/.agro/scripts/link-providers.sh"
 if [ -f "$LP" ]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Update policy and release automation live in [`/git`](.claude/skills/git/SKILL.m
 
 ### Changed
 
-- Group README installation options into npm and curl disclosures and add an npx alternative without a global install. ([#1038](https://github.com/mifunedev/agro/issues/1038))
+- Combine the README npm/npx example and remove the review-first block. ([#1038](https://github.com/mifunedev/agro/issues/1038))
 - Align package and display names with AGRO, correct sandbox setup guidance, and remove the stale root sandbox name. ([#1032](https://github.com/mifunedev/agro/issues/1032))
 - Publish only `@mifune/agro` on the automatic release path; keep the `@mifune/openharness` shim source and already-published versions without a new shim publish, wait, or deprecate step. ([#939](https://github.com/mifunedev/agro/issues/939))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Update policy and release automation live in [`/git`](.claude/skills/git/SKILL.m
 
 ### Changed
 
-- Combine the README npm/npx example and remove the review-first block. ([#1038](https://github.com/mifunedev/agro/issues/1038))
+- Clarify the README introduction, label setup as Quickstart, and combine npm/npx examples without the review-first block. ([#1038](https://github.com/mifunedev/agro/issues/1038))
 - Align package and display names with AGRO, correct sandbox setup guidance, and remove the stale root sandbox name. ([#1032](https://github.com/mifunedev/agro/issues/1032))
 - Publish only `@mifune/agro` on the automatic release path; keep the `@mifune/openharness` shim source and already-published versions without a new shim publish, wait, or deprecate step. ([#939](https://github.com/mifunedev/agro/issues/939))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Update policy and release automation live in [`/git`](.claude/skills/git/SKILL.m
 
 ### Changed
 
-- Streamline the README quickstart and replace repeated reference sections with documentation navigation. ([#1038](https://github.com/mifunedev/agro/issues/1038))
+- Refresh the README quickstart, messaging setup, and docs index; replace repeated reference sections with documentation navigation. ([#1038](https://github.com/mifunedev/agro/issues/1038))
 - Align package and display names with AGRO, correct sandbox setup guidance, and remove the stale root sandbox name. ([#1032](https://github.com/mifunedev/agro/issues/1032))
 - Publish only `@mifune/agro` on the automatic release path; keep the `@mifune/openharness` shim source and already-published versions without a new shim publish, wait, or deprecate step. ([#939](https://github.com/mifunedev/agro/issues/939))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Update policy and release automation live in [`/git`](.claude/skills/git/SKILL.m
 
 ### Changed
 
-- Clarify the README introduction, label setup as Quickstart, and combine npm/npx examples without the review-first block. ([#1038](https://github.com/mifunedev/agro/issues/1038))
+- Streamline the README quickstart and replace repeated reference sections with documentation navigation. ([#1038](https://github.com/mifunedev/agro/issues/1038))
 - Align package and display names with AGRO, correct sandbox setup guidance, and remove the stale root sandbox name. ([#1032](https://github.com/mifunedev/agro/issues/1032))
 - Publish only `@mifune/agro` on the automatic release path; keep the `@mifune/openharness` shim source and already-published versions without a new shim publish, wait, or deprecate step. ([#939](https://github.com/mifunedev/agro/issues/939))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Update policy and release automation live in [`/git`](.claude/skills/git/SKILL.m
 
 ### Changed
 
+- Group README installation options into npm and curl disclosures and add an npx alternative without a global install. ([#1038](https://github.com/mifunedev/agro/issues/1038))
 - Align package and display names with AGRO, correct sandbox setup guidance, and remove the stale root sandbox name. ([#1032](https://github.com/mifunedev/agro/issues/1032))
 - Publish only `@mifune/agro` on the automatic release path; keep the `@mifune/openharness` shim source and already-published versions without a new shim publish, wait, or deprecate step. ([#939](https://github.com/mifunedev/agro/issues/939))
 

--- a/README.md
+++ b/README.md
@@ -39,25 +39,17 @@ Node.js ≥ 20.
 
 ### 1. Get `agro`
 
-<details open><summary>npm</summary>
-
 **npm** — you already have Node ≥ 20:
 
 ```bash
-npm install -g @mifune/agro   # puts `agro` on your PATH
-```
+# Install globally
+npm install -g @mifune/agro
 
-Or run without a global install:
-
-```bash
+# Or run without a global install
 npx @mifune/agro --help
 ```
 
 Use `npx @mifune/agro` in place of `agro` in later commands.
-
-</details>
-
-<details><summary>curl</summary>
 
 **curl** — no Node yet; the bootstrap downloads the prebuilt `agro` artifact from
 the latest GitHub release (nothing is cloned or built on your host) and offers to
@@ -71,8 +63,6 @@ For a download-and-review alternative, see [Installation](docs/installation.md).
 
 It installs to `~/.local/bin/agro`; `AGRO_BIN_DIR` overrides the location, and
 `export PATH="$HOME/.local/bin:$PATH"` puts it on an already-open shell's PATH.
-
-</details>
 
 `agro update` upgrades it later. `oh` remains the compatibility alias for the
 same executable — `npm install -g @mifune/openharness` or the `get-oh.sh`

--- a/README.md
+++ b/README.md
@@ -273,7 +273,12 @@ Explore the [searchable docs](https://agro.mifune.dev) or [full docs index](docs
 
 Contributions, bug reports, and feedback are welcome.
 
-[Contributing guide](docs/contributing.md) · [GitHub issues](https://github.com/mifunedev/agro/issues) · [Join our Slack](https://join.slack.com/t/mifunedev/shared_invite/zt-3l2lnevo6-hOe5ZeoAz~xj7CFAJk2bzg)
+[Contributing guide](docs/contributing.md) · [GitHub issues](https://github.com/mifunedev/agro/issues)
+
+[![Slack](https://img.shields.io/badge/-Join_our_Slack-4A154B?style=flat-square&logo=slack&logoColor=white)](https://join.slack.com/t/mifunedev/shared_invite/zt-3l2lnevo6-hOe5ZeoAz~xj7CFAJk2bzg)
+[![X: JohnEggz](https://img.shields.io/badge/-JohnEggz-000000?style=flat-square&logo=x&logoColor=white)](https://x.com/JohnEggz)
+[![Instagram: mifune.dev](https://img.shields.io/badge/-mifune.dev-E4405F?style=flat-square&logo=instagram&logoColor=white)](https://www.instagram.com/mifune.dev)
+[![LinkedIn: Ryan Eggleston](https://img.shields.io/badge/-Ryan_Eggleston-0077B5?style=flat-square&logo=linkedin&logoColor=white)](https://www.linkedin.com/in/ryan-eggleston)
 
 ## 📄 License
 

--- a/README.md
+++ b/README.md
@@ -63,12 +63,6 @@ agro update
 agro --help
 ```
 
-`oh` remains the compatibility alias for the
-same executable — `npm install -g @mifune/openharness` or the `get-oh.sh`
-bootstrap — and every `agro` verb below also works as `oh <verb>`; see
-[AGRO compatibility](docs/agro-compatibility.md) and
-[Installation](docs/installation.md#compatibility-entry-point-oh).
-
 ### 2. Create the sandbox
 
 `agro sandbox install docker` runs from **any** directory — it needs no project

--- a/README.md
+++ b/README.md
@@ -166,16 +166,24 @@ With your coding harness and GitHub CLI configured, ask the agent to create a
 repository for your harness changes. We recommend **private visibility by
 default**, with `origin` pointing to your repository:
 
-> Create a private GitHub repository to track my harness changes and configure it as `origin`.
-> Verify my GitHub account and inspect existing history and remotes first. Ask before replacing an existing remote.
-> Exclude credentials, runtime state, and unrelated projects. Confirm the repository name and proposed files with me before creating it or pushing.
-> Work inside this sandbox and preserve my existing files.
+```text
+Create a private GitHub repo for my harness changes and set it as origin.
+Verify my account, exclude secrets and runtime files, and preserve existing work.
+Confirm the repo name, files, and any remote replacement before creating or pushing.
+```
 
-To contribute back, ask the agent to configure
-[`mifunedev/agro`](https://github.com/mifunedev/agro) as `upstream`, keeping your
-private `origin`. If the histories differ, use a separate checkout inside the
-sandbox and transfer only the changes you intend to contribute. See the
-[contributing guide](docs/contributing.md) for the branch and pull-request workflow.
+<details>
+<summary>Contribute back to AGRO (optional)</summary>
+
+```text
+Configure https://github.com/mifunedev/agro.git as upstream, preserving my origin.
+Check shared history; if unrelated, use a separate checkout inside the sandbox.
+Include only my selected changes, exclude private data, and confirm before pushing or opening a PR.
+```
+
+See the [contributing guide](docs/contributing.md) for the full workflow.
+
+</details>
 
 ### 6. Slack and scheduled work (optional)
 

--- a/README.md
+++ b/README.md
@@ -251,6 +251,33 @@ Message the bot and complete the trust challenge shown in the bridge. See the
 [Pi Slack setup guide](docs/integrations/slack.md) for token locations and access
 configuration.
 
+### 7. Open the sandbox in VS Code (optional)
+
+For a sandbox running on your local machine:
+
+1. Install VS Code's [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers).
+2. Check that your sandbox is running with `agro sandbox list` on the host.
+3. Open the Command Palette (`Ctrl+Shift+P` / `Cmd+Shift+P`), choose **Dev Containers: Attach to Running Container**, and select your sandbox.
+4. Choose **File → Open Folder** and open `/home/sandbox/harness` — the sandbox user's `~/harness` folder.
+
+Use **Attach to Running Container**, not **Reopen in Container**.
+
+<details>
+<summary>Remote sandbox: connect over SSH, then attach</summary>
+
+Complete the sandbox setup on your remote host first. Then, from VS Code on
+your local machine:
+
+1. Install the [Remote - SSH extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-ssh) alongside Dev Containers.
+2. Run **Remote-SSH: Connect to Host** and connect to your Docker host using `user@host`.
+3. In the SSH-connected window, run **Dev Containers: Attach to Running Container** and select the sandbox on that host.
+4. Choose **File → Open Folder** and open `/home/sandbox/harness` (`~/harness` for the sandbox user).
+
+Connect over SSH to the host, not directly to the container. See the
+[connection guide](docs/connecting.md) for more options.
+
+</details>
+
 ## 📚 Table of Contents
 
 Browse the [documentation](docs/README.md) or jump to a topic below.

--- a/README.md
+++ b/README.md
@@ -73,13 +73,8 @@ agro sandbox install docker   # wizard: name, timezone, git identity, SSH, Docke
 agro shell <name>             # attach as the sandbox user
 ```
 
-The wizard's answers land in a registry entry at
-`~/.agro/sandboxes/<name>/agro.json`, beside the compose files and the wrapper
-script the CLI regenerates on every lifecycle call. The default name is
-`agro-sbx-<n>`; `--yes` keeps every default and asks nothing. Without `--repo`
-the sandbox runs the published image and seeds its workspace from it. A sandbox
-created by an earlier release keeps its `~/.oh/sandboxes/<name>/oh.json` entry
-and keeps working; `agro migrate --home` moves the registry when you choose.
+The wizard creates a sandbox from the published image. Replace `<name>` with
+your sandbox name. To use an existing project, mount its checkout below.
 
 **Mount a project instead.** Point the sandbox at a checkout and it is
 bind-mounted at `/home/sandbox/harness`:

--- a/README.md
+++ b/README.md
@@ -184,17 +184,58 @@ See the [contributing guide](docs/contributing.md) for the full workflow.
 
 </details>
 
-### 6. Slack and scheduled work (optional)
+### 6. Configure messaging (optional)
 
-Configure Slack ([docs/integrations/slack.md](docs/integrations/slack.md),
-[docs/harnesses/hermes.md](docs/harnesses/hermes.md)), then run and verify the
-gateways from inside the sandbox:
+Set up either gateway inside the sandbox. If you use both with Slack, give each
+its own Slack app and configuration.
+
+#### Pi
+
+Create a Slack app and collect its app-level and bot tokens using the
+[Pi Slack setup guide](docs/integrations/slack.md).
 
 ```bash
-gateway pi && gateway hermes
+# Install Pi, then use /login in Pi and exit back to the shell
+agro harness install pi
+pi
+
+# Save Slack tokens using hidden input prompts
+cd /home/sandbox/harness
+agro secret set PI_SLACK_APP_TOKEN
+agro secret set PI_SLACK_BOT_TOKEN
+
+# Start the Pi bridge and check its status
+gateway pi
 gateway status
-tmux attach -r -t client-slack-pi   # read-only view; detach with Ctrl-b d
+
+# View the bridge; detach with Ctrl-b d
+tmux attach -r -t client-slack-pi
 ```
+
+Message the bot in Slack and complete the trust challenge shown in the bridge.
+
+#### Hermes
+
+Use Hermes' own setup wizard for provider login and messaging configuration.
+See the [Hermes gateway guide](docs/harnesses/hermes.md#model-and-gateway).
+
+```bash
+# Install Hermes and configure its provider
+agro harness install hermes
+hermes setup
+
+# Configure messaging, including the separate Slack app and access rules
+hermes gateway setup
+
+# Start the Hermes gateway and check its status
+gateway hermes
+gateway status
+
+# View the gateway; detach with Ctrl-b d
+tmux attach -r -t client-slack-hermes
+```
+
+Send a message through the configured channel and confirm that Hermes replies.
 
 ## 📚 Table of Contents
 

--- a/README.md
+++ b/README.md
@@ -41,18 +41,17 @@ npx @mifune/agro --help
 
 Use `npx @mifune/agro` in place of `agro` in later commands.
 
-**curl** — no Node yet; the bootstrap downloads the prebuilt `agro` artifact from
-the latest GitHub release (nothing is cloned or built on your host) and offers to
-install nvm + Node 22 for you:
+**curl**
 
 ```bash
+# Install AGRO to ~/.local/bin; offers Node.js setup if needed
 curl -fsSL https://agro.mifune.dev/get-agro.sh | bash
+
+# Add AGRO to this shell's PATH
+export PATH="$HOME/.local/bin:$PATH"
 ```
 
 For a download-and-review alternative, see [Installation](docs/installation.md).
-
-It installs to `~/.local/bin/agro`; `AGRO_BIN_DIR` overrides the location, and
-`export PATH="$HOME/.local/bin:$PATH"` puts it on an already-open shell's PATH.
 
 `agro update` upgrades it later. `oh` remains the compatibility alias for the
 same executable — `npm install -g @mifune/openharness` or the `get-oh.sh`

--- a/README.md
+++ b/README.md
@@ -68,19 +68,17 @@ agro --help
 `agro sandbox install docker` runs from **any** directory — it needs no project
 checkout:
 
-```bash
-agro sandbox install docker   # wizard: name, timezone, git identity, SSH, Docker socket
-agro shell <name>             # attach as the sandbox user
-```
-
-The wizard creates a sandbox from the published image. Replace `<name>` with
-your sandbox name. To use an existing project, mount its checkout below.
-
-**Mount a project instead.** Point the sandbox at a checkout and it is
-bind-mounted at `/home/sandbox/harness`:
+Choose either setup option, then enter the sandbox:
 
 ```bash
+# Create a sandbox with the setup wizard
+agro sandbox install docker
+
+# Or mount an existing project at /home/sandbox/harness
 agro sandbox install docker --repo ~/my-project --name my-project
+
+# Enter the sandbox; replace <name> with your sandbox name
+agro shell <name>
 ```
 
 Equip that checkout with the control plane first — `cd ~/my-project && oh

--- a/README.md
+++ b/README.md
@@ -276,9 +276,9 @@ Contributions, bug reports, and feedback are welcome.
 [Contributing guide](docs/contributing.md) · [GitHub issues](https://github.com/mifunedev/agro/issues)
 
 [![Slack](https://img.shields.io/badge/-Join_our_Slack-4A154B?style=flat-square&logo=slack&logoColor=white)](https://join.slack.com/t/mifunedev/shared_invite/zt-3l2lnevo6-hOe5ZeoAz~xj7CFAJk2bzg)
-[![X: JohnEggz](https://img.shields.io/badge/-JohnEggz-000000?style=flat-square&logo=x&logoColor=white)](https://x.com/JohnEggz)
+[![X: mifunedev](https://img.shields.io/badge/-mifunedev-000000?style=flat-square&logo=x&logoColor=white)](https://x.com/mifunedev)
 [![Instagram: mifune.dev](https://img.shields.io/badge/-mifune.dev-E4405F?style=flat-square&logo=instagram&logoColor=white)](https://www.instagram.com/mifune.dev)
-[![LinkedIn: Ryan Eggleston](https://img.shields.io/badge/-Ryan_Eggleston-0077B5?style=flat-square&logo=linkedin&logoColor=white)](https://www.linkedin.com/in/ryan-eggleston)
+[![LinkedIn: Mifune Dev](https://img.shields.io/badge/-Mifune_Dev-0077B5?style=flat-square&logo=linkedin&logoColor=white)](https://www.linkedin.com/company/mifune-dev)
 
 ## 📄 License
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
   <a href="https://github.com/mifunedev/agro/stargazers"><img alt="Stars" src="https://img.shields.io/github/stars/mifunedev/agro?style=plastic&logo=github&logoColor=white&labelColor=0B1220&color=D4AF37"></a>
   <a href="https://github.com/mifunedev/agro/issues"><img alt="Issues" src="https://img.shields.io/github/issues/mifunedev/agro?style=plastic&labelColor=0B1220&color=D4AF37"></a>
   <img alt="Docker required" src="https://img.shields.io/badge/Docker-required-D4AF37?style=plastic&logo=docker&logoColor=white&labelColor=0B1220">
-  <a href="https://deepwiki.com/mifunedev/agro"><img alt="Ask DeepWiki" src="https://img.shields.io/badge/DeepWiki-ask-D4AF37?style=plastic&labelColor=0B1220"></a>
 </p>
 
 <p align="center">
@@ -214,7 +213,6 @@ Explore the [searchable docs](https://agro.mifune.dev) or [full docs index](docs
 | Debugging and testing | [DebugMCP](docs/integrations/debugmcp.md) · [Property testing](docs/property-testing.md) |
 | Security | [Permissions and trust boundaries](docs/security-considerations.md) |
 | Contributing | [Contribution workflow](docs/contributing.md) · [Docs site source](https://github.com/mifunedev/agro-web) |
-| Codebase navigation | [DeepWiki](https://deepwiki.com/mifunedev/agro) |
 
 ## 🤝 Contributing & community
 

--- a/README.md
+++ b/README.md
@@ -126,24 +126,39 @@ gh auth status
 
 See [GitHub authentication](docs/integrations/github.md) for help.
 
-### 4. Authenticate one coding harness
+### 4. Install a coding harness
 
-Install and authenticate one harness from a Herdr pane. That is a complete first
-session — no fork, no clone, no private repository, no Slack, and no upstream
-contribution:
+Choose one harness to start. In a Herdr pane, install and authenticate it:
 
 ```bash
-agro harness install claude-code && claude auth login
-# ...or pick another one — you need exactly one to start:
-#   agro harness install codex && codex login --device-auth
-#   agro harness install pi && pi           # first run walks provider auth
-#   agro harness install hermes && hermes setup
+# List available harnesses
+agro harness list
+
+# Install Claude Code
+agro harness install claude-code
+
+# Sign in and verify authentication
+claude auth login
+claude auth status
+
+# Start Claude Code
+claude
 ```
 
-Every CLI arrives only through `agro harness install <id>` — nothing installs at
-boot. The simplest cross-provider login is `/login` inside the agent, then
-**device mode**, which works on a headless or remote sandbox. Per-harness detail:
-[harnesses overview](docs/harnesses/overview.md).
+| Harness | ID | Availability |
+| --- | --- | --- |
+| [Claude Code](docs/harnesses/claude-code.md) | `claude-code` | Install on demand |
+| [Codex](docs/harnesses/codex.md) | `codex` | Install on demand |
+| [Pi](docs/harnesses/pi.md) | `pi` | Install on demand |
+| [OpenCode](docs/harnesses/opencode.md) | `opencode` | Install on demand |
+| [Grok Build](docs/harnesses/grok-build.md) | `grok-build` | Install on demand |
+| [Hermes](docs/harnesses/hermes.md) | `hermes` | Install on demand |
+| [Muse Code](docs/harnesses/muse-code.md) | `muse-code` | Install on demand |
+| [T3 Code](docs/harnesses/t3code.md) | `t3code` | Run on demand via `npx` |
+
+Use `agro harness install <id>` for other installable harnesses. Follow the linked
+guides for authentication and launch commands. T3 Code requires an authenticated
+Claude Code, Codex, or OpenCode provider.
 
 ### 5. Repository workflows (optional)
 

--- a/README.md
+++ b/README.md
@@ -15,23 +15,13 @@
   <img src=".github/assets/mifune-banner.jpg" alt="AGRO" width="100%">
 </p>
 
-**AGRO provides the sandbox; you choose the harness.** It's a Docker-based workspace, agent-tended over time: one `agro sandbox install docker` boots a long-lived container where the coding agent of your choice — Claude Code, Codex, Pi, Hermes, Grok, and more, each installed with one `agro harness install` command — works on its own branch and identity. Because it's just Docker, it runs **identically on your laptop or a remote VM** — and remote is the default: deployed on a VM, AGRO becomes a **lights-out software factory**, where the agent works unattended, on a schedule and reachable over Slack, fanning out across isolated **git worktrees** — parallel branches, delegated sub-agents, even other cloned repos — while you're away and your laptop stays clean.
+**AGRO gives AI coding agents a workspace you control.** It packages a Docker sandbox and shared agent procedures around the coding harness you choose—Claude Code, Codex, Pi, or another.
 
-- **One project, one sandbox.** A single container scoped to a single repo. The agent owns its branch and its workspace; you keep your laptop clean.
-- **Parallel by design.** The worktrees skill fans one sandbox into isolated git worktrees — parallel branches, delegated sub-agents, even other cloned repos.
-- **Remote-first, lights-out.** Runs the same on your laptop or a cloud VM; on a VM it's an unattended software factory — agents build on a schedule, reachable over Slack.
-- **Agents that work while you sleep.** A tiny croner runtime reads `crons/*.md` markdown and wakes the agent on a schedule.
-- **Host dependencies: Docker, Git, and Node.js ≥ 20.** No Python, no pnpm, no agent CLIs, no toolchain rot on your laptop — Node runs the `agro` CLI and nothing else. (`get-agro.sh` installs Node for you if you don't have it — see [Prerequisites](docs/installation.md#prerequisites).) The same `agro` verbs work on the host and inside the sandbox — see [lifecycle commands](docs/lifecycle-commands.md).
-- **Composable infra.** Cherry-pick Cloudflare tunnels, SSH, Caddy gateway, or pack-supplied services via Compose overlays.
-- **Slack-ready.** The `pi-messenger-bridge` package bridges Slack (and other messengers) to a Pi agent — see [docs/integrations/slack.md](docs/integrations/slack.md).
-- **Herdr-first interactive work.** Nothing installs at boot: every harness and tool arrives through `agro harness install <id>` or `agro tool install <id>`. After entering the sandbox, install and run [Herdr](docs/integrations/herdr.md) first; keep setup, agents, tests, and servers organized in its persistent panes. Headless Slack and cron infrastructure remain independent.
+Develop on your laptop or a remote VM. Install tools and harnesses on demand, organize parallel changes in separate git worktrees, and use shared skills and evidence checks to guide the work.
 
----
+Start with the quickstart below. See the [docs](https://agro.mifune.dev) and [Start Here hub](docs/README.md) for more guidance.
 
-> 📖 **Read the docs → https://agro.mifune.dev**
-> Rendered, searchable docs, guides, and blog. New here? Start with the [Start Here hub](docs/README.md).
-
-## 📦 Install
+## 📦 Quickstart
 
 AGRO runs one project in one Docker sandbox, and **`agro` is the only
 front door**. Host prerequisites: Docker (with the Compose plugin), Git, and

--- a/README.md
+++ b/README.md
@@ -46,14 +46,24 @@ Use `npx @mifune/agro` in place of `agro` in later commands.
 ```bash
 # Install AGRO to ~/.local/bin; offers Node.js setup if needed
 curl -fsSL https://agro.mifune.dev/get-agro.sh | bash
-
-# Add AGRO to this shell's PATH
-export PATH="$HOME/.local/bin:$PATH"
 ```
 
 For a download-and-review alternative, see [Installation](docs/installation.md).
 
-`agro update` upgrades it later. `oh` remains the compatibility alias for the
+Check the installed version, update AGRO, or see available commands:
+
+```bash
+# Check the installed version
+agro --version
+
+# Update AGRO
+agro update
+
+# Show available commands
+agro --help
+```
+
+`oh` remains the compatibility alias for the
 same executable — `npm install -g @mifune/openharness` or the `get-oh.sh`
 bootstrap — and every `agro` verb below also works as `oh <verb>`; see
 [AGRO compatibility](docs/agro-compatibility.md) and

--- a/README.md
+++ b/README.md
@@ -81,23 +81,52 @@ agro sandbox install docker --repo ~/my-project --name my-project
 agro shell <name>
 ```
 
-Equip that checkout with the control plane first — `cd ~/my-project && oh
-update` writes `.agro/` and `crons/` and **nothing else**: no `AGENTS.md`, no
-provider configuration, no `.gitignore` line beyond the `.env` line
-`agro secret set` adds. Those files stay yours.
+### 3. Install tools
 
-Then, inside the sandbox, install and open the persistent interactive workspace
-first — a fresh sandbox has no `herdr`, because nothing installs at boot:
+Inside the sandbox, start with [Herdr](docs/integrations/herdr.md), the terminal
+workspace for your agents and development tools:
 
 ```bash
+# Install and open Herdr
 agro tool install herdr
 herdr
 ```
 
-Run the remaining setup, authentication, agents, tests, and servers from its
-panes.
+Run the remaining commands in a Herdr pane. Install only the tools you need:
 
-### 3. Authenticate one coding harness
+| Tool | Purpose | Availability |
+| --- | --- | --- |
+| `herdr` | Interactive terminal workspace | Install on demand |
+| `agent-browser` | Browser automation | Install on demand |
+| `cloudflared` | Public tunnels for local apps | Install on demand |
+| `microsandbox` | MicroVM runtime CLI | Install on demand |
+| `tailscale` | Private network connectivity | Install on demand |
+| `gh` | GitHub CLI | Included |
+| `docker-cli` | Docker client and Compose | Included |
+
+```bash
+# List tools and check availability
+agro tool list
+
+# Install an optional tool
+agro tool install <id>
+```
+
+**GitHub (optional):** authenticate before repository work that uses GitHub.
+Confirm that the status output shows your intended account.
+
+```bash
+# Sign in and configure Git credentials
+gh auth login
+gh auth setup-git
+
+# Verify your account
+gh auth status
+```
+
+See [GitHub authentication](docs/integrations/github.md) for help.
+
+### 4. Authenticate one coding harness
 
 Install and authenticate one harness from a Herdr pane. That is a complete first
 session — no fork, no clone, no private repository, no Slack, and no upstream
@@ -116,26 +145,10 @@ boot. The simplest cross-provider login is `/login` inside the agent, then
 **device mode**, which works on a headless or remote sandbox. Per-harness detail:
 [harnesses overview](docs/harnesses/overview.md).
 
-### 4. Authenticate GitHub before any repository work (optional)
+### 5. Repository workflows (optional)
 
-Local sandbox use stays available without a GitHub account. Work that reaches
-GitHub — pushing, creating a repository, opening a pull request — does not.
-Provider authentication authenticates the model, not GitHub, and grants no
-repository access.
-
-Run these five steps in this order, inside a Herdr pane:
-
-1. Authenticate the intended GitHub account with `gh auth login`.
-2. Run `gh auth setup-git` to configure Git's credential helper.
-3. Run `gh auth status`.
-4. Confirm the status output identifies the intended account with authenticated
-   access.
-5. Only after those checks pass, send either optional prompt below to the
-   authenticated coding agent.
-
-The initial login is never delegated to the prompts. Both prompts assume it is
-already complete and recheck it before acting. Command-level detail and recovery:
-[GitHub auth](docs/integrations/github.md).
+After completing GitHub authentication in step 3, send either prompt below to
+your coding agent. Provider login and GitHub login are separate.
 
 **Optional — version-control this sandbox in your own private repository.**
 
@@ -164,7 +177,7 @@ already complete and recheck it before acting. Command-level detail and recovery
 retired clone-and-own recipe and stays supported through the SLA. It is not the
 canonical onboarding path.
 
-### 5. Slack and scheduled work (optional)
+### 6. Slack and scheduled work (optional)
 
 Configure Slack ([docs/integrations/slack.md](docs/integrations/slack.md),
 [docs/harnesses/hermes.md](docs/harnesses/hermes.md)), then run and verify the

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 Develop on your laptop or a remote VM. Install tools and harnesses on demand, organize parallel changes in separate git worktrees, and use shared skills and evidence checks to guide the work.
 
-Start with the quickstart below. See the [docs](https://agro.mifune.dev) and [Start Here hub](docs/README.md) for more guidance.
+Start with the quickstart below. See the [documentation](docs/README.md) for more guidance.
 
 ## 📦 Quickstart
 
@@ -253,7 +253,7 @@ configuration.
 
 ## 📚 Table of Contents
 
-Explore the [searchable docs](https://agro.mifune.dev) or [full docs index](docs/README.md).
+Browse the [documentation](docs/README.md) or jump to a topic below.
 
 | Topic | Documentation |
 | --- | --- |
@@ -292,4 +292,4 @@ Apache-2.0 §6 grants no permission to use the Mifune or Open Harness names, log
 
 ---
 
-[Read the docs](https://agro.mifune.dev) · [Docs index](docs/README.md) · [Docs site source](https://github.com/mifunedev/agro-web)
+[Documentation](docs/README.md) · [Docs website](https://agro.mifune.dev) · [Docs site source](https://github.com/mifunedev/agro-web)

--- a/README.md
+++ b/README.md
@@ -197,110 +197,24 @@ gateway status
 tmux attach -r -t client-slack-pi   # read-only view; detach with Ctrl-b d
 ```
 
-### VS Code (secondary path)
+## 📚 Table of Contents
 
-Provision with `agro sandbox install docker`, then attach with **Dev Containers:
-Attach to Running Container** against your sandbox. That is the supported editor
-path.
+Explore the [searchable docs](https://agro.mifune.dev) or [full docs index](docs/README.md).
 
-**Do not provision with "Reopen in Container".** That path reads
-`.devcontainer/devcontainer.json`, which lists `docker-compose.yml` alone, so it
-bypasses `.agro/scripts/docker-compose.sh` and **no overlay applies** — no SSH
-(`access.ssh`), no host Docker socket (`access.dockerSocket`), no Hermes
-dashboard (`hermesDashboard.enabled`), and nothing from `composeOverrides[]`.
-Secrets still load, because compose auto-loads the `.devcontainer/.env` symlink
-beside the compose file; non-secret `agro.json` settings fall back to the compose
-defaults. Details: [lifecycle commands](docs/lifecycle-commands.md#vs-code-reopen-in-container-applies-no-overlays).
-
-> **Optional — DebugMCP.** Once attached from VS Code, you can install the
-> `microsoft/DebugMCP` extension to expose a debugging MCP server that **any
-> MCP-capable harness** (Claude Code, Codex, …) can drive. It's optional and not
-> tied to any single agent — see the
-> [DebugMCP runbook](docs/integrations/debugmcp.md#confirmed-setup-runbook).
-
-## 🧩 How the primitive pack ships
-
-Open Harness vendors the shared skills/hooks primitive pack directly into the `.agro/` control plane: `.agro/skills/`, `.agro/hooks/`, and `.agro/skills.lock` are tracked as ordinary files in this repo. Skills are the reusable-behavior primitive; the harness ships no repository-authored agent definitions, and provider-native sub-agents remain available as a bounded execution primitive through `/delegate`. `oh update` lays them down, so a fresh checkout has the skills immediately — no submodule, no recursive clone, no network step.
-
-Codex and Pi discover shared skills through `.agents/skills -> ../.agro/skills`. Claude uses `.claude/skills` for the same pack and `.claude/hooks` for `.agro/hooks`. The retired `.codex/skills` and `.pi/skills` links are absent from fresh clones. `.codex/` and `.pi/` retain their provider-specific configuration.
-
-## 🚀 Use it
-
-```bash
-agro sandbox list       # every sandbox: name, runtime, status, repo
-agro shell <name>       # enter the isolated sandbox
-agro tool install herdr # nothing installs at boot; install the workspace first
-herdr                 # open the primary interactive workspace
-# install an agent CLI the same way, then launch it from a Herdr pane:
-#   agro harness install claude-code  → claude    # Claude Code
-#   agro harness install codex        → codex     # OpenAI Codex CLI
-#   agro harness install pi           → pi        # Pi Coding Agent
-#   agro harness install opencode     → opencode  # OpenCode
-#   agro harness install hermes       → hermes    # Nous Research Hermes
-#   agro harness install grok-build   → grok      # xAI Grok Build
-agro stop <name>    # stop the sandbox, keeping volumes
-agro destroy <name> # stop the sandbox, wipe its volumes, drop the registry entry
-agro --help         # every verb
-```
-
-## 🧪 Testing
-
-- Property-based testing convention: [docs/property-testing.md](docs/property-testing.md)
-
-Prefer VS Code or remote SSH? Use the Dev Containers extension's "Attach to Running Container" against your sandbox name from `agro sandbox list` — not "Reopen in Container", which applies no overlays (see [VS Code (secondary path)](#vs-code-secondary-path)) — or SSH into your host first and then attach.
-
-## ⚙️ Configure (optional)
-
-Configuration is split by kind across two files. `agro.json` holds every
-non-secret setting — sandbox identity, git identity, the SSH and Docker-socket
-toggles. It holds no install field: `agro harness install <id>` and `agro tool
-install <id>` are the only door. A gitignored, mode-`0600` `.env` holds nothing
-but secrets (`GH_TOKEN`, `SANDBOX_PASSWORD`, `PI_SLACK_APP_TOKEN`,
-`PI_SLACK_BOT_TOKEN`, …); the tracked `.example.env` documents every
-allow-listed key. A sandbox keeps its pair inside its registry entry —
-`agro config set --sandbox <name> <field> <value>` and `agro secret set --sandbox
-<name> <KEY>` write there; without the flag both write the project root. Apply a
-change with `agro stop <name> && agro sandbox install docker --name <name>`.
-Full field reference: [Configuration](docs/configuration.md).
-
-Secrets are read on **every** path, including VS Code "Reopen in Container" —
-that path loads `.devcontainer/docker-compose.yml` directly and compose
-auto-loads the dotenv beside it, which is a symlink to the root one. Compose
-*overlays* are the exception: that path applies none, which is why
-`agro sandbox install docker` provisions and VS Code only attaches. A
-`harness.yaml` layer used to sit in front of these files and was invisible on
-exactly that path; it was removed in 0.4.0, and a leftover one is migrated
-automatically on the next lifecycle command. Compose overlay *paths* live in
-`composeOverrides[]` in `agro.json`. See
-[the `agro sandbox install docker` guide](docs/deployment-prebuilt-image.md) for
-the image-mode recipe.
-
-## ✨ What you get
-
-| | |
-|---|---|
-| **Core agents** | Defaults: Claude Code, Codex, Pi. Optional: OpenCode, Hermes, Grok Build |
-| **Runtimes** | Node 22, pnpm, Bun, uv (Python) |
-| **DevOps** | Herdr, Docker CLI + Compose, GitHub CLI, cloudflared, tmux, croner |
-| **Browser** | agent-browser + Chromium (headless) |
-| **One project, one sandbox** | A single container scoped to a single repo and branch |
-| **Worktrees** | One sandbox → many isolated git worktrees: parallel branches, delegated sub-agents, satellite project clones under `projects/` |
-| **Crons** | Markdown-defined schedules in `crons/*.md` driven by the in-container croner runtime |
-| **Multi-agent** | Claude, Codex, Pi, Hermes, Grok — each via `agro harness install <id>`; Slack bridging via [pi-messenger-bridge](docs/integrations/slack.md) |
-
-## 📚 Where to go next
-
-- **[Read the docs → agro.mifune.dev](https://agro.mifune.dev)** — the rendered, searchable documentation site (start here)
-- [Docs index](docs/README.md) — GitHub-readable docs kept with the core repo
-- [Quickstart](docs/quickstart.md) — full step-by-step
-- [DeepWiki](https://deepwiki.com/mifunedev/agro) — generated codebase map
-- [Docs site source](https://github.com/mifunedev/agro-web) — Docusaurus source repo that builds agro.mifune.dev (contribute doc edits here)
-
-## 🧹 Cleanup
-
-```bash
-agro destroy <name>
-```
+| Topic | Documentation |
+| --- | --- |
+| Getting started | [Quickstart](docs/quickstart.md) · [Installation](docs/installation.md) |
+| Sandbox setup | [Create a sandbox](docs/deployment-prebuilt-image.md) · [VS Code and SSH](docs/connecting.md) |
+| Daily operation | [Lifecycle commands, stopping, and cleanup](docs/lifecycle-commands.md) |
+| Terminal workspace | [Herdr](docs/integrations/herdr.md) |
+| Coding harnesses | [Harness overview and setup guides](docs/harnesses/overview.md) |
+| Configuration | [Settings and secrets](docs/configuration.md) |
+| Agent procedures | [Shared skills and hooks](docs/README.md#how-the-primitive-pack-ships) · [Directory layout](docs/oh-directory-layout.md) |
+| Integrations | [GitHub](docs/integrations/github.md) · [Slack](docs/integrations/slack.md) · [Langfuse](docs/integrations/langfuse.md) |
+| Debugging and testing | [DebugMCP](docs/integrations/debugmcp.md) · [Property testing](docs/property-testing.md) |
+| Security | [Permissions and trust boundaries](docs/security-considerations.md) |
+| Contributing | [Contribution workflow](docs/contributing.md) · [Docs site source](https://github.com/mifunedev/agro-web) |
+| Codebase navigation | [DeepWiki](https://deepwiki.com/mifunedev/agro) |
 
 ## 🤝 Contributing & community
 

--- a/README.md
+++ b/README.md
@@ -160,37 +160,22 @@ Use `agro harness install <id>` for other installable harnesses. Follow the link
 guides for authentication and launch commands. T3 Code requires an authenticated
 Claude Code, Codex, or OpenCode provider.
 
-### 5. Repository workflows (optional)
+### 5. Track your harness changes (optional)
 
-After completing GitHub authentication in step 3, send either prompt below to
-your coding agent. Provider login and GitHub login are separate.
+With your coding harness and GitHub CLI configured, ask the agent to create a
+repository for your harness changes. We recommend **private visibility by
+default**, with `origin` pointing to your repository:
 
-**Optional — version-control this sandbox in your own private repository.**
+> Create a private GitHub repository to track my harness changes and configure it as `origin`.
+> Verify my GitHub account and inspect existing history and remotes first. Ask before replacing an existing remote.
+> Exclude credentials, runtime state, and unrelated projects. Confirm the repository name and proposed files with me before creating it or pushing.
+> Work inside this sandbox and preserve my existing files.
 
-> I have completed `gh auth login` and verified the intended GitHub account inside this sandbox.
-> Help me version-control this sandbox workspace in my own private GitHub repository.
-> Recheck GitHub authentication before acting, then inspect existing Git history and remotes.
-> Preserve my files and existing repository configuration.
-> Review ignore rules and the proposed tracked files for credentials, runtime state, logs, and unrelated projects.
-> Ask me to confirm the account, repository name, and private visibility before creating the repository.
-> Show me the proposed commit contents and ask before pushing.
-> Do all work inside this sandbox; do not create a host-side source checkout.
-
-**Optional — prepare a contribution to AGRO.**
-
-> I have completed `gh auth login` and verified the intended GitHub account inside this sandbox.
-> Help me prepare an AGRO contribution from this sandbox.
-> Recheck GitHub authentication before acting.
-> Inspect existing remotes and check whether this checkout shares history with the canonical AGRO repository.
-> If the histories share ancestry, help me configure an upstream remote and a contribution branch without changing my private origin.
-> Otherwise, use a separate ordinary upstream checkout inside this sandbox and transfer only the changes I select.
-> Keep private configuration, credentials, and unrelated files out of the contribution.
-> Confirm the fork, target branch, and diff with me before pushing or opening a pull request.
-> Do not replace the live workspace or create a host-side source checkout.
-
-`agro config repo` (and `oh config repo`) remains a compatibility helper for the
-retired clone-and-own recipe and stays supported through the SLA. It is not the
-canonical onboarding path.
+To contribute back, ask the agent to configure
+[`mifunedev/agro`](https://github.com/mifunedev/agro) as `upstream`, keeping your
+private `origin`. If the histories differ, use a separate checkout inside the
+sandbox and transfer only the changes you intend to contribute. See the
+[contributing guide](docs/contributing.md) for the branch and pull-request workflow.
 
 ### 6. Slack and scheduled work (optional)
 

--- a/README.md
+++ b/README.md
@@ -39,11 +39,25 @@ Node.js ≥ 20.
 
 ### 1. Get `agro`
 
+<details open><summary>npm</summary>
+
 **npm** — you already have Node ≥ 20:
 
 ```bash
 npm install -g @mifune/agro   # puts `agro` on your PATH
 ```
+
+Or run without a global install:
+
+```bash
+npx @mifune/agro --help
+```
+
+Use `npx @mifune/agro` in place of `agro` in later commands.
+
+</details>
+
+<details><summary>curl</summary>
 
 **curl** — no Node yet; the bootstrap downloads the prebuilt `agro` artifact from
 the latest GitHub release (nothing is cloned or built on your host) and offers to
@@ -53,16 +67,13 @@ install nvm + Node 22 for you:
 curl -fsSL https://agro.mifune.dev/get-agro.sh | bash
 ```
 
-Review-first (download, read, then run — no extra dependency):
-
-```bash
-curl -fsSL -o get-agro.sh https://agro.mifune.dev/get-agro.sh
-# Review get-agro.sh in your editor or pager before running it.
-bash get-agro.sh
-```
+For a download-and-review alternative, see [Installation](docs/installation.md).
 
 It installs to `~/.local/bin/agro`; `AGRO_BIN_DIR` overrides the location, and
 `export PATH="$HOME/.local/bin:$PATH"` puts it on an already-open shell's PATH.
+
+</details>
+
 `agro update` upgrades it later. `oh` remains the compatibility alias for the
 same executable — `npm install -g @mifune/openharness` or the `get-oh.sh`
 bootstrap — and every `agro` verb below also works as `oh <verb>`; see

--- a/README.md
+++ b/README.md
@@ -271,7 +271,9 @@ Explore the [searchable docs](https://agro.mifune.dev) or [full docs index](docs
 
 ## 🤝 Contributing & community
 
-Open Harness is maintained under the [`mifunedev`](https://github.com/mifunedev) org — the canonical repo is [github.com/mifunedev/agro](https://github.com/mifunedev/agro). Contribute from a running sandbox: complete the GitHub-login prerequisite above, then use the contribution prompt or the workflow in [Contributing](docs/contributing.md). Issues and PRs welcome; if Open Harness is useful to you, please [give us a star](https://github.com/mifunedev/agro/stargazers).
+Contributions, bug reports, and feedback are welcome.
+
+[Contributing guide](docs/contributing.md) · [GitHub issues](https://github.com/mifunedev/agro/issues) · [Join our Slack](https://join.slack.com/t/mifunedev/shared_invite/zt-3l2lnevo6-hOe5ZeoAz~xj7CFAJk2bzg)
 
 ## 📄 License
 

--- a/README.md
+++ b/README.md
@@ -186,20 +186,55 @@ See the [contributing guide](docs/contributing.md) for the full workflow.
 
 ### 6. Configure messaging (optional)
 
-Set up either gateway inside the sandbox. If you use both with Slack, give each
-its own Slack app and configuration.
+Run setup inside the sandbox from a Herdr pane. Use a separate Slack app and
+configuration for each gateway. We recommend opening another Herdr pane to
+attach to its tmux session; detach with `Ctrl-b d` to leave the gateway running.
+
+#### Hermes
+
+```bash
+# Install Hermes and configure its provider
+agro harness install hermes
+hermes setup
+
+# Generate the Slack app manifest and print its location
+hermes slack manifest --agent-view --write
+```
+
+Open [Slack Apps](https://api.slack.com/apps), choose **Create New App → From an
+app manifest**, and paste the generated JSON. Review its permissions, then
+install the app to your workspace. Collect the bot token (`xoxb-`) and an
+app-level token (`xapp-`) with `connections:write` scope.
+
+```bash
+# Enter the Slack tokens and configure access rules
+hermes gateway setup
+
+# Start the Hermes gateway and check its status
+gateway hermes
+gateway status
+
+# Attach read-only from a Herdr pane; detach with Ctrl-b d
+tmux attach -r -t client-slack-hermes
+```
+
+Send the bot a message and confirm a reply. See the
+[Hermes Slack setup guide](https://github.com/NousResearch/hermes-agent/blob/main/website/docs/user-guide/messaging/slack.md)
+and [gateway documentation](docs/harnesses/hermes.md#model-and-gateway).
 
 #### Pi
 
-Create a Slack app and collect its app-level and bot tokens using the
-[Pi Slack setup guide](docs/integrations/slack.md).
+In [Slack Apps](https://api.slack.com/apps), create an app **From an app
+manifest** using [Pi's manifest](.pi/install/slack-manifest.json). It configures
+Socket Mode, events, and admin commands. Review permissions, install the app,
+and collect its own `xapp-` (`connections:write`) and `xoxb-` tokens.
 
 ```bash
 # Install Pi, then use /login in Pi and exit back to the shell
 agro harness install pi
 pi
 
-# Save Slack tokens using hidden input prompts
+# Save Pi's Slack tokens using hidden input prompts
 cd /home/sandbox/harness
 agro secret set PI_SLACK_APP_TOKEN
 agro secret set PI_SLACK_BOT_TOKEN
@@ -208,34 +243,13 @@ agro secret set PI_SLACK_BOT_TOKEN
 gateway pi
 gateway status
 
-# View the bridge; detach with Ctrl-b d
+# Attach read-only from a Herdr pane; detach with Ctrl-b d
 tmux attach -r -t client-slack-pi
 ```
 
-Message the bot in Slack and complete the trust challenge shown in the bridge.
-
-#### Hermes
-
-Use Hermes' own setup wizard for provider login and messaging configuration.
-See the [Hermes gateway guide](docs/harnesses/hermes.md#model-and-gateway).
-
-```bash
-# Install Hermes and configure its provider
-agro harness install hermes
-hermes setup
-
-# Configure messaging, including the separate Slack app and access rules
-hermes gateway setup
-
-# Start the Hermes gateway and check its status
-gateway hermes
-gateway status
-
-# View the gateway; detach with Ctrl-b d
-tmux attach -r -t client-slack-hermes
-```
-
-Send a message through the configured channel and confirm that Hermes replies.
+Message the bot and complete the trust challenge shown in the bridge. See the
+[Pi Slack setup guide](docs/integrations/slack.md) for token locations and access
+configuration.
 
 ## 📚 Table of Contents
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,41 +1,35 @@
-# Open Harness docs
+# AGRO documentation
 
-📖 **Full rendered docs & search → https://agro.mifune.dev**
-
-GitHub-readable documentation for the core Open Harness repo. Prefer this index
-for repo-local docs and [DeepWiki](https://deepwiki.com/mifunedev/agro)
-for generated codebase navigation. The rendered Docusaurus site and blog archive
-live in [`mifunedev/agro-web`](https://github.com/mifunedev/agro-web).
+Browse the [searchable docs](https://agro.mifune.dev) or use the guides below.
+The documentation site source lives in [`mifunedev/agro-web`](https://github.com/mifunedev/agro-web).
 
 ## Start here
 
-Open Harness provides the sandbox; you choose the harness — a Docker workspace you
-own, where `agro sandbox install docker` boots one long-lived container and the coding agent
-of your choice (Claude Code, Codex, Pi, Hermes, and more) works on its own branch and
-identity, running identically on your laptop or an unattended, lights-out remote VM.
+AGRO gives AI coding agents a workspace you control: a Docker sandbox and shared
+agent procedures around your chosen coding harness, locally or on a remote VM.
 
-**Attach in 3 steps (VS Code):**
+Start with the [README quickstart](../README.md#-quickstart): install AGRO, create
+a sandbox, open Herdr, and configure your tools and coding harness. GitHub and
+messaging setup are optional.
 
-1. `oh sandbox install docker` — write the registry entry and boot the container.
-2. VS Code → Command Palette (Ctrl/Cmd+Shift+P) → "Dev Containers: Attach to Running
-   Container" → select your sandbox name from `agro sandbox list`. Ports auto-forward while attached.
-3. Open a terminal and run `oh tool install herdr`, then `herdr`. Nothing installs at boot, so install each agent the same way — `oh harness install claude-code`, `codex`, `pi`, or `hermes` — then launch it from a Herdr pane.
-
-Full terminal, VS Code, and Remote-SSH options: see [Connecting to the sandbox](connecting.md).
-
-[Hermes](harnesses/hermes.md) — Nous Research's self-improving agent CLI — installs
-like every other harness: run `oh harness install hermes`, then `hermes setup`.
+- [Installation](installation.md) — prerequisites and installation details.
+- [Herdr](integrations/herdr.md) — the terminal workspace for interactive development.
+- [Harnesses](harnesses/overview.md) — choose and authenticate a coding harness.
+- [Connecting](connecting.md) — VS Code and remote access options.
 
 ## How the primitive pack ships
 
-Open Harness vendors the shared skills/hooks primitive pack directly into the `.agro/` control plane (`.agro/skills/`, `.agro/hooks/`, `.agro/skills.lock`), tracked as ordinary files — `oh update` lays them down, so a fresh checkout has them with no submodule or network step. Codex and Pi use `.agents/skills`; Claude uses `.claude/skills`. Both surfaces link to `.agro/skills`. Fresh clones omit the retired `.codex/skills` and `.pi/skills` links but retain provider-specific configuration.
+AGRO keeps shared skills and hooks in `.agro/skills/` and `.agro/hooks/`.
+Codex and Pi access shared skills through `.agents/skills`; Claude Code uses
+`.claude/skills`. Provider-specific configuration stays separate. See the
+[directory layout](oh-directory-layout.md) for details.
 
 ## Setup & first steps
 
 - [Introduction](intro.md)
 - [Quickstart](quickstart.md)
 - [Installation](installation.md)
-- [Creating a sandbox: `oh sandbox install docker`](deployment-prebuilt-image.md)
+- [Creating a sandbox: `agro sandbox install docker`](deployment-prebuilt-image.md)
 - [Connecting to the sandbox](connecting.md)
 - [Contributing](contributing.md)
 - [AGRO compatibility contract](agro-compatibility.md)
@@ -50,6 +44,7 @@ Open Harness vendors the shared skills/hooks primitive pack directly into the `.
 - [OpenCode](harnesses/opencode.md)
 - [Hermes](harnesses/hermes.md)
 - [Grok Build](harnesses/grok-build.md)
+- [Muse Code](harnesses/muse-code.md)
 - [T3 Code](harnesses/t3code.md)
 
 ## Integrations
@@ -64,7 +59,7 @@ Open Harness vendors the shared skills/hooks primitive pack directly into the `.
 
 ## Reference
 
-- [Lifecycle commands — the `agro` verb reference (`oh` is the alias)](lifecycle-commands.md)
+- [Lifecycle commands — the `agro` command reference](lifecycle-commands.md)
 - [Configuration — `agro.json` fields and the secrets split](configuration.md)
 - [Security considerations](security-considerations.md)
 - [Open-core boundary](open-core.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,8 @@
 # AGRO documentation
 
-Browse the [searchable docs](https://agro.mifune.dev) or use the guides below.
-The documentation site source lives in [`mifunedev/agro-web`](https://github.com/mifunedev/agro-web).
+Start with the guides below for documentation maintained alongside AGRO.
+The [docs website](https://agro.mifune.dev) is a separate presentation, with its
+source in [`mifunedev/agro-web`](https://github.com/mifunedev/agro-web).
 
 ## Start here
 


### PR DESCRIPTION
Closes #1038. Supports onboarding epic #1009 without claiming its completion.

[README preview](https://github.com/mifunedev/agro/blob/task/1038-readme-install-options/README.md) · [Docs index](https://github.com/mifunedev/agro/blob/task/1038-readme-install-options/docs/README.md)

Operator-directed revisions:
- Concise AGRO introduction and seven-step Quickstart.
- Combined installation examples and shared version/update/help commands.
- Current tool and harness catalogs, Herdr-first setup, and GitHub authentication.
- Copyable private-repo prompt and optional upstream contribution dropdown.
- Hermes messaging first, Pi second: separate Slack apps/manifests, token setup, gateway commands, further docs, and read-only tmux attachment from Herdr panes.
- Docs Table of Contents replaces repeated reference sections. Retire DeepWiki from both entry pages and refresh the Start Here index.

CI exposed two obsolete prose assertions. Update the existing docs-build probe to require the maintained documentation site rather than DeepWiki. Keep legacy bootstrap implementation checks unchanged and verify its documentation in the installation guide linked from README. No runtime changes or broad guide rewrite.

Verification: diff check PASS; both repaired probes PASS; targeted onboarding tests 15/15 PASS. Tool/harness catalog entries and doc destinations inspected against source. Hermes manifest command checked against its upstream Slack guide. All five CI checks passed on 82b33474. Step 7 covers local VS Code attachment and remote SSH attachment, both opening ~/harness. Primary documentation links target the repository index. Community links use the supplied Mifune accounts. No real Slack configuration, clean-install trial, or demo refresh is claimed.

Operator approved undrafting, merging, and release on 2026-09-10.